### PR TITLE
Fix 'Warning: Proper idle not in action_queue'

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -68,10 +68,9 @@ local function action_queue_find_idle(action, humanoid)
     end
   end
   if found_any then
-    error "Proper idle not in action_queue"
-  else
-    return -1
+    print("Warning: Proper idle not in action_queue")
   end
+  return -1
 end
 
 local function action_queue_find_drink_action(action, humanoid)


### PR DESCRIPTION
...drinks machine

When a drink machine was placed near a queue or when a reception desk
was placed near patients seeking for an reception (when there was none)
and the reception desk was placed near a drinks machine some patients
from the queue went to the drings machine by adding an use_object action.
When the onChangeQueuePosition handler of the queue then fired (while
that use_object action was enqueued for any of the patients), the
action_queue_find_idle function could not find an idle action.
That idle action would be enqueued after using the drinks machine.

I tested this change intensively, so no problems with the queueing system
are to be expected. I put several checks for the action_queue in place
on my working copy but non fired, so I think we're good here.

This fixes #162.

It is also mentioned in #323, but not the main issue.
