### PR TITLE
Update LDocGen links to point to GitHub

### DIFF
--- a/LDocGen/helpers.lua
+++ b/LDocGen/helpers.lua
@@ -135,8 +135,8 @@ function set(t)
 end
 
 function src_ref(obj)
-  return [[<a href="http://code.google.com/p/corsix-th/source/browse/trunk/CorsixTH/]]..
-    obj:getFile() .."#".. obj:getLine() ..[[">line ]].. obj:getLine() .." of ".. obj:getFile() .."</a>"
+  return [[<a href="http://www.github.com/CorsixTH/CorsixTH/blob/master/CorsixTH/]]..
+    obj:getFile() .."#L".. obj:getLine() ..[[">line ]].. obj:getLine() .." of ".. obj:getFile() .."</a>"
 end
 
 function isIteratorEmpty(f, s, v)


### PR DESCRIPTION
Generated links to source code currently point to Google Code. This change uses the master branch of the GitHub repository instead.
