### PR TITLE
Order of operations fix in th_movie.cpp

### DIFF
--- a/CorsixTH/Src/th_movie.cpp
+++ b/CorsixTH/Src/th_movie.cpp
@@ -986,7 +986,7 @@ int THMovie::decodeAudioFrame(bool fFirst)
 
             if(!iGotFrame)
             {
-                if(m_pAudioPacket->data && m_pAudioCodecContext->codec->capabilities & CODEC_CAP_DELAY)
+                if(m_pAudioPacket->data && (m_pAudioCodecContext->codec->capabilities & CODEC_CAP_DELAY))
                 {
                     fFlushComplete = true;
                 }


### PR DESCRIPTION
Fixes the test for CODEC_CAP_DELAY to know if we need to flush
buffered frames.
