### PR TITLE
Replace posix strdup with c standard strlen/malloc/memcpy

### DIFF
--- a/CorsixTH/Src/sdl_audio.cpp
+++ b/CorsixTH/Src/sdl_audio.cpp
@@ -174,7 +174,11 @@ static int load_music_async_thread(void* arg)
     load_music_async_t *async = (load_music_async_t*)arg;
     async->music = Mix_LoadMUS_RW(async->rwop);
     if(async->music == NULL)
-        async->err = strdup(Mix_GetError());
+    {
+        size_t iLen = strlen(Mix_GetError()) + 1;
+        async->err = (char*)malloc(iLen);
+        memcpy(async->err, Mix_GetError(), iLen);
+    }
     SDL_Event e;
     e.type = SDL_USEREVENT_CPCALL;
     e.user.data1 = (void*)l_load_music_async_callback;

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -580,14 +580,29 @@ static int l_surface_new(lua_State *L)
     if(SDL_WasInit(SDL_INIT_VIDEO))
     {
         char *sTitle, *sIcon;
+        char *sTitle2 = NULL, *sIcon2 = NULL;
+        size_t iLen;
         SDL_WM_GetCaption(&sTitle, &sIcon);
-        if(sTitle) sTitle = strdup(sTitle);
-        if(sIcon) sIcon = strdup(sIcon);
+        if(sTitle)
+        {
+            iLen = strlen(sTitle) + 1;
+            sTitle2 = (char*)malloc(iLen);
+            memcpy(sTitle2, sTitle, iLen);
+        }
+
+        if(sIcon)
+        {
+            iLen = strlen(sIcon) + 1;
+            sIcon2 = (char*)malloc(iLen);
+            memcpy(sIcon2, sIcon, iLen);
+        }
+
         SDL_QuitSubSystem(SDL_INIT_VIDEO);
         SDL_InitSubSystem(SDL_INIT_VIDEO);
-        SDL_WM_SetCaption(sTitle, sIcon);
-        if(sTitle) free(sTitle);
-        if(sIcon) free(sIcon);
+        SDL_WM_SetCaption(sTitle2, sIcon2);
+
+        free(sTitle2);
+        free(sIcon2);
     }
 #endif
 


### PR DESCRIPTION
On MSVC the strdup implmentation differs from the posix version causing a heap violation error when the resulting string is freed when CorsixTH is run in debug (at least on MSVC 2010)
