### PR TITLE
Possible fix for Issue #85

### DIFF
--- a/CorsixTH/Lua/persistance.lua
+++ b/CorsixTH/Lua/persistance.lua
@@ -98,6 +98,8 @@ local function MakePermanentObjectsTable(inverted)
           end
         end
       end
+    else
+      print("Warning: Expected table but got " .. type(lib) .. ". A library probably failed to load.")
     end
   end
   


### PR DESCRIPTION
For some reason, the package.loaded table had userdata in it which we weren't expecting. This occurs if the luasocket modules couldn't be loaded.

Quick and dirty but seems to work.
