### PR TITLE
Do not use pkg-config to find FFmpeg/Libav on Unix

### DIFF
--- a/CMake/CMakeFFmpegLibavMacros.cmake
+++ b/CMake/CMakeFFmpegLibavMacros.cmake
@@ -1,0 +1,65 @@
+#-------------------------------------------------------------------
+# FindFFmpeg.cmake and FindLibAV.cmake are dependent on this file.
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file
+#
+#-------------------------------------------------------------------
+
+### Macro: set_component_found
+#
+# Marks the given component as found if both *_LIBRARIES AND *_INCLUDE_DIRS is present.
+#
+macro(set_component_found _component )
+  if (${_component}_LIBRARIES AND ${_component}_INCLUDE_DIRS)
+    # message(STATUS "  - ${_component} found.")
+    set(${_component}_FOUND TRUE)
+  else ()
+    # message(STATUS "  - ${_component} not found.")
+  endif ()
+endmacro()
+
+#
+### Macro: find_component
+#
+# Finds each component's library file and include directory, and sets
+# *_LIBRARIES and *_INCLUDE_DIRS accordingly. Additionally detects each
+# component's version and sets *_VERSION_STRING.
+#
+macro(find_component _component _library _header _version)
+
+  find_path(${_component}_INCLUDE_DIRS ${_header}
+    PATH_SUFFIXES
+      ffmpeg
+      libav
+      include
+  )
+
+  find_library(${_component}_LIBRARIES
+      NAMES ${_library}
+      PATH_SUFFIXES
+        lib
+  )
+
+  if (${_component}_INCLUDE_DIRS AND EXISTS "${${_component}_INCLUDE_DIRS}/${_version}")
+    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_MAJOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+[0-9]+$")
+    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_MINOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+[0-9]+$")
+    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_PATCH_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MAJOR "${${_component}_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MINOR "${${_component}_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_PATCH "${${_component}_VERSION_PATCH_LINE}")
+    set(${_component}_VERSION_STRING ${${_component}_VERSION_MAJOR}.${${_component}_VERSION_MINOR}.${${_component}_VERSION_PATCH})
+    unset(${_component}_VERSION_MAJOR_LINE)
+    unset(${_component}_VERSION_MINOR_LINE)
+    unset(${_component}_VERSION_PATCH_LINE)
+    unset(${_component}_VERSION_MAJOR)
+    unset(${_component}_VERSION_MINOR)
+    unset(${_component}_VERSION_PATCH)
+  endif ()
+  find_package_handle_standard_args(${_component}
+                                    REQUIRED_VARS ${_component}_LIBRARIES ${_component}_INCLUDE_DIRS
+                                    VERSION_VAR ${_component}_VERSION_STRING)
+
+  set_component_found(${_component})
+
+endmacro()

--- a/CMake/FindFFmpeg.cmake
+++ b/CMake/FindFFmpeg.cmake
@@ -5,7 +5,6 @@
 #  FFMPEG_FOUND         - System has the all required components.
 #  FFMPEG_INCLUDE_DIRS  - Include directory necessary for using the required components headers.
 #  FFMPEG_LIBRARIES     - Link these to use the required ffmpeg components.
-#  FFMPEG_DEFINITIONS   - Compiler switches required for using the required ffmpeg components.
 #
 # For each of the components it will additionally set.
 #   - AVCODEC
@@ -16,11 +15,10 @@
 #   - SWSCALE
 #   - SWRESAMPLE
 # the following variables will be defined
-#  <component>_FOUND        - System has <component>
-#  <component>_INCLUDE_DIRS - Include directory necessary for using the <component> headers
-#  <component>_LIBRARIES    - Link these to use <component>
-#  <component>_DEFINITIONS  - Compiler switches required for using <component>
-#  <component>_VERSION      - The components version
+#  <component>_FOUND          - System has <component>
+#  <component>_INCLUDE_DIRS   - Include directory necessary for using the <component> headers
+#  <component>_LIBRARIES      - Link these to use <component>
+#  <component>_VERSION_STRING - The component's version
 #
 # Copyright (c) 2006, Matthias Kretz, <kretz@kde.org>
 # Copyright (c) 2008, Alexander Neundorf, <neundorf@kde.org>
