### PR TITLE
Added support for Lua DBGp Debugging such as Eclipse debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ CorsixTH/*.suo
 LevelEdit/bin/
 
 CorsixTH/Lua/debug_script.lua
+CorsixTH/Lua/debugger.lua

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -25,6 +25,7 @@ local TH = require "TH"
 local SDL = require "sdl"
 local assert, io, type, dofile, loadfile, pcall, tonumber, print, setmetatable
     = assert, io, type, dofile, loadfile, pcall, tonumber, print, setmetatable
+local runDebugger = dofile "run_debugger"
 
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
@@ -63,6 +64,12 @@ function App:App()
   self.strings = {}
   self.savegame_version = SAVEGAME_VERSION
   self.check_for_updates = true
+end
+
+--! Starts a Lua DBGp client & connects it to a DBGp server.
+--!return error_message (String) Returns an error message or nil.
+function App:connectDebugger()
+  return runDebugger()
 end
 
 function App:setCommandLine(...)
@@ -1324,6 +1331,8 @@ function App:checkForUpdates()
     -- LuaSocket is not available, just return
     print "Cannot check for updates since LuaSocket is not available."
     return
+  else
+    self.lua_socket_available = true
   end
   local http = require "socket.http"
   local url = require "socket.url"

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -121,6 +121,12 @@ local config_defaults = {
   audio_buffer_size = 2048,
   theme_hospital_install = [[F:\ThemeHospital\hospital]],
   debug = false,
+  DBGp_client_idehost = nil,
+  DBGp_client_ideport = nil,
+  DBGp_client_idekey = nil,
+  DBGp_client_transport = nil,
+  DBGp_client_platform = nil,
+  DBGp_client_workingdir = nil,
   track_fps = false,
   zoom_speed = 80,
   scroll_speed = 2,
@@ -421,6 +427,18 @@ audio_mp3 = nil -- [[X:\ThemeHospital\Music]]
 -- and a debug menu will be visible.
 -- ]=] .. '\n' ..
 'debug = ' .. tostring(config_values.debug) .. '\n' .. [=[
+
+--Optional settings for CorsixTH's Lua DBGp client.
+--Default settings are nil values, platform & workingdir will be autodected if nil.
+--https://wiki.eclipse.org/LDT/User_Area/User_Guides/User_Guide_1.2#Attach_session
+-- ]=] .. '\n' ..
+'idehost = ' .. tostring(config_values.DBGp_client_idehost) .. '\n' ..
+'ideport = ' .. tostring(config_values.DBGp_client_ideport) .. '\n' ..
+'idekey = ' .. tostring(config_values.DBGp_client_idekey) .. '\n' ..
+'transport = ' .. tostring(config_values.DBGp_client_transport) .. '\n' ..
+'platform = ' .. tostring(config_values.DBGp_platform) .. '\n' ..
+'workingdir = ' .. tostring(config_values.DBGp_workingdir) .. '\n' .. [=[
+
 -- If set to true, the FPS, Lua memory usage, and entity count will be shown
 -- in the dynamic information bar. Note that setting this to true also turns
 -- off the FPS limiter, causing much higher CPU utilisation, but resulting in

--- a/CorsixTH/Lua/debug_script.lua
+++ b/CorsixTH/Lua/debug_script.lua
@@ -1,6 +1,10 @@
 ---
 -- Calling "execute script" while CorsixTH is running will execute the latest
 -- code in this script so you don't need to restart CorsixTH.
+-- 
+-- This script's execution key command and the key commands for the debug console 
+-- & connecting a Lua DBGp server can be used anywhere at any time in CorsixTH 
+-- when debug mode is enabled.
 --
 -- Like with the console you can reference clicked humanoids with the underscore
 -- global variable so for example: _:die() will make a clicked patient die.

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -728,6 +728,7 @@ function UIMenuBar:makeMenu(app)
   if self.ui.app.config.debug then
     self:addMenu(_S.menu.debug, UIMenu() -- Debug
       :appendMenu(_S.menu_debug.jump_to_level, levels_menu)
+      :appendItem(_S.menu_debug.connect_debugger, function() self.ui:connectDebugger() end)
       :appendCheckItem(_S.menu_debug.limit_camera,         true, limit_camera, nil, function() return self.ui.limit_to_visible_diamond end)
       :appendCheckItem(_S.menu_debug.disable_salary_raise, false, disable_salary_raise, nil, function() return self.ui.app.world.debug_disable_salary_raise end)
       :appendItem(_S.menu_debug.make_debug_fax,     function() self.ui:makeDebugFax() end)

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -129,6 +129,7 @@ menu_charts = {
 
 menu_debug = {
   jump_to_level               = "  JUMP TO LEVEL  ",
+  connect_debugger            = "  (CTRL + C) CONNECT LUA DBGp SERVER  ",
   transparent_walls           = "  (X) TRANSPARENT WALLS  ",
   limit_camera                = "  LIMIT CAMERA  ",
   disable_salary_raise        = "  DISABLE SALARY RAISE  ",

--- a/CorsixTH/Lua/run_debugger.lua
+++ b/CorsixTH/Lua/run_debugger.lua
@@ -1,0 +1,37 @@
+---
+-- This script is responsible for starting a DBGp client for CorsixTH's
+-- Lua scripts and then connecting this to a running DBGp server.
+-- 
+-- It does this in the function it returns.
+---
+local function run()
+  local error_message = is_file_unreadable("CorsixTH/Lua/debugger.lua", true)
+  if error_message  then
+    print(error_message)
+    return "../Lua/debugger.lua is missing or can't be read. Devs are required to download this file: the wiki debugger tutorial has instructions."
+  end
+  
+  print "NOTE: While CorsixTH is connected to an IDE's debugger server,"
+  print "text will be printed in its output console instead of here."
+  
+  if not pcall(require, "socket") then
+    print("Can't connect debugger: LuaSocket is not available.")
+    return "Can't connect debugger: LuaSocket is not available."
+  end
+  
+  local _, config = dofile("config_finder")
+  local connect = dofile("debugger")
+  
+  local successful, error_message = pcall(connect, config.DBGp_client_idehost,
+                                                   config.DBGp_client_ideport,
+                                                   config.DBGp_client_idekey,
+                                                   config.DBGp_client_transport,
+                                                   config.DBGp_client_platform,
+                                                   config.DBGp_client_workingdir)
+  if not successful then
+    print("\nCan't connect DBGp client:\n" .. error_message .. "\n")
+    return "Failed to connect debugger, error printed in console."
+  end
+end
+return run
+

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -235,9 +235,13 @@ function UI:setupGlobalKeyHandlers()
   self:addKeyHandler({"alt", "f4"}, self, self.exitApplication)
   self:addKeyHandler({"shift", "f10"}, self, self.resetApp)
 
-  if self.app.config.debug then
-    self:addKeyHandler("f12", self, self.showLuaConsole)
-    self:addKeyHandler({"shift", "d"}, self, self.runDebugScript)
+  self:addOrRemoveDebugModeKeyHandlers()
+end
+
+function UI:connectDebugger()
+  local error_message = TheApp:connectDebugger()
+  if error_message then
+    self.ui:addWindow(UIInformation(self.ui, {error_message}))
   end
 end
 
@@ -759,9 +763,11 @@ function UI:getCursorPosition(window)
 end
 
 function UI:addOrRemoveDebugModeKeyHandlers()
+  self:removeKeyHandler({"ctrl", "c"}, self)
   self:removeKeyHandler("f12", self)
   self:removeKeyHandler({"shift", "d"}, self)
   if self.app.config.debug then
+    self:addKeyHandler({"ctrl", "c"}, self, self.connectDebugger)
     self:addKeyHandler("f12", self, self.showLuaConsole)
     self:addKeyHandler({"shift", "d"}, self, self.runDebugScript)
   end

--- a/CorsixTH/Lua/utility.lua
+++ b/CorsixTH/Lua/utility.lua
@@ -112,6 +112,24 @@ function table_length(table)
   return count
 end
 
+--! Checks if a file exists and is readable.
+--!param path (string)
+--!param root_path (boolean) Optional, default: false. If true the file's path
+-- will be appended to the CorsixTH root directory's path. 
+--!return (String) Returns an error message for the file read error or nil.
+function is_file_unreadable(path, root_path)
+  if root_path then
+    local root_dir = debug.getinfo(1, "S").source:sub(2, -26) .. package.config:sub(1, 1)
+    path = root_dir .. path
+  end
+  local file, error_message = io.open(path, "r")
+  if file then
+    io.close(file)
+  else
+    return error_message
+  end
+end
+
 -- Variation on loadfile() which allows for the loaded file to have global
 -- references resolved in supplied tables. On failure, returns nil and an
 -- error. On success, returns the file as a function just like loadfile() does

--- a/README.txt
+++ b/README.txt
@@ -37,7 +37,17 @@ Briefly:
     http://forums.corsixth.com/
     http://groups.google.com/group/corsix-th-dev
     #corsix-th on FreeNode (IRC)
-   
+
+------------------------------------------------------------------------------
+-- CorsixTH.exe Optional Startup Arguments
+------------------------------------------------------------------------------
+
+--connect-lua-dbgp : Before App.lua is executed connect a Lua DBGp client & to a Lua DBGp server.
+--interpreter=... : loadfile(...) instead of CorsixTH.lua.
+--config-file=... : Makes CorsixTH use the specified config file.
+--bitmap-dir=... : Makes CorsixTH use the specified bitmap directory.
+--lua-dir= : Makes CorsixTH use the specified Lua scripts directory.
+
 ------------------------------------------------------------------------------
 -- Contact Details
 ------------------------------------------------------------------------------


### PR DESCRIPTION
For issue: #346

To support this CorsixTH simply needs to have "debugger.lua" and a
"dofile('debugger')()" call to it.

This is a 3rd party Lua script and therefore won't be distributed
with CorsixTH, so developers will have to download it into their
Lua directory when setting up a computer for CorsixTH Lua DBGp
debugging.

I've made a new function for the call "dofile('debugger')()":
App:connectDebugger().

I've created a new main menu button to call connectDebugger() which
will only be in the main menu when config.debug = true. I've also
added a connectDebugger() command to the debug menu.

https://wiki.eclipse.org/LDT/User_Area/User_Guides/User_Guide_1.2#Attach_session