### PR TITLE
Make initial grace period a config option

### DIFF
--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -125,7 +125,7 @@ local config_defaults = {
   zoom_speed = 80,
   scroll_speed = 2,
   check_for_updates = true,
-  initial_grace = true
+  warmth_complaints_initial_grace = true
 }
 local fi = io.open(config_filename, "r")
 local config_values = {}
@@ -419,7 +419,7 @@ scroll_speed = ]=].. tostring(config_values.scroll_speed) ..[=[
 -- The initial grace is how long before staff and patients are less likely to be unhappy about
 -- how cold it is in your hospital.
 --
-initial_grace = ]=].. tostring(config_values.initial_grace) ..[=[ 
+warmth_complaints_initial_grace = ]=].. tostring(config_values.warmth_complaints_initial_grace) ..[=[ 
 --
 ------------------------------------------------ CAMPAIGN MENU -----------------------------------------------
 -- By default your computer log in will be your name in the game.  You can change it in the 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -49,7 +49,7 @@ function Hospital:Hospital(world, name)
   self.acc_overdraft = 0
   self.acc_heating = 0
   self.discover_autopsy_risk = 10
-  self.initial_grace = TheApp.config.initial_grace
+  self.warmth_complaints_initial_grace = TheApp.config.warmth_complaints_initial_grace
 
   -- The sum of all material values (tiles, rooms, objects).
   -- Initial value: hospital tile count * tile value + 20000

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1007,7 +1007,7 @@ function World:onTick()
           self.month = 12
           if self.year == 1 then
             for _, hospital in ipairs(self.hospitals) do
-              hospital.initial_grace = false
+              hospital.warmth_complaints_initial_grace = false
             end
           end
           -- It is crucial that the annual report gets to initialize before onEndYear is called.


### PR DESCRIPTION
This will allow the player to turn off the initial grace period in config.txt.
Which is what I think issue #74 is about.  Currently happiness does not
go down if it is too cold in the first year.
