### PR TITLE
Fix:Ensures that patients won't fall through walls when they die

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/die.lua
+++ b/CorsixTH/Lua/humanoid_actions/die.lua
@@ -61,12 +61,12 @@ end)
 
 local function action_die_start(action, humanoid)
   humanoid:setMoodInfo() -- clear all mood icons
+  local preferred_fall_direction = nil
   if math.random(0, 1) == 1 then
-    humanoid.last_move_direction = "east"
+    preferred_fall_direction = "east"
   else
-    humanoid.last_move_direction = "south"
+    preferred_fall_direction = "south"
   end
-  local direction = humanoid.last_move_direction
   local anims = humanoid.die_anims
   assert(anims, "Error: no death animation for humanoid ".. humanoid.humanoid_class)
   action.must_happen = true
@@ -77,11 +77,45 @@ local function action_die_start(action, humanoid)
   --If this isn't done their bald head will become bloated instead of suddenly having hair:
   if humanoid.disease.id == "baldness" then humanoid:setLayer(0,2) end
 
-  if direction == "east" then
-    humanoid:setAnimation(anims.fall_east, 0)
-  elseif direction == "south" then
-    humanoid:setAnimation(anims.fall_east, 1)
+  --[[Make the patient fall over: because this animation requires two tiles make sure there's
+  enough space for this animation--]]
+  local mirror_fall = -1
+  local east_tile_usable = humanoid.world:isTileEmpty(humanoid.tile_x + 1, humanoid.tile_y, true)
+  local south_tile_usable = humanoid.world:isTileEmpty(humanoid.tile_x, humanoid.tile_y + 1, true)
+  --Are the preferred fall directions usable?
+  if preferred_fall_direction == "east" and east_tile_usable then
+    humanoid.last_move_direction = "east"
+    mirror_fall = 0
+  elseif preferred_fall_direction == "south" and south_tile_usable then
+    humanoid.last_move_direction = "south"
+    mirror_fall = 1
+  else
+    --If the preferred direction isn't usable try the other direction:
+    if east_tile_usable then
+      humanoid.last_move_direction = "east"
+      mirror_fall = 0
+    elseif south_tile_usable then
+      humanoid.last_move_direction = "south"
+      mirror_fall = 1
+    --[[If the patient's last move direction was east or south then there could be no fall space available so this else
+      closure makes them walk to an accessible adjacent tile so that they can then fall on to their current tile:]]--
+    else
+      -- Either the west or north tile will be accessible because this else closure can only be reached if the tiles adjacent to
+      -- the patient east and south are blocked and this game doesn't allow patients to become stuck by having all the tiles
+      -- adjacent to them become obstructed by objects and/or rooms:
+      if humanoid.world:isTileEmpty(humanoid.tile_x - 1, humanoid.tile_y, true) then
+        humanoid:walkTo(humanoid.tile_x - 1, humanoid.tile_y)
+      else
+        humanoid:walkTo(humanoid.tile_x, humanoid.tile_y - 1)
+      end
+      humanoid:queueAction({name = "die"})
+      humanoid:finishAction()
+      return
+    end
   end
+
+  humanoid:setAnimation(anims.fall_east, mirror_fall)
+
   action.phase = 0
   humanoid:setTimer(humanoid.world:getAnimLength(fall), action_die_tick)
 end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1579,6 +1579,27 @@ function World:getIdleTile(x, y, idx)
   return cache.x[idx], cache.y[idx]
 end
 
+--[[
+This function checks if a tile has an entity on it and (optionally) if it is in
+a room.
+!param x (integer) the queried tile's x coardinate.
+!param y (integer) the queried tile's y coardinate.
+!param not_in_room (boolean) default = false, should this function also check that
+the tile isn't in a room?
+!return boolean
+--]]
+function World:isTileEmpty(x, y, not_in_room)
+  for _, entity in ipairs(self.entities) do
+    if entity.tile_x == x and entity.tile_y == y then
+      return false
+    end
+  end
+  if not_in_room then
+    return self:getRoom(x, y) == nil
+  end
+  return true
+end
+
 local face_dir = {
   [0] = "south",
   [1] = "west",


### PR DESCRIPTION
This commit fixes: [issue 947](http://code.google.com/p/corsix-th/issues/detail?id=947)

It adds code to Die.lua:action_die_start to ensure that patients have enough space to fall over when they die.

It also adds a supporting function to World.lua which checks that a tile has no entity on it and (optionally) isn't in a room: World:isTileEmpty()
