### PR TITLE
Fixed Issue #288: The Award Screen "Speed Up" Key Bug

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -459,7 +459,11 @@ function UIAnnualReport:close()
     end
     TheApp.world.ui.bottom_panel:openLastMessage()
   elseif TheApp.world:isCurrentSpeed("Pause") then
-    TheApp.world:setSpeed(TheApp.world.prev_speed)
+    if TheApp.ui.speed_up_key_pressed then
+      TheApp.world:setSpeed("Speed Up")
+    else
+      TheApp.world:setSpeed(TheApp.world.prev_speed)
+    end
   end
   self:updateAwards()
   Window.close(self)

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -69,6 +69,8 @@ function GameUI:GameUI(app, local_hospital)
 
   self.momentum = app.config.scrolling_momentum
   self.current_momentum = {x = 0.0, y = 0.0, z = 0.0}
+
+  self.speed_up_key_pressed = false
 end
 
 function GameUI:setupGlobalKeyHandlers()
@@ -221,6 +223,7 @@ end
 
 function GameUI:keySpeedUp()
   if self.key_codes[122] then
+    self.speed_up_key_pressed = true
     self.app.world:speedUp()
   end
 end
@@ -254,9 +257,14 @@ function GameUI:onKeyUp(code)
     self:updateKeyScroll()
     return
   end
-  if self.app.world:isCurrentSpeed("Speed Up")  then
+
+  -- Guess that the "Speed Up" key was released because the 
+  -- code parameter can't provide UTF-8 key codes:
+  self.speed_up_key_pressed = false
+  if self.app.world:isCurrentSpeed("Speed Up") then
     self.app.world:previousSpeed()
   end
+
   if self.transparent_walls then
     self:removeTransparentWalls()
   end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -959,7 +959,12 @@ function World:setSpeed(speed)
   elseif self:getCurrentSpeed() == "Pause" then
     self.user_actions_allowed = true
   end
-  self.prev_speed = self:getCurrentSpeed()
+  
+  local currentSpeed = self:getCurrentSpeed()
+  if currentSpeed ~= "Pause" and currentSpeed ~= "Speed Up" then
+    self.prev_speed = self:getCurrentSpeed()
+  end
+
   local numerator, denominator = unpack(tick_rates[speed])
   self.hours_per_tick = numerator
   self.tick_rate = denominator


### PR DESCRIPTION
Fixed Issue: #288 

This fix creates a very minor issue: the game speed wont be set to its
"Speed Up" state when a player is still holding down the "Speed Up" key
when they have closed the award screen and it has unpaused the game.

They can then resume the "Speed Up" speed state by releasing the "Speed
Up" key and then pressing it again.

I've created a commit which fixes this new issue for ASCII keyboards but it isn't
compatible with other keyboards because it would require OnKeyUp() to be able
to provide UTF-8 key codes in order to identify when the "Speed Up" key has been
released. So I've excluded this commit from this pull request because this commit's
keyboard compatibility problem would prevent the "Speed Up" game speed state
from being disabled. 

If the SDL2 branch will allow OnKeyUp() to provide UTF 8 key codes then I will submit
a pull request to this branch for this excluded commit.
