### PR TITLE
Fix status report crash with no patients

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
@@ -146,7 +146,19 @@ function UIProgressReport:drawMarkers(canvas, x, y)
   local warmth = self.ui.hospital:getAveragePatientAttribute("warmth")
   local world = self.ui.app.world
 
-  warmth = UIPatient.normaliseWarmth(warmth)
+  -- in lua, NaN value comparisons always return false
+  local function isnan(val)
+    return val ~= 0 and not (val < 0 or val > 0)
+  end
+
+  if isnan(happiness) then happiness = 0.5 end
+  if isnan(thirst) then thirst = 0.5 end
+  if isnan(warmth) then
+    warmth = 0.5
+  else
+    warmth = UIPatient.normaliseWarmth(warmth)
+  end
+
   self.panel_sprites:draw(canvas, 5, math.floor(x + x_min + width * happiness), y + 193)
   self.panel_sprites:draw(canvas, 5, math.floor(x + x_min + width * thirst), y + 223)
   self.panel_sprites:draw(canvas, 5, math.floor(x + x_min + width * warmth), y + 254)


### PR DESCRIPTION
Before there are any patients the average values of warmth, happiness, and
temperature are NaN which crashes the dialog. This accounts for NaN in the
dialog and displays the value right in the center.