### PR TITLE
Cleanup pathfinder

### DIFF
--- a/CorsixTH/Src/th_pathfind.cpp
+++ b/CorsixTH/Src/th_pathfind.cpp
@@ -28,7 +28,407 @@ SOFTWARE.
 #include <queue>
 #include <math.h>
 
-THPathfinder::THPathfinder()
+BasePathing::BasePathing(THPathfinder *pf) : m_pPf(pf)
+{
+}
+
+node_t *BasePathing::pathingInit(const THMap *pMap, int iStartX, int iStartY)
+{
+    int iWidth = pMap->getWidth();
+    m_pPf->m_pDestination = NULL;
+    m_pPf->_allocNodeCache(iWidth, pMap->getHeight());
+    node_t *pNode = m_pPf->m_pNodes + iStartY * iWidth + iStartX;
+    pNode->prev = NULL;
+    pNode->distance = 0;
+    pNode->guess = makeGuess(pNode);
+    m_pPf->m_ppDirtyList[0] = pNode;
+    m_pPf->m_iDirtyCount = 1;
+    m_pPf->m_iOpenCount = 0;
+    return pNode;
+}
+
+/*! No need to check for the node being on the map edge, as the N/E/S/W
+    flags are set as to prevent travelling off the map (as well as to
+    prevent walking through walls).
+ */
+bool BasePathing::pathingNeighbours(node_t *pNode, uint32_t iFlags, int iWidth)
+{
+    if(iFlags & THMN_CanTravelW)
+        if(tryNode(pNode, iFlags, pNode - 1, THTD_West)) return true;
+
+    if(iFlags & THMN_CanTravelE)
+        if (tryNode(pNode, iFlags, pNode + 1, THTD_East)) return true;
+
+    if(iFlags & THMN_CanTravelN)
+        if (tryNode(pNode, iFlags, pNode - iWidth, THTD_North)) return true;
+
+    if(iFlags & THMN_CanTravelS)
+        if (tryNode(pNode, iFlags, pNode + iWidth, THTD_South)) return true;
+
+    return false;
+}
+
+void BasePathing::pathingTryNode(node_t *pNode, uint32_t iNFlags, uint32_t iPassable, node_t *pNeighbour)
+{
+    if(iNFlags & THMN_Passable || iPassable == 0)
+    {
+        if(pNeighbour->prev == pNeighbour)
+        {
+            pNeighbour->prev = pNode;
+            pNeighbour->distance = pNode->distance + 1;
+            pNeighbour->guess = makeGuess(pNeighbour);
+            m_pPf->m_ppDirtyList[m_pPf->m_iDirtyCount++] = pNeighbour;
+            m_pPf->_openHeapPush(pNeighbour);
+        }
+        else if(pNode->distance + 1 < pNeighbour->distance)
+        {
+            pNeighbour->prev = pNode;
+            pNeighbour->distance = pNode->distance + 1;
+            /* guess doesn't change, and already in the dirty list */
+            m_pPf->_openHeapPromote(pNeighbour);
+        }
+    }
+}
+
+int PathFinder::makeGuess(node_t *pNode)
+{
+    // As diagonal movement is not allowed, the minimum distance between two
+    // points is the sum of the distance in X and the distance in Y.
+    return abs(pNode->x - m_iEndX) + abs(pNode->y - m_iEndY);
+}
+
+bool PathFinder::tryNode(node_t *pNode, uint32_t iFlags,
+                         node_t *pNeighbour, int direction)
+{
+    uint32_t iPassable = iFlags & THMN_Passable;
+    uint32_t iNFlags = m_pMap->getNodeUnchecked(pNeighbour->x, pNeighbour->y)->iFlags;
+    pathingTryNode(pNode, iNFlags, iPassable, pNeighbour);
+    return false;
+}
+
+bool PathFinder::findPath(const THMap *pMap, int iStartX, int iStartY, int iEndX, int iEndY)
+{
+    if(pMap == NULL)
+        pMap = m_pPf->m_pDefaultMap;
+    if(pMap == NULL || pMap->getNode(iEndX, iEndY) == NULL
+        || (pMap->getNodeUnchecked(iEndX, iEndY)->iFlags & THMN_Passable) == 0)
+    {
+        m_pPf->m_pDestination = NULL;
+        return false;
+    }
+
+    m_pMap = pMap;
+    m_iEndX = iEndX;
+    m_iEndY = iEndY;
+
+    node_t *pNode = pathingInit(pMap, iStartX, iStartY);
+    int iWidth = pMap->getWidth();
+    node_t *pTarget = m_pPf->m_pNodes + iEndY * iWidth + iEndX;
+
+    while(true)
+    {
+        if(pNode == pTarget)
+        {
+            m_pPf->m_pDestination = pTarget;
+            return true;
+        }
+
+        uint32_t iFlags = pMap->getNodeUnchecked(pNode->x, pNode->y)->iFlags;
+        if (pathingNeighbours(pNode, iFlags, iWidth)) return true;
+
+        if(m_pPf->m_iOpenCount == 0)
+        {
+            m_pPf->m_pDestination = NULL;
+            break;
+        }
+        else
+            pNode = m_pPf->_openHeapPop();
+    }
+    return false;
+}
+
+int HospitalFinder::makeGuess(node_t *pNode)
+{
+    return 0;
+}
+
+bool HospitalFinder::tryNode(node_t *pNode, uint32_t iFlags,
+                             node_t *pNeighbour, int direction)
+{
+    uint32_t iPassable = iFlags & THMN_Passable;
+    uint32_t iNFlags = m_pMap->getNodeUnchecked(pNeighbour->x, pNeighbour->y)->iFlags;
+    pathingTryNode(pNode, iNFlags, iPassable, pNeighbour);
+    return false;
+}
+
+bool HospitalFinder::findPathToHospital(const THMap *pMap, int iStartX, int iStartY)
+{
+    if(pMap == NULL)
+        pMap = m_pPf->m_pDefaultMap;
+    if(pMap == NULL || pMap->getNode(iStartX, iStartY) == NULL
+        || (pMap->getNodeUnchecked(iStartX, iStartY)->iFlags & THMN_Passable) == 0)
+    {
+        m_pPf->m_pDestination = NULL;
+        return false;
+    }
+
+    m_pMap = pMap;
+
+    node_t *pNode = pathingInit(pMap, iStartX, iStartY);
+    int iWidth = pMap->getWidth();
+
+    while(true)
+    {
+        uint32_t iFlags = pMap->getNodeUnchecked(pNode->x, pNode->y)->iFlags;
+
+        if(iFlags & THMN_Hospital)
+        {
+            m_pPf->m_pDestination = pNode;
+            return true;
+        }
+
+        if (pathingNeighbours(pNode, iFlags, iWidth)) return true;
+
+        if(m_pPf->m_iOpenCount == 0)
+        {
+            m_pPf->m_pDestination = NULL;
+            break;
+        }
+        else
+            pNode = m_pPf->_openHeapPop();
+    }
+    return false;
+}
+
+int IdleTileFinder::makeGuess(node_t *pNode)
+{
+    return 0;
+}
+
+bool IdleTileFinder::tryNode(node_t *pNode, uint32_t iFlags,
+                             node_t *pNeighbour, int direction)
+{
+    uint32_t iPassable = iFlags & THMN_Passable;
+    uint32_t iNFlags = m_pMap->getNodeUnchecked(pNeighbour->x, pNeighbour->y)->iFlags;
+    /* When finding an idle tile, do not navigate through doors */
+    switch(direction)
+    {
+    case THTD_North:
+        if((iFlags & THMN_DoorNorth) == 0)
+            pathingTryNode(pNode, iNFlags, iPassable, pNeighbour);
+        break;
+
+    case THTD_East:
+        if((iNFlags & THMN_DoorWest) == 0)
+            pathingTryNode(pNode, iNFlags, iPassable, pNeighbour);
+        break;
+
+    case THTD_South:
+        if((iNFlags & THMN_DoorNorth) == 0)
+            pathingTryNode(pNode, iNFlags, iPassable, pNeighbour);
+        break;
+
+    case THTD_West:
+        if((iFlags & THMN_DoorWest) == 0)
+            pathingTryNode(pNode, iNFlags, iPassable, pNeighbour);
+        break;
+    }
+
+    /* Identify the neighbour in the open list nearest to the start */
+    if(pNeighbour->prev != pNeighbour && pNeighbour->open_idx != -1)
+    {
+        int iDX = pNeighbour->x - m_iStartX;
+        int iDY = pNeighbour->y - m_iStartY;
+        double fDistance = sqrt((double)(iDX * iDX + iDY * iDY));
+        if(m_pBestNext == NULL || fDistance < m_fBestDistance)
+        {
+            m_pBestNext = pNeighbour; m_fBestDistance = fDistance;
+        }
+    }
+    return false;
+}
+
+bool IdleTileFinder::findIdleTile(const THMap *pMap, int iStartX, int iStartY, int iN)
+{
+    if(pMap == NULL)
+        pMap = m_pPf->m_pDefaultMap;
+    if(pMap == NULL)
+    {
+        m_pPf->m_pDestination = NULL;
+        return false;
+    }
+
+    m_iStartX = iStartX;
+    m_iStartY = iStartY;
+    m_pMap = pMap;
+
+    node_t *pNode = pathingInit(pMap, iStartX, iStartY);
+    int iWidth = pMap->getWidth();
+    node_t *pPossibleResult = NULL;
+
+    while(true)
+    {
+        pNode->open_idx = -1;
+        uint32_t iFlags = pMap->getNodeUnchecked(pNode->x, pNode->y)->iFlags;
+
+        if((iFlags & THMN_DoNotIdle) == 0 && (iFlags & THMN_Passable) && (iFlags & THMN_Hospital))
+        {
+            if(iN == 0)
+            {
+                m_pPf->m_pDestination = pNode;
+                return true;
+            }
+            else
+            {
+                pPossibleResult = pNode;
+                --iN;
+            }
+        }
+
+        m_pBestNext = NULL;
+        m_fBestDistance = 0.0;
+
+        if (pathingNeighbours(pNode, iFlags, iWidth)) return true;
+
+        if(m_pPf->m_iOpenCount == 0)
+        {
+            m_pPf->m_pDestination = NULL;
+            break;
+        }
+        if(m_pBestNext)
+        {
+            // Promote the best neighbour to the front of the open list
+            // This causes sequential iN to give neighbouring results for most iN
+            m_pBestNext->guess = -m_pBestNext->distance;
+            m_pPf->_openHeapPromote(m_pBestNext);
+        }
+        pNode = m_pPf->_openHeapPop();
+    }
+    if(pPossibleResult)
+    {
+        m_pPf->m_pDestination = pPossibleResult;
+        return true;
+    }
+    return false;
+}
+
+int Objectsvisitor::makeGuess(node_t *pNode)
+{
+    return 0;
+}
+
+bool Objectsvisitor::tryNode(node_t *pNode, uint32_t iFlags, node_t *pNeighbour, int direction)
+{
+    int iObjectNumber = 0;
+    const THMapNode *pMapNode = m_pMap->getNodeUnchecked(pNeighbour->x, pNeighbour->y);
+    uint32_t iNFlags = m_pMap->getNodeUnchecked(pNeighbour->x, pNeighbour->y)->iFlags;
+    if ((iNFlags & 0xFF000000) == m_iTHOB)
+        iObjectNumber = 1;
+    if(pMapNode->pExtendedObjectList != NULL)
+    {
+        int count = *pMapNode->pExtendedObjectList & 7;
+        for(int i = 0; i < count; i++)
+        {
+            int thob = (*pMapNode->pExtendedObjectList >> (3 + i* 8)) & 255;
+            if(thob == m_eTHOB)
+                iObjectNumber++;
+        }
+    }
+    if(m_bAnyObjectType)
+        iObjectNumber = 1;
+    bool bSucces = false;
+    for(int i = 0; i < iObjectNumber; i++)
+    {
+        /* call the given Lua function, passing four arguments: */
+        /* The x and y position of the object (Lua tile co-ords) */
+        /* The direction which was last travelled in to reach (x,y); */
+        /*   0 (north), 1 (east), 2 (south), 3 (west) */
+        /* The distance to the object from the search starting point */
+        lua_pushvalue(m_pL, m_iVisitFunction);
+        lua_pushinteger(m_pL, pNeighbour->x + 1);
+        lua_pushinteger(m_pL, pNeighbour->y + 1);
+        lua_pushinteger(m_pL, direction);
+        lua_pushinteger(m_pL, pNode->distance);
+        lua_call(m_pL, 4, 1);
+        if(lua_toboolean(m_pL, -1) != 0)
+        {
+            bSucces = true;
+        }
+        lua_pop(m_pL, 1);
+    }
+    if(bSucces)
+        return true;
+
+    if(pNode->distance < m_iMaxDistance)
+    {
+        uint32_t iPassable = iFlags & THMN_Passable;
+        switch(direction)
+        {
+        case THTD_North:
+            if((iFlags & THMN_DoorNorth) == 0)
+                pathingTryNode(pNode, iNFlags, iPassable, pNeighbour);
+            break;
+
+        case THTD_East:
+            if((iNFlags & THMN_DoorWest) == 0)
+                pathingTryNode(pNode, iNFlags, iPassable, pNeighbour);
+            break;
+
+        case THTD_South:
+            if((iNFlags & THMN_DoorNorth) == 0)
+                pathingTryNode(pNode, iNFlags, iPassable, pNeighbour);
+            break;
+
+        case THTD_West:
+            if((iFlags & THMN_DoorWest) == 0)
+                pathingTryNode(pNode, iNFlags, iPassable, pNeighbour);
+            break;
+        }
+    }
+    return false;
+}
+
+bool Objectsvisitor::visitObjects(const THMap *pMap, int iStartX, int iStartY,
+                                  THObjectType eTHOB, int iMaxDistance,
+                                  lua_State *L, int iVisitFunction, bool anyObjectType)
+{
+    if(pMap == NULL)
+        pMap = m_pPf->m_pDefaultMap;
+    if(pMap == NULL)
+    {
+        m_pPf->m_pDestination = NULL;
+        return false;
+    }
+
+    m_iTHOB = static_cast<uint32_t>(eTHOB) << 24;
+    m_pL = L;
+    m_iVisitFunction = iVisitFunction;
+    m_iMaxDistance = iMaxDistance;
+    m_bAnyObjectType = anyObjectType;
+    m_eTHOB = eTHOB;
+    m_pMap = pMap;
+
+    node_t *pNode = pathingInit(pMap, iStartX, iStartY);
+    int iWidth = pMap->getWidth();
+
+    while(true)
+    {
+        uint32_t iFlags = pMap->getNodeUnchecked(pNode->x, pNode->y)->iFlags;
+        if (pathingNeighbours(pNode, iFlags, iWidth)) return true;
+
+        if(m_pPf->m_iOpenCount == 0)
+        {
+            m_pPf->m_pDestination = NULL;
+            break;
+        }
+        else
+            pNode = m_pPf->_openHeapPop();
+    }
+    return false;
+}
+
+THPathfinder::THPathfinder() : m_oPathFinder(this), m_oHospitalFinder(this),
+                               m_oIdleTileFinder(this), m_oObjectsvisitor(this)
 {
     m_pNodes = NULL;
     m_ppDirtyList = NULL;
@@ -54,341 +454,7 @@ void THPathfinder::setDefaultMap(const THMap *pMap)
     m_pDefaultMap = pMap;
 }
 
