### PR TITLE
New humanoid action: idle_spawn

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
@@ -24,10 +24,12 @@ local function action_idle_spawn_start(action, humanoid)
   humanoid:setTilePositionSpeed(action.point.x,action.point.y)
   
   if action.spawn_animation then
-    humanoid:queueAction({name="idle",count = humanoid.world:getAnimLength(action.spawn_animation),loop_callback=--[[persistable:idle_spawn_animation]]function()
-                                                                                                                   if action.spawn_sound then humanoid:playSound(action.spawn_sound) end      
-                                                                                                                   humanoid:setAnimation(action.spawn_animation)
-                                                                                                                 end})
+    humanoid:queueAction({name="idle",count = humanoid.world:getAnimLength(action.spawn_animation),
+                                      loop_callback=--[[persistable:idle_spawn_animation]]
+                                      function()
+                                        if action.spawn_sound then humanoid:playSound(action.spawn_sound) end      
+                                        humanoid:setAnimation(action.spawn_animation)
+                                      end})
   elseif action.spawn_sound then
     humanoid:playSound(action.spawn_sound)                                                                                                                  
   end


### PR DESCRIPTION
The existing spawn action requires spawned humanoids to walk to a tile
after they've spawned, where as this new spawn action doesn't require
this so a humanoid can spawn on a tile and then stand idle on it.

This is how the Grim Reaper spawns in TH, standing idle for a few
seconds before walking to a lava hole. This is why I created this action
and it can play the Grim Reaper's spawn animation and sound effect.

This action's fields:
- point (mandatory):  {x, y, direction}  Where the humanoid will spawn.
- spawn_animation (optional)
- spawn_sound (optional)
- Idle action's fields:  count (optional), loop_callback (optional)
