### PR TITLE
Fix mismatched delete

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -923,7 +923,7 @@ bool THSpriteSheet::loadFromTHFile(const unsigned char* pTableData, size_t iTabl
             oRenderer.decodeChunks(pChunkData + pTHSprite->position, iDataLen, bComplexChunks);
             pData = oRenderer.takeData();
             pSprite->pData = convertLegacySprite(pData, pSprite->iWidth * pSprite->iHeight);
-            delete pData;
+            delete [] pData;
         }
     }
     return true;

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -923,7 +923,7 @@ bool THSpriteSheet::loadFromTHFile(const unsigned char* pTableData, size_t iTabl
             oRenderer.decodeChunks(pChunkData + pTHSprite->position, iDataLen, bComplexChunks);
             pData = oRenderer.takeData();
             pSprite->pData = convertLegacySprite(pData, pSprite->iWidth * pSprite->iHeight);
-            delete [] pData;
+            delete[] pData;
         }
     }
     return true;


### PR DESCRIPTION
```
==15050==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x60200001e1f0
    #0 0x495e41 in operator delete(void*) (/home/pwaller/.local/src/CorsixTH/build/CorsixTH/CorsixTH+0x495e41)
    #1 0x8a7af2 in THSpriteSheet::loadFromTHFile(unsigned char const*, unsigned long, unsigned char const*, unsigned long, bool, THRenderTarget*) /home/pwaller/.local/src/CorsixTH/CorsixTH/Src/th_gfx_sdl.cpp:926
    #2 0x85b901 in l_spritesheet_load(lua_State*) /home/pwaller/.local/src/CorsixTH/CorsixTH/Src/th_lua_gfx.cpp:135
    #3 0x7f0ab4a06a9a (/usr/lib/x86_64-linux-gnu/libluajit-5.1.so.2+0x9a9a)
    #4 0x616114 in CorsixTH_lua_main(lua_State*) /home/pwaller/.local/src/CorsixTH/CorsixTH/Src/main.cpp:192
    #5 0x7f0ab4a06a9a (/usr/lib/x86_64-linux-gnu/libluajit-5.1.so.2+0x9a9a)
    #6 0x7f0ab4a49cff (/usr/lib/x86_64-linux-gnu/libluajit-5.1.so.2+0x4ccff)
    #7 0x4ae94d in main /home/pwaller/.local/src/CorsixTH/CorsixTH/SrcUnshared/main.cpp:85
    #8 0x7f0ab1cccec4 (/lib/x86_64-linux-gnu/libc.so.6+0x21ec4)
    #9 0x4adcdc in _start (/home/pwaller/.local/src/CorsixTH/build/CorsixTH/CorsixTH+0x4adcdc)

0x60200001e1f0 is located 0 bytes inside of 5-byte region [0x60200001e1f0,0x60200001e1f5)
allocated by thread T0 here:
    #0 0x495b11 in operator new[](unsigned long) (/home/pwaller/.local/src/CorsixTH/build/CorsixTH/CorsixTH+0x495b11)
    #1 0x8a6c92 in THSpriteSheet::loadFromTHFile(unsigned char const*, unsigned long, unsigned char const*, unsigned long, bool, THRenderTarget*) /home/pwaller/.local/src/CorsixTH/CorsixTH/Src/th_gfx_sdl.cpp:918
    #2 0x85b901 in l_spritesheet_load(lua_State*) /home/pwaller/.local/src/CorsixTH/CorsixTH/Src/th_lua_gfx.cpp:135
    #3 0x7f0ab4a06a9a (/usr/lib/x86_64-linux-gnu/libluajit-5.1.so.2+0x9a9a)

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch ??:0 operator delete(void*)
```