### PR TITLE
Use zoogie PPA for SDL2 for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
   # Get SDL
   - sudo apt-get install -q -y libsdl2-dev libsdl2-mixer
   # Get LUA
+  - mkdir lua
   - wget http://skylink.dl.sourceforge.net/project/mingw/MinGW/Extension/lua/lua-5.1.4-4/lua-5.1.4-4-mingw32-dll-51.tar.xz
   - tar xJf lua-5.1.4-4-mingw32-dll-51.tar.xz -C lua
   - wget http://netcologne.dl.sourceforge.net/project/mingw/MinGW/Extension/lua/lua-5.1.4-4/lua-5.1.4-4-mingw32-dev.tar.xz


### PR DESCRIPTION
The version of mingw in the travis ci environment is not capable
of building SDL 2.0.3. Zoogie has a PA which includes the latest
versions of SDL prebuilt.

This pull request is experimental as I don't have another way of testing the changes.  I will remove this message when I feel it's ready to be reviewed.
