### PR TITLE
Disable recolouring if the image has no palette to prevent a crash

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -37,11 +37,12 @@ function UIEditRoom:UIEditRoom(ui, room_type)
   self:addKeyHandler("return", self.confirm) -- UIPlaceObjects does not need this
 
   local app = ui.app
+  local blue_red_swap = self.anims.Alt32_BlueRedSwap
   -- Set alt palette on wall blueprint to make it red
-  self.anims:setAnimationGhostPalette(124, app.gfx:loadGhost("QData", "Ghost1.dat", 6))
+  self.anims:setAnimationGhostPalette(124, app.gfx:loadGhost("QData", "Ghost1.dat", 6), blue_red_swap)
   -- Set on door and window blueprints too
-  self.anims:setAnimationGhostPalette(126, app.gfx:loadGhost("QData", "Ghost1.dat", 6))
-  self.anims:setAnimationGhostPalette(130, app.gfx:loadGhost("QData", "Ghost1.dat", 6))
+  self.anims:setAnimationGhostPalette(126, app.gfx:loadGhost("QData", "Ghost1.dat", 6), blue_red_swap)
+  self.anims:setAnimationGhostPalette(130, app.gfx:loadGhost("QData", "Ghost1.dat", 6), blue_red_swap)
   self.cell_outline = TheApp.gfx:loadSpriteTable("Bitmap", "aux_ui", true)
   if not room_type.room_info then
     self.blueprint_rect = {

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -333,13 +333,14 @@ function UIPlaceObjects:setActiveIndex(index)
     self.ui:tutorialStep(1, {4, 5}, 6)
   end
   local anims = self.anims
+  local grey_scale = anims.Alt32_GreyScale
   local _, ghost = self.ui.app.gfx:loadPalette()
   for _, anim in pairs(object.idle_animations) do
-    anims:setAnimationGhostPalette(anim, ghost)
+    anims:setAnimationGhostPalette(anim, ghost, grey_scale)
   end
   if object.slave_type then
     for _, anim in pairs(object.slave_type.idle_animations) do
-      anims:setAnimationGhostPalette(anim, ghost)
+      anims:setAnimationGhostPalette(anim, ghost, grey_scale)
     end
   end
 

--- a/CorsixTH/Lua/dialogs/place_staff.lua
+++ b/CorsixTH/Lua/dialogs/place_staff.lua
@@ -46,7 +46,8 @@ function UIPlaceStaff:UIPlaceStaff(ui, profile, x, y)
   local idle_anim = Humanoid.getIdleAnimation(profile.humanoid_class)
   self.anim:setAnimation(self.world.anims, idle_anim)
   local _, ghost = ui.app.gfx:loadPalette()
-  self.world.anims:setAnimationGhostPalette(idle_anim, ghost)
+  local grey_scale = self.world.anims.Alt32_GreyScale
+  self.world.anims:setAnimationGhostPalette(idle_anim, ghost, grey_scale)
   self:onCursorWorldPositionChange(x, y)
   self:Window()
 end

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -717,7 +717,7 @@ unsigned int THAnimationManager::getNextFrame(unsigned int iFrame) const
         return iFrame;
 }
 
-void THAnimationManager::setAnimationAltPaletteMap(unsigned int iAnimation, const unsigned char* pMap)
+void THAnimationManager::setAnimationAltPaletteMap(unsigned int iAnimation, const unsigned char* pMap, uint32_t iAlt32)
 {
     if(iAnimation >= m_iAnimationCount)
         return;
@@ -735,7 +735,7 @@ void THAnimationManager::setAnimationAltPaletteMap(unsigned int iAnimation, cons
 
             element_t& oElement = m_vElements[iElement];
             if (oElement.pSpriteSheet != NULL)
-                oElement.pSpriteSheet->setSpriteAltPaletteMap(oElement.iSprite, pMap);
+                oElement.pSpriteSheet->setSpriteAltPaletteMap(oElement.iSprite, pMap, iAlt32);
         }
         iFrame = m_vFrames[iFrame].iNextFrame;
     } while(iFrame != iFirstFrame);

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -61,6 +61,21 @@ enum THDrawFlags
     //! Draw using a remapped palette
     THDF_AltPalette     = 1 <<  4,
 
+    /** How to draw alternative palette in 32bpp. */
+    /* A 3 bit field (bits 5,6,7), currently 2 bits used. */
+
+    //! Lowest bit of the field.
+    THDF_Alt32_Start = 5,
+    //! Mask for the 32bpp alternative drawing values.
+    THDF_Alt32_Mask = 0x7 << THDF_Alt32_Start,
+
+    //! Draw the sprite with the normal palette (fallback option).
+    THDF_Alt32_Plain       = 0 << THDF_Alt32_Start,
+    //! Draw the sprite in grey scale.
+    THDF_Alt32_GreyScale   = 1 << THDF_Alt32_Start,
+    //! Draw the sprite with red and blue colours swapped.
+    THDF_Alt32_BlueRedSwap = 2 << THDF_Alt32_Start,
+
     /** Object attached to tile flags **/
     /* (should be set prior to attaching to a tile) */
 
