### PR TITLE
Possible fix for issue #64

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -240,26 +240,30 @@ function Hospital:praiseBench()
   end  
 end
 
--- Messages regarding numbers cured and killed
+--! Messages regarding numbers cured and killed
 function Hospital:msgCured()
   local msg_chance = math.random(1, 15)
-  if msg_chance == 3 and self.msg_counter > 10 then
-    self.world.ui.adviser:say(_A.level_progress.another_patient_cured:format(self.num_cured))
-    self.msg_counter = 0
-  elseif msg_chance == 12 and self.msg_counter > 10 then
-    self.world.ui.adviser:say(_A.praise.patients_cured:format(self.num_cured))
-    self.msg_counter = 0   
+  if self.num_cured > 1 then
+    if msg_chance == 3 and self.msg_counter > 10 then
+      self.world.ui.adviser:say(_A.level_progress.another_patient_cured:format(self.num_cured))
+      self.msg_counter = 0
+    elseif msg_chance == 12 and self.msg_counter > 10 then
+      self.world.ui.adviser:say(_A.praise.patients_cured:format(self.num_cured))
+      self.msg_counter = 0
+    end      
   end 
 end
--- So the messages don't show too often there will need to be at least 10 days before one can show again.
+--! So the messages don't show too often there will need to be at least 10 days before one can show again.
 function Hospital:msgKilled()
-  local msg_chance = math.random(1, 10)      
-  if msg_chance < 4 and self.msg_counter > 10 then
-    self.world.ui.adviser:say(_A.warnings.many_killed:format(self.num_deaths))
-    self.msg_counter = 0
-  elseif msg_chance > 7 and self.msg_counter > 10 then
-    self.world.ui.adviser:say(_A.level_progress.another_patient_killed:format(self.num_deaths))
-    self.msg_counter = 0    
+  local msg_chance = math.random(1, 10) 
+  if self.num_deaths > 1 then  
+    if msg_chance < 4 and self.msg_counter > 10 then
+      self.world.ui.adviser:say(_A.warnings.many_killed:format(self.num_deaths))
+      self.msg_counter = 0
+    elseif msg_chance > 7 and self.msg_counter > 10 then
+      self.world.ui.adviser:say(_A.level_progress.another_patient_killed:format(self.num_deaths))
+      self.msg_counter = 0 
+    end      
   end   
 end
 


### PR DESCRIPTION
Ensure that neither of the messages from the advisor for numbers cured
or killed are displayed for the first of either as there is already
special messages for both these.
