### PR TITLE
Let the game respect "no earthquakes"

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1318,8 +1318,9 @@ function World:nextEarthquake()
     self.earthquake_size = control.Severity
     self.current_map_earthquake = self.current_map_earthquake + 1
   else
-    if (tonumber(self.map.level_number) and tonumber(self.map.level_number) >= 5) or
-    (not tonumber(self.map.level_number)) and self.map.level_config.quake_control.Severity == 0  then
+  -- ! Stops any earthquakes in the early levels (less than level 5) 
+  -- ! of the TH campaign and allows the map creator to stop them if desired
+    if self.map.level_config.quake_control.Severity == 0  then
       local current_month = (self.year - 1) * 12 + self.month
 
       -- Support standard values for mean and variance


### PR DESCRIPTION
Small change that should let the game respect the mapmakers decision to not have earthquakes in a level by setting the severity to 0.
Unsure if this will also stop random quakes in games were there are no pre-determined quakes left in the level file as I need a long running save.
This might fix http://code.google.com/p/corsix-th/issues/detail?id=1653&q=quake, but I could do with a save, perhaps from the original campaign that is at or above year 10 to test this on to make sure that I have not also stopped those random earthquakes.