@@ -32,75 +30,12 @@
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
 include(FindPackageHandleStandardArgs)
+include(${CMAKE_CURRENT_LIST_DIR}/CMakeFFmpegLibavMacros.cmake)
 
 # The default components were taken from a survey over other FindFFMPEG.cmake files
 if (NOT FFmpeg_FIND_COMPONENTS)
   set(FFmpeg_FIND_COMPONENTS AVCODEC AVFORMAT AVUTIL)
 endif ()
-
-#
-### Macro: set_component_found
-#
-# Marks the given component as found if both *_LIBRARIES AND *_INCLUDE_DIRS is present.
-#
-macro(set_component_found _component )
-  if (${_component}_LIBRARIES AND ${_component}_INCLUDE_DIRS)
-    # message(STATUS "  - ${_component} found.")
-    set(${_component}_FOUND TRUE)
-  else ()
-    # message(STATUS "  - ${_component} not found.")
-  endif ()
-endmacro()
-
-#
-### Macro: find_component
-#
-macro(find_component _component _library _header _version)
-  
-  find_path(${_component}_INCLUDE_DIRS ${_header}
-    HINTS
-      ${PC_LIB${_component}_INCLUDEDIR}
-      ${PC_LIB${_component}_INCLUDE_DIRS}
-    PATH_SUFFIXES
-      ffmpeg
-      include
-  )
-
-  find_library(${_component}_LIBRARIES
-      NAMES ${_library}
-      HINTS
-        ${PC_LIB${_component}_LIBDIR}
-        ${PC_LIB${_component}_LIBRARY_DIRS}
-      PATH_SUFFIXES
-        lib
-  )
-
-  if (${_component}_INCLUDE_DIRS AND EXISTS "${${_component}_INCLUDE_DIRS}/${_version}")
-    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_MAJOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+[0-9]+$")
-    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_MINOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+[0-9]+$")
-    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_MICRO_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+[0-9]+$")
-    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MAJOR "${${_component}_VERSION_MAJOR_LINE}")
-    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MINOR "${${_component}_VERSION_MINOR_LINE}")
-    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MICRO "${${_component}_VERSION_MICRO_LINE}")
-    set(${_component}_VERSION_STRING ${${_component}_VERSION_MAJOR}.${${_component}_VERSION_MINOR}.${${_component}_VERSION_MICRO})
-    unset(${_component}_VERSION_MAJOR_LINE)
-    unset(${_component}_VERSION_MINOR_LINE)
-    unset(${_component}_VERSION_MICRO_LINE)
-    unset(${_component}_VERSION_MAJOR)
-    unset(${_component}_VERSION_MINOR)
-    unset(${_component}_VERSION_MICRO)
-  endif ()
-  find_package_handle_standard_args(${_component}
-                                    REQUIRED_VARS ${_component}_LIBRARIES ${_component}_INCLUDE_DIRS
-                                    VERSION_VAR ${_component}_VERSION_STRING)
-
-  set(${_component}_DEFINITIONS  ${PC_${_component}_CFLAGS_OTHER} CACHE STRING "The ${_component} CFLAGS.")
-  set(${_component}_VERSION      ${PC_${_component}_VERSION}      CACHE STRING "The ${_component} version number.")
-
-  set_component_found(${_component})
-
-endmacro()
-
 
 # Check for cached results. If there are skip the costly part.
 if (NOT FFMPEG_LIBRARIES)
@@ -119,7 +54,6 @@ if (NOT FFMPEG_LIBRARIES)
     if (${_component}_FOUND)
       # message(STATUS "Required component ${_component} present.")
       set(FFMPEG_LIBRARIES   ${FFMPEG_LIBRARIES}   ${${_component}_LIBRARIES})
-      set(FFMPEG_DEFINITIONS ${FFMPEG_DEFINITIONS} ${${_component}_DEFINITIONS})
       list(APPEND FFMPEG_INCLUDE_DIRS ${${_component}_INCLUDE_DIRS})
     else ()
       # message(STATUS "Required component ${_component} missing.")
@@ -134,11 +68,9 @@ if (NOT FFMPEG_LIBRARIES)
   # cache the vars.
   set(FFMPEG_INCLUDE_DIRS ${FFMPEG_INCLUDE_DIRS} CACHE STRING "The FFmpeg include directories." FORCE)
   set(FFMPEG_LIBRARIES    ${FFMPEG_LIBRARIES}    CACHE STRING "The FFmpeg libraries." FORCE)
