### PR TITLE
Fix nesting of conditions in Humanoid:afterLoad

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -291,7 +291,6 @@ end
 
 -- Save game compatibility
 function Humanoid:afterLoad(old, new)
-
   if old < 38 then
     -- should existing patients be updated and be getting really ill?
     -- adds the new variables for health icons 
@@ -301,11 +300,11 @@ function Humanoid:afterLoad(old, new)
   if old < 42 then
     if self.humanoid_class == "Slack Female Patient" then
       self.die_anims = die_animations["Slack Female Patient"]
+    end
   end
   if old < 77 then
     self.has_vomitted = 0
   end
-end   
   if old < 49 then
     self.has_fallen = 1
   end


### PR DESCRIPTION
The wrong nesting of conditions in Humanoid:afterLoad() before this fix:
![bad_indentation](https://f.cloud.github.com/assets/6353342/2148934/425b95ca-93ed-11e3-84fc-ffa453a5e735.png)
