### PR TITLE
Fixed small spelling mistake in the update checker

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1334,7 +1334,7 @@ function App:checkForUpdates()
     end
   end
   if not valid_url then
-    print ("Update download url is not on the trusted domains list (" .. updateTable["download_url"] .. ")")
+    print ("Update download url is not on the trusted domains list (" .. update_table["download_url"] .. ")")
     return
   end
 


### PR DESCRIPTION
While updating the "update checker latest version" on our web page I noticed that there was a small error in the code. This part is usually only run if someone is trying to do a middle-man attack, which is probably why we haven't noticed the error before.