-#define Pathing_Init() \
-    int iWidth = pMap->getWidth(); \
-    m_pDestination = NULL; \
-    _allocNodeCache(iWidth, pMap->getHeight()); \
-    node_t *pNode = m_pNodes + iStartY * iWidth + iStartX; \
-    pNode->prev = NULL; \
-    pNode->distance = 0; \
-    MakeGuess(pNode); \
-    m_ppDirtyList[0] = pNode; \
-    m_iDirtyCount = 1; \
-    m_iOpenCount = 0;
 
-    /* No need to check for the node being on the map edge, as the N/E/S/W
-       flags are set as to prevent travelling off the map (as well as to
-       prevent walking through walls). */
-#define Pathing_Neighbours() \
-    uint32_t iPassable = iFlags & THMN_Passable; \
-    if(iFlags & THMN_CanTravelW) \
-    { \
-        TryNode(pNode - 1, 3); \
-    } \
-    if(iFlags & THMN_CanTravelE) \
-    { \
-        TryNode(pNode + 1, 1); \
-    } \
-    if(iFlags & THMN_CanTravelN) \
-    { \
-        TryNode(pNode - iWidth, 0); \
-    } \
-    if(iFlags & THMN_CanTravelS) \
-    { \
-        TryNode(pNode + iWidth, 2); \
-    } \
-
-#define Pathing_TryNode() \
-    if(iNFlags & THMN_Passable || iPassable == 0) \
-    { \
-        if(pNeighbour->prev == pNeighbour) \
-        { \
-            pNeighbour->prev = pNode; \
-            pNeighbour->distance = pNode->distance + 1; \
-            MakeGuess(pNeighbour); \
-            m_ppDirtyList[m_iDirtyCount++] = pNeighbour; \
-            _openHeapPush(pNeighbour); \
-        } \
-        else if((pNode->distance + 1) < pNeighbour->distance) \
-        { \
-            pNeighbour->prev = pNode; \
-            pNeighbour->distance = pNode->distance + 1; \
-            /* guess doesn't change, and already in the dirty list */ \
-            _openHeapPromote(pNeighbour); \
-        } \
-    }
-
-#define Pathing_Next() \
-    if(m_iOpenCount == 0) \
-    { \
-        m_pDestination = NULL; \
-        break; \
-    } \
-    else \
-        pNode = _openHeapPop()
-
-bool THPathfinder::findPath(const THMap *pMap, int iStartX, int iStartY, int iEndX, int iEndY)
-{
-    if(pMap == NULL)
-        pMap = m_pDefaultMap;
-    if(pMap == NULL || pMap->getNode(iEndX, iEndY) == NULL
-        || (pMap->getNodeUnchecked(iEndX, iEndY)->iFlags & THMN_Passable) == 0)
-    {
-        m_pDestination = NULL;
-        return false;
-    }
-
-    // As diagonal movement is not allowed, the minimum distance between two
-    // points is the sum of the distance in X and the distance in Y. Provided
-    // that the compiler generates clever assembly for abs(), this means that
-    // guesses can be calculated without branching and without sqrt().
-#define MakeGuess(pNode) \
-    pNode->guess = abs(pNode->x - iEndX) + abs(pNode->y - iEndY)
-
-    Pathing_Init();
-    node_t *pTarget = m_pNodes + iEndY * iWidth + iEndX;
-
-    while(true)
-    {
-        if(pNode == pTarget)
-        {
-            m_pDestination = pTarget;
-            return true;
-        }
-
-        uint32_t iFlags = pMap->getNodeUnchecked(pNode->x, pNode->y)->iFlags;
-
-#define TryNode(n, d) \
-        node_t *pNeighbour = n; \
-        uint32_t iNFlags = pMap->getNodeUnchecked(pNeighbour->x, pNeighbour->y)->iFlags; \
-        Pathing_TryNode()
-
-        Pathing_Neighbours();
-        Pathing_Next();
-    }
-    return false;
-
-#undef MakeGuess
-#undef TryNode
-}
-
-bool THPathfinder::findPathToHospital(const THMap *pMap, int iStartX, int iStartY)
-{
-    if(pMap == NULL)
-        pMap = m_pDefaultMap;
-    if(pMap == NULL || pMap->getNode(iStartX, iStartY) == NULL
-        || (pMap->getNodeUnchecked(iStartX, iStartY)->iFlags & THMN_Passable) == 0)
-    {
-        m_pDestination = NULL;
-        return false;
-    }
-
-#define MakeGuess(pNode) pNode->guess = 0
-
-    Pathing_Init();
-
-    while(true)
-    {
-        uint32_t iFlags = pMap->getNodeUnchecked(pNode->x, pNode->y)->iFlags;
-
-        if(iFlags & THMN_Hospital)
-        {
-            m_pDestination = pNode;
-            return true;
-        }
-
-#define TryNode(n, d) \
-        node_t *pNeighbour = n; \
-        uint32_t iNFlags = pMap->getNodeUnchecked(pNeighbour->x, pNeighbour->y)->iFlags; \
-        Pathing_TryNode()
-
-        Pathing_Neighbours();
-        Pathing_Next();
-    }
-    return false;
-
-#undef MakeGuess
-#undef TryNode
-}
-
-bool THPathfinder::findIdleTile(const THMap *pMap, int iStartX, int iStartY, int iN)
-{
-    if(pMap == NULL)
-        pMap = m_pDefaultMap;
-    if(pMap == NULL)
-    {
-        m_pDestination = NULL;
-        return false;
-    }
-
-#define MakeGuess(pNode) \
-    pNode->guess = 0
-
-    Pathing_Init();
-    node_t *pPossibleResult = NULL;
-
-    while(true)
-    {
-        pNode->open_idx = -1;
-        uint32_t iFlags = pMap->getNodeUnchecked(pNode->x, pNode->y)->iFlags;
-
-        if((iFlags & THMN_DoNotIdle) == 0 && (iFlags & THMN_Passable) && (iFlags & THMN_Hospital))
-        {
-            if(iN == 0)
-            {
-                m_pDestination = pNode;
-                return true;
-            }
-            else
-            {
-                pPossibleResult = pNode;
-                --iN;
-            }
-        }
-
-        node_t* pBestNext = NULL;
-        double fBestDistance = 0.0;
-
-#define TryNode(n, d) \
-        node_t *pNeighbour = n; \
-        uint32_t iNFlags = pMap->getNodeUnchecked(pNeighbour->x, pNeighbour->y)->iFlags; \
-        /* When finding an idle tile, do not navigate through doors */ \
-        switch(d) \
-        { \
-        case 0: \
-            if((iFlags & THMN_DoorNorth) == 0) {Pathing_TryNode()} \
-            break; \
-        case 1: \
-            if((iNFlags & THMN_DoorWest) == 0) {Pathing_TryNode()} \
-            break; \
-        case 2: \
-            if((iNFlags & THMN_DoorNorth) == 0) {Pathing_TryNode()} \
-            break; \
-        case 3: \
-            if((iFlags & THMN_DoorWest) == 0)  {Pathing_TryNode()} \
-            break; \
-        } \
-        /* Identify the neighbour in the open list nearest to the start */ \
-        if(pNeighbour->prev != pNeighbour && pNeighbour->open_idx != -1) \
-        { \
-            int iDX = pNeighbour->x - iStartX; \
-            int iDY = pNeighbour->y - iStartY; \
-            double fDistance = sqrt((double)(iDX * iDX + iDY * iDY)); \
-            if(pBestNext == NULL || fDistance < fBestDistance) \
-                pBestNext = pNeighbour, fBestDistance = fDistance; \
-        }
-
-        Pathing_Neighbours();
-
-        if(m_iOpenCount == 0)
-        {
-            m_pDestination = NULL;
-            break;
-        }
-        if(pBestNext)
-        {
-            // Promote the best neighbour to the front of the open list
-            // This causes sequential iN to give neighbouring results for most iN
-            pBestNext->guess = -pBestNext->distance;
-            _openHeapPromote(pBestNext);
-        }
-        pNode = _openHeapPop();
-    }
-    if(pPossibleResult)
-    {
-        m_pDestination = pPossibleResult;
-        return true;
-    }
-    return false;
-
-#undef MakeGuess
-#undef TryNode
-}
-
-bool THPathfinder::visitObjects(const THMap *pMap, int iStartX, int iStartY,
-                                THObjectType eTHOB, int iMaxDistance,
-                                lua_State *L, int iVisitFunction, bool anyObjectType)
-{
-    if(pMap == NULL)
-        pMap = m_pDefaultMap;
-    if(pMap == NULL)
-    {
-        m_pDestination = NULL;
-        return false;
-    }
-
-#define MakeGuess(pNode) \
-    pNode->guess = 0
-
-    Pathing_Init();
-    uint32_t iTHOB = static_cast<uint32_t>(eTHOB) << 24;
-
-    while(true)
-    {
-        uint32_t iFlags = pMap->getNodeUnchecked(pNode->x, pNode->y)->iFlags;
-
-#define TryNode(n, d) \
-        node_t *pNeighbour = n; \
-        int iObjectNumber = 0; \
-        const THMapNode *pMapNode = pMap->getNodeUnchecked(pNeighbour->x, pNeighbour->y);\
-        uint32_t iNFlags = pMap->getNodeUnchecked(pNeighbour->x, pNeighbour->y)->iFlags; \
-        if ((iNFlags & 0xFF000000) == iTHOB) \
-            iObjectNumber = 1; \
-        if(pMapNode->pExtendedObjectList != NULL)\
-        {\
-            int count = *pMapNode->pExtendedObjectList & 7;\
-            for(int i = 0; i < count; i++) \
-            { \
-                int thob = (*pMapNode->pExtendedObjectList & (255 << (3  + (i << 3)))) >> (3 + (i << 3)); \
-                if(thob == eTHOB)\
-                    iObjectNumber++; \
-            } \
-        } \
-        if(anyObjectType) \
-            iObjectNumber = 1; \
-        bool bSucces = false; \
-        for(int i = 0; i < iObjectNumber; i++) \
-        { \
-            /* call the given Lua function, passing four arguments: */ \
-            /* The x and y position of the object (Lua tile co-ords) */ \
-            /* The direction which was last travelled in to reach (x,y); */ \
-            /*   0 (north), 1 (east), 2 (south), 3 (west) */ \
-            /* The distance to the object from the search starting point */ \
-            lua_pushvalue(L, iVisitFunction); \
-            lua_pushinteger(L, pNeighbour->x + 1); \
-            lua_pushinteger(L, pNeighbour->y + 1); \
-            lua_pushinteger(L, d); \
-            lua_pushinteger(L, pNode->distance); \
-            lua_call(L, 4, 1); \
-            if(lua_toboolean(L, -1) != 0) \
-            { \
-                bSucces = true; \
-            } \
-            lua_pop(L, 1); \
-        } \
-        if(bSucces) \
-            return true; \
-        if(pNode->distance < iMaxDistance) \
-        { \
-            switch(d) \
-            { \
-            case 0: \
-                if((iFlags & THMN_DoorNorth) == 0) {Pathing_TryNode()} \
-                break; \
-            case 1: \
-                if((iNFlags & THMN_DoorWest) == 0) {Pathing_TryNode()} \
-                break; \
-            case 2: \
-                if((iNFlags & THMN_DoorNorth) == 0) {Pathing_TryNode()} \
-                break; \
-            case 3: \
-                if((iFlags & THMN_DoorWest) == 0)  {Pathing_TryNode()} \
-                break; \
-            } \
-        }
-
-        Pathing_Neighbours();
-        Pathing_Next();
-    }
-    return false;
-
-#undef MakeGuess
-#undef TryNode
-}
-
-#undef Pathing_Init
-#undef Pathing_TryNode
-#undef Pathing_NeighboursAndNext
 
 void THPathfinder::_allocNodeCache(int iWidth, int iHeight)
 {
@@ -474,7 +540,7 @@ void THPathfinder::pushResult(lua_State *L) const
     }
 }
 