@@ -292,11 +307,11 @@ public:
     /*!
         This sets the palette remap data for every single sprite used by the
         given animation. If the animation (or any of its sprites) are drawn
-        using the THDF_AltPalette flag, then palette indicies will be mapped to
-        new palette indicies by the 256 byte array pMap. This is typically used
+        using the THDF_AltPalette flag, then palette indices will be mapped to
+        new palette indices by the 256 byte array pMap. This is typically used
         to draw things in different colours or in greyscale.
     */
-    void setAnimationAltPaletteMap(unsigned int iAnimation, const unsigned char* pMap);
+    void setAnimationAltPaletteMap(unsigned int iAnimation, const unsigned char* pMap, uint32_t iAlt32);
 
     //! Draw an animation frame
     /*!

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -53,9 +53,10 @@ public:
     /*!
         @param pImg Encoded 32bpp image.
         @param pPalette Palette of a legacy sprite.
+        @param iSpriteFlags Flags how to render the sprite.
         @return Decoding was successful.
     */
-    bool decodeImage(const unsigned char* pImg, const THPalette *pPalette);
+    bool decodeImage(const unsigned char* pImg, const THPalette *pPalette, uint32_t iSpriteFlags);
 
 protected:
     //! Store a decoded pixel. Use m_iX and m_iY if necessary.
@@ -203,7 +204,7 @@ public: // Internal (this rendering engine only) API
     SDL_Renderer *getRenderer() const { return m_pRenderer; }
     bool shouldScaleBitmaps(float* pFactor);
     SDL_Texture* createPalettizedTexture(int iWidth, int iHeight, const unsigned char* pPixels,
-                                         const THPalette* pPalette) const;
+                                         const THPalette* pPalette, uint32_t iSpriteFlags) const;
     SDL_Texture* createTexture(int iWidth, int iHeight, const uint32_t* pPixels) const;
     void draw(SDL_Texture *pTexture, const SDL_Rect *prcSrcRect, const SDL_Rect *prcDstRect, int iFlags);
     void drawLine(THLine *pLine, int iX, int iY);
@@ -450,8 +451,9 @@ public: // External API
     /*!
         @param iSprite Sprite getting the mapped palette.
         @param pMap The palette map to apply.
+        @param iAlt32 What to do for a 32bpp sprite (#THDF_Alt32_Mask bits).
     */
-    void setSpriteAltPaletteMap(unsigned int iSprite, const unsigned char* pMap);
+    void setSpriteAltPaletteMap(unsigned int iSprite, const unsigned char* pMap, uint32_t iAlt32);
 
     //! Get the number of sprites at the sheet.
     /*!
@@ -557,6 +559,9 @@ protected:
 
         //! Alternative palette (if available).
         const unsigned char *pAltPaletteMap;
+
+        //! Flags how to render the sprite, contains #THDF_Alt32_Mask bits.
+        uint32_t iSpriteFlags;
 
         //! Width of the sprite.
         unsigned int iWidth;

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -150,8 +150,9 @@ static int l_anims_set_alt_pal(lua_State *L)
     const unsigned char *pPal = luaT_checkfile(L, 3, &iPalLen);
     if(iPalLen != 256)
         return luaL_typerror(L, 3, "GhostPalette string");
+    uint32_t iAlt32 = luaL_checkinteger(L, 4);
 
-    pAnims->setAnimationAltPaletteMap(iAnimation, pPal);
+    pAnims->setAnimationAltPaletteMap(iAnimation, pPal, iAlt32);
 
     lua_getfenv(L, 1);
     lua_insert(L, 2);
@@ -657,6 +658,8 @@ void THLuaRegisterAnims(const THLuaRegisterState_t *pState)
     luaT_setfunction(l_anims_set_marker, "setFrameMarker");
     luaT_setfunction(l_anims_set_secondary_marker, "setFrameSecondaryMarker");
     luaT_setfunction(l_anims_draw, "draw", MT_Surface, MT_Layers);
+    luaT_setconstant("Alt32_GreyScale",   THDF_Alt32_GreyScale);
+    luaT_setconstant("Alt32_BlueRedSwap", THDF_Alt32_BlueRedSwap);
     luaT_endclass();
 
     // Weak table at AnimMetatable[1] for light UD -> object lookup

--- a/CorsixTH/Src/th_lua_internal.h
+++ b/CorsixTH/Src/th_lua_internal.h
@@ -118,4 +118,13 @@ void luaT_setclosure(const THLuaRegisterState_t *pState, lua_CFunction fn,
     luaT_setclosure(pState, fn, ## __VA_ARGS__, MT_Count); \
     lua_setfield(pState->L, -2, name)
 
+/**
+ * Add a named constant to the lua interface.
+ * @param name (string literal) Name of the constant.
+ * @param value (tested with int) Value of the constant.
+ */
+#define luaT_setconstant(name, value) \
+    luaT_push(pState->L, value); \
+    lua_setfield(pState->L, -2, name)
+
 #endif


### PR DESCRIPTION
Fixes recolouring crashes in 32bpp due to trying to do palette recolouring (which makes no sense in 32bpp).

Added new recolour flags for greyscale conversion (non-placable objects), and red/blue colour swapping (bluprints turning red). The latter doesn't really work well, and needs further work, but it needs proper graphics first.
