### PR TITLE
If a handyman dies, deallocate him from his task

### DIFF
--- a/CorsixTH/Lua/calls_dispatcher.lua
+++ b/CorsixTH/Lua/calls_dispatcher.lua
@@ -227,7 +227,8 @@ function CallsDispatcher:answerCall(staff)
   local min_call = nil
   local min_key = nil
   assert(not staff.on_call, "Staff should be idea before he can answer another call")
-
+  assert(staff.hospital, "Staff should still be a member of the hospital to answer a call"); 
+  
   if staff.humanoid_class == "Handyman" then
    staff:searchForHandymanTask()
    return true

--- a/CorsixTH/Lua/entities/staff.lua
+++ b/CorsixTH/Lua/entities/staff.lua
@@ -382,6 +382,12 @@ end
 
 function Staff:die()
   self:setHospital(nil)
+  if self.task then
+    -- If the staff member had a task outstanding, unassigning them from that task. 
+    -- Tasks with no handyman assigned will be eligable for reassignment by the hospital.
+    self.task.assignedHandyman = nil
+    self.task = nil
+  end
   -- Update the staff management screen (if present) accordingly
   local window = self.world.ui:getWindow(UIStaffManagement)
   if window then

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1666,6 +1666,12 @@ function Hospital:searchForHandymanTask(handyman, taskType)
       if v.assignedHandyman then
         if v.assignedHandyman.fired then
           v.assignedHandyman = nil
+        elseif not v.assignedHandyman.hospital then
+          -- This should normally never be the case. If the handyman doesn't belong to a hsopital
+          -- then they should not have any tasks assigned to them however it was previously possible
+          -- We need to tidy up to make sure the task can be reassigned.
+          print("Warning: Orphaned handyman is still assigned a task. Removing.");
+          v.assignedHandyman = nil
         else
           local assignedDistance = self.world:getPathDistance(v.tile_x, v.tile_y, v.assignedHandyman.tile_x, v.assignedHandyman.tile_y)
           if assignedDistance ~= false then


### PR DESCRIPTION
Fixes issue #62. See the comments in this issue for more info.
