### PR TITLE
Changed all Lua classes to make Eclipse LDT outline methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ before_script:
 script:
   # Check if there are trailing whitespaces.
   - ${TRAVIS_BUILD_DIR}/scripts/check_trailing_whitespaces.py $TRAVIS_BUILD_DIR
+  # Check if there are lua classes with invalid/improper declarations.
+  - python ${TRAVIS_BUILD_DIR}/scripts/check_lua_classes.py
   # Build CorsixTH
   - make
   # Validate lua files

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -33,6 +33,9 @@ local SAVEGAME_VERSION = 89
 
 class "App"
 
+---@type App
+local App = _G["App"]
+
 function App:App()
   self.command_line = {}
   self.config = {}

--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -29,6 +29,9 @@ local ipairs
 --! Layer which handles the Lua-facing side of loading and playing audio.
 class "Audio"
 
+---@type Audio
+local Audio = _G["Audio"]
+
 function Audio:Audio(app)
   self.app = app
 

--- a/CorsixTH/Lua/calls_dispatcher.lua
+++ b/CorsixTH/Lua/calls_dispatcher.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "CallsDispatcher"
 
+---@type CallsDispatcher
+local CallsDispatcher = _G["CallsDispatcher"]
+
 local debug = false -- Turn on for debug message
 
 function CallsDispatcher:CallsDispatcher(world, entities)

--- a/CorsixTH/Lua/class.lua
+++ b/CorsixTH/Lua/class.lua
@@ -23,6 +23,9 @@ SOFTWARE. --]]
 --  class "Name"
 -- OR
 --  class "Name" (SuperclassName)
+--  
+--  ---@type Name
+--  local Name = _G["Name"]
 --
 --  function Name:Name(arguments)
 --    self:SuperclassName(arguments) -- required when there is a superclass

--- a/CorsixTH/Lua/command.lua
+++ b/CorsixTH/Lua/command.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "Command"
 
+---@type Command
+local Command = _G["Command"]
+
 function Command:Command(can_undo)
   self.can_undo = can_undo
 end

--- a/CorsixTH/Lua/command_stack.lua
+++ b/CorsixTH/Lua/command_stack.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "CommandStack"
 
+---@type CommandStack
+local CommandStack = _G["CommandStack"]
+
 function CommandStack:CommandStack()
   self.undo_stack = {}
   self.redo_stack = {}

--- a/CorsixTH/Lua/commands/compound.lua
+++ b/CorsixTH/Lua/commands/compound.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "CompoundCommand" (Command)
 
+---@type CompoundCommand
+local CompoundCommand = _G["CompoundCommand"]
+
 function CompoundCommand:CompoundCommand()
   self:Command(true)
   self.command_list = {}

--- a/CorsixTH/Lua/commands/set_map_cell.lua
+++ b/CorsixTH/Lua/commands/set_map_cell.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "SetMapCellCommand" (Command)
 
+---@type SetMapCellCommand
+local SetMapCellCommand = _G["SetMapCellCommand"]
+
 function SetMapCellCommand:SetMapCellCommand(map)
   self:Command(true)
   self.map = map

--- a/CorsixTH/Lua/commands/set_map_cell_flags.lua
+++ b/CorsixTH/Lua/commands/set_map_cell_flags.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "SetMapCellFlagsCommand" (Command)
 
+---@type SetMapCellFlagsCommand
+local SetMapCellFlagsCommand = _G["SetMapCellFlagsCommand"]
+
 function SetMapCellFlagsCommand:SetMapCellFlagsCommand(map)
   self:Command(true)
   self.map = map

--- a/CorsixTH/Lua/dialogs/adviser.lua
+++ b/CorsixTH/Lua/dialogs/adviser.lua
@@ -23,6 +23,9 @@ local TH = require "TH"
 --! The (ideally) helpful advisor who pops up from the bottom dialog during a game.
 class "UIAdviser" (Window)
 
+---@type UIAdviser
+local UIAdviser = _G["UIAdviser"]
+
 function UIAdviser:UIAdviser(ui)
   self:Window()
 

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! The multi-purpose panel for launching dialogs / screens and dynamic information.
 class "UIBottomPanel" (Window)
 
+---@type UIBottomPanel
+local UIBottomPanel = _G["UIBottomPanel"]
+
 function UIBottomPanel:UIBottomPanel(ui)
   self:Window()
 

--- a/CorsixTH/Lua/dialogs/build_room.lua
+++ b/CorsixTH/Lua/dialogs/build_room.lua
@@ -22,6 +22,9 @@ local TH = require "TH"
 
 class "UIBuildRoom" (Window)
 
+---@type UIBuildRoom
+local UIBuildRoom = _G["UIBuildRoom"]
+
 function UIBuildRoom:UIBuildRoom(ui)
   self:Window()
 

--- a/CorsixTH/Lua/dialogs/confirm_dialog.lua
+++ b/CorsixTH/Lua/dialogs/confirm_dialog.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Dialog for "Are you sure you want to quit?" and similar yes/no questions.
 class "UIConfirmDialog" (Window)
 
+---@type UIConfirmDialog
+local UIConfirmDialog = _G["UIConfirmDialog"]
+
 function UIConfirmDialog:UIConfirmDialog(ui, text, callback_ok, callback_cancel)
   self:Window()
 

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -26,6 +26,9 @@ dofile "dialogs/place_objects"
 
 class "UIEditRoom" (UIPlaceObjects)
 
+---@type UIEditRoom
+local UIEditRoom = _G["UIEditRoom"]
+
 function UIEditRoom:UIEditRoom(ui, room_type)
 
   -- NB: UIEditRoom:onCursorWorldPositionChange is called by the UIPlaceObjects

--- a/CorsixTH/Lua/dialogs/fullscreen.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Base class for 640x480px dialogs (fullscreen in original game resolution).
 class "UIFullscreen" (Window)
 
+---@type UIFullscreen
+local UIFullscreen = _G["UIFullscreen"]
+
 function UIFullscreen:UIFullscreen(ui)
   self:Window()
 

--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -23,6 +23,9 @@ local TH = require "TH"
 --! Annual Report fullscreen window shown at the start of each year.
 class "UIAnnualReport" (UIFullscreen)
 
+---@type UIAnnualReport
+local UIAnnualReport = _G["UIAnnualReport"]
+
 function UIAnnualReport:UIAnnualReport(ui, world)
 
   self:UIFullscreen(ui)

--- a/CorsixTH/Lua/dialogs/fullscreen/bank_manager.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/bank_manager.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Bank manager (for loans / insurance companies) and bank statement fullscreen windows.
 class "UIBankManager" (UIFullscreen)
 
+---@type UIBankManager
+local UIBankManager = _G["UIBankManager"]
+
 function UIBankManager:UIBankManager(ui)
   self:UIFullscreen(ui)
   local gfx = ui.app.gfx

--- a/CorsixTH/Lua/dialogs/fullscreen/drug_casebook.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/drug_casebook.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Drug Casebook fullscreen window (view disease statistics and set prices).
 class "UICasebook" (UIFullscreen)
 
