### PR TITLE
I've fixed the faulty Chewbacca fall animation

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local assert, io, type, dofile, loadfile, pcall, tonumber, print, setmetatable
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 82
+local SAVEGAME_VERSION = 83
 
 class "App"
 

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -138,7 +138,7 @@ die_anims("Transparent Male Patient",  4412, 2434, 2438, 2446,  2450,  4416) -- 
 die_anims("Standard Female Patient",   3116, 3208, 3212, 3216,  3220)
 die_anims("Slack Female Patient",      4288, 3208, 3212, 3216,  3220)
 die_anims("Transparent Female Patient",4420, 3208, 3212, 3216,  3220,  4428) -- Extra = Transformation
-die_anims("Chewbacca Patient",         4182, 2434, 2438, 2446,  2450) -- Only males die... (1222 is the Female)
+die_anims("Chewbacca Patient",         4182, 2434, 2438, 2446,  2450, 1682) -- Only males die... (1222 is the Female)
 die_anims("Elvis Patient",              974, 2434, 2438, 2446,  2450,  4186) -- Extra = Transformation
 die_anims("Invisible Patient",         4200, 2434, 2438, 2446,  2450)
 die_anims("Alien Male Patient",        4882, 2434, 2438, 2446,  2450)
@@ -320,6 +320,9 @@ function Humanoid:afterLoad(old, new)
       self.build_callbacks[self.toilet_callback] = true
       self.toilet_callback = nil
     end
+  end
+  if old < 83 and self.humanoid_class == "Chewbacca Patient" then
+    self.die_anims.extra_east = 1682
   end
   Entity.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/humanoid_actions/die.lua
+++ b/CorsixTH/Lua/humanoid_actions/die.lua
@@ -83,7 +83,14 @@ local function action_die_start(action, humanoid)
     humanoid:setAnimation(anims.fall_east, 1)
   end
   action.phase = 0
-  humanoid:setTimer(humanoid.world:getAnimLength(fall), action_die_tick)
+
+  if humanoid.humanoid_class == "Chewbacca Patient" then
+    --After 21 ticks the first frame of the buggy falling part of this animation is reached
+    --so this animation is ended early, action_die_tick will then use the standard male fall animation:
+    humanoid:setTimer(21, action_die_tick)
+  else
+    humanoid:setTimer(humanoid.world:getAnimLength(fall), action_die_tick)
+  end
 end
 
 return action_die_start


### PR DESCRIPTION
The falling part of this animation (4182) is faulty with a missing heads layer
in frame 30:
http://www.mediafire.com/view/c2r6bf5ld4pu9x4/Chewbacca_buggy_death_anim_fix.mp4

So this fix lets the first 21 standing transformation frames be played
and then changes the animation to the standard male fall animation by
using it as an extra east animation.