-  set(FFMPEG_DEFINITIONS  ${FFMPEG_DEFINITIONS}  CACHE STRING "The FFmpeg cflags." FORCE)
 
   mark_as_advanced(FFMPEG_INCLUDE_DIRS
-                   FFMPEG_LIBRARIES
-                   FFMPEG_DEFINITIONS)
+                   FFMPEG_LIBRARIES)
 
 endif ()
 

--- a/CMake/FindFFmpeg.cmake
+++ b/CMake/FindFFmpeg.cmake
@@ -55,7 +55,7 @@ endmacro()
 #
 ### Macro: find_component
 #
-macro(find_component _component _library _header)
+macro(find_component _component _library _header _version)
   
   find_path(${_component}_INCLUDE_DIRS ${_header}
     HINTS
@@ -75,6 +75,25 @@ macro(find_component _component _library _header)
         lib
   )
 
+  if (${_component}_INCLUDE_DIRS AND EXISTS "${${_component}_INCLUDE_DIRS}/${_version}")
+    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_MAJOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+[0-9]+$")
+    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_MINOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+[0-9]+$")
+    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_MICRO_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MAJOR "${${_component}_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MINOR "${${_component}_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MICRO "${${_component}_VERSION_MICRO_LINE}")
+    set(${_component}_VERSION_STRING ${${_component}_VERSION_MAJOR}.${${_component}_VERSION_MINOR}.${${_component}_VERSION_MICRO})
+    unset(${_component}_VERSION_MAJOR_LINE)
+    unset(${_component}_VERSION_MINOR_LINE)
+    unset(${_component}_VERSION_MICRO_LINE)
+    unset(${_component}_VERSION_MAJOR)
+    unset(${_component}_VERSION_MINOR)
+    unset(${_component}_VERSION_MICRO)
+  endif ()
+  find_package_handle_standard_args(${_component}
+                                    REQUIRED_VARS ${_component}_LIBRARIES ${_component}_INCLUDE_DIRS
+                                    VERSION_VAR ${_component}_VERSION_STRING)
+
   set(${_component}_DEFINITIONS  ${PC_${_component}_CFLAGS_OTHER} CACHE STRING "The ${_component} CFLAGS.")
   set(${_component}_VERSION      ${PC_${_component}_VERSION}      CACHE STRING "The ${_component} version number.")
 
@@ -87,13 +106,13 @@ endmacro()
 if (NOT FFMPEG_LIBRARIES)
 
   # Check for all possible component.
-  find_component(AVCODEC  avcodec  libavcodec/avcodec.h)
-  find_component(AVFORMAT avformat libavformat/avformat.h)
-  find_component(AVDEVICE avdevice libavdevice/avdevice.h)
-  find_component(AVUTIL   avutil   libavutil/avutil.h)
-  find_component(SWSCALE  swscale  libswscale/swscale.h)
-  find_component(POSTPROC postproc libpostproc/postprocess.h)
-  find_component(SWRESAMPLE swresample libswresample/swresample.h)
+  find_component(AVCODEC  avcodec  libavcodec/avcodec.h   libavcodec/version.h)
+  find_component(AVFORMAT avformat libavformat/avformat.h libavformat/version.h)
+  find_component(AVDEVICE avdevice libavdevice/avdevice.h libavdevice/version.h)
+  find_component(AVUTIL   avutil   libavutil/avutil.h     libavutil/version.h)
+  find_component(SWSCALE  swscale  libswscale/swscale.h   libswscale/version.h)
+  find_component(POSTPROC postproc libpostproc/postprocess.h libpostproc/version.h)
+  find_component(SWRESAMPLE swresample libswresample/swresample.h libswresample/version.h)
 
   # Check if the required components were found and add their stuff to the FFMPEG_* vars.
   foreach (_component ${FFmpeg_FIND_COMPONENTS})
@@ -102,25 +121,6 @@ if (NOT FFMPEG_LIBRARIES)
       set(FFMPEG_LIBRARIES   ${FFMPEG_LIBRARIES}   ${${_component}_LIBRARIES})
       set(FFMPEG_DEFINITIONS ${FFMPEG_DEFINITIONS} ${${_component}_DEFINITIONS})
       list(APPEND FFMPEG_INCLUDE_DIRS ${${_component}_INCLUDE_DIRS})
