### PR TITLE
Add 0.40 to getVersion list, tagged to save game version 88

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local assert, io, type, dofile, loadfile, pcall, tonumber, print, setmetatable
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 88
+local SAVEGAME_VERSION = 89
 
 class "App"
 
@@ -1147,8 +1147,10 @@ end
 -- a specific savegame verion is from.
 function App:getVersion(version)
   local ver = version or self.savegame_version
-  if ver > 78 then
+  if ver > 89 then
     return "Trunk"
+  elseif ver > 78 then
+    return "0.40"
   elseif ver > 72 then
     return "0.30"
   elseif ver > 66 then


### PR DESCRIPTION
@Lego3 I didn't actually look at getVersion when I was commenting earlier.  This should be committed before RC1, you're right.
