### PR TITLE
Play music tracks in order they appear in MIDI.TXT

### DIFF
--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -166,9 +166,6 @@ function Audio:init()
     print "Notice: Audio system loaded, but found no background tracks"
     self.has_bg_music = false
   else
-    table.sort(self.background_playlist, function(left, right)
-      return left.title:upper() < right.title:upper()
-    end)
     self.has_bg_music = true
   end
 


### PR DESCRIPTION
The original game played music tracks in the order they appeared in MIDI.TXT. Perhaps this was arbitrary, but perhaps it was intended - either way, when the next track isn't the one I expect it's very jarring!

Prior to this change, MIDI.TXT was loaded, titles extracted, then the playlist was sorted on the titles. This is no less arbitrary than the original order. This change removes the sorting step.

I suppose longer-term, the better thing to do would be to have a setting for 'shuffle play', but this is enough to keep me happy for now and I doubt it will inconvenience anyone!