-      string(TOLOWER ${${_component}_INCLUDE_DIRS}/lib${_component}/version.h VERSION_HEADER)
-      if (${_component}_INCLUDE_DIRS AND EXISTS "${VERSION_HEADER}")
-        file(STRINGS "${VERSION_HEADER}" ${_component}_VERSION_MAJOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+[0-9]+$")
-        file(STRINGS "${VERSION_HEADER}" ${_component}_VERSION_MINOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+[0-9]+$")
-        file(STRINGS "${VERSION_HEADER}" ${_component}_VERSION_MICRO_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+[0-9]+$")
-        string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MAJOR "${${_component}_VERSION_MAJOR_LINE}")
-        string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MINOR "${${_component}_VERSION_MINOR_LINE}")
-        string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MICRO "${${_component}_VERSION_MICRO_LINE}")
-        set(${_component}_VERSION_STRING ${${_component}_VERSION_MAJOR}.${${_component}_VERSION_MINOR}.${${_component}_VERSION_MICRO})
-        unset(${_component}_VERSION_MAJOR_LINE)
-        unset(${_component}_VERSION_MINOR_LINE)
-        unset(${_component}_VERSION_MICRO_LINE)
-        unset(${_component}_VERSION_MAJOR)
-        unset(${_component}_VERSION_MINOR)
-        unset(${_component}_VERSION_MICRO)
-      endif ()
-      find_package_handle_standard_args(${_component}
-                                        REQUIRED_VARS ${_component}_LIBRARIES ${_component}_INCLUDE_DIRS
-                                        VERSION_VAR ${_component}_VERSION_STRING)
     else ()
       # message(STATUS "Required component ${_component} missing.")
     endif ()

--- a/CMake/FindFFmpeg.cmake
+++ b/CMake/FindFFmpeg.cmake
@@ -26,6 +26,7 @@
 # Copyright (c) 2008, Alexander Neundorf, <neundorf@kde.org>
 # Copyright (c) 2011, Michael Jansen, <kde@michael-jansen.biz>
 # Copyright (c) 2013, Stephen Baker
+# Copyright (c) 2015, Alexander Bessman
 #
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
@@ -54,32 +55,27 @@ endmacro()
 #
 ### Macro: find_component
 #
-# Checks for the given component by invoking pkgconfig and then looking up the libraries and
-# include directories.
-#
-macro(find_component _component _pkgconfig _library _header)
+macro(find_component _component)
+  
+  string(TOLOWER ${_component} _library)
 
