### PR TITLE
Correct foruma for earnings from an emergency

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1195,7 +1195,10 @@ function Hospital:resolveEmergency()
   local total = emer.victims
   local max_bonus = emer.bonus * total
   local emergency_success = rescued_patients/total >= emer.percentage
-  local earned = math.floor((emergency_success and rescued_patients/total or 0) * 10) * max_bonus/10
+  local earned = 0
+  if emergency_success then
+    earned = emer.bonus * rescued_patients
+  end
   local message = {
     {text = _S.fax.emergency_result.saved_people
       :format(rescued_patients, total)},


### PR DESCRIPTION
If the emergency is a success, earnings is now the per patient
bonus times the number of rescued patients.  This removes the
error that existed when using floating point and math.floor.

Fixes issue #152
