### PR TITLE
Fix global fullscreen shortcut in SDL2

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local assert, io, type, dofile, loadfile, pcall, tonumber, print, setmetatable
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 82
+local SAVEGAME_VERSION = 100
 
 class "App"
 

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -219,7 +219,7 @@ function UI:setupGlobalKeyHandlers()
   self:addKeyHandler("escape", self, self.stopMovie)
   self:addKeyHandler("space", self, self.stopMovie)
   self:addKeyHandler({"ctrl", "s"}, self, self.makeScreenshot)
-  self:addKeyHandler({"alt", "enter"}, self, self.toggleFullscreen)
+  self:addKeyHandler({"alt", "Return"}, self, self.toggleFullscreen)
   self:addKeyHandler({"alt", "f4"}, self, self.exitApplication)
   self:addKeyHandler({"shift", "f10"}, self, self.resetApp)
 
@@ -768,6 +768,11 @@ function UI:afterLoad(old, new)
     self:removeKeyHandler({"alt", "f4"}, self, self.quit)
     self:addKeyHandler({"alt", "f4"}, self, self.exitApplication)
   end
+  if old < 100 then
+    self:removeKeyHandler({"alt", "enter"}, self)
+    self:addKeyHandler({"alt", "Return"}, self, self.toggleFullscreen)
+  end
+
   Window.afterLoad(self, old, new)
 end
 


### PR DESCRIPTION
Keycode for enter in SDL2 is "Return" not "enter"
http://wiki.libsdl.org/SDL_Keycode

Set the SAVEGAME_VERSION to 100, as the version in master keeps changing, and SDL2 changes belong after them.
