### PR TITLE
Add documentation about issue templates

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -47,14 +47,9 @@ What version of the product are you using? On what operating system?
 
 PULL REQUEST
 
-If you want to do a pull request (see at bottom of this file how to do this,)
-please create a pull request, add the following questions to it and answer them:
-
-What are the major things which your pull request changes / adds?
-
-What version of the product are you using? On what operating system?
-
-Please provide any additional information below.
+When providing a pull request insure the description field describes the major 
+changes from the request. If your pull request relates to any existing 
+issues, include those issues in the description. e.g. "Fixes issue #1"
 
 
 HOW TO UPLOAD GAMELOG AND/OR SAVES


### PR DESCRIPTION
Mailed the GitHub guys about this and they said that it is currently not possible to let bug reporters fill this in automaticly, as you could with Google Code, but they will might do this in the future. So, this issue is a kind of workaround till GitHub fully supports issue templates.
They said the following:

"Adding an issue template is not possible currently, but we might add it in the future. Thanks for the suggestion, I'll add it to the Feature Request List so the team can see it.

In the meantime, you could add an issue template to your repository's CONTRIBUTING.md file, which is linked whenever someone creates a new issue or pull request."
