### PR TITLE
Remove outdated LuaJIT 64bit check

### DIFF
--- a/CorsixTH/Src/main.cpp
+++ b/CorsixTH/Src/main.cpp
@@ -89,11 +89,6 @@ int CorsixTH_lua_main_no_eval(lua_State *L)
         lua_getglobal(L, "print");
         lua_pushliteral(L, "Notice: LuaJIT not being used.\nConsider replacing"
             " Lua with LuaJIT to improve performance.");
-#ifdef CORSIX_TH_64BIT
-        lua_pushliteral(L, " Note that there is not currently a 64 bit version"
-            " of LuaJIT.");
-        lua_concat(L, 2);
-#endif
         lua_call(L, 1, 0);
     }
     else


### PR DESCRIPTION
Removed an outdated check for LuaJIT 64bit which states that a 64bit version is not available. This is no longer true as a 64bit version of LuaJIT is now available. This fixes #432.
