### PR TITLE
Allow mapmaker the option to disable earthquakes

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1356,14 +1356,16 @@ function World:nextEarthquake()
   self.map.level_config.quake_control[self.current_map_earthquake] and
   self.map.level_config.quake_control[self.current_map_earthquake].Severity ~= 0 then
       -- this map has rules to follow when making earthquakes, let's follow them
+      -- if severity is 0 there should be no earthquakes, not even with the cheat
     local control = self.map.level_config.quake_control[self.current_map_earthquake]
     self.next_earthquake_month = math.random(control.StartMonth, control.EndMonth)
     self.next_earthquake_day = math.random(1, month_length[(self.next_earthquake_month % 12)+1])
     self.earthquake_size = control.Severity
     self.current_map_earthquake = self.current_map_earthquake + 1
   else
-    if (tonumber(self.map.level_number) and tonumber(self.map.level_number) >= 5) or
-    (not tonumber(self.map.level_number)) then
+    -- ! Stops any earthquakes in the early levels (less than level 5)
+    -- ! of the TH campaign and allows the map creator to stop them if desired
+    if self.map.level_config.quake_control[self.current_map_earthquake].Severity ~= 0 then
       local current_month = (self.year - 1) * 12 + self.month
 
       -- Support standard values for mean and variance


### PR DESCRIPTION
Small change that allows the mapmaker to disable earthquakes and also
turns them off in the campaign levels 1-4.  At the moment it is hard coded that there can be no earthquakes in the first 4 levels of the campaign.  However this does not help with custom maps as leaving earthquake control blank still generates random earthquakes.  The change is to make use of what is already in the level files, namely for the campaign earthquakes amongst other things have a base of 0 in the 00.sam file which can be overridden in the actual level file.  By making proper use of this the creators of custom maps can now set this in their level files `#quake_control[0].StartMonth.EndMonth.Severity      0   0   0` and no random earthquakes will be created.
