### PR TITLE
Load black_font if it doesn't exist in staff_rise.lua

### DIFF
--- a/CorsixTH/Lua/dialogs/staff_rise.lua
+++ b/CorsixTH/Lua/dialogs/staff_rise.lua
@@ -190,3 +190,9 @@ function UIStaffRise:increaseSalary()
     world:setSpeed(world.prev_speed)
   end
 end
+
+function UIStaffRise:afterLoad(old, new)
+  if not self.black_font then
+    self.black_font = self.ui.app.gfx:loadFont("QData", "Font00V")
+  end
+end


### PR DESCRIPTION
Fixes #605. Old saves did not include that font.