### PR TITLE
Fix #370 (zoom glitches on some platforms)

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -303,6 +303,7 @@ bool THRenderTarget::setScaleFactor(float fScale, THScaledItems eWhatToScale)
                                            virtWidth,
                                            virtHeight
                                           );
+
         SDL_RenderSetLogicalSize(m_pRenderer, virtWidth, virtHeight);
         if(SDL_SetRenderTarget(m_pRenderer, m_pZoomTexture) != 0)
         {
@@ -310,6 +311,10 @@ bool THRenderTarget::setScaleFactor(float fScale, THScaledItems eWhatToScale)
             m_pZoomTexture = NULL;
             return false;
         }
+
+        // Clear the new texture to transparent/black.
+        SDL_SetRenderDrawColor(m_pRenderer, 0, 0, 0, SDL_ALPHA_TRANSPARENT);
+        SDL_RenderClear(m_pRenderer);
 
         return true;
     }
@@ -509,7 +514,7 @@ void THRenderTarget::_flushZoomBuffer()
 
     SDL_SetRenderTarget(m_pRenderer, NULL);
     SDL_RenderSetScale(m_pRenderer, 1, 1);
-    SDL_SetTextureBlendMode(m_pZoomTexture, SDL_BLENDMODE_NONE);
+    SDL_SetTextureBlendMode(m_pZoomTexture, SDL_BLENDMODE_BLEND);
     SDL_RenderCopy(m_pRenderer, m_pZoomTexture, NULL, NULL);
     SDL_DestroyTexture(m_pZoomTexture);
     m_pZoomTexture = NULL;


### PR DESCRIPTION
The `m_pZoomTexture` was being used as a render target even though
it was uninitialized. This sometimes worked out, depending on your
platform, and other times not.

The fix is to initialize the zoom buffer to transparent and then use
SDL_BLENDMODE_BLEND when it is time to flush the zoom buffer.

Fixes #370

I've played the game briefly and this resolves all of the graphical glitching-making-it-unplayable issues I know of right now.

The only potential downside is that due to the alpha blending, some of the cursors may not look quite pixel perfect. Noticably the red square used to highlight tiles doesn't have quite the right perceived colour (compare it with the red build blueprint):
 
![screenshot from 2015-02-11 02 12 00](https://cloud.githubusercontent.com/assets/438648/6140700/673b5802-b193-11e4-9501-0783eec28f10.png)

compared with the usual unzoomed:

![screenshot from 2015-02-11 02 14 32](https://cloud.githubusercontent.com/assets/438648/6140721/c6906450-b193-11e4-9ba6-41d59f0aea17.png)

.. but this is preferable to the graphics completely breaking :)

--

After spending too much time staring at an OpenGL API trace with [vogl](https://github.com/ValveSoftware/vogl), it's apparent that an uninitialized texture ends up being the render target. Sometimes this coincidentally contains "okay-ish" textures, and other times it contains unaligned junk (whatever happens to be in texture memory).

[I suspect offending code is this `SDL_CreateTexture`](https://github.com/CorsixTH/CorsixTH/blob/c384754bad1fdcb1d9a258e924ebb13fcc8ab61b/CorsixTH/Src/th_gfx_sdl.cpp#L300-L307), where a texture is created and then immediately used as render target.

I've been struggling to think of a decent fix, my first thought was to blank the texture with `fillBlack()`, which works fine until you zoom whilst constructing and then it breaks (everything is black except the cursor). I then tried copying various buffers around but obviously this was slow (and difficult to get correctly aligned). So I went with the alpha-blend trick.