### PR TITLE
Fixed th_sound:getSoundDuration(index) crash error:#588

### DIFF
--- a/CorsixTH/Src/th_sound.cpp
+++ b/CorsixTH/Src/th_sound.cpp
@@ -125,9 +125,11 @@ size_t THSoundArchive::getSoundDuration(size_t iIndex)
                 break;
             iChunkLength -= 16;
         }
+        //Finally:
         if(iFourCC == FOURCC('d','a','t','a'))
         {
             iWaveDataLength = iChunkLength;
+            break;
         }
         if(SDL_RWseek(pFile, iChunkLength + (iChunkLength & 1), SEEK_CUR) == -1)
             break;


### PR DESCRIPTION
This function's loop for parsing a WAV file would crash CorsixTH by
getting stuck in an infinite loop because this loop has no end condition
and none of its break statements were executed.

Each language TH supports has its own sound effects stored in
SOUND-X.dat. This error would occur for LAVA004.WAV (182) in:
*SOUND-1.dat (CD distribution)
*SOUND-5.dat (gog.com TH distribution)

I've simply inserted a break statement after this loop's variable
assignment statement for the last duration calculation variable it
parses.

I've tested this with the SOUND-5.dat from the gog.com distribution but
I've not tested this with the SOUND-1.dat from @Sigzegv 's TH CD.