### PR TITLE
Ensured debug mode key handlers always exist

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1233,6 +1233,7 @@ end
 
 --! This function is automatically called after loading a game and serves for compatibility.
 function App:afterLoad()
+  self.ui:addOrRemoveDebugModeKeyHandlers()
   local old = self.world.savegame_version or 0
   local new = self.savegame_version
 

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -872,6 +872,15 @@ function UI:getCursorPosition(window)
   return x, y
 end
 
+function UI:addOrRemoveDebugModeKeyHandlers()
+  self:removeKeyHandler("f12", self)
+  self:removeKeyHandler({"shift", "d"}, self)
+  if self.app.config.debug then
+    self:addKeyHandler("f12", self, self.showLuaConsole)
+    self:addKeyHandler({"shift", "d"}, self, self.runDebugScript)
+  end
+end
+
 function UI:afterLoad(old, new)
   if old < 5 then
     self.editing_allowed = true
@@ -887,6 +896,8 @@ function UI:afterLoad(old, new)
       end
     end
     -- some global key shortcuts were converted to use keyHandlers
+    self:removeKeyHandler("f12", self)
+    self:removeKeyHandler({"shift", "d"}, self)
     self:setupGlobalKeyHandlers()
   end
 
@@ -905,9 +916,7 @@ function UI:afterLoad(old, new)
     self:removeKeyHandler({"alt", "f4"}, self, self.quit)
     self:addKeyHandler({"alt", "f4"}, self, self.exitApplication)
   end
-  if old < 85 and self.app.config.debug then
-    self:addKeyHandler({"shift", "d"}, self, self.runDebugScript)
-  end
+
   Window.afterLoad(self, old, new)
 end
 


### PR DESCRIPTION
Before this commit the debug console's key handler wasn't added to saved games which didn't have it because they weren't started with debugging enabled and the debug script's key handler would
only be added to saved games older than 85 when debugging was enabled. So if debugging was enabled for a saved game newer than 85 the key handler for the debug script would be missing.
