### PR TITLE
Fix crash on screenshot

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -456,6 +456,12 @@ bool THRenderTarget::takeScreenshot(const char* sFile)
     //cannot directly save it.  Instead we have to create a new surface based
     //on the pixel data in the renderer and save that.
     SDL_Surface* pWindowSurface = SDL_GetWindowSurface(m_pWindow);
+    if (pWindowSurface == NULL)
+    {
+        fprintf(stderr, "Unable to take screenshot (pWindowSurface == NULL)\n");
+        return false;
+    }
+
     SDL_Surface* pRgbSurface = NULL;
     int iPitch = pWindowSurface->w * pWindowSurface->format->BitsPerPixel;
     unsigned char* pPixels = new unsigned char[pWindowSurface->h * iPitch];


### PR DESCRIPTION
I pressed CTRL-S expecting to save my game, and it rudely crashed instead.

The reason was that pWindowSurface was NULL.