### PR TITLE
Update Travis with SDL2-2.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ before_install:
   - unzip -n freetype-2.3.5-1-bin.zip -d freetype
   - unzip -n freetype-2.3.5-1-dep.zip -d freetype
   # Get SDL
-  - wget http://libsdl.org/release/SDL2-devel-2.0.2-mingw.tar.gz
-  - tar xfz SDL2-devel-2.0.2-mingw.tar.gz
+  - wget http://libsdl.org/release/SDL2-devel-2.0.3-mingw.tar.gz
+  - tar xfz SDL2-devel-2.0.3-mingw.tar.gz
   - sudo mkdir /usr/i686-w64-mingw32/bin/
-  - sudo cp SDL2-2.0.2/i686-w64-mingw32/bin/* /usr/i686-w64-mingw32/bin/
-  - sudo cp -r SDL2-2.0.2/i686-w64-mingw32/include/SDL2/* /usr/i686-w64-mingw32/include/
-  - sudo cp -r SDL2-2.0.2/i686-w64-mingw32/lib/* /usr/i686-w64-mingw32/lib/
+  - sudo cp SDL2-2.0.3/i686-w64-mingw32/bin/* /usr/i686-w64-mingw32/bin/
+  - sudo cp -r SDL2-2.0.3/i686-w64-mingw32/include/SDL2/* /usr/i686-w64-mingw32/include/
+  - sudo cp -r SDL2-2.0.3/i686-w64-mingw32/lib/* /usr/i686-w64-mingw32/lib/
   - sudo chmod +x /usr/i686-w64-mingw32/bin/sdl2-config
   # Get SDL Mixer
   - wget http://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.0-mingw.tar.gz
@@ -46,7 +46,7 @@ before_install:
 install:
   - cd $TRAVIS_BUILD_DIR
   # Create unix makefiles
-  - cmake -DCMAKE_TOOLCHAIN_FILE=build_files/toolchain-mingw.cmake -DWITH_AUDIO=ON -DWITH_MOVIES=ON -DSDL_LIBRARY=$TRAVIS_BUILD_DIR/libs/SDL2-2.0.2/i686-w64-mingw32/lib/libSDL2.dll.a -DSDL_INCLUDE_DIR=libs/SDL2-2.0.2/i686-w64-mingw32/include/SDL2 -DSDLMAIN_LIBRARY=libs/SDL2-2.0.2/i686-w64-mingw32/lib/libSDL2main.a -DSDLMIXER_INCLUDE_DIR=$TRAVIS_BUILD_DIR/libs/SDL2_mixer-2.0.0/i686-w64-mingw32/include/SDL2 -DSDLMIXER_LIBRARY=$TRAVIS_BUILD_DIR/libs/SDL2_mixer-2.0.0/i686-w64-mingw32/lib/libSDL2_mixer.dll.a -DLUA_LIBRARY=libs/lua/lib/liblua.dll.a -DLUA_INCLUDE_DIR=libs/lua/include -DFREETYPE_INCLUDE_DIR_freetype2=libs/freetype/include/freetype2 -DFREETYPE_INCLUDE_DIR_ft2build=libs/freetype/include -DFREETYPE_LIBRARY=libs/freetype/lib/libfreetype.dll.a -DFFMPEG_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVFORMAT_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVUTIL_INCLUDE_DIRS=libs/ffmpeg-dev/include -DSWSCALE_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVCODEC_INCLUDE_DIRS=libs/ffmpeg-dev/include -DSWRESAMPLE_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVFORMAT_LIBRARIES=libs/ffmpeg-dev/lib/avformat.lib -DAVCODEC_LIBRARIES=libs/ffmpeg-dev/lib/avcodec.lib -DAVUTIL_LIBRARIES=libs/ffmpeg-dev/lib/avutil.lib -DSWSCALE_LIBRARIES=libs/ffmpeg-dev/lib/swscale.lib -DSWRESAMPLE_LIBRARIES=libs/ffmpeg-dev/lib/swresample.lib -Bfresh -H. --debug-output
+  - cmake -DCMAKE_TOOLCHAIN_FILE=build_files/toolchain-mingw.cmake -DWITH_AUDIO=ON -DWITH_MOVIES=ON -DSDL_LIBRARY=$TRAVIS_BUILD_DIR/libs/SDL2-2.0.3/i686-w64-mingw32/lib/libSDL2.dll.a -DSDL_INCLUDE_DIR=libs/SDL2-2.0.3/i686-w64-mingw32/include/SDL2 -DSDLMAIN_LIBRARY=libs/SDL2-2.0.3/i686-w64-mingw32/lib/libSDL2main.a -DSDLMIXER_INCLUDE_DIR=$TRAVIS_BUILD_DIR/libs/SDL2_mixer-2.0.0/i686-w64-mingw32/include/SDL2 -DSDLMIXER_LIBRARY=$TRAVIS_BUILD_DIR/libs/SDL2_mixer-2.0.0/i686-w64-mingw32/lib/libSDL2_mixer.dll.a -DLUA_LIBRARY=libs/lua/lib/liblua.dll.a -DLUA_INCLUDE_DIR=libs/lua/include -DFREETYPE_INCLUDE_DIR_freetype2=libs/freetype/include/freetype2 -DFREETYPE_INCLUDE_DIR_ft2build=libs/freetype/include -DFREETYPE_LIBRARY=libs/freetype/lib/libfreetype.dll.a -DFFMPEG_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVFORMAT_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVUTIL_INCLUDE_DIRS=libs/ffmpeg-dev/include -DSWSCALE_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVCODEC_INCLUDE_DIRS=libs/ffmpeg-dev/include -DSWRESAMPLE_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVFORMAT_LIBRARIES=libs/ffmpeg-dev/lib/avformat.lib -DAVCODEC_LIBRARIES=libs/ffmpeg-dev/lib/avcodec.lib -DAVUTIL_LIBRARIES=libs/ffmpeg-dev/lib/avutil.lib -DSWSCALE_LIBRARIES=libs/ffmpeg-dev/lib/swscale.lib -DSWRESAMPLE_LIBRARIES=libs/ffmpeg-dev/lib/swresample.lib -Bfresh -H. --debug-output
 before_script:
   # Don't ask for confirmation when using scp
   - echo -e "Host armedpineapple.co.uk\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
@@ -66,7 +66,7 @@ after_success:
   # Package LevelEdit
   - cp LevelEdit/dist/LevelEdit.jar fresh/CorsixTH/
   # Copy required DLLs
-  - cp libs/SDL2-2.0.2/i686-w64-mingw32/bin/*.dll fresh/CorsixTH/
+  - cp libs/SDL2-2.0.3/i686-w64-mingw32/bin/*.dll fresh/CorsixTH/
   - cp libs/SDL2_mixer-2.0.0/i686-w64-mingw32/bin/*.dll fresh/CorsixTH/
   - cp libs/ffmpeg-bin/bin/*.dll fresh/CorsixTH/
   - cp libs/freetype/bin/*.dll fresh/CorsixTH/


### PR DESCRIPTION
This commit updates the SDL version used in Travis to 2.0.3. See here for a changelog in this new version: http://hg.libsdl.org/SDL/shortlog This is a bug-fix release.
