### PR TITLE
Indentation fixes, deduplicating findHandymanTaskSubtable call.

### DIFF
--- a/CorsixTH/Lua/calls_dispatcher.lua
+++ b/CorsixTH/Lua/calls_dispatcher.lua
@@ -306,12 +306,12 @@ function CallsDispatcher:findSuitableStaff(call)
   for _, e in ipairs(self.world.entities) do
     if class.is(e, Staff) then
       if e.humanoid_class ~= "Handyman" then
-    local score = call.verification(e) and call.priority(e) or nil
-    if score ~= nil and score < min_score then
-      min_score = score
-      min_staff = e
-    end
-    end
+        local score = call.verification(e) and call.priority(e) or nil
+        if score ~= nil and score < min_score then
+          min_score = score
+          min_staff = e
+        end
+      end
     end
   end
 

--- a/CorsixTH/Lua/dialogs/machine_dialog.lua
+++ b/CorsixTH/Lua/dialogs/machine_dialog.lua
@@ -90,12 +90,12 @@ end
 function UIMachine:callHandyman()
   if self.machine.times_used ~= 0 then
     local taskIndex = self.machine.hospital:getIndexOfTask(self.machine.tile_x, self.machine_tile_y, "repairing")
-  if taskIndex == -1 then
-    local call = self.ui.app.world.dispatcher:callForRepair(self.machine, false, true)
-    self.machine.hospital:addHandymanTask(self.machine, "repairing", 2, self.machine.tile_x, self.machine.tile_y, call)
-  else
-    self.machine.hospital:modifyHandymanTaskPriority(taskIndex, 2, "repairing")
-  end
+    if taskIndex == -1 then
+      local call = self.ui.app.world.dispatcher:callForRepair(self.machine, false, true)
+      self.machine.hospital:addHandymanTask(self.machine, "repairing", 2, self.machine.tile_x, self.machine.tile_y, call)
+    else
+      self.machine.hospital:modifyHandymanTaskPriority(taskIndex, 2, "repairing")
+    end
   end
 end
 
@@ -118,10 +118,10 @@ function UIMachine:replaceMachine()
       machine.total_usage = 0
       machine.times_used = 0
       self.machine.strength = strength
-    local index = machine.hospital:getIndexOfTask(machine.tile_x, machine.tile_y, "repairing")
-    if index ~= -1 then
-    machine.hospital:removeHandymanTask(index, "repairing")
-    end
+      local index = machine.hospital:getIndexOfTask(machine.tile_x, machine.tile_y, "repairing")
+      if index ~= -1 then
+        machine.hospital:removeHandymanTask(index, "repairing")
+      end
       machine:setRepairing(nil)
     end
   ))

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -342,10 +342,10 @@ function UIStaff:changeHandymanAttributes(increased)
   end
   if extra_decrease ~= 0 then
     for no, attr in ipairs(attributes) do
-    if attr ~= increased then
-      self.staff:changeAttribute(attr, -extra_decrease)
+      if attr ~= increased then
+        self.staff:changeAttribute(attr, -extra_decrease)
+      end
     end
-  end
   end
 end
 

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -567,9 +567,10 @@ function Patient:tickDay()
     elseif self.waiting == 30 then
       self:checkWatch()
     end
-  if self.has_vomitted and self.has_vomitted > 0 then
-    self.has_vomitted = 0
-  end
+
+    if self.has_vomitted and self.has_vomitted > 0 then
+      self.has_vomitted = 0
+    end
   end
 
   -- if patients are getting unhappy, then maybe we should see this!

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1769,7 +1769,6 @@ function AIHospital:logTransaction()
 end
 
 function Hospital:addHandymanTask(object, taskType, priority, x, y, call)
-
   local parcelId = self.world.map.th:getCellFlags(x, y).parcelId
   local subTable = self:findHandymanTaskSubtable(taskType)
   table.insert(subTable, {["object"] = object, ["priority"] = priority, ["tile_x"] = x, ["tile_y"] = y, ["parcelId"] = parcelId, ["call"] = call});
