### PR TITLE
Fix: "t" mode suffix in io.open breaks Lua 5.2

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -521,7 +521,7 @@ function App:dumpStrings()
   end
   local dir = self.command_line["config-file"] or ""
   dir = string.sub(dir, 0, -11)
-  local fi = assert(io.open(dir .. "debug-strings-orig.txt", "wt"))
+  local fi = assert(io.open(dir .. "debug-strings-orig.txt", "w"))
   for i, sec in ipairs(_S.deprecated) do
     for j, str in ipairs(sec) do
       fi:write("[" .. i .. "," .. j .. "] " .. ("%q\n"):format(val(str)))
@@ -569,11 +569,11 @@ function App:dumpStrings()
     end
   end
 
-  fi = assert(io.open(dir .. "debug-strings-new-lines.txt", "wt"))
+  fi = assert(io.open(dir .. "debug-strings-new-lines.txt", "w"))
   dump_by_line(fi, _S, "")
   fi:close()
 
-  fi = assert(io.open(dir .. "debug-strings-new-grouped.txt", "wt"))
+  fi = assert(io.open(dir .. "debug-strings-new-grouped.txt", "w"))
   dump_grouped(fi, _S, "")
   fi:close()
 
@@ -644,7 +644,7 @@ function App:checkMissingStringsInLanguage(dir, language)
       end
     end
 
-    local fi = assert(io.open(dir .. "debug-strings-diff-" .. language_english:lower() .. ".txt", "wt"))
+    local fi = assert(io.open(dir .. "debug-strings-diff-" .. language_english:lower() .. ".txt", "w"))
     fi:write("------------------------------------\n")
     fi:write("MISSING STRINGS IN LANGUAGE \"" .. language:upper() .. "\":\n")
     fi:write("------------------------------------\n")

--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -239,7 +239,7 @@ function Audio:initSpeech(speech_file)
 end
 
 function Audio:dumpSoundArchive(out_dir)
-  local info,warning = io.open(out_dir .. "info.csv", "wt")
+  local info,warning = io.open(out_dir .. "info.csv", "w")
 
   if info == nil then
     print("Error: Audio dump failed because info.csv couldn't be created and/or opened in the dump directory:" .. out_dir)


### PR DESCRIPTION
replacing all "wt" modes to "w" mode, as that's what the manual claims to support.
