### PR TITLE
Properly detect UIInformation window for tutorial

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -241,10 +241,10 @@ function UIEditRoom:confirm(force)
     self.world:markRoomAsBuilt(self.room)
     self.closed_cleanly = true
     -- If information dialogs are disabled, go ahead.
-    if self.world.room_information_dialogs_off then
-      self.ui:tutorialStep(3, 15, "next")
-    else
+    if self.ui:getWindow(UIInformation) then
       self.ui:tutorialStep(3, 15, 16)
+    else
+      self.ui:tutorialStep(3, 15, "next")
     end
     self:close()
   end


### PR DESCRIPTION
Fixes #256 by looking for the UIInformation window instead of
trying to predict rather it will appear. This solves the problem
of the player running the tutorial out of order so that the window
did not come up.
