### PR TITLE
Remove bad debugger.lua file check

### DIFF
--- a/CorsixTH/Lua/run_debugger.lua
+++ b/CorsixTH/Lua/run_debugger.lua
@@ -5,12 +5,6 @@
 -- It does this in the function it returns.
 ---
 local function run()
-  local error_message = is_file_unreadable("CorsixTH/Lua/debugger.lua", true)
-  if error_message  then
-    print(error_message)
-    return "../Lua/debugger.lua is missing or can't be read. Devs are required to download this file: the wiki debugger tutorial has instructions."
-  end
-  
   print "NOTE: While CorsixTH is connected to an IDE's debugger server,"
   print "text will be printed in its output console instead of here."
   


### PR DESCRIPTION
This file check looked for debugger using io methods, which are not suitable
for determining if the file is in the lua path. This causes the check to fail
when the setup is perfectly fine under numerous scenarios, and on some
platforms prevents running the debugger at all. The dofile will fail with a
missing file error anyway, though it would be clearer if we could replace it.