### PR TITLE
Compile fix for SDL2 version without movies.

### DIFF
--- a/CorsixTH/Src/th_movie.h
+++ b/CorsixTH/Src/th_movie.h
@@ -123,7 +123,7 @@ public:
     THMovie();
     ~THMovie();
 
-    void setRenderer(SDL_Renderer *pRenderer);
+    void setRenderer(struct SDL_Renderer *pRenderer);
 
     bool moviesEnabled();
 


### PR DESCRIPTION
th_movie.cpp jumps to th_movie.h
th_movie.h stops processing at line 32 (#ifdef CORSIX_TH_USE_FFMPEG) and
continues at line 121.
At line 126, it sees the SDL_Renderer struct reference which is not
defined at that point.
If I revert the #includes of th_movie.h of
7ad0493b3186eb2b6bd5b1c58c846517437744b4, it works again. My change is
however much smaller, and also seems to work.
