### PR TITLE
Fix race condition decoding audio while movie is terminating

### DIFF
--- a/CorsixTH/Src/th_movie.h
+++ b/CorsixTH/Src/th_movie.h
@@ -167,6 +167,7 @@ protected:
 
     //abort playing movie
     bool m_fAborting;
+    SDL_mutex *m_pDecodingAudioMutex;
 
     //current movie dimensions and placement
     int m_iX, m_iY, m_iWidth, m_iHeight;


### PR DESCRIPTION
The race condition would sometimes cause a segfault or 0xc0000005 error when
closing a movie with audio (such as the intro) early.