### PR TITLE
Key presses

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local assert, io, type, dofile, loadfile, pcall, tonumber, print, setmetatable
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 80
+local SAVEGAME_VERSION = 81
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -128,7 +128,7 @@ end
 
 function UIBottomPanel:openJukebox()
   self.ui:addWindow(UIJukebox(self.ui.app))
-end  
+end
 
 function UIBottomPanel:openSave()
   self.ui:addWindow(UISaveGame(self.ui))

--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -154,6 +154,9 @@ function UIAnnualReport:UIAnnualReport(ui, world)
     table.sort(self.salary_sort, sort_order)
     
   -- Pause the game to allow the player plenty of time to check all statistics and trophies won
+  if world and world:isCurrentSpeed("Speed Up") then
+    world:previousSpeed()
+  end    
   world:setSpeed("Pause")
   TheApp.video:setBlueFilterActive(false)
 end

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -692,9 +692,6 @@ function UIMenuBar:makeMenu(app)
     :appendItem(_S.menu_charts.briefing, function() self.ui:showBriefing() end)
   )
   local function _(s) return "  " .. s:upper() .. "  " end
-  local function transparent_walls(item)
-    app.ui:toggleWallsTransparent()
-  end
   local function limit_camera(item)
     app.ui:limitCamera(item.checked)
   end
