### PR TITLE
corrects the visuals_id for pregnant

### DIFF
--- a/CorsixTH/Lua/diseases/pregnant.lua
+++ b/CorsixTH/Lua/diseases/pregnant.lua
@@ -19,7 +19,7 @@ SOFTWARE. --]]
 local disease = {}
 disease.id = "pregnant"
 disease.expertise_id = 14
-disease.non_visuals_id = 19
+disease.visuals_id = 12
 disease.name = _S.diseases.pregnancy.name
 disease.cause = _S.diseases.pregnancy.cause
 disease.symptoms = _S.diseases.pregnancy.symptoms


### PR DESCRIPTION
Fixes issue #141
Line 22 has non_visuals_id when it should be visuals_id to match the level files
