### PR TITLE
Make patients dress and leave room before being evacuated

### DIFF
--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -524,6 +524,10 @@ end
 --[[ Forces evacuation of the hospital - it makes ALL patients leave and storm out. ]]
 function Epidemic:evacuateHospital()
   for _, patient in ipairs(self.hospital.patients) do
+    local patient_room = patient:getRoom()
+    if patient_room then
+      patient_room:makeHumanoidDressIfNecessaryAndThenLeave(patient)
+    end
     if patient.has_passed_reception then
       patient:clearDynamicInfo()
       patient:setDynamicInfo('text', {_S.dynamic_info.patient.actions.epidemic_sent_home})


### PR DESCRIPTION
Part fix for issue #674. Causes patients who are evacuating to get dressed if necessary and leave the room before evacuating the hospital.