@@ -725,7 +722,6 @@ function UIMenuBar:makeMenu(app)
   if self.ui.app.config.debug then
     self:addMenu(_S.menu.debug, UIMenu() -- Debug
       :appendMenu(_S.menu_debug.jump_to_level, levels_menu)
-      :appendCheckItem(_S.menu_debug.transparent_walls,    false, transparent_walls, nil, function() return self.ui.transparent_walls end)
       :appendCheckItem(_S.menu_debug.limit_camera,         true, limit_camera, nil, function() return self.ui.limit_to_visible_diamond end)
       :appendCheckItem(_S.menu_debug.disable_salary_raise, false, disable_salary_raise, nil, function() return self.ui.app.world.debug_disable_salary_raise end)
       :appendItem(_S.menu_debug.make_debug_fax,     function() self.ui:makeDebugFax() end)

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -76,8 +76,9 @@ function GameUI:setupGlobalKeyHandlers()
 
   self:addKeyHandler("esc", self, self.setEditRoom, false)
   self:addKeyHandler("esc", self, self.showMenuBar)
+  self:addKeyHandler("z", self, self.keySpeedUp)
+  self:addKeyHandler("x", self, self.keyTransparent  
   self:addKeyHandler({"shift", "a"}, self, self.toggleAdviser)
-
   self:addKeyHandler({"ctrl", "d"}, self.app.world, self.app.world.dumpGameLog)
   self:addKeyHandler({"ctrl", "t"}, self.app, self.app.dumpStrings)
   self:addKeyHandler({"alt", "a"}, self, self.togglePlayAnnouncements)
@@ -86,7 +87,6 @@ function GameUI:setupGlobalKeyHandlers()
 
   if self.app.config.debug then
     self:addKeyHandler("f11", self, self.showCheatsWindow)
-    self:addKeyHandler("x", self, self.toggleWallsTransparent)
   end
 end
 
@@ -219,6 +219,18 @@ function GameUI:updateKeyScroll()
   end
 end
 
+function GameUI:keySpeedUp()
+  if self.key_codes[122] then
+    self.app.world:speedUp()
+  end 
+end
+ 
+function GameUI:keyTransparent() 
+  if self.key_codes[120] then
+    self:makeTransparentWalls()
+  end   
+end
+
 function GameUI:onKeyDown(code, rawchar)
   if UI.onKeyDown(self, code, rawchar) then
     -- Key has been handled already
@@ -226,6 +238,7 @@ function GameUI:onKeyDown(code, rawchar)
   end
   rawchar = self.key_code_to_rawchar[code] -- UI may have translated rawchar
   local key = self:_translateKeyCode(code, rawchar)
+  
   if scroll_keys[key] then
     self:updateKeyScroll()
     return
@@ -243,6 +256,14 @@ function GameUI:onKeyUp(code)
     self:updateKeyScroll()
     return
   end
+  
+  if self.app.world:isCurrentSpeed("Speed Up")  then
+    self.app.world:previousSpeed()
+  end
+  
+  if self.transparent_walls then
+    self:removeTransparentWalls()
+  end    
 end
 
 function GameUI:makeDebugFax()
@@ -685,9 +706,13 @@ function GameUI:setWallsTransparent(mode)
 end
 
 --! Toggles transparency of walls, i.e. enables if currently disabled, and vice versa
-function GameUI:toggleWallsTransparent()
-  self:setWallsTransparent(not self.transparent_walls)
+function GameUI:makeTransparentWalls()
+  self:setWallsTransparent(true)
 end
+
+function GameUI:removeTransparentWalls()
+  self:setWallsTransparent(not self.transparent_walls) 
+end 
 
 function UI:toggleAdviser()
   self.app.config.adviser_disabled = not self.app.config.adviser_disabled
@@ -962,7 +987,11 @@ function GameUI:afterLoad(old, new)
   if old < 78 then
     self.current_momentum = { x = 0, y = 0, z = 0}
   end
-
+  if old < 81 then 
+    self:removeKeyHandler("x", self, self.toggleWallsTransparent)
+    self:addKeyHandler("z", self, self.keySpeedUp)
+    self:addKeyHandler("x", self, self.keyTransparent) 
+  end
   
   return UI.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -784,7 +784,7 @@ end
 
 function Hospital:purchasePlot(plot_number)
   local map = self.world.map
-  if map.th:isParcelPurchasable(plot_number, self:getPlayerIndex()) then
+  if map.th:isParcelPurchasable(plot_number, self:getPlayerIndex()) and not self.world.ui.transparent_walls then
     local cost = not self.world.free_build_mode and map:getParcelPrice(plot_number) or 0
     if cost <= self.balance then
       self.world:setPlotOwner(plot_number, self:getPlayerIndex())

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -92,6 +92,8 @@ function UI:initKeyAndButtonCodes()
     down = 274,
     right = 275,
     left = 276,
+    x = 120,
+    z = 122,    
     f1 = 282,
     f2 = 283,
     f3 = 284,

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -874,6 +874,7 @@ local tick_rates = {
   ["Normal"]             = {1, 3},
   ["Max speed"]          = {1, 1},
   ["And then some more"] = {3, 1},
+  ["Speed Up"]           = {3, 1},
 }
 
 -- Return the length of the current month
@@ -894,6 +895,16 @@ function World:getCurrentSpeed()
       return name
     end
   end
+end
+
+function World:speedUp() 
+  self:setSpeed("Speed Up")  
+end
+
+function World:previousSpeed()
+  if self:isCurrentSpeed("Speed Up") then
+    self:setSpeed(self.prev_speed)
+  end  
 end
 
 -- Set the (approximate) number of seconds per tick.
@@ -1454,6 +1465,9 @@ function World:winGame(player_no)
       end
     end
     self.hospitals[player_no].game_won = true
+    if self:isCurrentSpeed("Speed Up") then
+      self:previousSpeed()
+    end     
     self:setSpeed("Pause")
     self.ui.app.video:setBlueFilterActive(false)
     self.ui.bottom_panel:queueMessage("information", message, nil, 0, 2, callback)


### PR DESCRIPTION
Copy of pull request from MarkL with unrelated commits removed:

To speed up the game press Z, on release the speed changes to what it
was.

Moved transparent walls from a debug option to the main game. Press X
and the walls become transparent and return to normal on release of the
key.
Whilst the walls are transparent you cannot buy plots of land.
this should fix issue 1470
Issue 1493 and Issue 1468 are also related