-void THPathfinder::_openHeapPush(THPathfinder::node_t* pNode)
+void THPathfinder::_openHeapPush(node_t* pNode)
 {
     if(m_iOpenCount == m_iOpenSize)
     {
@@ -487,7 +553,7 @@ void THPathfinder::_openHeapPush(THPathfinder::node_t* pNode)
     _openHeapPromote(pNode);
 }
 
-void THPathfinder::_openHeapPromote(THPathfinder::node_t* pNode)
+void THPathfinder::_openHeapPromote(node_t* pNode)
 {
     int i = pNode->open_idx;
     while(i > 0)
@@ -504,7 +570,7 @@ void THPathfinder::_openHeapPromote(THPathfinder::node_t* pNode)
     pNode->open_idx = i;
 }
 
-THPathfinder::node_t* THPathfinder::_openHeapPop()
+node_t* THPathfinder::_openHeapPop()
 {
     node_t *pResult = m_ppOpenHeap[0];
     node_t *pNode = m_ppOpenHeap[--m_iOpenCount];

--- a/CorsixTH/Src/th_pathfind.h
+++ b/CorsixTH/Src/th_pathfind.h
@@ -26,6 +26,174 @@ SOFTWARE.
 
 class LuaPersistReader;
 class LuaPersistWriter;
+class THPathfinder;
+
+/** Directions of movement. */
+enum TravelDirections
+{
+    THTD_North = 0, ///< Move to the north.
+    THTD_East  = 1, ///< Move to the east.
+    THTD_South = 2, ///< Move to the south.
+    THTD_West  = 3, ///< Move to the west.
+};
+
+/** Node in the path finder routines. */
+struct node_t
+{
+    //! Pointer to the previous node in the path to this cell.
+    /*!
+        Points to NULL if this is the first cell in the path, or points to
+        itself if it is not part of a path.
+    */
+    const node_t* prev;
+
+    //! X-position of this cell (constant)
+    int x;
+
+    //! Y-position of this cell (constant)
+    int y;
+
+    //! Current shortest distance to this cell
+    /*!
+        Defined as prev->distance + 1 (or 0 if prev == NULL).
+        Value is undefined if not part of a path.
+    */
+    int distance;
+
+    //! Minimum distance from this cell to the goal
+    /*!
+        Value is only dependant upon the cell position and the goal
+        position, and is undefined if not part of a path.
+    */
+    int guess;
+
+    //! Index of this cell in the open heap
+    /*!
+        If the cell is not in the open heap, then this value is undefined.
+    */
+    int open_idx;
+
+    //! Total cost of this node.
+    /*!
+        @return Total cost of the node, traveled distance and guess to the destination.
+     */
+    inline int value() const { return distance + guess; }
+};
+
+/** Base class of the path finders. */
+class BasePathing
+{
+public:
+    BasePathing(THPathfinder *pf);
+
+    //! Initialize the path finder.
+    /*!
+        @param pMap Map to search on.
+        @param iStartX X coordinate of the start position.
+        @param iStarty Y coordinate of the start position.
+        @return The initial node to expand.
+     */
+    node_t *pathingInit(const THMap *pMap, int iStartX, int iStarty);
+
+    //! Expand the \a pNode to its neighbours.
+    /*!
+        @param pNode Node to expand.
+        @param iFlags Flags of the node.
+        @param iWidth Width of the map.
+        @return Whether the search is done.
+     */
+    bool pathingNeighbours(node_t *pNode, uint32_t iFlags, int iWidth);
+
+    void pathingTryNode(node_t *pNode, uint32_t iNFlags, uint32_t iPassable,
+                        node_t *pNeighbour);
+
+    //! Guess distance to the destination for \a pNode.
+    /*!
+        @param pNode Node to fill.
+     */
+    virtual int makeGuess(node_t *pNode) = 0;
+
+    //! Try the \a pNeighbour node.
+    /*!
+        @param pNode Source node.
+        @param iFlags Flags of the node.
+        @param iPassable
+        @param pNeighbour Neighbour of \a pNode to try.
+        @param direction Direction of travel.
+        @return Whether the search is done.
+     */
+    virtual bool tryNode(node_t *pNode, uint32_t iFlags,
+                         node_t *pNeighbour, int direction) = 0;
+
+protected:
+    THPathfinder *m_pPf; ///< Path finder parent object, containing shared data.
+    const THMap *m_pMap; ///< Map being searched.
+};
+
+class PathFinder : public BasePathing
+{
+public:
+    PathFinder(THPathfinder *pf) : BasePathing(pf) { }
+
+    virtual int makeGuess(node_t *pNode);
+    virtual bool tryNode(node_t *pNode, uint32_t iFlags,
+                         node_t *pNeighbour, int direction);
+
+    bool findPath(const THMap *pMap, int iStartX, int iStartY, int iEndX, int iEndY);
+
+    int m_iEndX; ///< X coordinate of the destination of the path.
+    int m_iEndY; ///< Y coordinate of the destination of the path.
+};
+
+class HospitalFinder : public BasePathing
+{
+public:
+    HospitalFinder(THPathfinder *pf) : BasePathing(pf) { }
+
+    virtual int makeGuess(node_t *pNode);
+    virtual bool tryNode(node_t *pNode, uint32_t iFlags,
+                         node_t *pNeighbour, int direction);
+
+    bool findPathToHospital(const THMap *pMap, int iStartX, int iStartY);
+};
+
+class IdleTileFinder : public BasePathing
+{
+public:
+    IdleTileFinder(THPathfinder *pf) : BasePathing(pf) { }
+
+    virtual int makeGuess(node_t *pNode);
+    virtual bool tryNode(node_t *pNode, uint32_t iFlags,
+                         node_t *pNeighbour, int direction);
+
+    bool findIdleTile(const THMap *pMap, int iStartX, int iStartY, int iN);
+
+    node_t *m_pBestNext;
+    double m_fBestDistance;
+    int m_iStartX;       ///< X coordinate of the start position.
+    int m_iStartY;       ///< Y coordinate of the start position.
+};
+
+class Objectsvisitor : public BasePathing
+{
+public:
+    Objectsvisitor(THPathfinder *pf) : BasePathing(pf) { }
+
+    virtual int makeGuess(node_t *pNode);
+    virtual bool tryNode(node_t *pNode, uint32_t iFlags,
+                         node_t *pNeighbour, int direction);
+
+    bool visitObjects(const THMap *pMap, int iStartX, int iStartY,
+                      THObjectType eTHOB, int iMaxDistance,
+                      lua_State *L, int iVisitFunction, bool anyObjectType);
+
+    uint32_t m_iTHOB;
+    lua_State *m_pL;
+    int m_iVisitFunction;
+    int m_iMaxDistance;
+    bool m_bAnyObjectType;
+    THObjectType m_eTHOB;
+};
 
 //! Finds paths through maps
 /*!
@@ -50,13 +218,30 @@ public:
 
     void setDefaultMap(const THMap *pMap);
 
-    bool findPath(const THMap *pMap, int iStartX, int iStartY, int iEndX,
-                  int iEndY);
-    bool findIdleTile(const THMap *pMap, int iStartX, int iStartY, int iN);
-    bool findPathToHospital(const THMap *pMap, int iStartX, int iStartY);
-    bool visitObjects(const THMap *pMap, int iStartX, int iStartY,
+    inline bool findPath(const THMap *pMap, int iStartX, int iStartY, int iEndX,
+                         int iEndY)
+    {
+        return m_oPathFinder.findPath(pMap, iStartX, iStartY, iEndX, iEndY);
+    }
+
+    inline bool findIdleTile(const THMap *pMap, int iStartX, int iStartY, int iN)
+    {
+        return m_oIdleTileFinder.findIdleTile(pMap, iStartX, iStartY, iN);
+    }
+
+    inline bool findPathToHospital(const THMap *pMap, int iStartX, int iStartY)
+    {
+        return m_oHospitalFinder.findPathToHospital(pMap, iStartX, iStartY);
+    }
+
+    inline bool visitObjects(const THMap *pMap, int iStartX, int iStartY,
                       THObjectType eTHOB, int iMaxDistance, lua_State *L,
-                      int iVisitFunction, bool anyObjectType);
+                      int iVisitFunction, bool anyObjectType)
+    {
+        return m_oObjectsvisitor.visitObjects(
+                            pMap, iStartX, iStartY, eTHOB, iMaxDistance,
+                            L, iVisitFunction, anyObjectType);
+    }
 
     int getPathLength() const;
     bool getPathEnd(int* pX, int* pY) const;
@@ -65,45 +250,11 @@ public:
     void persist(LuaPersistWriter *pWriter) const;
     void depersist(LuaPersistReader *pReader);
 
-protected:
-    struct node_t
-    {
-        //! Pointer to the previous node in the path to this cell.
-        /*!
-            Points to NULL if this is the first cell in the path, or points to
-            itself if it is not part of a path.
-        */
-        const node_t* prev;
-
-        //! X-position of this cell (constant)
-        int x;
-
-        //! Y-position of this cell (constant)
-        int y;
-
-        //! Current shortest distance to this cell
-        /*!
-            Defined as prev->distance + 1 (or 0 if prev == NULL).
-            Value is undefined if not part of a path.
-        */
-        int distance;
-
-        //! Minimum distance from this cell to the goal
-        /*!
-            Value is only dependant upon the cell position and the goal
-            position, and is undefined if not part of a path.
-        */
-        int guess;
-
-        //! Index of this cell in the open heap
-        /*!
-            If the cell is not in the open heap, then this value is undefined.
-        */
-        int open_idx;
-
-        inline int value() const {return distance + guess;}
-    };
-
+    //! Allocate node cache for all tiles of the map.
+    /*!
+        @param iWidth Width of the map.
+        @param iHeight Height of the map.
+     */
     void _allocNodeCache(int iWidth, int iHeight);
 
     node_t* _openHeapPop();
@@ -118,7 +269,7 @@ protected:
     //! Array of "dirty" nodes which need to be reset before the next path find
     /*!
         This array is always large enough to hold every single node, and
-        m_iDirtyCount holds the number of items currently in the array.
+        #m_iDirtyCount holds the number of items currently in the array.
     */
     node_t **m_ppDirtyList;
 
@@ -129,8 +280,8 @@ protected:
           value(i) <= value(i * 2 + 2)
         This causes the array to be a minimum binary heap.
 
-        Note that unlike the dirty list, there is only space for m_iOpenSize
-        items (with m_iOpenCount being the current number of items).
+        Note that unlike the dirty list, there is only space for #m_iOpenSize
+        items (with #m_iOpenCount being the current number of items).
     */
     node_t **m_ppOpenHeap;
 
@@ -140,6 +291,12 @@ protected:
     int m_iDirtyCount;
     int m_iOpenCount;
     int m_iOpenSize;
+
+protected:
+    PathFinder m_oPathFinder;
+    HospitalFinder m_oHospitalFinder;
+    IdleTileFinder m_oIdleTileFinder;
+    Objectsvisitor m_oObjectsvisitor;
 };
 
 #endif // CORSIX_TH_TH_PATHFIND_H_


### PR DESCRIPTION
Move the #define magic of the 4 path finders to 4 derived classes, cleaning up compile warnings along the way. Focus was on making the code readable, and remove the compiler warnings.

Intentionally left the patch as many small changes (except for 1 or 2), so it's at least somewhat trackable what I did, until it is decided this is what is wanted.

Some things remain to be handled somewhen in the future, as far as I can see
- _openHeapPromote method in BasePathing::pathingTryNode looks wrong. The path finder could be broken here. It does get called as well.
- The 'return 0;' in MakeGuess reduces A* to Dijkstra algorithm, a much slower algorithm. By reversing the search direction, it may be possible to make it an A* search
- C++ has a priority queue nowadays in std::

Throwing out path finding uses in the lua code (and switch to entity map) may make some of the path finders completely obsolete.
