### PR TITLE
Make initial grace period a config option

### DIFF
--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -124,7 +124,8 @@ local config_defaults = {
   track_fps = false,
   zoom_speed = 80,
   scroll_speed = 2,
-  check_for_updates = true
+  check_for_updates = true,
+  warmth_complaints_initial_grace = true
 }
 local fi = io.open(config_filename, "r")
 local config_values = {}
@@ -412,6 +413,13 @@ zoom_speed = ]=].. tostring(config_values.zoom_speed) ..[=[
 -- Press shift when you are scrolling and it will be a lot quicker
 --
 scroll_speed = ]=].. tostring(config_values.scroll_speed) ..[=[ 
+--
+-------------------------------------------------------------------------------------------------------------------------
+-- Initial Grace Period: By default this is set at True and is in place for 12 months
+-- The initial grace is how long before staff and patients are less likely to be unhappy about
+-- how cold it is in your hospital.
+--
+warmth_complaints_initial_grace = ]=].. tostring(config_values.warmth_complaints_initial_grace) ..[=[ 
 --
 ------------------------------------------------ CAMPAIGN MENU -----------------------------------------------
 -- By default your computer log in will be your name in the game.  You can change it in the 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -49,7 +49,7 @@ function Hospital:Hospital(world, name)
   self.acc_overdraft = 0
   self.acc_heating = 0
   self.discover_autopsy_risk = 10
-  self.initial_grace = true
+  self.warmth_complaints_initial_grace = TheApp.config.warmth_complaints_initial_grace
 
   -- The sum of all material values (tiles, rooms, objects).
   -- Initial value: hospital tile count * tile value + 20000
@@ -240,30 +240,26 @@ function Hospital:praiseBench()
   end  
 end
 
---! Messages regarding numbers cured and killed
+-- Messages regarding numbers cured and killed
 function Hospital:msgCured()
   local msg_chance = math.random(1, 15)
-  if self.num_cured > 1 then
-    if msg_chance == 3 and self.msg_counter > 10 then
-      self.world.ui.adviser:say(_A.level_progress.another_patient_cured:format(self.num_cured))
-      self.msg_counter = 0
-    elseif msg_chance == 12 and self.msg_counter > 10 then
-      self.world.ui.adviser:say(_A.praise.patients_cured:format(self.num_cured))
-      self.msg_counter = 0
-    end      
+  if msg_chance == 3 and self.msg_counter > 10 then
+    self.world.ui.adviser:say(_A.level_progress.another_patient_cured:format(self.num_cured))
+    self.msg_counter = 0
+  elseif msg_chance == 12 and self.msg_counter > 10 then
+    self.world.ui.adviser:say(_A.praise.patients_cured:format(self.num_cured))
+    self.msg_counter = 0   
   end 
 end
---! So the messages don't show too often there will need to be at least 10 days before one can show again.
+-- So the messages don't show too often there will need to be at least 10 days before one can show again.
 function Hospital:msgKilled()
-  local msg_chance = math.random(1, 10) 
-  if self.num_deaths > 1 then  
-    if msg_chance < 4 and self.msg_counter > 10 then
-      self.world.ui.adviser:say(_A.warnings.many_killed:format(self.num_deaths))
-      self.msg_counter = 0
-    elseif msg_chance > 7 and self.msg_counter > 10 then
-      self.world.ui.adviser:say(_A.level_progress.another_patient_killed:format(self.num_deaths))
-      self.msg_counter = 0 
-    end      
+  local msg_chance = math.random(1, 10)      
+  if msg_chance < 4 and self.msg_counter > 10 then
+    self.world.ui.adviser:say(_A.warnings.many_killed:format(self.num_deaths))
+    self.msg_counter = 0
+  elseif msg_chance > 7 and self.msg_counter > 10 then
+    self.world.ui.adviser:say(_A.level_progress.another_patient_killed:format(self.num_deaths))
+    self.msg_counter = 0    
   end   
 end
 
@@ -778,7 +774,7 @@ end
 
 function Hospital:purchasePlot(plot_number)
   local map = self.world.map
-  if map.th:isParcelPurchasable(plot_number, self:getPlayerIndex()) and not self.world.ui.transparent_walls then
+  if map.th:isParcelPurchasable(plot_number, self:getPlayerIndex()) then
     local cost = not self.world.free_build_mode and map:getParcelPrice(plot_number) or 0
     if cost <= self.balance then
       self.world:setPlotOwner(plot_number, self:getPlayerIndex())

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -221,7 +221,6 @@ function World:initLevel(app)
         vis = disease.visuals_id and visual[disease.visuals_id].Value 
         or non_visual[disease.non_visuals_id].Value
       end
-      -- TODO: Where the value is greater that 0 should determine the frequency of the patients
       if vis ~= 0 then
         self.available_diseases[#self.available_diseases + 1] = disease
         self.available_diseases[disease.id] = disease
@@ -488,38 +487,12 @@ function World:spawnPatient(hospital)
   if not hospital then
     hospital = self:getLocalPlayerHospital()
   end
-  --! What is the current month?
-  local current_month = (self.year - 1) * 12 + self.month 
-  --! level files can delay visuals to a given month
-  --! and / or until a given number of patients have arrived
-  local hold_visual_months = self.map.level_config.gbv.HoldVisualMonths
-  local hold_visual_peep_count = self.map.level_config.gbv.HoldVisualPeepCount
-  --! Function to determine whether a given disease is visible and available.
-  --!param disease (disease) Disease to test.
-  --!return (boolean) Whether the disease is visible and available.
-  local function isVisualDiseaseAvailable(disease)
-    if not disease.visuals_id then 
-      return true
-    end
-    --! if the month is greater than either of these values then visuals will not appear in the game
-    if hold_visual_months and hold_visual_months > current_month or
-    hold_visual_peep_count and hold_visual_peep_count > hospital.num_visitors then
-      return false
-    end
-    --! the value against #visuals_available determines from which month a disease can appear. 0 means it can show up anytime.
-    local level_config = self.map.level_config 
-    if level_config.visuals_available[disease.visuals_id].Value >= current_month then 
-      return false
-    end   
-    return true
-  end 
-
   if hospital:hasStaffedDesk() then
     local spawn_point = self.spawn_points[math.random(1, #self.spawn_points)]
     local patient = self:newEntity("Patient", 2)
     local disease = self.available_diseases[math.random(1, #self.available_diseases)]
-    while disease.only_emergency or not isVisualDiseaseAvailable(disease) do
-      disease = self.available_diseases[math.random(1, #self.available_diseases)] 
+    while disease.only_emergency do
+      disease = self.available_diseases[math.random(1, #self.available_diseases)]
     end
     patient:setDisease(disease)
     patient:setNextAction{name = "spawn", mode = "spawn", point = spawn_point}
@@ -903,22 +876,11 @@ local tick_rates = {
   ["Normal"]             = {1, 3},
   ["Max speed"]          = {1, 1},
   ["And then some more"] = {3, 1},
-  ["Speed Up"]           = {4, 1},
 }
 
 -- Return the length of the current month
 function World:getCurrentMonthLength()
   return month_length[self.month]
-end
-
-function World:speedUp()
-  self:setSpeed("Speed Up")
-end
-
-function World:previousSpeed()
-  if self:isCurrentSpeed("Speed Up") then
-    self:setSpeed(self.prev_speed)
-  end
 end
 
 -- Return if the selected speed the same as the current speed.
@@ -1045,7 +1007,7 @@ function World:onTick()
           self.month = 12
           if self.year == 1 then
             for _, hospital in ipairs(self.hospitals) do
-              hospital.initial_grace = false
+              hospital.warmth_complaints_initial_grace = false
             end
           end
           -- It is crucial that the annual report gets to initialize before onEndYear is called.
@@ -1495,9 +1457,6 @@ function World:winGame(player_no)
       end
     end
     self.hospitals[player_no].game_won = true
-    if self:isCurrentSpeed("Speed Up") then
-      self:previousSpeed()
-    end
     self:setSpeed("Pause")
     self.ui.app.video:setBlueFilterActive(false)
     self.ui.bottom_panel:queueMessage("information", message, nil, 0, 2, callback)
@@ -2312,9 +2271,6 @@ function World:afterLoad(old, new)
   if old < 77 then
     self.ui:addKeyHandler({"shift", "+"}, self, self.adjustZoom, 5)
     self.ui:addKeyHandler({"shift", "-"}, self, self.adjustZoom, -5)  
-  end
-  if old < 80 then
-    self:determineWinningConditions()
   end
   
   self.savegame_version = new


### PR DESCRIPTION
To replace issue #81 

This will allow the player to turn off the initial grace period in config.txt.
Which is what I think issue #74 is about. Currently happiness does not
go down if it is too cold in the first year.
