### PR TITLE
Machine usage - re-done

### DIFF
--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -80,10 +80,10 @@ function Machine:machineUsed(room)
     return
   end
   self:updateDynamicInfo()
-  local threshold =  self.strength - self.times_used
+  local threshold = self.strength - self.times_used
   -- ! Too late it is about to explode
   local taskIndex = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "repairing")
-   if threshold < 1 then
+  if threshold < 1 then
     self.hospital:removeHandymanTask(taskIndex, "repairing")
     room:crashRoom()
     self:setCrashedAnimation()


### PR DESCRIPTION
Changes the way usage is counted for calling for repair, exploding etc
see http://code.google.com/p/corsix-th/issues/detail?id=1352 for more
information.
The current method is based on percentage of use, then oddly explode the
machine at or above 90% usage. So for a machine with a strength of 20
it is exploding whilst still having two uses left! Calls for
repair/urgent repair are also happening too late, so that the siren
never gets the chance to sound.
My proposed change is to forget about percentage used and work on actual
uses that are left. Meaning a machine explodes only when there are no
uses left .
