### PR TITLE
Enable loading and using offsets from custom sprites.

### DIFF
--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -365,13 +365,13 @@ void THAnimationManager::drawFrame(THRenderTarget* pCanvas, unsigned int iFrame,
             unsigned int iWidth, iHeight;
             m_pSpriteSheet->getSpriteSizeUnchecked(pElement->iSprite, &iWidth, &iHeight);
 
-            m_pSpriteSheet->drawSprite(pCanvas, pElement->iSprite, iX - pElement->iX - iWidth,
-                iY + pElement->iY, iPassOnFlags | (pElement->iFlags ^ THDF_FlipHorizontal));
+            m_pSpriteSheet->drawSprite(pCanvas, pElement->iSprite, iX, iY, -pElement->iX - iWidth,
+               pElement->iY, iPassOnFlags | (pElement->iFlags ^ THDF_FlipHorizontal));
         }
         else
         {
-            m_pSpriteSheet->drawSprite(pCanvas, pElement->iSprite,
-                iX + pElement->iX, iY + pElement->iY, iPassOnFlags | pElement->iFlags);
+            m_pSpriteSheet->drawSprite(pCanvas, pElement->iSprite, iX, iY,
+                pElement->iX, pElement->iY, iPassOnFlags | pElement->iFlags);
         }
     }
 }
@@ -1256,7 +1256,7 @@ void THSpriteRenderList::draw(THRenderTarget* pCanvas, int iDestX, int iDestY)
         pSprite != pLast; ++pSprite)
     {
         m_pSpriteSheet->drawSprite(pCanvas, pSprite->iSprite,
-            iDestX + pSprite->iX, iDestY + pSprite->iY, m_iFlags);
+            iDestX, iDestY, pSprite->iX, pSprite->iY, m_iFlags);
     }
 }
 

--- a/CorsixTH/Src/th_gfx_font.cpp
+++ b/CorsixTH/Src/th_gfx_font.cpp
@@ -220,7 +220,7 @@ void THBitmapFont::drawText(THRenderTarget* pCanvas, const char* sMessage, size_
             {
                 iChar -= iFirstASCII;
                 unsigned int iWidth, iHeight;
-                m_pSpriteSheet->drawSprite(pCanvas, iChar, iX, iY, 0);
+                m_pSpriteSheet->drawSprite(pCanvas, iChar, iX, iY, ZERO_XOFFSET, ZERO_YOFFSET, 0);
                 m_pSpriteSheet->getSpriteSizeUnchecked(iChar, &iWidth, &iHeight);
                 iX += iWidth + m_iCharSep;
             }

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -414,7 +414,19 @@ protected:
 
     //! Height of the stored image.
     int m_iHeight;
+
+    //! Whether to use the m_iXOffset and m_iYOffset.
+    bool m_bUseOffsets;
+
+    //! Horizontal offset of the stored image, if m_bUseOffsets is set.
+    int m_iXOffset;
+    //
+    //! Vertical offset of the stored image, if m_bUseOffsets is set.
+    int m_iYOffset;
 };
+
+#define ZERO_XOFFSET 0
+#define ZERO_YOFFSET 0
 
 //! Sheet of sprites.
 class THSpriteSheet
@@ -495,11 +507,14 @@ public: // External API
     /*!
         @param pCanvas Canvas to draw on.
         @param iSprite Sprite to draw.
-        @param iX X position to draw the sprite.
-        @param iY Y position to draw the sprite.
+        @param iXPos X position to draw the sprite.
+        @param iYPos Y position to draw the sprite.
+        @param iXOffset X offset to draw the sprite.
+        @param iYOffset Y offset to draw the sprite.
         @param iFlags Flags to apply for drawing.
     */
