### PR TITLE
Harmonize all language files to be encoded in UTF-8 without BOM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ before_script:
 script:
   # Check if there are trailing whitespaces.
   - ${TRAVIS_BUILD_DIR}/scripts/check_trailing_whitespaces.py $TRAVIS_BUILD_DIR
+  # Check for incorrectly encoded language files.
+  - python ${TRAVIS_BUILD_DIR}/scripts/check_language_files_not_BOM.py $TRAVIS_BUILD_DIR/CorsixTH/Lua/languages
   # Build CorsixTH
   - make
   # Validate lua files

--- a/CorsixTH/Lua/languages/danish.lua
+++ b/CorsixTH/Lua/languages/danish.lua
@@ -1,4 +1,4 @@
-﻿--[[
+--[[
 Copyright (c) 2010 Robin Madsen (RobseRob)
 Copyright (c) 2010-2011 Ole Frandsen (Froksen)
 Copyright (c) 2011 Rene Bergfort (Kleeze)

--- a/CorsixTH/Lua/languages/dutch.lua
+++ b/CorsixTH/Lua/languages/dutch.lua
@@ -1,4 +1,4 @@
-﻿--[[ Copyright (c) 2010 RAS
+--[[ Copyright (c) 2010 RAS
                    2011 FlyingBastard, L_konings, Nossah, KasperVld
                    2012-2013 Omni, Maarten
 

--- a/CorsixTH/Lua/languages/french.lua
+++ b/CorsixTH/Lua/languages/french.lua
@@ -1,4 +1,4 @@
-﻿--[[ Copyright (c) 2010-2011 Nicolas "MeV" Elie
+--[[ Copyright (c) 2010-2011 Nicolas "MeV" Elie
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/CorsixTH/Lua/languages/iberic_portuguese.lua
+++ b/CorsixTH/Lua/languages/iberic_portuguese.lua
@@ -1,4 +1,4 @@
-﻿--[[ Copyright (c) 2010 Manuel "Roujin" Wolf, "Fabiomsouto"
+--[[ Copyright (c) 2010 Manuel "Roujin" Wolf, "Fabiomsouto"
 Copyright (c) 2011 Sérgio "Get_It" Ribeiro
 Copyright (c) 2012 <Filipe "Aka" Carvalho>
 

--- a/CorsixTH/Lua/languages/korean.lua
+++ b/CorsixTH/Lua/languages/korean.lua
@@ -1,4 +1,4 @@
-﻿--[[ Copyright (c) 2013 nullstein
+--[[ Copyright (c) 2013 nullstein
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/CorsixTH/Lua/languages/polish.lua
+++ b/CorsixTH/Lua/languages/polish.lua
@@ -1,4 +1,4 @@
-﻿--[[
+--[[
 Copyright (c) 2013 - translation -  BuTcHeR (extragry.pl)
 
 The study, diagnosis and surgery on the translation performed by:

--- a/scripts/check_language_files_not_BOM.py
+++ b/scripts/check_language_files_not_BOM.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+"""
+  Usage: check_language_files_not_BOM.py [root]
+  This script will check the presence of language files encoded in UTF-8 with BOM.
+  It will return 0 if none is found. Otherwise, it will print the
+  path of the violating files and return an error code.
+  If root is not specified, it will use the current directory.
+"""
+
+import codecs
+import os
+import sys
+
+def is_BOM_encoded_file(path):
+  """ Returns whether |path| is a file that is encoded in UTF-8 with BOM. """
+  with open(path, 'rb') as f:
+    raw = f.read(4)
+    return raw.startswith(codecs.BOM_UTF8)
+
+if (len(sys.argv) > 2):
+  sys.exit('Usage: ' + sys.argv[0] + ' [root]')
+
+top = os.getcwd()
+if len(sys.argv) == 2:
+  top += '/' + sys.argv[1]
+
+offending_files = []
+for root, dirs, files in os.walk(top):
+  for f in files:
+    if f.endswith('.lua'):
+         path = root + '/' + f
+         if is_BOM_encoded_file(path):
+           offending_files.append(f)
+
+if offending_files:
+  sys.exit('Found files with UTF-8 with BOM encoding: ' + str(offending_files))
+sys.exit(0)


### PR DESCRIPTION
Since most of our language files are encoded in UTF-8 without BOM we could as well do that for all of them. Expecially since Eclipse doesn't like files with BOM.
