### PR TITLE
Change game speed with numpad

### DIFF
--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -591,8 +591,6 @@ local workaround_shift = {
 function UI:numPadValue(code)
   if (self:isCodeFromNumPad(code)) then
     return tostring(code - 256)
-  else
-    return nil
   end
 end
 


### PR DESCRIPTION
I noticed that I wasn't able to change game speed via the key shortcut (although I could pause the game by pressing P) and it was a bit frustrating. I had a look into the code and I realized that shortcuts handling assumes a qwerty keyboard. It doesn't work for me because I'm using an azerty keyboard.

That seemed a bit complicated to change, so I thought it would already be a bit better to be able to use numpad keys to change game speed.

This is the very first time I'm using git and doing anything in Lua, so it is indeed a modest contribution. I hope I'll have some time on the occasion to further contribute.
