### PR TITLE
Games are now always paused when the award screen appears

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -154,7 +154,7 @@ function UIAnnualReport:UIAnnualReport(ui, world)
     table.sort(self.salary_sort, sort_order)
 
   -- Pause the game to allow the player plenty of time to check all statistics and trophies won
-  if world and world:isCurrentSpeed("Speed Up") then
+  if world and not world:isCurrentSpeed("Pause") then
     world:setSpeed("Pause")
   end
   TheApp.video:setBlueFilterActive(false)


### PR DESCRIPTION
Previously games would only be paused when the game speed was set
to "Speed Up".

Fixed issue: #286
