### PR TITLE
Made the annual report window do end of year "game won?" checks

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -467,6 +467,7 @@ function UIAnnualReport:close()
   end
   self:updateAwards()
   Window.close(self)
+  self.ui.app.world:checkIfGameWon()
 end
 
 --! Changes the page of the annual report

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1204,20 +1204,26 @@ function World:onEndDay()
   -- staff at the moment and making plants need water.
 end
 
+function World:checkIfGameWon()
+  for i, hospital in ipairs(self.hospitals) do
+    local res = self:checkWinningConditions(i)
+    if res.state == "win" then
+      self:winGame(i)
+    end
+  end
+end
+
 -- Called immediately prior to the ingame month changing.
 -- returns true if the game was killed due to the player losing
 function World:onEndMonth()
-  -- Check if a player has won the level.
+  -- Check if a player has won the level if the year hasn't ended, if it has the
+  -- annual report window will perform this check when it has been closed.
+
   -- TODO.... this is a step closer to the way TH would check.
   -- What is missing is that if offer is declined then the next check should be
   -- either 6 months later or at the end of month 12 and then every 6 months
-  if self.month % 3 == 0 then
-    for i, hospital in ipairs(self.hospitals) do
-      local res = self:checkWinningConditions(i)
-      if res.state == "win" then
-        self:winGame(i)
-      end
-    end
+  if self.month % 3 == 0 and self.month < 12 then
+    self:checkIfGameWon()
   end
 
   -- Change population share for the hospitals, TODO according to reputation.


### PR DESCRIPTION
It will now do them when its closed instead of OnEndMonth().

@TheCycoONE please rename my "288_fix" commit to be: "286_fix". I guess
this new commit should maybe be squashed with my "288_fix" comit because
that commit can't resolve issue #286 (See this issue's latest comments) without 
the changes in this new commit.

This commit's changes are also required to make the "end level?" fax window
visible and usable when its shown at the end of a year.

World:onTick() would first display the fax window for the "end level?"
fax by calling OnEndMonth() and then it would call OnEndYear() which
would open the window for the annual report and consequently close the
"end level?" fax window before a player could see and use it. This fax
window's close() function would also unpause the game while the annual
report window was shown.
