### PR TITLE
Only call onMusicOver if the music naturally ends.

### DIFF
--- a/CorsixTH/Src/sdl_audio.cpp
+++ b/CorsixTH/Src/sdl_audio.cpp
@@ -51,8 +51,16 @@ struct music_t
     }
 };
 
+static int halting_music = 0;
+
 static void audio_music_over_callback()
 {
+    // This is a workaround for a change to SDL_Mixer where they started
+    // calling this method when you `halt' the music yourself.
+    // https://github.com/CorsixTH/CorsixTH/issues/129
+    if (halting_music)
+        return;
+
     SDL_Event e;
     e.type = SDL_USEREVENT_MUSIC_OVER;
     SDL_PushEvent(&e);
@@ -276,7 +284,10 @@ static int l_resume_music(lua_State *L)
 
 static int l_stop_music(lua_State *L)
 {
+    halting_music = 1;
     Mix_HaltMusic();
+    halting_music = 0;
+
     return 0;
 }
 


### PR DESCRIPTION
We were playing the bg music over the cutscene music.

This stops us from calling onMusicOver when we call Mix_HaltMusic. This is a
regression after upgrading to the latest SDL_mixer, due to a change in
functionality. (https://bugzilla.libsdl.org/show_bug.cgi?id=1610)

Fixes GH-129.
