### PR TITLE
[WIP] New debug menu & global key command: Save & Restart CorsixTH

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local assert, io, type, dofile, loadfile, pcall, tonumber, print, setmetatable
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 101
+local SAVEGAME_VERSION = 102
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -728,6 +728,7 @@ function UIMenuBar:makeMenu(app)
   if self.ui.app.config.debug then
     self:addMenu(_S.menu.debug, UIMenu() -- Debug
       :appendMenu(_S.menu_debug.jump_to_level, levels_menu)
+      :appendItem(_S.menu_debug.save_and_restart, function() self.ui:save_and_restart() end)
       :appendCheckItem(_S.menu_debug.limit_camera,         true, limit_camera, nil, function() return self.ui.limit_to_visible_diamond end)
       :appendCheckItem(_S.menu_debug.disable_salary_raise, false, disable_salary_raise, nil, function() return self.ui.app.world.debug_disable_salary_raise end)
       :appendItem(_S.menu_debug.make_debug_fax,     function() self.ui:makeDebugFax() end)

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -129,6 +129,7 @@ menu_charts = {
 
 menu_debug = {
   jump_to_level               = "  JUMP TO LEVEL  ",
+  save_and_restart            = "  (CTRL + R) SAVE & RESTART",
   transparent_walls           = "  (X) TRANSPARENT WALLS  ",
   limit_camera                = "  LIMIT CAMERA  ",
   disable_salary_raise        = "  DISABLE SALARY RAISE  ",

--- a/CorsixTH/Lua/persistance.lua
+++ b/CorsixTH/Lua/persistance.lua
@@ -263,4 +263,7 @@ function LoadGameFile(filename)
   local data = f:read"*a"
   f:close()
   LoadGame(data)
+  if filename:find("RestartSave.sav") then
+    os.remove(filename)
+  end
 end

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -233,11 +233,11 @@ function UI:setupGlobalKeyHandlers()
   self:addKeyHandler({"ctrl", "s"}, self, self.makeScreenshot)
   self:addKeyHandler({"alt", "Return"}, self, self.toggleFullscreen)
   self:addKeyHandler({"alt", "f4"}, self, self.exitApplication)
-  self:addKeyHandler({"shift", "f10"}, self, self.resetApp)
 
   if self.app.config.debug then
     self:addKeyHandler("f12", self, self.showLuaConsole)
     self:addKeyHandler({"shift", "d"}, self, self.runDebugScript)
+    self:addKeyHandler({"ctrl", "r"}, self, self.saveAndRestart)
   end
 end
 
@@ -786,7 +786,6 @@ function UI:afterLoad(old, new)
 
   if old < 70 then
     self:removeKeyHandler("f10", self)
-    self:addKeyHandler({"shift", "f10"}, self, self.resetApp)
     self:removeKeyHandler("a", self)
   end
   -- changing this so that it is quit application and Shift + Q is quit to main menu
@@ -799,6 +798,13 @@ function UI:afterLoad(old, new)
     self:removeKeyHandler({"alt", "enter"}, self)
     self:addKeyHandler({"alt", "Return"}, self, self.toggleFullscreen)
   end
+  
+  if old < 102 then
+    self:removeKeyHandler({"shift", "f10"}, self)
+    if self.app.config.debug then
+      self:addKeyHandler({"ctrl", "r"}, self, self.saveAndRestart)
+    end
+  end
 
   Window.afterLoad(self, old, new)
 end
@@ -806,6 +812,16 @@ end
 -- Stub to allow the function to be called in e.g. the information
 -- dialog without having to worry about a GameUI being present
 function UI:tutorialStep(...)
+end
+
+--! This developer function saves the running hospital, if there's
+-- a running hospital and then restarts CorsixTH.
+function UI:saveAndRestart()
+  if self.app.world then
+    self.app:save("RestartSave.sav")
+    print("Game saved as: RestartSave.sav")
+  end
+  self:resetApp()
 end
 
 function UI:makeScreenshot()


### PR DESCRIPTION
If there's a running game its saved as RestartSave.sav and then the
existing App:resetApp() function is called. RestartSave.sav will be
deleted when it has been successfully loaded.

I've removed the old SHIFT + F10 global key command for calling
resetApp() directly.

New functions:
- ui.lua:saveAndRestart() : key command : CTRL + R (When debug mode is enabled)