+---@type UICasebook
+local UICasebook = _G["UICasebook"]
+
 function UICasebook:UICasebook(ui, disease_selection)
   self:UIFullscreen(ui)
   local gfx = ui.app.gfx

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "UIFax" (UIFullscreen)
 
+---@type UIFax
+local UIFax = _G["UIFax"]
+
 function UIFax:UIFax(ui, icon)
   self:UIFullscreen(ui)
   local gfx = ui.app.gfx

--- a/CorsixTH/Lua/dialogs/fullscreen/graphs.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/graphs.lua
@@ -22,6 +22,9 @@ SOFTWARE. --]]
 --! Charts fullscreen window
 class "UIGraphs" (UIFullscreen)
 
+---@type UIGraphs
+local UIGraphs = _G["UIGraphs"]
+
 local TH = require "TH"
 
 -- These values are based on the background colours of the pen symbols

--- a/CorsixTH/Lua/dialogs/fullscreen/hospital_policy.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/hospital_policy.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Hospital policy fullscreen window (set staff tiredness and patient cure thresholds, etc.).
 class "UIPolicy" (UIFullscreen)
 
+---@type UIPolicy
+local UIPolicy = _G["UIPolicy"]
+
 function UIPolicy:UIPolicy(ui, disease_selection)
   self:UIFullscreen(ui)
   local gfx = ui.app.gfx

--- a/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
@@ -23,6 +23,9 @@ local TH = require "TH"
 --! Progress Report fullscreen window (check level goals, competitors and alerts).
 class "UIProgressReport" (UIFullscreen)
 
+---@type UIProgressReport
+local UIProgressReport = _G["UIProgressReport"]
+
 function UIProgressReport:UIProgressReport(ui)
   -- TODO: Refactor this file!
   self:UIFullscreen(ui)

--- a/CorsixTH/Lua/dialogs/fullscreen/research_policy.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/research_policy.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "UIResearch" (UIFullscreen)
 
