### PR TITLE
Pause when the window loses focus Pause when the window loses focus

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local assert, io, type, dofile, loadfile, pcall, tonumber, print, setmetatable
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 82
+local SAVEGAME_VERSION = 83
 
 class "App"
 

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -109,6 +109,7 @@ local config_defaults = {
   grant_wage_increase = false,  
   movies = true,
   play_intro = true,
+  pause_on_focus_lost = false,
   allow_user_actions_while_paused = false,
   volume_opens_casebook = false,  
   alien_dna_only_by_emergency = true,
@@ -287,6 +288,13 @@ movies = ]=].. tostring(config_values.movies) ..[=[
 play_intro = ]=].. tostring(config_values.play_intro) ..[=[ 
  
 -------------------------------------------------------------------------------------------------------------------------
+-- Pause when window loses focus.
+-- If set to true, the game will pause when the window loses focus (e.g. when
+-- minimised).
+pause_on_focus_lost = ]=].. tostring(config_values.pause_on_focus_lost) ..[=[ 
+--
+--
+-------------------------------------------------------------------------------
 -- Allow user actions while game is paused
 -- In Theme Hospital the player would only be allowed to use the top menu if
 -- the game was paused. That is the default setting in CorsixTH too, but by

--- a/CorsixTH/Lua/dialogs/resizables/customise.lua
+++ b/CorsixTH/Lua/dialogs/resizables/customise.lua
@@ -58,7 +58,7 @@ local col_caption = {
 }
 
 function UICustomise:UICustomise(ui, mode)
-  self:UIResizable(ui, 320, 280, col_bg)
+  self:UIResizable(ui, 500, 225, col_bg)
 
   local app = ui.app
   self.mode = mode
@@ -72,68 +72,85 @@ function UICustomise:UICustomise(ui, mode)
 
   -- Window parts definition
   -- Title
-  self:addBevelPanel(80, 10, 160, 20, col_caption):setLabel(_S.customise_window.caption)
-    .lowered = true 
-  
+  self:addBevelPanel(160, 10, 180, 20, col_caption):setLabel(_S.customise_window.caption)
+    .lowered = true
+
   -- Movies, global switch
   self:addBevelPanel(20, 40, 135, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.customise_window.movies):setTooltip(_S.tooltip.customise_window.movies).lowered = true
   self.movies_panel =
-    self:addBevelPanel(160, 40, 135, 20, col_bg):setLabel(app.config.movies and _S.customise_window.option_on or _S.customise_window.option_off)
-  self.movies_button = self.movies_panel:makeToggleButton(0, 0, 140, 20, nil, self.buttonMoviesGlobal)
+    self:addBevelPanel(160, 40, 80, 20, col_bg):setLabel(app.config.movies and _S.customise_window.option_on or _S.customise_window.option_off)
+  self.movies_button = self.movies_panel:makeToggleButton(0, 0, 80, 20, nil, self.buttonMoviesGlobal)
     :setToggleState(app.config.movies):setTooltip(_S.tooltip.customise_window.movies)
-  
+
   -- Intro movie
-  self:addBevelPanel(20, 65, 135, 20, col_shadow, col_bg, col_bg)
+  self:addBevelPanel(260, 40, 135, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.customise_window.intro):setTooltip(_S.tooltip.customise_window.intro).lowered = true
   self.intro_panel =
-    self:addBevelPanel(160, 65, 135, 20, col_bg):setLabel(app.config.play_intro and _S.customise_window.option_on or _S.customise_window.option_off)
-  self.intro_button = self.intro_panel:makeToggleButton(0, 0, 140, 20, nil, self.buttonIntro)
-    :setToggleState(app.config.play_intro):setTooltip(_S.tooltip.customise_window.intro)  
-  
+    self:addBevelPanel(400, 40, 80, 20, col_bg):setLabel(app.config.play_intro and _S.customise_window.option_on or _S.customise_window.option_off)
+  self.intro_button = self.intro_panel:makeToggleButton(0, 0, 80, 20, nil, self.buttonIntro)
+    :setToggleState(app.config.play_intro):setTooltip(_S.tooltip.customise_window.intro)
+
   -- Allow user actions when paused
-  self:addBevelPanel(20, 90, 135, 20, col_shadow, col_bg, col_bg)
+  self:addBevelPanel(20, 65, 135, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.customise_window.paused):setTooltip(_S.tooltip.customise_window.paused).lowered = true
   self.paused_panel =
-    self:addBevelPanel(160, 90, 135, 20, col_bg):setLabel(app.config.allow_user_actions_while_paused and _S.customise_window.option_on or _S.customise_window.option_off)
-  self.paused_button = self.paused_panel:makeToggleButton(0, 0, 140, 20, nil, self.buttonPaused)
-    :setToggleState(app.config.allow_user_actions_while_paused):setTooltip(_S.tooltip.customise_window.paused)   
-  
+    self:addBevelPanel(160, 65, 80, 20, col_bg):setLabel(app.config.allow_user_actions_while_paused and _S.customise_window.option_on or _S.customise_window.option_off)
+  self.paused_button = self.paused_panel:makeToggleButton(0, 0, 80, 20, nil, self.buttonPaused)
+    :setToggleState(app.config.allow_user_actions_while_paused):setTooltip(_S.tooltip.customise_window.paused)
+
   -- Volume down is opening casebook
-  self:addBevelPanel(20, 115, 135, 20, col_shadow, col_bg, col_bg)
+  self:addBevelPanel(260, 65, 135, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.customise_window.volume):setTooltip(_S.tooltip.customise_window.volume).lowered = true
   self.volume_panel =
-    self:addBevelPanel(160, 115, 135, 20, col_bg):setLabel(app.config.volume_opens_casebook and _S.customise_window.option_on or _S.customise_window.option_off)
-  self.volume_button = self.volume_panel:makeToggleButton(0, 0, 140, 20, nil, self.buttonVolume)
-    :setToggleState(app.config.volume_opens_casebook):setTooltip(_S.tooltip.customise_window.volume)    
-  
+    self:addBevelPanel(400, 65, 80, 20, col_bg):setLabel(app.config.volume_opens_casebook and _S.customise_window.option_on or _S.customise_window.option_off)
+  self.volume_button = self.volume_panel:makeToggleButton(0, 0, 80, 20, nil, self.buttonVolume)
+    :setToggleState(app.config.volume_opens_casebook):setTooltip(_S.tooltip.customise_window.volume)  
+
   -- Alien DNA from emergencies only/must stand/can knock on doors
-  self:addBevelPanel(20, 140, 135, 20, col_shadow, col_bg, col_bg)
+  self:addBevelPanel(20, 90, 135, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.customise_window.aliens):setTooltip(_S.tooltip.customise_window.aliens).lowered = true
   self.aliens_panel =
-    self:addBevelPanel(160, 140, 135, 20, col_bg):setLabel(app.config.alien_dna_only_by_emergency and _S.customise_window.option_on or _S.customise_window.option_off)
-  self.aliens_button = self.aliens_panel:makeToggleButton(0, 0, 140, 20, nil, self.buttonAliens)
-    :setToggleState(app.config.alien_dna_only_by_emergency):setTooltip(_S.tooltip.customise_window.aliens) 
+    self:addBevelPanel(160, 90, 80, 20, col_bg):setLabel(app.config.alien_dna_only_by_emergency and _S.customise_window.option_on or _S.customise_window.option_off)
+  self.aliens_button = self.aliens_panel:makeToggleButton(0, 0, 80, 20, nil, self.buttonAliens)
+    :setToggleState(app.config.alien_dna_only_by_emergency):setTooltip(_S.tooltip.customise_window.aliens)
 
   -- Allow female patients with Fractured Bones
-  self:addBevelPanel(20, 165, 135, 20, col_shadow, col_bg, col_bg)
+  self:addBevelPanel(260, 90, 135, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.customise_window.fractured_bones):setTooltip(_S.tooltip.customise_window.fractured_bones).lowered = true
   self.fractured_bones_panel =
-    self:addBevelPanel(160, 165, 135, 20, col_bg):setLabel(app.config.disable_fractured_bones_females and _S.customise_window.option_on or _S.customise_window.option_off)
-  self.fractured_bones_button = self.fractured_bones_panel:makeToggleButton(0, 0, 140, 20, nil, self.buttonFractured_bones)
-    :setToggleState(app.config.disable_fractured_bones_females):setTooltip(_S.tooltip.customise_window.fractured_bones)   
+    self:addBevelPanel(400, 90, 80, 20, col_bg):setLabel(app.config.disable_fractured_bones_females and _S.customise_window.option_on or _S.customise_window.option_off)
+  self.fractured_bones_button = self.fractured_bones_panel:makeToggleButton(0, 0, 80, 20, nil, self.buttonFractured_bones)
+    :setToggleState(app.config.disable_fractured_bones_females):setTooltip(_S.tooltip.customise_window.fractured_bones)
 
   -- Allow average contents when building rooms
-  self:addBevelPanel(20, 190, 135, 20, col_shadow, col_bg, col_bg)
+  self:addBevelPanel(20, 115, 135, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.customise_window.average_contents):setTooltip(_S.tooltip.customise_window.average_contents).lowered = true
   self.average_contents_panel =
-    self:addBevelPanel(160, 190, 135, 20, col_bg):setLabel(app.config.enable_avg_contents and _S.customise_window.option_on or _S.customise_window.option_off)
-  self.average_contents_button = self.average_contents_panel:makeToggleButton(0, 0, 140, 20, nil, self.buttonAverage_contents)
-    :setToggleState(app.config.enable_avg_contents):setTooltip(_S.tooltip.customise_window.average_contents)     
-  
+    self:addBevelPanel(160, 115, 80, 20, col_bg):setLabel(app.config.enable_avg_contents and _S.customise_window.option_on or _S.customise_window.option_off)
+  self.average_contents_button = self.average_contents_panel:makeToggleButton(0, 0, 80, 20, nil, self.buttonAverage_contents)
+    :setToggleState(app.config.enable_avg_contents):setTooltip(_S.tooltip.customise_window.average_contents)
+
+      -- Pause game when focus is lost
+  self:addBevelPanel(260, 115, 135, 20, col_shadow, col_bg, col_bg)
+    :setLabel(_S.customise_window.on_focus_lost):setTooltip(_S.tooltip.customise_window.on_focus_lost).lowered = true
+  self.on_focus_lost_panel =
+    self:addBevelPanel(400, 115, 80, 20, col_bg):setLabel(app.config.pause_on_focus_lost and _S.customise_window.option_on or _S.customise_window.option_off)
+  self.on_focus_lost_button = self.on_focus_lost_panel:makeToggleButton(0, 0, 80, 20, nil, self.buttonOnFocusLost)
+    :setToggleState(app.config.pause_on_focus_lost):setTooltip(_S.tooltip.customise_window.on_focus_lost)
+
+
+      -- Check for updated version of CorsixTH
+  self:addBevelPanel(20, 140, 135, 20, col_shadow, col_bg, col_bg)
+    :setLabel(_S.customise_window.updates):setTooltip(_S.tooltip.customise_window.updates).lowered = true
+  self.updates_panel =
+    self:addBevelPanel(160, 140, 80, 20, col_bg):setLabel(app.config.check_for_updates and _S.customise_window.option_on or _S.customise_window.option_off)
+  self.updates_button = self.updates_panel:makeToggleButton(0, 0, 80, 20, nil, self.buttonUpdates)
+    :setToggleState(app.config.check_for_updates):setTooltip(_S.tooltip.customise_window.updates)
+
   -- "Back" button
-  self:addBevelPanel(20, 220, 280, 40, col_bg):setLabel(_S.customise_window.back)
-    :makeButton(0, 0, 280, 40, nil, self.buttonBack):setTooltip(_S.tooltip.customise_window.back)
+  self:addBevelPanel(20, 175, 460, 40, col_bg):setLabel(_S.customise_window.back)
+    :makeButton(0, 0, 460, 40, nil, self.buttonBack):setTooltip(_S.tooltip.customise_window.back)
 end
 
 function UICustomise:buttonAudioGlobal(checked)
@@ -146,7 +163,7 @@ function UICustomise:buttonMoviesGlobal(checked)
   app.config.movies = not app.config.movies
   self.movies_button:toggle()
   self.movies_panel:setLabel(app.config.movies and _S.customise_window.option_on or _S.customise_window.option_off)
-  self:reload()   
+  self:reload()
   app:saveConfig()
 end
 
@@ -155,7 +172,7 @@ function UICustomise:buttonIntro(checked)
   app.config.play_intro = not app.config.play_intro
   self.intro_button:toggle()
   self.intro_panel:setLabel(app.config.play_intro and _S.customise_window.option_on or _S.customise_window.option_off)
-  self:reload()   
+  self:reload()
   app:saveConfig()
 end
 
@@ -164,7 +181,7 @@ function UICustomise:buttonPaused(checked)
   app.config.allow_user_actions_while_paused = not app.config.allow_user_actions_while_paused
   self.paused_button:toggle()
   self.paused_panel:setLabel(app.config.allow_user_actions_while_paused and _S.customise_window.option_on or _S.customise_window.option_off)
-  self:reload()   
+  self:reload()
   app:saveConfig()
 end
 
@@ -173,7 +190,7 @@ function UICustomise:buttonVolume(checked)
   app.config.volume_opens_casebook = not app.config.volume_opens_casebook
   self.volume_button:toggle()
   self.volume_panel:setLabel(app.config.volume_opens_casebook and _S.customise_window.option_on or _S.customise_window.option_off)
-  self:reload()   
+  self:reload()
   app:saveConfig()
 end
 
@@ -185,7 +202,7 @@ function UICustomise:buttonAliens(checked)
   self.aliens_button:toggle()
   self.aliens_panel:setLabel(app.config.alien_dna_only_by_emergency and _S.customise_window.option_on or _S.customise_window.option_off)
   app:saveConfig()
-  self:reload()    
+  self:reload()
   local err = {_S.errors.alien_dna}
   self.ui:addWindow(UIInformation(self.ui, err))
 end
@@ -196,7 +213,7 @@ function UICustomise:buttonFractured_bones(checked)
   self.fractured_bones_button:toggle()
   self.fractured_bones_panel:setLabel(app.config.disable_fractured_bones_females and _S.customise_window.option_on or _S.customise_window.option_off)
   app:saveConfig()
-  self:reload()    
+  self:reload()
   local err = {_S.errors.fractured_bones}
   self.ui:addWindow(UIInformation(self.ui, err))
 end
@@ -207,7 +224,25 @@ function UICustomise:buttonAverage_contents(checked)
   self.average_contents_button:toggle()
   self.average_contents_panel:setLabel(app.config.enable_avg_contents and _S.customise_window.option_on or _S.customise_window.option_off)
   app:saveConfig()
-  self:reload()    
+  self:reload()  
+end
+
+function UICustomise:buttonUpdates(checked)
+  local app = self.ui.app
+  app.config.check_for_updates = not app.config.check_for_updates
+  self.updates_button:toggle()
+  self.updates_panel:setLabel(app.config.check_for_updates and _S.customise_window.option_on or _S.customise_window.option_off)
+  app:saveConfig()
+  self:reload()   
+end
+
+function UICustomise:buttonOnFocusLost(checked)
+  local app = self.ui.app
+  app.config.pause_on_focus_lost = not app.config.pause_on_focus_lost
+  self.on_focus_lost_button:toggle()
+  self.on_focus_lost_panel:setLabel(app.config.pause_on_focus_lost and _S.customise_window.option_on or _S.customise_window.option_off)
+  app:saveConfig()
+  self:reload()  
 end
 
 function UICustomise:buttonBack()
@@ -220,7 +255,7 @@ end
 function UICustomise:reload()
   local window = UICustomise(self.ui, "menu")
   self.ui:addWindow(window)
-end  
+end
 
 function UICustomise:close()
   UIResizable.close(self)

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -231,8 +231,11 @@ install = {
   cancel = "Cancel",
 }
 
-misc.not_yet_implemented = "(not yet implemented)"
-misc.no_heliport = "Either no diseases have been discovered yet, or there is no heliport on this map.  It might be that you need to build a reception desk and hire a receptionist"
+
+misc = {
+not_yet_implemented = "(not yet implemented)",
+no_heliport = "You are not able to create an emergency for one or more of the following reasons: there are either no diseases that have been discovered yet, or there is no accessible heliport on this map or you need a staffed reception desk.",
+}
 
 main_menu = {
   new_game = "Campaign",
@@ -322,10 +325,10 @@ tooltip.options_window = {
   height = "Enter desired screen height",
   apply = "Apply the entered resolution",
   cancel = "Return without changing the resolution",
-  audio_button = "Turn on or off all game audio", 
-  audio_toggle = "Toggle on or off",   
+  audio_button = "Turn on or off all game audio",
+  audio_toggle = "Toggle on or off", 
   customise_button = "More settings you can change to customise your game play experience",
-  folder_button = "Folder Options",  
+  folder_button = "Folder Options",
   language = "The language texts in the game will appear in",
   select_language = "Select the game language",
   language_dropdown_item = "Choose %s as language",
@@ -344,16 +347,20 @@ customise_window = {
   aliens = "Alien Patients",
   fractured_bones = "Fractured Bones",
   average_contents = "Average contents",
+  updates = "Check for updates",
+  on_focus_lost = "Pause on lost focus",
 }
 
 tooltip.customise_window = {
-  movies = "Global movie control, this will allow you to disable all the movies",  
+  movies = "Global movie control, this will allow you to disable all the movies",
   intro = "Turn off or on the intro movie, global movies will need to be on if you want the intro movie to play each time you load CorsixTH",
   paused = "In Theme Hospital the player would only be allowed to use the top menu if the game was paused. That is the default setting in CorsixTH too, but by turning this on everything is allowed while the game is paused",
   volume = "If the volume down button is opening the casebook as well, turn this on to change the hotkey for the casebook to Shift + C",
   aliens = "Because of the lack of proper animations we have by default made patients with Alien DNA so that they can only come from an emergency. To allow patients with Alien DNA to visit your hospital, other than by an emergency, turn this off",
   fractured_bones = "Because of a poor animation we have by default made it so there are no patients with Fractured Bones that are female. To allow female patients with Fractured Bones to visit your hospital, turn this off",
-  average_contents = "If you would like the game to remember what extra objects you usually add when you build rooms, then turn this option on",  
+  average_contents = "If you would like the game to remember what extra objects you usually add when you build rooms, then turn this option on",
+  updates = "Checks for updates and notifies you when there is a newer version of CorsixTH available",
+  on_focus_lost = "Option to pause the game when minimized and the focus on the game window is lost",
   back = "Close this menu and go back to the Settings Menu",
 }
 

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -745,7 +745,7 @@ end
 local UpdateCursorPosition = TH.cursor.setPosition
 
 --! Called when the mouse enters or leaves the game window.
-function UI:onWindowActive(gain)
+function UI:onWindowActive(gain, state)
 end
 
 function UI:onMouseMove(x, y, dx, dy)

--- a/CorsixTH/Src/sdl_core.cpp
+++ b/CorsixTH/Src/sdl_core.cpp
@@ -195,7 +195,8 @@ static int l_mainloop(lua_State *L)
             case SDL_ACTIVEEVENT:
                 lua_pushliteral(dispatcher, "active");
                 lua_pushinteger(dispatcher, e.active.gain);
-                nargs = 2;
+                lua_pushinteger(dispatcher, e.active.state);
+                nargs = 3;
                 break;
             case SDL_USEREVENT_MUSIC_OVER:
                 lua_pushliteral(dispatcher, "music_over");


### PR DESCRIPTION
From issue 1534 on googlecode where the patch was first added a year ago!

Adds a config option to pause the game when it loses focus - by default this is off.
Tweaked the original patch from Alan and added a button in the customise menu
added a button for check for updates option at the same time 
amended the no heliport message to make it read better
NOTE: That save game version and afterload function will want updating as the actual number will depend on when and if this is merged

Build
available:http://www.armedpineapple.co.uk/cth/builds/MarkL/CTH-20140306-test_2-bb45445235.zip
