### PR TITLE
Ignore all folders in the root with names starting with build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ Release/
 MinSizeRel/
 RelWithDebInfo/
 
+# Build folders
+/build*/
+
 # OSX metadata
 .DS_Store
 !LevelEdit/src/com/corsixth/leveledit/*.xcodeproj


### PR DESCRIPTION
This allows using cmake to set up multiple build folders without showing
up in the git status using folder structures like:
```
/build-luajit
/build-libav
```
or
```
/builds/luajit
/builds/libav
```