### PR TITLE
Fix humanoid empty action queue

### DIFF
--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -668,8 +668,10 @@ function Room:tryToFindNearbyPatients()
       while queue:reportedSize() > 1 do
         local patient = queue:back()
         local px, py = patient.tile_x, patient.tile_y
-        if world:getPathDistance(px, py, our_x, our_y) + our_score <
-        world:getPathDistance(px, py, other_x, other_y) + other_score then
+        -- Don't reroute the patient if he just decided to go to the toilet
+        if not patient.going_to_toilet and
+          world:getPathDistance(px, py, our_x, our_y) + our_score <
+          world:getPathDistance(px, py, other_x, other_y) + other_score then
           -- Update the queues
           queue:removeValue(patient)
           patient.next_room_to_visit = self


### PR DESCRIPTION
This fixes the problem reported in #306.

When the tickDay function sends a patient to the toilets, there is a small timeframe (the time required for standing up), where the tryToFindNearbyPatients function tries to reroute a patient who is going to the toilet.

This will set the seek_toilets todo_interrupt and the finishAction function is then called one time too often by the seek_toilets action itself and all actions from the action queue are consumed, so the error message pops up.
