### PR TITLE
Fix 32bpp pixel access

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -551,7 +551,7 @@ protected:
         //! SDL structure containing the sprite with alternative palette.
         SDL_Texture *pAltTexture;
 
-        //! Data of the sprite (width * height bytes).
+        //! Data of the sprite.
         unsigned char *pData;
 
         //! Alternative palette (if available).


### PR DESCRIPTION
32bpp image data is not  width \* height \* 4bytes, you have to decode it.
(function is sort-of a copy of a draw-sprite function)

This probably never failed because the legacy 8bpp -> 32bpp conversion is kind of stupid, so you always have enough data to pretend pData[y*width + x] works.