-    void drawSprite(THRenderTarget* pCanvas, unsigned int iSprite, int iX, int iY, unsigned long iFlags);
+    void drawSprite(THRenderTarget* pCanvas, unsigned int iSprite, int iXPos, int iYPos,
+                    int iXOffset, int iYOffset, unsigned long iFlags);
 
     //! Test whether a sprite was hit.
     /*!
@@ -562,6 +577,15 @@ protected:
 
         //! Height of the sprite.
         unsigned int iHeight;
+
+        //! Whether to use the supplied offsets.
+        bool bUseOffsets;
+
+        //! Horizontal offset of the sprite if bUseOffsets is true.
+        unsigned int iXOffset;
+
+        //! Vertical offset of the sprite if bUseOffsets is true.
+        unsigned int iYOffset;
     } *m_pSprites;
 
     //! Original palette.

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -199,7 +199,7 @@ static int l_spritesheet_draw(lua_State *L)
     THRenderTarget* pCanvas = luaT_testuserdata<THRenderTarget>(L, 2);
     int iSprite = luaL_checkint(L, 3); // No array adjustment
 
-    pSheet->drawSprite(pCanvas, iSprite, luaL_optint(L, 4, 0), luaL_optint(L, 5, 0), luaL_optint(L, 6, 0));
+    pSheet->drawSprite(pCanvas, iSprite, luaL_optint(L, 4, 0), luaL_optint(L, 5, 0), ZERO_XOFFSET, ZERO_YOFFSET, luaL_optint(L, 6, 0));
 
     lua_settop(L, 1);
     return 1;

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -760,7 +760,7 @@ void THMap::draw(THRenderTarget* pCanvas, int iScreenX, int iScreenY,
         m_pBlocks->getSpriteSize(iBlock & 0xFF, NULL, &iH);
         m_pBlocks->drawSprite(pCanvas, iBlock & 0xFF,
             itrNode1.x() + iCanvasX - 32,
-            itrNode1.y() + iCanvasY - iH + 32, iBlock >> 8);
+            itrNode1.y() + iCanvasY - iH + 32, ZERO_XOFFSET, ZERO_YOFFSET, iBlock >> 8);
     }
     pCanvas->finishNonOverlapping();
 
@@ -772,12 +772,12 @@ void THMap::draw(THRenderTarget* pCanvas, int iScreenX, int iScreenY,
         if(itrNode2->iFlags & THMN_ShadowFull)
         {
             m_pBlocks->drawSprite(pCanvas, 74, itrNode2.x() + iCanvasX - 32,
-                itrNode2.y() + iCanvasY, THDF_Alpha75);
+                itrNode2.y() + iCanvasY, ZERO_XOFFSET, ZERO_YOFFSET, THDF_Alpha75);
         }
         else if(itrNode2->iFlags & THMN_ShadowHalf)
         {
             m_pBlocks->drawSprite(pCanvas, 75, itrNode2.x() + iCanvasX - 32,
-                itrNode2.y() + iCanvasY, THDF_Alpha75);
+                itrNode2.y() + iCanvasY, ZERO_XOFFSET, ZERO_YOFFSET, THDF_Alpha75);
         }
 
         if(!itrNode2.isLastOnScanline())
@@ -791,7 +791,7 @@ void THMap::draw(THRenderTarget* pCanvas, int iScreenX, int iScreenY,
                 NULL, &iH) && iH > 0)
             {
                 m_pBlocks->drawSprite(pCanvas, iBlock & 0xFF, itrNode.x() - 32,
-                    itrNode.y() - iH + 32, iBlock >> 8);
+                    itrNode.y() - iH + 32, ZERO_XOFFSET, ZERO_YOFFSET, iBlock >> 8);
                 if(itrNode->iFlags & THMN_ShadowWall)
                 {
                     THClipRect rcOldClip, rcNewClip;
@@ -803,7 +803,7 @@ void THMap::draw(THRenderTarget* pCanvas, int iScreenX, int iScreenY,
                     IntersectTHClipRect(rcNewClip, rcOldClip);
                     pCanvas->setClipRect(&rcNewClip);
                     m_pBlocks->drawSprite(pCanvas, 156, itrNode.x() - 32,
-                        itrNode.y() - 56, THDF_Alpha75);
+                        itrNode.y() - 56, ZERO_XOFFSET, ZERO_YOFFSET, THDF_Alpha75);
                     pCanvas->setClipRect(&rcOldClip);
                 }
             }
@@ -834,14 +834,14 @@ void THMap::draw(THRenderTarget* pCanvas, int iScreenX, int iScreenY,
                 NULL, &iH) && iH > 0)
             {
                 m_pBlocks->drawSprite(pCanvas, iBlock & 0xFF, itrNode.x() - 32,
-                    itrNode.y() - iH + 32, iBlock >> 8);
+                    itrNode.y() - iH + 32, ZERO_XOFFSET, ZERO_YOFFSET, iBlock >> 8);
             }
             iBlock = itrNode->iBlock[3];
             if(iBlock != 0 && m_pBlocks->getSpriteSize(iBlock & 0xFF,
                 NULL, &iH) && iH > 0)
             {
                 m_pBlocks->drawSprite(pCanvas, iBlock & 0xFF, itrNode.x() - 32,
-                    itrNode.y() - iH + 32, iBlock >> 8);
+                    itrNode.y() - iH + 32, ZERO_XOFFSET, ZERO_YOFFSET, iBlock >> 8);
             }
             iBlock = itrNode->iBlock[1];
             if(iBlock != 0 && m_pBlocks->getSpriteSize(iBlock & 0xFF,
@@ -906,7 +906,7 @@ void THMap::draw(THRenderTarget* pCanvas, int iScreenX, int iScreenY,
                         NULL, &iH) && iH > 0)
                     {
                         m_pBlocks->drawSprite(pCanvas, iBlock & 0xFF, itrNode.x() - 96,
-                            itrNode.y() - iH + 32, iBlock >> 8);
+                            itrNode.y() - iH + 32, ZERO_XOFFSET, ZERO_YOFFSET, iBlock >> 8);
                         if(itrNode.getPreviousNode()->iFlags & THMN_ShadowWall)
                         {
                             THClipRect rcOldClip, rcNewClip;
@@ -918,7 +918,7 @@ void THMap::draw(THRenderTarget* pCanvas, int iScreenX, int iScreenY,
                             IntersectTHClipRect(rcNewClip, rcOldClip);
                             pCanvas->setClipRect(&rcNewClip);
                             m_pBlocks->drawSprite(pCanvas, 156, itrNode.x() - 96,
-                                itrNode.y() - 56, THDF_Alpha75);
+                                itrNode.y() - 56, ZERO_XOFFSET, ZERO_YOFFSET, THDF_Alpha75);
                             pCanvas->setClipRect(&rcOldClip);
                         }
                     }

--- a/CorsixTH/Src/th_map_overlays.cpp
+++ b/CorsixTH/Src/th_map_overlays.cpp
@@ -85,7 +85,7 @@ void THMapTextOverlay::drawCell(THRenderTarget* pCanvas, int iCanvasX,
     if(m_pSprites && m_iBackgroundSprite)
     {
         m_pSprites->drawSprite(pCanvas, m_iBackgroundSprite, iCanvasX,
-            iCanvasY, 0);
+            iCanvasY, ZERO_XOFFSET, ZERO_YOFFSET, 0);
     }
     if(m_pFont)
     {
@@ -124,16 +124,16 @@ void THMapFlagsOverlay::drawCell(THRenderTarget* pCanvas, int iCanvasX,
     if(m_pSprites)
     {
         if(pNode->iFlags & THMN_Passable)
-            m_pSprites->drawSprite(pCanvas, 3, iCanvasX, iCanvasY, 0);
+            m_pSprites->drawSprite(pCanvas, 3, iCanvasX, iCanvasY, ZERO_XOFFSET, ZERO_YOFFSET, 0);
         if(pNode->iFlags & THMN_Hospital)
-            m_pSprites->drawSprite(pCanvas, 8, iCanvasX, iCanvasY, 0);
+            m_pSprites->drawSprite(pCanvas, 8, iCanvasX, iCanvasY, ZERO_XOFFSET, ZERO_YOFFSET, 0);
         if(pNode->iFlags & THMN_Buildable)
-            m_pSprites->drawSprite(pCanvas, 9, iCanvasX, iCanvasY, 0);
+            m_pSprites->drawSprite(pCanvas, 9, iCanvasX, iCanvasY, ZERO_XOFFSET, ZERO_YOFFSET, 0);
 #define TRAVEL(flag, dx, dy, sprite) \
         if(pNode->iFlags & flag && pMap->getNode(iNodeX + dx, iNodeY + dy)-> \
             iFlags & THMN_Passable) \
         { \
-            m_pSprites->drawSprite(pCanvas, sprite, iCanvasX, iCanvasY, 0); \
+            m_pSprites->drawSprite(pCanvas, sprite, iCanvasX, iCanvasY, ZERO_XOFFSET, ZERO_YOFFSET, 0); \
         }
         TRAVEL(THMN_CanTravelN,  0, -1, 4);
         TRAVEL(THMN_CanTravelE,  1,  0, 5);
@@ -165,7 +165,7 @@ void THMapParcelsOverlay::drawCell(THRenderTarget* pCanvas, int iCanvasX,
 #define DIR(dx, dy, sprite) \
         pNode = pMap->getNode(iNodeX + dx, iNodeY + dy); \
         if(!pNode || pNode->iParcelId != iParcel) \
-            m_pSprites->drawSprite(pCanvas, sprite, iCanvasX, iCanvasY, 0)
+            m_pSprites->drawSprite(pCanvas, sprite, iCanvasX, iCanvasY, ZERO_XOFFSET, ZERO_YOFFSET, 0)
         DIR( 0, -1, 18);
         DIR( 1,  0, 19);
         DIR( 0,  1, 20);


### PR DESCRIPTION
Currently, the program inherits offsets in custom sprites from the old graphics. This works as long as the new psrites have equal layout. New sprites that do not follow this layout, will fail to get rendered at the right spot.

The Graphics repo PR #5 changes the sprite file format to include custom offsets. This patch enables CorsixTH to read and use those new files
- Sprite offsets are not added to the position in the animation manager, but passed on to the actual sprite renderer. I added ZERO_XOFFSET and ZERO_YOFFSET to be clear where this happens.
- Custom offsets of new sprites are stored while loading. Old graphics are supported by disabling usage of this new offset.
- The sprite draw routine is extended to replace the provided offsets from the animation manager by its own offsets for the sprite if the bUseOffsets allows it.
- The sprite file version number is incremented to match with the new file format created after applying Graphics PR #5 to the encoder

While this works for the static sprites, I have doubts it will nicely work for animations too. In hindsight, I should have modified animations instead of sprite loading, perhaps?
