### PR TITLE
Do not play another track onMusicOver if stopped.

### DIFF
--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -473,7 +473,7 @@ function Audio:playBackgroundTrack(index)
 end
 
 function Audio:onMusicOver()
-  if self.not_loaded or #self.background_playlist == 0 then
+  if self.not_loaded or #self.background_playlist == 0 or self.background_music == nil then
     return
   end
   self:playNextBackgroundTrack()


### PR DESCRIPTION
Due to a change in SDL_mixer, onMusicOver is now called when
the music is stopped with Mix_HaltMusic. When the music is stopped
we do not want onMusicOver starting another background track.

Fixes GH-129.

This is based on the work of @jorgenpt in pr #243
