### PR TITLE
Update staff action before calling dealtWithPatient

### DIFF
--- a/CorsixTH/Lua/rooms/psych.lua
+++ b/CorsixTH/Lua/rooms/psych.lua
@@ -102,13 +102,14 @@ function PsychRoom:commandEnteringPatient(patient)
           name = "use_screen",
           object = obj,
           after_use = --[[persistable:psych_screen_after_use]] function()
+            self:getStaffMember():setNextAction{name = "meander"}
             self:dealtWithPatient(patient)
           end,
         }
       else
+        self:getStaffMember():setNextAction{name = "meander"}
         self:dealtWithPatient(patient)
       end
-      self:getStaffMember():setNextAction{name = "meander"}
       return
     end
     if bookcase and (duration % 10) == 0 and math.random(1, 2) == 1 then


### PR DESCRIPTION
This fixes a problem, where the doctor was stuck in psychiatry.
Before this commit, the action of the doctor was set to 'meander'
_after_ the dealtWithPatient() function was called (which, in turn,
called findWorkForStaff()). The call dispatcher then skipped that doctor.

Fixes  #332 
