### PR TITLE
Add lpeg.dll, lfs.dll and all luasocket files to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,24 @@ before_install:
   - tar xJf lua-5.1.4-4-mingw32-dll-51.tar.xz -C lua
   - wget http://netcologne.dl.sourceforge.net/project/mingw/MinGW/Extension/lua/lua-5.1.4-4/lua-5.1.4-4-mingw32-dev.tar.xz
   - tar xJf lua-5.1.4-4-mingw32-dev.tar.xz -C lua
+  # Get LuaFileSystem
+  - wget http://github.com/keplerproject/luafilesystem/archive/v_1_6_3.tar.gz
+  - tar xzf v_1_6_3.tar.gz
+  - pushd luafilesystem-v_1_6_3
+  - i686-w64-mingw32-gcc -O2 -c -o src/lfs.o src/lfs.c -I../lua/include
+  - i686-w64-mingw32-gcc -shared -o lfs.dll src/lfs.o ../lua/bin/lua51.dll
+  - popd
+  # Get LPeg
+  - wget http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-0.12.1.tar.gz
+  - tar xzf lpeg-0.12.1.tar.gz
+  - pushd lpeg-0.12.1
+  - i686-w64-mingw32-gcc -std=c99 -O2 -I../lua/include -c -o lpcap.o lpcap.c
+  - i686-w64-mingw32-gcc -std=c99 -O2 -I../lua/include -c -o lpcode.o lpcode.c
+  - i686-w64-mingw32-gcc -std=c99 -O2 -I../lua/include -c -o lpprint.o lpprint.c
+  - i686-w64-mingw32-gcc -std=c99 -O2 -I../lua/include -c -o lptree.o lptree.c
+  - i686-w64-mingw32-gcc -std=c99 -O2 -I../lua/include -c -o lpvm.o lpvm.c
+  - i686-w64-mingw32-gcc -shared -o lpeg.dll lpcap.o lpcode.o lpprint.o lptree.o lpvm.o ../lua/bin/lua51.dll
+  - popd
   - mkdir $TRAVIS_BUILD_DIR/LevelEdit/bin
 install:
   - cd $TRAVIS_BUILD_DIR
@@ -91,6 +109,8 @@ after_success:
   - cp libs/ffmpeg-bin/bin/*.dll fresh/CorsixTH/
   - cp libs/freetype/bin/*.dll fresh/CorsixTH/
   - cp libs/lua/bin/*.dll fresh/CorsixTH/
+  - cp libs/luafilesystem-v_1_6_3/lfs.dll fresh/CorsixTH/
+  - cp libs/lpeg-0.12.1/lpeg.dll fresh/CorsixTH/
   # Copy CTH
   - cd CorsixTH/
   - cp -r * ../fresh/CorsixTH/

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,11 @@ before_install:
   - i686-w64-mingw32-gcc -std=c99 -O2 -I../lua/include -c -o lpvm.o lpvm.c
   - i686-w64-mingw32-gcc -shared -o lpeg.dll lpcap.o lpcode.o lpprint.o lptree.o lpvm.o ../lua/bin/lua51.dll
   - popd
+  - git clone https://github.com/diegonehab/luasocket.git luasocket
+  - pushd luasocket
+  - git checkout 5edf093
+  - make PLAT=mingw LUAINC_mingw=$TRAVIS_BUILD_DIR/libs/lua/include LUALIB_mingw=$TRAVIS_BUILD_DIR/libs/lua/bin/lua51.dll CC_mingw=i686-w64-mingw32-gcc LD_mingw=i686-w64-mingw32-gcc prefix=$TRAVIS_BUILD_DIR/libs/luasocket LUAV=5.1
+  - make PLAT=mingw LUAINC_mingw=$TRAVIS_BUILD_DIR/libs/lua/include LUALIB_mingw=$TRAVIS_BUILD_DIR/libs/lua/bin/lua51.dll CC_mingw=i686-w64-mingw32-gcc LD_mingw=i686-w64-mingw32-gcc prefix=$TRAVIS_BUILD_DIR/libs/luasocket LUAV=5.1 install
   - mkdir $TRAVIS_BUILD_DIR/LevelEdit/bin
 install:
   - cd $TRAVIS_BUILD_DIR
@@ -111,6 +116,7 @@ after_success:
   - cp libs/lua/bin/*.dll fresh/CorsixTH/
   - cp libs/luafilesystem-v_1_6_3/lfs.dll fresh/CorsixTH/
   - cp libs/lpeg-0.12.1/lpeg.dll fresh/CorsixTH/
+  - cp -r libs/luasocket/lua/5.1/* fresh/CorsixTH/
   # Copy CTH
   - cd CorsixTH/
   - cp -r * ../fresh/CorsixTH/


### PR DESCRIPTION
Sadly the makefiles for luafilesytem and lpeg didn't consider cross compiling with mingw so I had to do the compiling myself.  luasockets did have mingw support in it's makefile so I took advantage of it (which is helpful because it has a much more involved compile process).