### PR TITLE
Update program run by the installer at end of install

### DIFF
--- a/WindowsInstaller/Win32Script.nsi
+++ b/WindowsInstaller/Win32Script.nsi
@@ -91,7 +91,7 @@ var ICONS_GROUP
 !insertmacro MUI_PAGE_INSTFILES
 
 ; Finish page
-!define MUI_FINISHPAGE_RUN "$INSTDIR\CorsixTH_SDL.exe"
+!define MUI_FINISHPAGE_RUN "$INSTDIR\CorsixTH.exe"
 !define MUI_FINISHPAGE_RUN_NOTCHECKED
 !insertmacro MUI_PAGE_FINISH
 


### PR DESCRIPTION
CorsixTH_SDL.exe no longer exists, CorsxiTH.exe should be run instead.