### PR TITLE
Ensure range of month is correct for next emergency day

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1108,7 +1108,8 @@ function World:onEndDay()
     -- Postpone it if anything clock related is already underway.
     if self.ui:getWindow(UIWatch) then
       self.next_emergency_month = self.next_emergency_month + 1
-      self.next_emergency_day = math.random(1, month_length[self.next_emergency_month])
+      local month_of_year = 1 + ((self.next_emergency_month - 1) % 12)
+      self.next_emergency_day = math.random(1, month_length[month_of_year])
     else
       -- Do it only for the player hospital for now. TODO: Multiplayer
       local control = self.map.level_config.emergency_control


### PR DESCRIPTION
Because we count in months and not years in world.lua any index over 12 will cause nil returning 
from the month_length table when deciding the next day the emergency is scheduled for. 
This change calculates the actual month in the range 1-12 from the current emergency month count. 

This bug managed to survive because there was up to this point only a timer when the hospital was opening
so the months was in the range 1-12, but for something else which uses a timer we would get a nil exception
when trying to use the result. 