+---@type UIResearch
+local UIResearch = _G["UIResearch"]
+
 local research_categories = {
   "cure",
   "diagnosis",

--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -23,6 +23,9 @@ local math_floor = math.floor
 --! Staff management screen
 class "UIStaffManagement" (UIFullscreen)
 
+---@type UIStaffManagement
+local UIStaffManagement = _G["UIStaffManagement"]
+
 function UIStaffManagement:UIStaffManagement(ui, disease_selection)
   self:UIFullscreen(ui)
   local gfx = ui.app.gfx

--- a/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
@@ -23,6 +23,9 @@ local TH = require "TH"
 --! Town map fullscreen window (purchase land, set radiator levels, map overview).
 class "UITownMap" (UIFullscreen)
 
+---@type UITownMap
+local UITownMap = _G["UITownMap"]
+
 function UITownMap:UITownMap(ui)
   self:UIFullscreen(ui)
 

--- a/CorsixTH/Lua/dialogs/furnish_corridor.lua
+++ b/CorsixTH/Lua/dialogs/furnish_corridor.lua
@@ -25,6 +25,9 @@ local math_floor
 --! Dialog for purchasing `Object`s (for the corridor or for rooms).
 class "UIFurnishCorridor" (Window)
 
+---@type UIFurnishCorridor
+local UIFurnishCorridor = _G["UIFurnishCorridor"]
+
 function UIFurnishCorridor:UIFurnishCorridor(ui, objects, edit_dialog)
   self:Window()
 

--- a/CorsixTH/Lua/dialogs/hire_staff.lua
+++ b/CorsixTH/Lua/dialogs/hire_staff.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "UIHireStaff" (Window)
 
+---@type UIHireStaff
+local UIHireStaff = _G["UIHireStaff"]
+
 function UIHireStaff:UIHireStaff(ui)
   self:Window()
   self.modal_class = "main"

--- a/CorsixTH/Lua/dialogs/information.lua
+++ b/CorsixTH/Lua/dialogs/information.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Dialog that informs the player of for example what the goals for the level are.
 class "UIInformation" (Window)
 
+---@type UIInformation
+local UIInformation = _G["UIInformation"]
+
 --! Constructor for the Information Dialog.
 --!param text The text to show, held in a table. All elements of the table will be written
 -- beneath each other. If instead a table within the table is supplied the texts

--- a/CorsixTH/Lua/dialogs/jukebox.lua
+++ b/CorsixTH/Lua/dialogs/jukebox.lua
@@ -23,6 +23,9 @@ local ipairs
 
 class "UIJukebox" (Window)
 
+---@type UIJukebox
+local UIJukebox = _G["UIJukebox"]
+
 function UIJukebox:UIJukebox(app)
   self:Window()
   self.modal_class = "jukebox"

--- a/CorsixTH/Lua/dialogs/machine_dialog.lua
+++ b/CorsixTH/Lua/dialogs/machine_dialog.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "UIMachine" (Window)
 
+---@type UIMachine
+local UIMachine = _G["UIMachine"]
+
 function UIMachine:UIMachine(ui, machine, room)
   self:Window()
 

--- a/CorsixTH/Lua/dialogs/map_editor.lua
+++ b/CorsixTH/Lua/dialogs/map_editor.lua
@@ -26,6 +26,9 @@ dofile "commands/compound"
 
 class "UIMapEditor" (Window)
 
+---@type UIMapEditor
+local UIMapEditor = _G["UIMapEditor"]
+
 local math_floor
     = math.floor
 

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -25,6 +25,9 @@ local TH = require "TH"
 --! The ingame menu bar which sits (nominally hidden) at the top of the screen.
 class "UIMenuBar" (Window)
 
+---@type UIMenuBar
+local UIMenuBar = _G["UIMenuBar"]
+
 function UIMenuBar:UIMenuBar(ui)
   self:Window()
 
@@ -454,6 +457,9 @@ function UIMenuBar:calculateMenuSize(menu)
 end
 
 class "UIMenu"
+
+---@type UIMenu
+local UIMenu = _G["UIMenu"]
 
 function UIMenu:UIMenu()
   self.items = {}

--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Small fax notification window which sits on the bottom bar.
 class "UIMessage" (Window)
 
+---@type UIMessage
+local UIMessage = _G["UIMessage"]
+
 function UIMessage:UIMessage(ui, x, stop_x, onClose, type, message, owner, timeout, default_choice, callback)
   self:Window()
 

--- a/CorsixTH/Lua/dialogs/patient.lua
+++ b/CorsixTH/Lua/dialogs/patient.lua
@@ -30,6 +30,9 @@ end
 --! Individual patient information dialog
 class "UIPatient" (Window)
 
+---@type UIPatient
+local UIPatient = _G["UIPatient"]
+
 function UIPatient:UIPatient(ui, patient)
   self:Window()
 

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -30,6 +30,9 @@ local ATTACH_BLUEPRINT_TO_TILE = false
 --! The dialog shown when placing objects.
 class "UIPlaceObjects" (Window)
 
+---@type UIPlaceObjects
+local UIPlaceObjects = _G["UIPlaceObjects"]
+
 --[[ Constructor for the class.
 !param ui (UI) The active ui.
 !param object_list (table) a list of tables with objects to place. Keys are "object", "qty" and

--- a/CorsixTH/Lua/dialogs/place_staff.lua
+++ b/CorsixTH/Lua/dialogs/place_staff.lua
@@ -25,6 +25,9 @@ local TH = require "TH"
 --! Invisible window which handles placing a `Staff` member in the world.
 class "UIPlaceStaff" (Window)
 
+---@type UIPlaceStaff
+local UIPlaceStaff = _G["UIPlaceStaff"]
+
 function UIPlaceStaff:UIPlaceStaff(ui, profile, x, y)
   self.ui = ui
   self.world = ui.app.world

--- a/CorsixTH/Lua/dialogs/queue_dialog.lua
+++ b/CorsixTH/Lua/dialogs/queue_dialog.lua
@@ -25,6 +25,9 @@ local math_floor
 --! Room / door / reception desk queue visualisation dialog.
 class "UIQueue" (Window)
 
+---@type UIQueue
+local UIQueue = _G["UIQueue"]
+
 function UIQueue:UIQueue(ui, queue)
   self:Window()
 
@@ -339,6 +342,9 @@ function UIQueue:drawPatient(canvas, x, y, patient)
 end
 
 class "UIQueuePopup" (Window)
+
+---@type UIQueuePopup
+local UIQueuePopup = _G["UIQueuePopup"]
 
 function UIQueuePopup:UIQueuePopup(ui, x, y, patient)
   self:Window()

--- a/CorsixTH/Lua/dialogs/resizable.lua
+++ b/CorsixTH/Lua/dialogs/resizable.lua
@@ -23,6 +23,9 @@ SOFTWARE. --]]
 --any of the corners.
 class "UIResizable" (Window)
 
+---@type UIResizable
+local UIResizable = _G["UIResizable"]
+
 local border_offset_x = 9
 local border_offset_y = 9
 local border_size_x = 40

--- a/CorsixTH/Lua/dialogs/resizables/calls_dispatcher.lua
+++ b/CorsixTH/Lua/dialogs/resizables/calls_dispatcher.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Calls Dispatcher Window
 class "UICallsDispatcher" (UIResizable)
 
+---@type UICallsDispatcher
+local UICallsDispatcher = _G["UICallsDispatcher"]
+
 local col_bg = {
   red = 154,
   green = 146,

--- a/CorsixTH/Lua/dialogs/resizables/cheats.lua
+++ b/CorsixTH/Lua/dialogs/resizables/cheats.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! A dialog for activating cheats
 class "UICheats" (UIResizable)
 
+---@type UICheats
+local UICheats = _G["UICheats"]
+
 local col_bg = {
   red = 154,
   green = 146,

--- a/CorsixTH/Lua/dialogs/resizables/customise.lua
+++ b/CorsixTH/Lua/dialogs/resizables/customise.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Customise window used in the main menu and ingame.
 class "UICustomise" (UIResizable)
 
+---@type UICustomise
+local UICustomise = _G["UICustomise"]
+
 local col_bg = {
   red = 154,
   green = 146,

--- a/CorsixTH/Lua/dialogs/resizables/directory_browser.lua
+++ b/CorsixTH/Lua/dialogs/resizables/directory_browser.lua
@@ -23,6 +23,9 @@ local lfs = require "lfs"
 --! A tree node representing a directory in the physical file-system.
 class "DirTreeNode" (FileTreeNode)
 
+---@type DirTreeNode
+local DirTreeNode = _G["DirTreeNode"]
+
 local pathsep = package.config:sub(1, 1)
 
 function DirTreeNode:DirTreeNode(path)
@@ -52,6 +55,9 @@ end
 
 --! This tree only shows directories and highlights valid TH directories.
 class "InstallDirTreeNode" (DirTreeNode)
+
+---@type InstallDirTreeNode
+local InstallDirTreeNode = _G["InstallDirTreeNode"]
 
 function InstallDirTreeNode:InstallDirTreeNode(path)
   self:FileTreeNode(path)
@@ -96,6 +102,9 @@ end
 
 --! Prompter for Theme Hospital install directory
 class "UIDirectoryBrowser" (UIResizable)
+
+---@type UIDirectoryBrowser
+local UIDirectoryBrowser = _G["UIDirectoryBrowser"]
 
 --! Creates a new directory browser window
 --!param ui The active UI to hook into.

--- a/CorsixTH/Lua/dialogs/resizables/dropdown.lua
+++ b/CorsixTH/Lua/dialogs/resizables/dropdown.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Dropdown "window" used for selection of one item from a list.
 class "UIDropdown" (UIResizable)
 
+---@type UIDropdown
+local UIDropdown = _G["UIDropdown"]
+
 --! Constructor for the dropdown "window"
 --!param ui (UI) The ui the window is created in
 --!param parent_window (Window) The window that this dropdown will be attached to

--- a/CorsixTH/Lua/dialogs/resizables/file_browser.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browser.lua
@@ -24,6 +24,9 @@ local lfs = require "lfs"
 --  that meets a given file extension criterion.
 class "FilteredFileTreeNode" (FileTreeNode)
 
+---@type FilteredFileTreeNode
+local FilteredFileTreeNode = _G["FilteredFileTreeNode"]
+
 local pathsep = package.config:sub(1, 1)
 
 function FilteredFileTreeNode:FilteredFileTreeNode(path, filter)
@@ -78,6 +81,9 @@ end
 --! A sortable tree control that accomodates a certain file type and also possibly shows
 --  their last modification dates.
 class "FilteredTreeControl" (TreeControl)
+
+---@type FilteredTreeControl
+local FilteredTreeControl = _G["FilteredTreeControl"]
 
 function FilteredTreeControl:FilteredTreeControl(root, x, y, width, height, col_bg, col_fg, has_font, show_dates)
   self:TreeControl(root, x, y, width, height, col_bg, col_fg, 14, has_font)
@@ -145,6 +151,9 @@ end
 
 --! A file browser with a scrollbar. Used by load_game and save_game.
 class "UIFileBrowser" (UIResizable)
+
+---@type UIFileBrowser
+local UIFileBrowser = _G["UIFileBrowser"]
 
 local col_caption = {
   red = 174,

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/choose_font.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/choose_font.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Window where the user can choose a font file.
 class "UIChooseFont" (UIFileBrowser)
 
+---@type UIChooseFont
+local UIChooseFont = _G["UIChooseFont"]
+
 local pathsep = package.config:sub(1, 1)
 
 local col_textbox = {

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Load Game Window
 class "UILoadGame" (UIFileBrowser)
 
+---@type UILoadGame
+local UILoadGame = _G["UILoadGame"]
+
 function UILoadGame:UILoadGame(ui, mode)
   local treenode = FilteredFileTreeNode(ui.app.savegame_dir, ".sav")
   treenode.label = "Saves"

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Save Game Window
 class "UISaveGame" (UIFileBrowser)
 
+---@type UISaveGame
+local UISaveGame = _G["UISaveGame"]
+
 local pathsep = package.config:sub(1, 1)
 
 local col_textbox = {

--- a/CorsixTH/Lua/dialogs/resizables/folder_settings.lua
+++ b/CorsixTH/Lua/dialogs/resizables/folder_settings.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Customise window used in the main menu and ingame.
 class "UIFolder" (UIResizable)
 
+---@type UIFolder
+local UIFolder = _G["UIFolder"]
+
 local col_bg = {
   red = 154,
   green = 146,

--- a/CorsixTH/Lua/dialogs/resizables/lua_console.lua
+++ b/CorsixTH/Lua/dialogs/resizables/lua_console.lua
@@ -24,6 +24,9 @@ _ = nil
 --! Interactive Lua Console for ingame debugging.
 class "UILuaConsole" (UIResizable)
 
+---@type UILuaConsole
+local UILuaConsole = _G["UILuaConsole"]
+
 local col_bg = {
   red = 46,
   green = 186,

--- a/CorsixTH/Lua/dialogs/resizables/main_menu.lua
+++ b/CorsixTH/Lua/dialogs/resizables/main_menu.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Class for main menu window.
 class "UIMainMenu" (UIResizable)
 
+---@type UIMainMenu
+local UIMainMenu = _G["UIMainMenu"]
+
 local col_bg = {
   red = 154,
   green = 146,

--- a/CorsixTH/Lua/dialogs/resizables/menu_list_dialog.lua
+++ b/CorsixTH/Lua/dialogs/resizables/menu_list_dialog.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! A menu list with a scrollbar. Used by load_game, save_game and custom_game.
 class "UIMenuList" (UIResizable)
 
+---@type UIMenuList
+local UIMenuList = _G["UIMenuList"]
+
 local col_caption = {
   red = 174,
   green = 166,

--- a/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_game.lua
@@ -23,6 +23,9 @@ local pathsep = package.config:sub(1, 1)
 --! Custom Game Window
 class "UICustomGame" (UIMenuList)
 
+---@type UICustomGame
+local UICustomGame = _G["UICustomGame"]
+
 function UICustomGame:UICustomGame(ui)
 
   -- Supply the required list of items to UIMenuList

--- a/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/make_debug_patient.lua
+++ b/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/make_debug_patient.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "UIMakeDebugPatient" (UIMenuList)
 
+---@type UIMakeDebugPatient
+local UIMakeDebugPatient = _G["UIMakeDebugPatient"]
+
 function UIMakeDebugPatient:UIMakeDebugPatient(ui)
   local items = {}
   for _, disease in ipairs(ui.app.diseases) do

--- a/CorsixTH/Lua/dialogs/resizables/new_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/new_game.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Class for the difficulty choice window.
 class "UINewGame" (UIResizable)
 
+---@type UINewGame
+local UINewGame = _G["UINewGame"]
+
 local col_bg = {
   red = 154,
   green = 146,

--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Options window used in the main menu and ingame.
 class "UIOptions" (UIResizable)
 
+---@type UIOptions
+local UIOptions = _G["UIOptions"]
+
 local col_bg = {
   red = 154,
   green = 146,
@@ -279,6 +282,9 @@ end
 
 --! A custom resolution selection window
 class "UIResolution" (UIResizable)
+
+---@type UIResolution
+local UIResolution = _G["UIResolution"]
 
 function UIResolution:UIResolution(ui, callback)
   self:UIResizable(ui, 200, 140, col_bg)

--- a/CorsixTH/Lua/dialogs/resizables/tip_of_the_day.lua
+++ b/CorsixTH/Lua/dialogs/resizables/tip_of_the_day.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Tip of the Day Window
 class "UITipOfTheDay" (UIResizable)
 
+---@type UITipOfTheDay
+local UITipOfTheDay = _G["UITipOfTheDay"]
+
 local col_bg = {
   red = math.random(20, 200),
   green = math.random(20, 200),

--- a/CorsixTH/Lua/dialogs/resizables/update.lua
+++ b/CorsixTH/Lua/dialogs/resizables/update.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Options window used in the main menu and ingame.
 class "UIUpdate" (UIResizable)
 
+---@type UIUpdate
+local UIUpdate = _G["UIUpdate"]
+
 local col_bg = {
   red = 154,
   green = 146,

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -31,6 +31,9 @@ end
 --! Individual staff information dialog
 class "UIStaff" (Window)
 
+---@type UIStaff
+local UIStaff = _G["UIStaff"]
+
 function UIStaff:changeParcel()
   local index = 0
   for i, v in ipairs(self.staff.hospital.ownedPlots) do

--- a/CorsixTH/Lua/dialogs/staff_rise.lua
+++ b/CorsixTH/Lua/dialogs/staff_rise.lua
@@ -24,6 +24,9 @@ local math_floor
 --! Dialog for staff member requesting a salaray raise.
 class "UIStaffRise" (Window)
 
+---@type UIStaffRise
+local UIStaffRise = _G["UIStaffRise"]
+
 function UIStaffRise:UIStaffRise(ui, staff, rise_amount)
   self:Window()
   local app = ui.app

--- a/CorsixTH/Lua/dialogs/tree_ctrl.lua
+++ b/CorsixTH/Lua/dialogs/tree_ctrl.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Iterface for items within a UI tree control
 class "TreeNode"
 
+---@type TreeNode
+local TreeNode = _G["TreeNode"]
+
 function TreeNode:TreeNode()
   self.is_expanded = false
   self.num_visible_descendants = 0
@@ -180,6 +183,9 @@ end
 
 --! A tree node representing a file (or directory) in the physical file-system.
 class "FileTreeNode" (TreeNode)
+
+---@type FileTreeNode
+local FileTreeNode = _G["FileTreeNode"]
 
 local pathsep = package.config:sub(1, 1)
 
@@ -444,6 +450,9 @@ end
 -- multiple root nodes.
 class "DummyRootNode" (TreeNode)
 
+---@type DummyRootNode
+local DummyRootNode = _G["DummyRootNode"]
+
 --!param roots (array) An array of `TreeNode`s which should be displayed as
 -- root nodes.
 function DummyRootNode:DummyRootNode(roots)
@@ -473,6 +482,9 @@ end
 --! A control (to be placed on a window) which allows the user to navigate a
 -- tree of items and select one item from it.
 class "TreeControl" (Window)
+
+---@type TreeControl
+local TreeControl = _G["TreeControl"]
 
 --!param root (TreeNode) The single root node of the tree (use a `DummyRootNode`
 -- here if multiple root nodes are desired).

--- a/CorsixTH/Lua/dialogs/watch.lua
+++ b/CorsixTH/Lua/dialogs/watch.lua
@@ -22,6 +22,9 @@ SOFTWARE. --]]
 --! The timer lasts approximately 100 days, split into 13 segments
 class "UIWatch" (Window)
 
+---@type UIWatch
+local UIWatch = _G["UIWatch"]
+
 --!param count_type (string) One of: "open_countdown" or "emergency" or "epidemic"
 function UIWatch:UIWatch(ui, count_type)
   self:Window()

--- a/CorsixTH/Lua/entities/grim_reaper.lua
+++ b/CorsixTH/Lua/entities/grim_reaper.lua
@@ -19,6 +19,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 class "GrimReaper" (Humanoid)
+
+---@type GrimReaper
+local GrimReaper = _G["GrimReaper"]
+
 local TH = require "TH"
 
 function GrimReaper:GrimReaper(...)

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! An `Entity` which occupies a single tile and is capable of moving around the map.
 class "Humanoid" (Entity)
 
+---@type Humanoid
+local Humanoid = _G["Humanoid"]
+
 local TH = require "TH"
 
 local walk_animations = permanent"humanoid_walk_animations"({})

--- a/CorsixTH/Lua/entities/inspector.lua
+++ b/CorsixTH/Lua/entities/inspector.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --[[ An `Inspector` is called to the hospital after an epidemic to issue a report]]
 class "Inspector" (Humanoid)
 
+---@type Inspector
+local Inspector = _G["Inspector"]
+
 function Inspector:Inspector(...)
   self:Humanoid(...)
   self.hover_cursor = TheApp.gfx:loadMainCursor("default")

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -23,6 +23,9 @@ local TH = require "TH"
 --! An `Object` which needs occasional repair (to prevent explosion).
 class "Machine" (Object)
 
+---@type Machine
+local Machine = _G["Machine"]
+
 function Machine:Machine(world, object_type, x, y, direction, etc)
 
   self.total_usage = -1 -- Incremented in the constructor of Object.

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -23,6 +23,9 @@ local TH = require "TH"
 --! An `Entity` which occupies at least a single map tile and does not move.
 class "Object" (Entity)
 
+---@type Object
+local Object = _G["Object"]
+
 local orient_mirror = {
   north = "west",
   west = "north",

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! A `Humanoid` who is in the hospital for diagnosis and/or treatment.
 class "Patient" (Humanoid)
 
+---@type Patient
+local Patient = _G["Patient"]
+
 function Patient:Patient(...)
   self:Humanoid(...)
   self.hover_cursor = TheApp.gfx:loadMainCursor("patient")

--- a/CorsixTH/Lua/entities/staff.lua
+++ b/CorsixTH/Lua/entities/staff.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! A Doctor, Nurse, Receptionist, Handyman, or Surgeon
 class "Staff" (Humanoid)
 
+---@type Staff
+local Staff = _G["Staff"]
+
 --!param ... Arguments to base class constructor.
 function Staff:Staff(...)
   self:Humanoid(...)

--- a/CorsixTH/Lua/entities/vip.lua
+++ b/CorsixTH/Lua/entities/vip.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! A `Vip` who is in the hospital to evaluate the hospital and produce a report
 class "Vip" (Humanoid)
 
+---@type Vip
+local Vip = _G["Vip"]
+
 function Vip:Vip(...)
   self:Humanoid(...)
   self.hover_cursor = TheApp.gfx:loadMainCursor("default")

--- a/CorsixTH/Lua/entity.lua
+++ b/CorsixTH/Lua/entity.lua
@@ -21,6 +21,9 @@ SOFTWARE. --]]
 --! Abstraction for visible gameplay things which sit somewhere on the map.
 class "Entity"
 
+---@type Entity
+local Entity = _G["Entity"]
+
 local TH = require "TH"
 
 function Entity:Entity(animation)

--- a/CorsixTH/Lua/entity_map.lua
+++ b/CorsixTH/Lua/entity_map.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "EntityMap"
 
+---@type EntityMap
+local EntityMap = _G["EntityMap"]
+
 --[[ An entity map is a structure is a 2 dimensional structure created from a
 game map, it has the same dimensions as the game map which intitalises it.
 The purpose of the map is store the location of entities in the map in

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "Epidemic"
 
+---@type Epidemic
+local Epidemic = _G["Epidemic"]
+
 --[[Manages the epidemics that occur in hospitals. Generally, any epidemic
 logic that happens outside this class will call functions contained here.]]
 function Epidemic:Epidemic(hospital, contagious_patient)

--- a/CorsixTH/Lua/filesystem.lua
+++ b/CorsixTH/Lua/filesystem.lua
@@ -26,6 +26,9 @@ local ISO_FS = require "ISO_FS"
 --! Layer for abstracting away differences in file systems
 class "FileSystem"
 
+---@type FileSystem
+local FileSystem = _G["FileSystem"]
+
 function FileSystem:FileSystem()
 end
 

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -23,6 +23,9 @@ dofile "ui"
 --! Variant of UI for running games
 class "GameUI" (UI)
 
+---@type GameUI
+local GameUI = _G["GameUI"]
+
 local TH = require "TH"
 local WM = require "sdl".wm
 local SDL = require "sdl"

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -30,6 +30,9 @@ local assert, string_char, table_concat, unpack, type, pairs, ipairs
 -- the other Lua code.
 class "Graphics"
 
+---@type Graphics
+local Graphics = _G["Graphics"]
+
 local cursors_name = {
   default = 1,
   clicked = 2,
@@ -444,6 +447,9 @@ end
 
 --! Utility class for setting animation markers and querying animation length.
 class "AnimationManager"
+
+---@type AnimationManager
+local AnimationManager = _G["AnimationManager"]
 
 function AnimationManager:AnimationManager(anims)
   self.anim_length_cache = {}

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "Hospital"
 
+---@type Hospital
+local Hospital = _G["Hospital"]
+
 function Hospital:Hospital(world, name)
   self.world = world
   local level_config = world.map.level_config
@@ -1743,6 +1746,9 @@ function Hospital:checkDiseaseRequirements(disease)
 end
 
 class "AIHospital" (Hospital)
+
+---@type AIHospital
+local AIHospital = _G["AIHospital"]
 
 function AIHospital:AIHospital(competitor, ...)
   self:Hospital(...)

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -20,6 +20,10 @@ SOFTWARE. --]]
 
 --! Lua extensions to the C++ THMap class
 class "Map"
+
+---@type Map
+local Map = _G["Map"]
+
 local pathsep = package.config:sub(1, 1)
 local math_floor, tostring, table_concat
     = math.floor, tostring, table.concat

--- a/CorsixTH/Lua/movie_player.lua
+++ b/CorsixTH/Lua/movie_player.lua
@@ -25,6 +25,9 @@ local pathsep = package.config:sub(1, 1)
 
 class "MoviePlayer"
 
+---@type MoviePlayer
+local MoviePlayer = _G["MoviePlayer"]
+
 function MoviePlayer:MoviePlayer(app, audio)
   self.app = app
   self.audio = audio

--- a/CorsixTH/Lua/objects/analyser.lua
+++ b/CorsixTH/Lua/objects/analyser.lua
@@ -58,6 +58,9 @@ object.orientations = {
 
 class "AtomAnalyser" (Object)
 
+---@type AtomAnalyser
+local AtomAnalyser = _G["AtomAnalyser"]
+
 function AtomAnalyser:AtomAnalyser(...)
   self:Object(...)
 end

--- a/CorsixTH/Lua/objects/bench.lua
+++ b/CorsixTH/Lua/objects/bench.lua
@@ -145,6 +145,9 @@ object.orientations = {
 
 class "Bench" (Object)
 
+---@type Bench
+local Bench = _G["Bench"]
+
 function Bench:Bench(...)
   self:Object(...)
 end

--- a/CorsixTH/Lua/objects/bin.lua
+++ b/CorsixTH/Lua/objects/bin.lua
@@ -41,6 +41,9 @@ object.orientations = {
 
 class "SideObject" (Object)
 
+---@type SideObject
+local SideObject = _G["SideObject"]
+
 function SideObject:SideObject(...)
   self:Object(...)
 end

--- a/CorsixTH/Lua/objects/door.lua
+++ b/CorsixTH/Lua/objects/door.lua
@@ -34,6 +34,9 @@ dofile "queue"
 
 class "Door" (Object)
 
+---@type Door
+local Door = _G["Door"]
+
 function Door:Door(...)
   self:Object(...)
   self.queue = Queue()

--- a/CorsixTH/Lua/objects/doors/entrance_right_door.lua
+++ b/CorsixTH/Lua/objects/doors/entrance_right_door.lua
@@ -33,6 +33,9 @@ object.supports_creation_for_map = true
 
 class "EntranceDoor" (Object)
 
+---@type EntranceDoor
+local EntranceDoor = _G["EntranceDoor"]
+
 function EntranceDoor:EntranceDoor(world, object_type, x, y, direction, etc)
   self.is_master = object_type == object
   self:Object(world, object_type, x, y, direction, etc)

--- a/CorsixTH/Lua/objects/doors/swing_door_right.lua
+++ b/CorsixTH/Lua/objects/doors/swing_door_right.lua
@@ -32,6 +32,9 @@ object.idle_animations = {
 
 class "SwingDoor" (Door)
 
+---@type SwingDoor
+local SwingDoor = _G["SwingDoor"]
+
 function SwingDoor:SwingDoor(world, object_type, x, y, direction, etc)
   self.is_master = object_type == object
   self:Door(world, object_type, x, y, direction, etc)

--- a/CorsixTH/Lua/objects/helicopter.lua
+++ b/CorsixTH/Lua/objects/helicopter.lua
@@ -37,6 +37,9 @@ object.orientations = {
 --! An `Object` which drops of emergency patients.
 class "Helicopter" (Object)
 
+---@type Helicopter
+local Helicopter = _G["Helicopter"]
+
 function Helicopter:Helicopter(world, object_type, hospital, direction, etc)
   local x, y = hospital:getHeliportPosition()
   self:Object(world, object_type, x, y, direction, etc)

--- a/CorsixTH/Lua/objects/litter.lua
+++ b/CorsixTH/Lua/objects/litter.lua
@@ -50,6 +50,9 @@ litter_types[4] = 1900
 
 class "Litter" (Entity)
 
+---@type Litter
+local Litter = _G["Litter"]
+
 function Litter:Litter(world, object_type, x, y, direction, etc)
   local th = TH.animation()
   self:Entity(th)

--- a/CorsixTH/Lua/objects/machines/operating_table.lua
+++ b/CorsixTH/Lua/objects/machines/operating_table.lua
@@ -115,6 +115,10 @@ object.orientations = {
 }
 
 class "OperatingTable" (Machine)
+
+---@type OperatingTable
+local OperatingTable = _G["OperatingTable"]
+
 OperatingTable:slaveMixinClass()
 
 function OperatingTable:machineUsed(...)

--- a/CorsixTH/Lua/objects/op_sink1.lua
+++ b/CorsixTH/Lua/objects/op_sink1.lua
@@ -64,6 +64,10 @@ object.orientations = {
 }
 
 class "OperatingSink" (Object)
+
+---@type OperatingSink
+local OperatingSink = _G["OperatingSink"]
+
 OperatingSink:slaveMixinClass()
 
 return object

--- a/CorsixTH/Lua/objects/plant.lua
+++ b/CorsixTH/Lua/objects/plant.lua
@@ -84,6 +84,9 @@ local days_unreachable = 10
 --! An `Object` which needs watering now and then.
 class "Plant" (Object)
 
+---@type Plant
+local Plant = _G["Plant"]
+
 function Plant:Plant(world, object_type, x, y, direction, etc)
   -- It doesn't matter which direction the plant is facing. It will be rotated so that an approaching
   -- handyman uses the correct usage animation when appropriate.

--- a/CorsixTH/Lua/objects/radiation_shield.lua
+++ b/CorsixTH/Lua/objects/radiation_shield.lua
@@ -71,6 +71,10 @@ object.orientations = {
 }
 
 class "RadiationShield" (Object)
+
+---@type RadiationShield
+local RadiationShield = _G["RadiationShield"]
+
 RadiationShield:slaveMixinClass()
 
 return object

--- a/CorsixTH/Lua/objects/reception_desk.lua
+++ b/CorsixTH/Lua/objects/reception_desk.lua
@@ -70,6 +70,9 @@ dofile "queue"
 
 class "ReceptionDesk" (Object)
 
+---@type ReceptionDesk
+local ReceptionDesk = _G["ReceptionDesk"]
+
 function ReceptionDesk:ReceptionDesk(...)
   self:Object(...)
   self.queue = Queue()

--- a/CorsixTH/Lua/objects/surgeon_screen.lua
+++ b/CorsixTH/Lua/objects/surgeon_screen.lua
@@ -39,6 +39,10 @@ object.orientations = {
 }
 
 class "SurgeonScreen" (Object)
+
+---@type SurgeonScreen
+local SurgeonScreen = _G["SurgeonScreen"]
+
 function SurgeonScreen:SurgeonScreen(...)
   self:Object(...)
   self.num_green_outfits = 2

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -30,6 +30,9 @@ SOFTWARE. --]]
 -- a queue via its methods rather than directly.
 class "Queue"
 
+---@type Queue
+local Queue = _G["Queue"]
+
 function Queue:Queue()
   self.reported_size = 0
   self.expected = {}

--- a/CorsixTH/Lua/research_department.lua
+++ b/CorsixTH/Lua/research_department.lua
@@ -31,6 +31,9 @@ stored for future use anyway.
 --! Manages all things related to research for one hospital.
 class "ResearchDepartment"
 
+---@type ResearchDepartment
+local ResearchDepartment = _G["ResearchDepartment"]
+
 function ResearchDepartment:ResearchDepartment(hospital)
   self.hospital = hospital
   self.world = hospital.world

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -22,6 +22,9 @@ local TH = require "TH"
 
 class "Room"
 
+---@type Room
+local Room = _G["Room"]
+
 function Room:Room(x, y, w, h, id, room_info, world, hospital, door, door2)
   self.id = id
   self.world = world

--- a/CorsixTH/Lua/rooms/blood_machine_room.lua
+++ b/CorsixTH/Lua/rooms/blood_machine_room.lua
@@ -43,6 +43,9 @@ room.handyman_call_sound = "maint015.wav"
 
 class "BloodMachineRoom" (Room)
 
+---@type BloodMachineRoom
+local BloodMachineRoom = _G["BloodMachineRoom"]
+
 function BloodMachineRoom:BloodMachineRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/cardiogram.lua
+++ b/CorsixTH/Lua/rooms/cardiogram.lua
@@ -43,6 +43,9 @@ room.handyman_call_sound = "maint010.wav"
 
 class "CardiogramRoom" (Room)
 
+---@type CardiogramRoom
+local CardiogramRoom = _G["CardiogramRoom"]
+
 function CardiogramRoom:CardiogramRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/decontamination.lua
+++ b/CorsixTH/Lua/rooms/decontamination.lua
@@ -43,6 +43,9 @@ room.handyman_call_sound = "maint012.wav"
 
 class "DecontaminationRoom" (Room)
 
+---@type DecontaminationRoom
+local DecontaminationRoom = _G["DecontaminationRoom"]
+
 function DecontaminationRoom:DecontaminationRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/dna_fixer.lua
+++ b/CorsixTH/Lua/rooms/dna_fixer.lua
@@ -44,6 +44,9 @@ room.handyman_call_sound = "maint006.wav"
 
 class "DNAFixerRoom" (Room)
 
+---@type DNAFixerRoom
+local DNAFixerRoom = _G["DNAFixerRoom"]
+
 function DNAFixerRoom:DNAFixerRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/electrolysis.lua
+++ b/CorsixTH/Lua/rooms/electrolysis.lua
@@ -43,6 +43,9 @@ room.handyman_call_sound = "maint008.wav"
 
 class "ElectrolysisRoom" (Room)
 
+---@type ElectrolysisRoom
+local ElectrolysisRoom = _G["ElectrolysisRoom"]
+
 function ElectrolysisRoom:ElectrolysisRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/fracture_clinic.lua
+++ b/CorsixTH/Lua/rooms/fracture_clinic.lua
@@ -43,6 +43,9 @@ room.handyman_call_sound = "maint014.wav"
 
 class "FractureRoom" (Room)
 
+---@type FractureRoom
+local FractureRoom = _G["FractureRoom"]
+
 function FractureRoom:FractureRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/general_diag.lua
+++ b/CorsixTH/Lua/rooms/general_diag.lua
@@ -42,6 +42,9 @@ room.call_sound = "reqd021.wav"
 
 class "GeneralDiagRoom" (Room)
 
+---@type GeneralDiagRoom
+local GeneralDiagRoom = _G["GeneralDiagRoom"]
+
 function GeneralDiagRoom:GeneralDiagRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/gp.lua
+++ b/CorsixTH/Lua/rooms/gp.lua
@@ -42,6 +42,9 @@ room.call_sound = "reqd008.wav"
 
 class "GPRoom" (Room)
 
+---@type GPRoom
+local GPRoom = _G["GPRoom"]
+
 function GPRoom:GPRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/hair_restoration.lua
+++ b/CorsixTH/Lua/rooms/hair_restoration.lua
@@ -43,6 +43,9 @@ room.handyman_call_sound = "maint007.wav"
 
 class "HairRestorationRoom" (Room)
 
+---@type HairRestorationRoom
+local HairRestorationRoom = _G["HairRestorationRoom"]
+
 function HairRestorationRoom:HairRestorationRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/inflation.lua
+++ b/CorsixTH/Lua/rooms/inflation.lua
@@ -43,6 +43,9 @@ room.handyman_call_sound = "maint013.wav"
 
 class "InflationRoom" (Room)
 
+---@type InflationRoom
+local InflationRoom = _G["InflationRoom"]
+
 function InflationRoom:InflationRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/jelly_vat.lua
+++ b/CorsixTH/Lua/rooms/jelly_vat.lua
@@ -43,6 +43,9 @@ room.handyman_call_sound = "maint009.wav"
 
 class "JellyVatRoom" (Room)
 
+---@type JellyVatRoom
+local JellyVatRoom = _G["JellyVatRoom"]
+
 function JellyVatRoom:JellyVatRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/operating_theatre.lua
+++ b/CorsixTH/Lua/rooms/operating_theatre.lua
@@ -49,6 +49,9 @@ room.call_sound = "reqd010.wav" -- TODO: There is also an unused sound
 
 class "OperatingTheatreRoom" (Room)
 
+---@type OperatingTheatreRoom
+local OperatingTheatreRoom = _G["OperatingTheatreRoom"]
+
 function OperatingTheatreRoom:OperatingTheatreRoom(...)
   self:Room(...)
   self.staff_member_set = {}

--- a/CorsixTH/Lua/rooms/pharmacy.lua
+++ b/CorsixTH/Lua/rooms/pharmacy.lua
@@ -42,6 +42,9 @@ room.call_sound = "reqd012.wav"
 
 class "PharmacyRoom" (Room)
 
+---@type PharmacyRoom
+local PharmacyRoom = _G["PharmacyRoom"]
+
 function PharmacyRoom:PharmacyRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/psych.lua
+++ b/CorsixTH/Lua/rooms/psych.lua
@@ -43,6 +43,9 @@ room.call_sound = "reqd003.wav"
 
 class "PsychRoom" (Room)
 
+---@type PsychRoom
+local PsychRoom = _G["PsychRoom"]
+
 function PsychRoom:PsychRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/research.lua
+++ b/CorsixTH/Lua/rooms/research.lua
@@ -49,6 +49,9 @@ room.call_sound = "reqd023.wav"
 
 class "ResearchRoom" (Room)
 
+---@type ResearchRoom
+local ResearchRoom = _G["ResearchRoom"]
+
 function ResearchRoom:ResearchRoom(...)
   self:Room(...)
   self.staff_member_set = {}

--- a/CorsixTH/Lua/rooms/scanner_room.lua
+++ b/CorsixTH/Lua/rooms/scanner_room.lua
@@ -45,6 +45,9 @@ room.call_sound = "reqd002.wav"
 
 class "ScannerRoom" (Room)
 
+---@type ScannerRoom
+local ScannerRoom = _G["ScannerRoom"]
+
 function ScannerRoom:ScannerRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/slack_tongue.lua
+++ b/CorsixTH/Lua/rooms/slack_tongue.lua
@@ -43,6 +43,9 @@ room.handyman_call_sound = "maint004.wav"
 
 class "SlackTongueRoom" (Room)
 
+---@type SlackTongueRoom
+local SlackTongueRoom = _G["SlackTongueRoom"]
+
 function SlackTongueRoom:SlackTongueRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/staff_room.lua
+++ b/CorsixTH/Lua/rooms/staff_room.lua
@@ -38,6 +38,9 @@ room.has_no_queue_dialog = true
 
 class "StaffRoom" (Room)
 
+---@type StaffRoom
+local StaffRoom = _G["StaffRoom"]
+
 function StaffRoom:StaffRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/toilets.lua
+++ b/CorsixTH/Lua/rooms/toilets.lua
@@ -37,6 +37,9 @@ room.floor_tile = 21
 
 class "ToiletRoom" (Room)
 
+---@type ToiletRoom
+local ToiletRoom = _G["ToiletRoom"]
+
 room.free_loos = 0
 
 function ToiletRoom:ToiletRoom(...)

--- a/CorsixTH/Lua/rooms/training.lua
+++ b/CorsixTH/Lua/rooms/training.lua
@@ -38,6 +38,9 @@ room.has_no_queue_dialog = true
 
 class "TrainingRoom" (Room)
 
+---@type TrainingRoom
+local TrainingRoom = _G["TrainingRoom"]
+
 function TrainingRoom:TrainingRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/ultrascan.lua
+++ b/CorsixTH/Lua/rooms/ultrascan.lua
@@ -43,6 +43,9 @@ room.handyman_call_sound = "maint016.wav"
 
 class "UltrascanRoom" (Room)
 
+---@type UltrascanRoom
+local UltrascanRoom = _G["UltrascanRoom"]
+
 function UltrascanRoom:UltrascanRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/rooms/ward.lua
+++ b/CorsixTH/Lua/rooms/ward.lua
@@ -50,6 +50,9 @@ room.call_sound = "reqd009.wav"
 
 class "WardRoom" (Room)
 
+---@type WardRoom
+local WardRoom = _G["WardRoom"]
+
 function WardRoom:WardRoom(...)
   self:Room(...)
   self.staff_member_set = {}

--- a/CorsixTH/Lua/rooms/x_ray_room.lua
+++ b/CorsixTH/Lua/rooms/x_ray_room.lua
@@ -43,6 +43,9 @@ room.handyman_call_sound = "maint005.wav"
 
 class "XRayRoom" (Room)
 
+---@type XRayRoom
+local XRayRoom = _G["XRayRoom"]
+
 function XRayRoom:XRayRoom(...)
   self:Room(...)
 end

--- a/CorsixTH/Lua/staff_profile.lua
+++ b/CorsixTH/Lua/staff_profile.lua
@@ -20,6 +20,9 @@ SOFTWARE. --]]
 
 class "StaffProfile"
 
+---@type StaffProfile
+local StaffProfile = _G["StaffProfile"]
+
 function StaffProfile:StaffProfile(world, humanoid_class, local_string)
   self.world = world
   self.humanoid_class = humanoid_class

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -28,6 +28,9 @@ local rawset, rawget
 --! Layer which handles the loading of localised text.
 class "Strings"
 
+---@type Strings
+local Strings = _G["Strings"]
+
 function Strings:Strings(app)
   self.app = app
 end

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -23,6 +23,9 @@ dofile "window"
 --! Top-level container for all other user-interface components.
 class "UI" (Window)
 
+---@type UI
+local UI = _G["UI"]
+
 local TH = require "TH"
 local WM = require "sdl".wm
 local SDL = require "sdl"

--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -23,6 +23,9 @@ dofile "persistance"
 --! Base class for user-interface dialogs.
 class "Window"
 
+---@type Window
+local Window = _G["Window"]
+
 -- NB: pressed mouse buttons are denoted with a "mouse_" prefix in buttons_down,
 -- i.e. mouse_left, mouse_middle, mouse_right
 Window.buttons_down = permanent"Window.buttons_down" {}
@@ -132,6 +135,9 @@ end
 -- them and hit-testing against them) are implemented in the `Window` class,
 -- thus reducing the amount of work that each individual dialog has to do.
 class "Panel"
+
+---@type Panel
+local Panel = _G["Panel"]
 
 -- !dummy
 function Panel:Panel()
@@ -512,6 +518,9 @@ end
 --! A region of a `Panel` which causes some action when clicked.
 class "Button"
 
+---@type Button
+local Button = _G["Button"]
+
 --!dummy
 function Button:Button()
   self.ui = nil
@@ -730,6 +739,9 @@ end
 --! A window element used to scroll in lists
 class "Scrollbar"
 
+---@type Scrollbar
+local Scrollbar = _G["Scrollbar"]
+
 --!dummy
 function Scrollbar:Scrollbar()
   self.base = nil
@@ -835,6 +847,9 @@ end
 
 --! A window element used to enter text
 class "Textbox"
+
+---@type Textbox
+local Textbox = _G["Textbox"]
 
 --!dummy
 function Textbox:Textbox()

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -38,6 +38,9 @@ dofile "entity_map"
 --! Manages entities, rooms, and the date.
 class "World"
 
+---@type World
+local World = _G["World"]
+
 local local_criteria_variable = {
   {name = "reputation",       icon = 10, formats = 2},
   {name = "balance",          icon = 11, formats = 2},

--- a/scripts/check_lua_classes.py
+++ b/scripts/check_lua_classes.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python
+
+import fileinput
+import os
+import re
+import sys
+
+#This regex can't find all class declaration mistakes and only checks the first few lines:
+#Regex: ^class "(.+)".*\n\n(?!---@type \1\nlocal \1 = _G\["\1"])
+regex = r"^class \"(.+)\".*\n\n(?!---@type \1\nlocal \1 = _G\[\"\1\"])"
+
+print_root_regex = re.compile("Lua.*") 
+script_dir = os.getcwd() + "/../CorsixTH/Lua"
+ignored = os.listdir(script_dir + "/languages")
+problem_found = False
+for root, _, files in os.walk(script_dir):
+  for script in files:
+    if script.endswith(".lua") and script not in ignored:
+      script_string = open(root + "/" + script, 'r').read()
+      for found_class in re.findall(regex, script_string, re.MULTILINE):
+        if not problem_found:
+          print("******* CHECK CLASS DECLARATIONS *******")
+          problem_found = True
+          print("Invalid/Improper Class Declarations Found:")
+        print("*" + print_root_regex.search(root).group(0) + "\\" + script + ":" + found_class)
+
+if problem_found:
+  print("\nReason: The class declaration(s) didn't begin as follows:")
+  print("")
+  print("class \"Name\" / class \"Name\" (Parent)")
+  print("")
+  print("---@type Name")
+  print("local Name = _G[\"Name\"]")
+  print("-----------------------------------------\n")
+  sys.exit(1)
+  
+sys.exit(0)


### PR DESCRIPTION
![Screenshot](https://www.mediafire.com/convkey/f7b6/640uyqd2lcd856p6g.jpg)

For issue: #400

I've carefully double checked all of my class script changes to make sure there's no mistakes.

I've also created a build test script for Lua classes to check that:
* A class can have its methods outlined by Eclipse's LDT plugin.
* Mistakes haven't been made in a class's first statements which
would prevent its methods from being declared.

This is the regular expression this test script uses:
``` 
^class "(.+)".*\n\n(?!---@type \1\nlocal \1 = _G\["\1"])
```

It can be tested with this: http://www.pythonregex.com/ (Enable "Multi line")

Test code you could copy & paste into this web tool and/or debug_script.lua: the regex shouldn't find any problems with these class declaration statements:
```
class "Car" (Vehicle)

---@type Car
local Car = _G["Car"]


class "Person"

---@type Person
local Person = _G["Person"]
```