### PR TITLE
Fixed #293 & Scanner:makeHumanoidLeave()

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local assert, io, type, dofile, loadfile, pcall, tonumber, print, setmetatable
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 85
+local SAVEGAME_VERSION = 86
 
 class "App"
 

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -357,6 +357,7 @@ local function action_queue_start(action, humanoid)
   end
   humanoid:queueAction({
     name = "idle",
+    is_leaving = humanoid:isLeaving(),
     must_happen = true,
   }, 0)
   action:onChangeQueuePosition(humanoid)

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -260,6 +260,7 @@ navigateDoor = function(humanoid, x1, y1, dir)
     end
     humanoid:queueAction({
       name = "queue",
+      is_leaving = humanoid:isLeaving(),
       x = x1,
       y = y1,
       queue = queue,

--- a/CorsixTH/Lua/rooms/general_diag.lua
+++ b/CorsixTH/Lua/rooms/general_diag.lua
@@ -54,18 +54,6 @@ function GeneralDiagRoom:commandEnteringPatient(patient)
     object = screen,
     after_use = --[[persistable:general_diag_screen_after_use1]] function()
       local staff = self.staff_member
-      if not staff or patient.going_home then
-        -- If, by some fluke, the staff member left the room while the
-        -- patient used the screen, then the patient should get changed
-        -- again (they will already have been instructed to leave by the
-        -- staff leaving).
-        patient:queueAction({
-          name = "use_screen",
-          object = screen,
-          must_happen = true,
-        }, 1)
-        return
-      end
       local trolley, cx, cy = self.world:findObjectNear(patient, "crash_trolley")
       staff:walkTo(trolley:getSecondaryUsageTile())
       local staff_idle = {name = "idle"}
@@ -75,7 +63,7 @@ function GeneralDiagRoom:commandEnteringPatient(patient)
         name = "multi_use_object",
         object = trolley,
         use_with = staff,
-        must_happen = true, -- set so that the second use_screen always happens
+        must_happen = false,
         prolonged_usage = false,
         after_use = --[[persistable:general_diag_trolley_after_use]] function()
           if #staff.action_queue == 1 then
@@ -89,12 +77,14 @@ function GeneralDiagRoom:commandEnteringPatient(patient)
         name = "walk",
         x = sx,
         y = sy,
-        must_happen = true,
+        is_leaving = true,
+        must_happen = false,
         no_truncate = true,
       }
       patient:queueAction{
         name = "use_screen",
         object = screen,
+        is_leaving = true,
         must_happen = true,
         after_use = --[[persistable:general_diag_screen_after_use2]] function()
           if #patient.action_queue == 1 then
@@ -112,6 +102,14 @@ function GeneralDiagRoom:onHumanoidLeave(humanoid)
     self.staff_member = nil
   end
   Room.onHumanoidLeave(self, humanoid)
+end
+
+function GeneralDiagRoom:makeHumanoidLeave(humanoid)
+  self:makeHumanoidDressIfNecessaryAndThenLeave(humanoid)
+end
+
+function GeneralDiagRoom:shouldHavePatientReenter(patient)
+  return not patient:isLeaving()
 end
 
 return room


### PR DESCRIPTION
Bug #293 would make undressed patients leave a room without getting
dressed. It would occur in the cardiogram room and the general diagnosis
room.

I've fixed this bug by creating and inserting call statements for:
Room:makeHumanoidDressIfNecessaryAndThenLeave(humanoid)

This bug fix requires the affected rooms to override shouldHavePatientReenter().

It also requires this commit to fix Scanner:makeHumanoidLeave() by
making it make patients leave a room with a correct action queue by
making the scanner's after_use function become nil preventing its
dealtWithPatient() call from queuing wrong actions.

And it requires the queue action to record when a patient is
queuing to use a door in order to leave a room.

This commit also increments the saved game version to 86 because of its
patient action queue changes.
