### PR TITLE
Use translated language name for language option

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -112,7 +112,14 @@ function UIOptions:UIOptions(ui, mode)
   self.resolution_button = self.resolution_panel:makeToggleButton(0, 0, 135, 20, nil, self.dropdownResolution):setTooltip(_S.tooltip.options_window.select_resolution)
 
   -- Language
-  local lang = string.upper(app.config.language)
+  -- Get language name in the language to normalize display.
+  -- If it doesn't exist, display the current config option.
+  local lang = self.app.strings:getLanguageNames(app.config.language)
+  if lang then
+    lang = lang[1]
+  else
+    lang = app.config.language
+  end
   self:addBevelPanel(20, 95, 135, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.options_window.language):setTooltip(_S.tooltip.options_window.language).lowered = true
   self.language_panel = self:addBevelPanel(165, 95, 135, 20, col_bg):setLabel(lang)


### PR DESCRIPTION
Was using the language name directly out of the config file which
was not always consistent.

Fixes #374 and #375

I was originally hesitant to fix such a minor issue at this point in 0.40 but I think given the simplicity of the patch I'm alright with it going in.
