### PR TITLE
Utility:tables_length() unlike # this can return the length of any table

### DIFF
--- a/CorsixTH/Lua/utility.lua
+++ b/CorsixTH/Lua/utility.lua
@@ -104,9 +104,11 @@ function print_table(obj, max_level, level)
 end
 
 -- Can return the length of any table, where as #table_name is only suitable for use with arrays of one contiguous part without nil values.
-function tables_length(table)
+function table_length(table)
   local count = 0
-  for _,_ in pairs(table) do count = count + 1 end
+  for _,_ in pairs(table) do 
+    count = count + 1 
+  end
   return count
 end
 


### PR DESCRIPTION
_#table_name_ is only suitable for use with arrays of one contiguous part
without nil values:

http://stackoverflow.com/questions/2705793/how-to-get-number-of-entries-in-a-lua-table

This function is used by the audio code I've made for my WIP hell deaths
implementation.