-  if (NOT WIN32)
-     # use pkg-config to get the directories and then use these values
-     # in the FIND_PATH() and FIND_LIBRARY() calls
-     find_package(PkgConfig)
-     if (PKG_CONFIG_FOUND)
-       pkg_check_modules(PC_${_component} ${_pkgconfig})
-     endif ()
-  endif (NOT WIN32)
-
-  find_path(${_component}_INCLUDE_DIRS ${_header}
+  find_path(${_component}_INCLUDE_DIRS ${_library}.h
     HINTS
       ${PC_LIB${_component}_INCLUDEDIR}
       ${PC_LIB${_component}_INCLUDE_DIRS}
     PATH_SUFFIXES
       ffmpeg
+      include
+      include/lib${_library}
   )
 
-  find_library(${_component}_LIBRARIES NAMES ${_library}
+  find_library(${_component}_LIBRARIES
+      NAMES ${_library}
       HINTS
-      ${PC_LIB${_component}_LIBDIR}
-      ${PC_LIB${_component}_LIBRARY_DIRS}
+        ${PC_LIB${_component}_LIBDIR}
+        ${PC_LIB${_component}_LIBRARY_DIRS}
+      PATH_SUFFIXES
+        lib
   )
 
   set(${_component}_DEFINITIONS  ${PC_${_component}_CFLAGS_OTHER} CACHE STRING "The ${_component} CFLAGS.")
@@ -109,6 +105,24 @@ if (NOT FFMPEG_LIBRARIES)
       set(FFMPEG_LIBRARIES   ${FFMPEG_LIBRARIES}   ${${_component}_LIBRARIES})
       set(FFMPEG_DEFINITIONS ${FFMPEG_DEFINITIONS} ${${_component}_DEFINITIONS})
       list(APPEND FFMPEG_INCLUDE_DIRS ${${_component}_INCLUDE_DIRS})
+      if (${_component}_INCLUDE_DIRS AND EXISTS "${${_component}_INCLUDE_DIRS}/version.h")
+        file(STRINGS "${${_component}_INCLUDE_DIRS}/version.h" ${_component}_VERSION_MAJOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+[0-9]+$")
+        file(STRINGS "${${_component}_INCLUDE_DIRS}/version.h" ${_component}_VERSION_MINOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+[0-9]+$")
+        file(STRINGS "${${_component}_INCLUDE_DIRS}/version.h" ${_component}_VERSION_MICRO_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+[0-9]+$")
+        string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MAJOR "${${_component}_VERSION_MAJOR_LINE}")
+        string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MINOR "${${_component}_VERSION_MINOR_LINE}")
+        string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MICRO "${${_component}_VERSION_MICRO_LINE}")
+        set(${_component}_VERSION_STRING ${${_component}_VERSION_MAJOR}.${${_component}_VERSION_MINOR}.${${_component}_VERSION_MICRO})
+        unset(${_component}_VERSION_MAJOR_LINE)
+        unset(${_component}_VERSION_MINOR_LINE)
+        unset(${_component}_VERSION_MICRO_LINE)
+        unset(${_component}_VERSION_MAJOR)
+        unset(${_component}_VERSION_MINOR)
+        unset(${_component}_VERSION_MICRO)
+      endif ()
+      find_package_handle_standard_args(${_component}
+                                        REQUIRED_VARS ${_component}_LIBRARIES ${_component}_INCLUDE_DIRS
+                                        VERSION_VAR ${_component}_VERSION_STRING)
     else ()
       # message(STATUS "Required component ${_component} missing.")
     endif ()

--- a/CMake/FindFFmpeg.cmake
+++ b/CMake/FindFFmpeg.cmake
@@ -55,18 +55,15 @@ endmacro()
 #
 ### Macro: find_component
 #
-macro(find_component _component)
+macro(find_component _component _library _header)
   
-  string(TOLOWER ${_component} _library)
-
-  find_path(${_component}_INCLUDE_DIRS ${_library}.h
+  find_path(${_component}_INCLUDE_DIRS ${_header}
     HINTS
       ${PC_LIB${_component}_INCLUDEDIR}
       ${PC_LIB${_component}_INCLUDE_DIRS}
     PATH_SUFFIXES
       ffmpeg
       include
-      include/lib${_library}
   )
 
   find_library(${_component}_LIBRARIES
@@ -90,13 +87,13 @@ endmacro()
 if (NOT FFMPEG_LIBRARIES)
 
   # Check for all possible component.
-  find_component(AVCODEC  libavcodec  avcodec  libavcodec/avcodec.h)
-  find_component(AVFORMAT libavformat avformat libavformat/avformat.h)
-  find_component(AVDEVICE libavdevice avdevice libavdevice/avdevice.h)
-  find_component(AVUTIL   libavutil   avutil   libavutil/avutil.h)
-  find_component(SWSCALE  libswscale  swscale  libswscale/swscale.h)
-  find_component(POSTPROC libpostproc postproc libpostproc/postprocess.h)
-  find_component(SWRESAMPLE libswresample swresample libswresample/swresample.h)
+  find_component(AVCODEC  avcodec  libavcodec/avcodec.h)
+  find_component(AVFORMAT avformat libavformat/avformat.h)
+  find_component(AVDEVICE avdevice libavdevice/avdevice.h)
+  find_component(AVUTIL   avutil   libavutil/avutil.h)
+  find_component(SWSCALE  swscale  libswscale/swscale.h)
+  find_component(POSTPROC postproc libpostproc/postprocess.h)
+  find_component(SWRESAMPLE swresample libswresample/swresample.h)
 
   # Check if the required components were found and add their stuff to the FFMPEG_* vars.
   foreach (_component ${FFmpeg_FIND_COMPONENTS})
@@ -105,10 +102,11 @@ if (NOT FFMPEG_LIBRARIES)
       set(FFMPEG_LIBRARIES   ${FFMPEG_LIBRARIES}   ${${_component}_LIBRARIES})
       set(FFMPEG_DEFINITIONS ${FFMPEG_DEFINITIONS} ${${_component}_DEFINITIONS})
       list(APPEND FFMPEG_INCLUDE_DIRS ${${_component}_INCLUDE_DIRS})
-      if (${_component}_INCLUDE_DIRS AND EXISTS "${${_component}_INCLUDE_DIRS}/version.h")
-        file(STRINGS "${${_component}_INCLUDE_DIRS}/version.h" ${_component}_VERSION_MAJOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+[0-9]+$")
-        file(STRINGS "${${_component}_INCLUDE_DIRS}/version.h" ${_component}_VERSION_MINOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+[0-9]+$")
-        file(STRINGS "${${_component}_INCLUDE_DIRS}/version.h" ${_component}_VERSION_MICRO_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+[0-9]+$")
+      string(TOLOWER ${${_component}_INCLUDE_DIRS}/lib${_component}/version.h VERSION_HEADER)
+      if (${_component}_INCLUDE_DIRS AND EXISTS "${VERSION_HEADER}")
+        file(STRINGS "${VERSION_HEADER}" ${_component}_VERSION_MAJOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+[0-9]+$")
+        file(STRINGS "${VERSION_HEADER}" ${_component}_VERSION_MINOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+[0-9]+$")
+        file(STRINGS "${VERSION_HEADER}" ${_component}_VERSION_MICRO_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+[0-9]+$")
         string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MAJOR "${${_component}_VERSION_MAJOR_LINE}")
         string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MINOR "${${_component}_VERSION_MINOR_LINE}")
         string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MICRO "${${_component}_VERSION_MICRO_LINE}")

--- a/CMake/FindLibAV.cmake
+++ b/CMake/FindLibAV.cmake
@@ -5,7 +5,6 @@
 #  LIBAV_FOUND         - System has the all required components.
 #  LIBAV_INCLUDE_DIRS  - Include directory necessary for using the required components headers.
 #  LIBAV_LIBRARIES     - Link these to use the required libav components.
-#  LIBAV_DEFINITIONS   - Compiler switches required for using the required libav components.
 #
 # For each of the components it will additionally set.
 #   - AVCODEC
@@ -16,11 +15,10 @@
 #   - AVUTIL
 #   - SWSCALE
 # the following variables will be defined
-#  <component>_FOUND        - System has <component>
-#  <component>_INCLUDE_DIRS - Include directory necessary for using the <component> headers
-#  <component>_LIBRARIES    - Link these to use <component>
-#  <component>_DEFINITIONS  - Compiler switches required for using <component>
-#  <component>_VERSION      - The components version
+#  <component>_FOUND          - System has <component>
+#  <component>_INCLUDE_DIRS   - Include directory necessary for using the <component> headers
+#  <component>_LIBRARIES      - Link these to use <component>
+#  <component>_VERSION_STRING - The component's version
 #
 # Copyright (c) 2006, Matthias Kretz, <kretz@kde.org>
 # Copyright (c) 2008, Alexander Neundorf, <neundorf@kde.org>
@@ -32,75 +30,12 @@
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
 include(FindPackageHandleStandardArgs)
+include(${CMAKE_CURRENT_LIST_DIR}/CMakeFFmpegLibavMacros.cmake)
 
 # The default components were taken from a survey over other FindLIBAV.cmake files
 if (NOT LibAV_FIND_COMPONENTS)
   set(LibAV_FIND_COMPONENTS AVCODEC AVFORMAT AVUTIL)
 endif ()
-
-#
-### Macro: set_component_found
-#
-# Marks the given component as found if both *_LIBRARIES AND *_INCLUDE_DIRS is present.
-#
-macro(set_component_found _component )
-  if (${_component}_LIBRARIES AND ${_component}_INCLUDE_DIRS)
-    # message(STATUS "  - ${_component} found.")
-    set(${_component}_FOUND TRUE)
-  else ()
-    # message(STATUS "  - ${_component} not found.")
-  endif ()
-endmacro()
-
-#
-### Macro: find_component
-#
-macro(find_component _component _library _header _version)
-
-  find_path(${_component}_INCLUDE_DIRS ${_header}
-    HINTS
-      ${PC_LIB${_component}_INCLUDEDIR}
-      ${PC_LIB${_component}_INCLUDE_DIRS}
-    PATH_SUFFIXES
-      libav
-      include
-  )
-
-  find_library(${_component}_LIBRARIES
-      NAMES ${_library}
-      HINTS
-        ${PC_LIB${_component}_LIBDIR}
-        ${PC_LIB${_component}_LIBRARY_DIRS}
-      PATH_SUFFIXES
-        lib
-  )
-
-  if (${_component}_INCLUDE_DIRS AND EXISTS "${${_component}_INCLUDE_DIRS}/${_version}")
-    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_MAJOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+[0-9]+$")
-    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_MINOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+[0-9]+$")
-    file(STRINGS "${${_component}_INCLUDE_DIRS}/${_version}" ${_component}_VERSION_MICRO_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+[0-9]+$")
-    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MAJOR "${${_component}_VERSION_MAJOR_LINE}")
-    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MINOR "${${_component}_VERSION_MINOR_LINE}")
-    string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MICRO "${${_component}_VERSION_MICRO_LINE}")
-    set(${_component}_VERSION_STRING ${${_component}_VERSION_MAJOR}.${${_component}_VERSION_MINOR}.${${_component}_VERSION_MICRO})
-    unset(${_component}_VERSION_MAJOR_LINE)
-    unset(${_component}_VERSION_MINOR_LINE)
-    unset(${_component}_VERSION_MICRO_LINE)
-    unset(${_component}_VERSION_MAJOR)
-    unset(${_component}_VERSION_MINOR)
-    unset(${_component}_VERSION_MICRO)
-  endif ()
-  find_package_handle_standard_args(${_component}
-                                    REQUIRED_VARS ${_component}_LIBRARIES ${_component}_INCLUDE_DIRS
-                                    VERSION_VAR ${_component}_VERSION_STRING)
-
-  set(${_component}_DEFINITIONS  ${PC_${_component}_CFLAGS_OTHER} CACHE STRING "The ${_component} CFLAGS.")
-  set(${_component}_VERSION      ${PC_${_component}_VERSION}      CACHE STRING "The ${_component} version number.")
-
-  set_component_found(${_component})
-
-endmacro()
-
 
 # Check for cached results. If there are skip the costly part.
 if (NOT LIBAV_LIBRARIES)
@@ -119,7 +54,6 @@ if (NOT LIBAV_LIBRARIES)
     if (${_component}_FOUND)
       # message(STATUS "Required component ${_component} present.")
       set(LIBAV_LIBRARIES   ${LIBAV_LIBRARIES}   ${${_component}_LIBRARIES})
-      set(LIBAV_DEFINITIONS ${LIBAV_DEFINITIONS} ${${_component}_DEFINITIONS})
       list(APPEND LIBAV_INCLUDE_DIRS ${${_component}_INCLUDE_DIRS})
     else ()
       # message(STATUS "Required component ${_component} missing.")
@@ -134,11 +68,9 @@ if (NOT LIBAV_LIBRARIES)
   # cache the vars.
   set(LIBAV_INCLUDE_DIRS ${LIBAV_INCLUDE_DIRS} CACHE STRING "The LibAV include directories." FORCE)
   set(LIBAV_LIBRARIES    ${LIBAV_LIBRARIES}    CACHE STRING "The LibAV libraries." FORCE)
-  set(LIBAV_DEFINITIONS  ${LIBAV_DEFINITIONS}  CACHE STRING "The LibAV cflags." FORCE)
 
   mark_as_advanced(LIBAV_INCLUDE_DIRS
-                   LIBAV_LIBRARIES
-                   LIBAV_DEFINITIONS)
+                   LIBAV_LIBRARIES)
 
 endif ()
 

--- a/CMake/FindLibAV.cmake
+++ b/CMake/FindLibAV.cmake
@@ -55,18 +55,15 @@ endmacro()
 #
 ### Macro: find_component
 #
-macro(find_component _component)
+macro(find_component _component _library _header)
 
-  string(TOLOWER ${_component} _library)
-  
-  find_path(${_component}_INCLUDE_DIRS ${_library}.h
+  find_path(${_component}_INCLUDE_DIRS ${_header}
     HINTS
       ${PC_LIB${_component}_INCLUDEDIR}
       ${PC_LIB${_component}_INCLUDE_DIRS}
     PATH_SUFFIXES
       libav
       include
-      include/lib${_library}
   )
 
   find_library(${_component}_LIBRARIES
@@ -90,13 +87,13 @@ endmacro()
 if (NOT LIBAV_LIBRARIES)
 
   # Check for all possible component.
-  find_component(AVCODEC  libavcodec  avcodec  libavcodec/avcodec.h)
-  find_component(AVFORMAT libavformat avformat libavformat/avformat.h)
-  find_component(AVDEVICE libavdevice avdevice libavdevice/avdevice.h)
-  find_component(AVFILTER libavfilter avfilter libavfilter/avfilter.h)
-  find_component(AVRESAMPLE libavresample avresample libavresample/avresample.h)
-  find_component(AVUTIL   libavutil   avutil   libavutil/avutil.h)
-  find_component(SWSCALE  libswscale  swscale  libswscale/swscale.h)
+  find_component(AVCODEC  avcodec  libavcodec/avcodec.h)
+  find_component(AVFORMAT avformat libavformat/avformat.h)
+  find_component(AVDEVICE avdevice libavdevice/avdevice.h)
+  find_component(AVFILTER avfilter libavfilter/avfilter.h)
+  find_component(AVRESAMPLE avresample libavresample/avresample.h)
+  find_component(AVUTIL   avutil   libavutil/avutil.h)
+  find_component(SWSCALE  swscale  libswscale/swscale.h)
 
   # Check if the required components were found and add their stuff to the LIBAV_* vars.
   foreach (_component ${LibAV_FIND_COMPONENTS})
@@ -105,10 +102,11 @@ if (NOT LIBAV_LIBRARIES)
       set(LIBAV_LIBRARIES   ${LIBAV_LIBRARIES}   ${${_component}_LIBRARIES})
       set(LIBAV_DEFINITIONS ${LIBAV_DEFINITIONS} ${${_component}_DEFINITIONS})
       list(APPEND LIBAV_INCLUDE_DIRS ${${_component}_INCLUDE_DIRS})
-      if (${_component}_INCLUDE_DIRS AND EXISTS "${${_component}_INCLUDE_DIRS}/version.h")
-        file(STRINGS "${${_component}_INCLUDE_DIRS}/version.h" ${_component}_VERSION_MAJOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+[0-9]+$")
-        file(STRINGS "${${_component}_INCLUDE_DIRS}/version.h" ${_component}_VERSION_MINOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+[0-9]+$")
-        file(STRINGS "${${_component}_INCLUDE_DIRS}/version.h" ${_component}_VERSION_MICRO_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+[0-9]+$")
+      string(TOLOWER ${${_component}_INCLUDE_DIRS}/lib${_component}/version.h VERSION_HEADER)
+      if (${_component}_INCLUDE_DIRS AND EXISTS "${VERSION_HEADER}")
+        file(STRINGS "${VERSION_HEADER}" ${_component}_VERSION_MAJOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+[0-9]+$")
+        file(STRINGS "${VERSION_HEADER}" ${_component}_VERSION_MINOR_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+[0-9]+$")
+        file(STRINGS "${VERSION_HEADER}" ${_component}_VERSION_MICRO_LINE REGEX "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+[0-9]+$")
         string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MAJOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MAJOR "${${_component}_VERSION_MAJOR_LINE}")
         string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MINOR[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MINOR "${${_component}_VERSION_MINOR_LINE}")
         string(REGEX REPLACE "^#define[ \t]+LIB${_component}_VERSION_MICRO[ \t]+([0-9]+)$" "\\1" ${_component}_VERSION_MICRO "${${_component}_VERSION_MICRO_LINE}")


### PR DESCRIPTION
This is necessary for CMake to find FFmpeg/Libav in a cloned CorsixTH/deps repo on GNU/Linux. As a bonus, it now uses the same method to find includes/libraries on all platforms.

I have only tested this on GNU/Linux. I haven't touched any of the Windows stuff so that should work normally, and it will probably work on OSX too. Could definitely use some testing on various platforms though.