### PR TITLE
Female patient "flying to heaven" sound fix

### DIFF
--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1003,7 +1003,11 @@ void THAnimation::tick()
             m_pMorphTarget->m_iY = m_pMorphTarget->m_iX;
     }
 
-    m_iSoundToPlay = m_pManager->getFrameSound(m_iFrame);
+    //Female flying to heaven sound fix:
+    if(m_iFrame == 6987)
+        m_iSoundToPlay = 123;
+    else
+        m_iSoundToPlay = m_pManager->getFrameSound(m_iFrame);
 }
 
 void THAnimationBase::removeFromTile()


### PR DESCRIPTION
The flying to heaven animation for females returned a null sound number for frame 6987 in _THAnimation.tick()_ when it should have been returning 123.
