### PR TITLE
idle_spawn:The spawn animation function is now persisted

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
@@ -25,8 +25,7 @@ local function action_idle_spawn_start(action, humanoid)
 
   if action.spawn_animation then
     humanoid:queueAction({name="idle",count = humanoid.world:getAnimLength(action.spawn_animation),
-                                      loop_callback=--[[persistable:idle_spawn_animation]]
-                                      function()
+                                      loop_callback=--[[persistable:idle_spawn_animation]] function()
                                         if action.spawn_sound then humanoid:playSound(action.spawn_sound) end
                                         humanoid:setAnimation(action.spawn_animation)
                                       end})


### PR DESCRIPTION
It wasn't persisted before because the comment
"[[persistable:idle_spawn_animation]]" was not on the same line as the
word: function.
