### PR TITLE
make_debug_patient Bug fix: prevents initPatient() being called twice.

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/make_debug_patient.lua
+++ b/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/make_debug_patient.lua
@@ -39,7 +39,6 @@ function UIMakeDebugPatient:buttonClicked(num)
   local patient = self.ui.app.world:newEntity("Patient", 2)
   patient.is_debug = true
   table.insert(self.ui.hospital.debug_patients, patient)
-  item.disease.initPatient(patient)
   patient:setDisease(item.disease)
   patient.diagnosed = true
   local x, y = self.ui:ScreenToWorld(self.x + self.width / 2, self.y + self.height + 100)


### PR DESCRIPTION
_disease.initPatient()_ doesn't need to be called in
_make_debug_patient.lua_ because its called by
_patient:setDisease()_

Calling it twice when spawning debug patients can make male patients
look like females and vice versa, until they are told to stop standing
idle.
