### PR TITLE
Add shift_scroll_speed and make scroll_speed apply to unshifted scrolling

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -688,6 +688,15 @@ function App:fixConfig()
     if key == "height" and type(value) == "number" and value < 480 then
       self.config[key] = 480
     end
+
+    if (key == "scroll_speed" or key == "shift_scroll_speed") and
+        type(value) == "number" then
+      if value > 10 then
+        self.config[key] = 10
+      elseif value < 1 then
+        self.config[key] = 1
+      end
+    end
   end
 end
 

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -130,6 +130,7 @@ local config_defaults = {
   track_fps = false,
   zoom_speed = 80,
   scroll_speed = 2,
+  shift_scroll_speed = 4,
   new_graphics_folder = nil,
   use_new_graphics = false,
   check_for_updates = true
@@ -453,11 +454,11 @@ audio_mp3 = nil -- [[X:\ThemeHospital\Music]]
 'zoom_speed = ' .. tostring(config_values.zoom_speed) .. '\n' .. [=[
 
 -------------------------------------------------------------------------------------------------------------------------
--- Scroll Speed: By default this is set at level 2
+-- Scroll Speeds: The speed of scrolling with and without shift being held.
 -- Any number value between 1 and 10, 1 is very slow and 10 is fast!
--- Press shift when you are scrolling and it will be a lot quicker
 -- ]=] .. '\n' ..
-'scroll_speed = ' .. tostring(config_values.scroll_speed) .. '\n' .. [=[
+'scroll_speed = ' .. tostring(config_values.scroll_speed) .. '\n' ..
+'shift_scroll_speed = ' .. tostring(config_values.shift_scroll_speed) .. '\n' .. [=[
 
 ------------------------------------------------ CAMPAIGN MENU -----------------------------------------------
 -- By default your computer log in will be your name in the game.  You can change it in the

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -642,10 +642,18 @@ function GameUI:onTick()
       dy = dy + self.tick_scroll_amount.y
     end
 
-    -- Faster scrolling with shift key
-    local factor = self.app.config.scroll_speed
+    -- Adjust scroll speed based on config value:
+    -- there is a separate config value for whether or not shift is held.
+    -- the speed is multiplied by 0.5 for consistency between the old and
+    -- new configuration. In the past scroll_speed applied only to shift
+    -- and defaulted to 2, where 1 was regular scroll speed. By
+    -- By multiplying by 0.5, we allow for setting slower than normal
+    -- scroll speeds, and ensure there is no behaviour change for players
+    -- who do not modify their config file.
     if self.app.key_modifiers.shift then
-      mult = mult * factor
+      mult = mult * self.app.config.shift_scroll_speed * 0.5
+    else
+      mult = mult * self.app.config.scroll_speed * 0.5
     end
 
     self:scrollMap(dx * mult, dy * mult)


### PR DESCRIPTION
Solves #724 

~~Warning, since the old shift scroll speed setting was called scroll_speed and this is now the unshifted scroll speed, existing players will have their regular scroll speed increased to twice normal.  Adjust your config.~~