### PR TITLE
Fixed hell deaths error #351

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/die.lua
+++ b/CorsixTH/Lua/humanoid_actions/die.lua
@@ -104,7 +104,7 @@ local action_die_tick_reaper; action_die_tick_reaper = permanent"action_die_tick
       holes_orientation = spawn_scenario[1]
       hole_x, hole_y = humanoid.world.pathfinder:findIdleTile(spawn_scenario[2], spawn_scenario[3], 0)
 
-      if humanoid.world:canNonSideObjectBeSpawnedAt(hole_x, hole_y, "gates_to_hell", holes_orientation, 0) then
+      if hole_x and humanoid.world:canNonSideObjectBeSpawnedAt(hole_x, hole_y, "gates_to_hell", holes_orientation, 0) then
         if holes_orientation == "east" then
           mirror_grim = 1
         end
@@ -124,7 +124,7 @@ local action_die_tick_reaper; action_die_tick_reaper = permanent"action_die_tick
         for _, find_grim_spawn_attempt in ipairs(spawn_scenario[9]) do
           grim_spawn_idle_direction = find_grim_spawn_attempt.after_spawn_idle_direction or spawn_scenario[6]
           grim_x, grim_y = humanoid.world.pathfinder:findIdleTile(hole_x + find_grim_spawn_attempt.hole_x_offset, hole_y + find_grim_spawn_attempt.hole_y_offset, 0)
-          if not humanoid.world:getRoom(grim_x, grim_y) then
+          if grim_x and not humanoid.world:getRoom(grim_x, grim_y) then
             grim_cant_walk_to_use_tile = false
             break
           end


### PR DESCRIPTION
In die.lua:die_tick_reaper:tryHellDeathSpawnScenario() I had not included responses to the possibility of this function's findIdleTile() calls returning nil tile coordinates when it couldn't find idle tiles, so in this commit I've simply added two IF statement conditions to check that there are no nil tile coordinates before they are used.

```
if hole_x and humanoid.world:canNonSideObjectBeSpawnedAt(...) then
```

If the hole_x coordinate is nil then the call after this condition's AND statement won't be made.
