### PR TITLE
Add vertical scrollbar to the Animviewer sprite display.

### DIFF
--- a/AnimView/frmSprites.h
+++ b/AnimView/frmSprites.h
@@ -29,8 +29,23 @@ SOFTWARE.
 #include <wx/panel.h>
 #include <wx/timer.h>
 #include <wx/listbox.h>
+#include <wx/vscroll.h>
 #include "th.h"
 #include <vector>
+
+static const int ROW_COUNT = 1000;
+
+// Derived class to add scrollbars to the window.
+class MyVScrolled : public wxVScrolledWindow {
+public:
+    MyVScrolled(wxWindow *parent) : wxVScrolledWindow(parent, wxID_ANY) { iMyCount = ROW_COUNT; }
+
+    wxCoord OnGetRowHeight(size_t  row) const { return 1; }
+
+    wxCoord EstimateTotalHeight() const { return iMyCount; }
+
+    int iMyCount;
+};
 
 class frmSprites : public wxFrame
 {
@@ -70,6 +85,6 @@ protected:
     wxTextCtrl* m_txtTable;
     wxTextCtrl* m_txtData;
     wxTextCtrl* m_txtPalette;
-    wxPanel* m_panFrame;
+    MyVScrolled* m_panFrame;
     DECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
AnimViewer sprite display missed a vertical scrollbar, which made viewing the contents of bigger sprite files somewhat challenging.

Together with sadger, I hacked a scrollbar sub-window into the application.
It's not the most beautiful piece of work, as it decides on the scrollbar size while drawing. However, it does the job, would seems sufficient for now.
