### PR TITLE
Show SDL_Init failure reason

### DIFF
--- a/CorsixTH/Src/sdl_core.cpp
+++ b/CorsixTH/Src/sdl_core.cpp
@@ -51,6 +51,7 @@ static int l_init(lua_State *L)
     }
     if(SDL_Init(flags) != 0)
     {
+        fprintf(stderr, "SDL_Init failed: %s\n", SDL_GetError());
         lua_pushboolean(L, 0);
         return 1;
     }


### PR DESCRIPTION
When using my own SDL2 build, it was failing and CorsixTH did not show the
reason why.