@@ -1778,7 +1777,7 @@ end
 function Hospital:modifyHandymanTaskPriority(taskIndex, newPriority, taskType)
   if taskIndex ~= -1 then
     local subTable = self:findHandymanTaskSubtable(taskType)
-    self:findHandymanTaskSubtable(taskType)[taskIndex].priority = newPriority;
+    subTable[taskIndex].priority = newPriority;
   end
 end
 
@@ -1813,10 +1812,10 @@ function Hospital:assignHandymanToTask(handyman, taskIndex, taskType)
   if taskIndex ~= -1 then
     local subTable = self:findHandymanTaskSubtable(taskType)
     if not subTable[taskIndex].assignedHandyman then
-      subTable[taskIndex].assignedHandyman  = handyman
+      subTable[taskIndex].assignedHandyman = handyman
     else
       local formerHandyman = subTable[taskIndex].assignedHandyman
-      subTable[taskIndex].assignedHandyman  = handyman
+      subTable[taskIndex].assignedHandyman = handyman
       formerHandyman:interruptHandymanTask()
     end
   end

--- a/CorsixTH/Lua/objects/plant.lua
+++ b/CorsixTH/Lua/objects/plant.lua
@@ -200,29 +200,29 @@ end
 function Plant:callForWatering()
 
   if self.unreachable then
-  local ux, uy = self:getBestUsageTileXY(handyman.tile_x, handyman.tile_y)
-  if ux and uy then
-    self.unreachable = nil
-  end
+    local ux, uy = self:getBestUsageTileXY(handyman.tile_x, handyman.tile_y)
+    if ux and uy then
+      self.unreachable = nil
+    end
   end
   -- If self.ticks is true it means that a handyman is currently watering the plant.
   -- If there are no tiles to water from, just die.
   if not self.ticks and not self.unreachable then
     local index = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "watering")
-  if index == -1 then
-    local call = self.world.dispatcher:callForWatering(self)
-    if self.current_state > 1 and not self.plant_announced then
-      self.world.ui.adviser:say(_A.warnings.plants_thirsty)
-      self.plant_announced = true
+    if index == -1 then
+      local call = self.world.dispatcher:callForWatering(self)
+      if self.current_state > 1 and not self.plant_announced then
+        self.world.ui.adviser:say(_A.warnings.plants_thirsty)
+        self.plant_announced = true
+      end
+      self.hospital:addHandymanTask(self, "watering", self.current_state + 1, self.tile_x, self.tile_y, call)
+    else
+      if self.current_state > 1 and not self.plant_announced then
+        self.world.ui.adviser:say(_A.warnings.plants_thirsty)
+        self.plant_announced = true
+      end
+      self.hospital:modifyHandymanTaskPriority(index, self.current_state + 1, "watering")
     end
-    self.hospital:addHandymanTask(self, "watering", self.current_state + 1, self.tile_x, self.tile_y, call)
-  else
-    if self.current_state > 1 and not self.plant_announced then
-      self.world.ui.adviser:say(_A.warnings.plants_thirsty)
-      self.plant_announced = true
-    end
-    self.hospital:modifyHandymanTaskPriority(index, self.current_state + 1, "watering")
-  end
   end
 end
 
@@ -239,10 +239,10 @@ function Plant:createHandymanActions(handyman)
     -- The plant cannot be reached.
     self.unreachable = true
     self.unreachable_counter = days_unreachable
-  local index = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "watering")
-  if index ~= -1 then
-    self.hospital:removeHandymanTask(index, "watering")
-  end
+    local index = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "watering")
+    if index ~= -1 then
+      self.hospital:removeHandymanTask(index, "watering")
+    end
     -- Release Handyman
     handyman:setCallCompleted()
     if handyman_room then


### PR DESCRIPTION
Several indenting fixes, found by having several consecutive "end" straight under each other, which can't be right.

In hospital.lua, hunks 1 and 3 fix whitespace.
hunk 2 deduplicates a call to findHandymanTaskSubtable, no point in querying the same subtable twice. It's probably a copy/paste error, as the surrounding functions also have the "subtable = ..." call.
