### PR TITLE
Rename parcel to plot

### DIFF
--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -174,7 +174,7 @@ function UIStaff:draw(canvas, x_, y_)
   font:draw(canvas, profile.name, x + 42, y + 28) -- Name
   if profile.humanoid_class == "Handyman" then
     font:draw(canvas, "$" .. profile.wage, x + 135, y + 226) -- Wage
-    font:draw(canvas, self:getParcelText(), x + 25, y + 215, 50, 0)
+    font:draw(canvas, self:getParcelText(), x + 35, y + 215, 50, 0)
     -- The concentration areas
     local cleaning_width, watering_width, repairing_width = 0, 0, 0
     if self.staff.attributes["cleaning"] then -- Backwards compatibility

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -397,12 +397,12 @@ font_location_window = {
 }
 
 handyman_window = {
-  all_parcels = "All parcels",
-  parcel = "Parcel"
+  all_parcels = "All plots",
+  parcel = "Plot"
 }
 
 tooltip.handyman_window = {
-  parcel_select = "The parcel where the handyman accepts tasks, click to change setting"
+  parcel_select = "The plot where the handyman accepts tasks, click to change setting"
 }
 
 new_game_window = {


### PR DESCRIPTION
When you zone the handyman it refers to parcels, unless you have made a map you won't know what a parcel is.  They are referred to as plots in the town map, also this small change will make this fit better on the
staff dialog.
