### PR TITLE
Update textbox label if keypress changes text

### DIFF
--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -1136,6 +1136,8 @@ function Textbox:keyInput(char, rawchar)
     else
       self.text = new_line
     end
+    -- update label
+    self.panel:setLabel(self.text)
   end
   -- make cursor visible
   self.cursor_counter = 0


### PR DESCRIPTION
This handles the case of backspace and delete changes not being reflected on
the screen until you entered more text. Fixes #750