### PR TITLE
Fix font cache segfault with unicode fonts when no canvas is given

### DIFF
--- a/CorsixTH/Src/th_gfx_font.cpp
+++ b/CorsixTH/Src/th_gfx_font.cpp
@@ -322,7 +322,7 @@ THFreeTypeFont::THFreeTypeFont()
         pEntry->iLastX = 0;
         pEntry->pData = NULL;
         pEntry->bIsValid = false;
-        _setNullTexture(pEntry);
+        pEntry->pTexture = NULL;
     }
 }
 
@@ -373,7 +373,6 @@ void THFreeTypeFont::clearCache()
     {
         pEntry->bIsValid = false;
         _freeTexture(pEntry);
-        _setNullTexture(pEntry);
     }
 }
 
@@ -526,7 +525,6 @@ int THFreeTypeFont::drawTextWrapped(THRenderTarget* pCanvas, const char* sMessag
         // Cache entry does not match the message being drawn, so discard the
         // cache entry.
         _freeTexture(pEntry);
-        _setNullTexture(pEntry);
         delete[] pEntry->pData;
         pEntry->pData = NULL;
         pEntry->bIsValid = false;
@@ -730,13 +728,15 @@ int THFreeTypeFont::drawTextWrapped(THRenderTarget* pCanvas, const char* sMessag
             FT_Done_Glyph(itr->second.pGlyph);
         }
 
-        // Convert the canvas to a texture
-        _makeTexture(pCanvas, pEntry);
         pEntry->bIsValid = true;
     }
 
     if(pCanvas != NULL)
+    {
+        if(pEntry->pTexture == NULL)
+            _makeTexture(pCanvas, pEntry);
         _drawTexture(pCanvas, pEntry, iX, iY);
+    }
     if(pResultingWidth != NULL)
         *pResultingWidth = pEntry->iWidestLine;
     if(pLastX != NULL)

--- a/CorsixTH/Src/th_gfx_font.h
+++ b/CorsixTH/Src/th_gfx_font.h
@@ -216,19 +216,37 @@ public:
 protected:
     struct cached_text_t
     {
+        //! The text being converted to pixels
         char* sMessage;
+
+        //! Raw pixel data in row major 8-bit greyscale
         uint8_t* pData;
-        union {
-            void* pTexture;
-            int iTexture;
-        };
+
+        //! Generated texture ready to be rendered
+        void* pTexture;
+
+        //! The length of sMessage
         size_t iMessageLength;
+
+        //! The size of the buffer allocated to store sMessage
         size_t iMessageBufferLength;
+
+        //! Width of the image to draw
         int iWidth;
+
+        //! Height of the image to draw
         int iHeight;
+
+        //! The width of the longest line of text in in the textbox in pixels
         int iWidestLine;
+
+        //! X Coordinate trailing the last character in canvas coordinates
         int iLastX;
+
+        //! Alignment of the message in the box
         eTHAlign eAlign;
+
+        //! True when the pData reflects the sMessage given the size constraints
         bool bIsValid;
     };
 
@@ -256,14 +274,6 @@ protected:
     */
     bool _isMonochrome() const;
 
-    //! Set the texture field of a cache entry to indicate no texture.
-    /*!
-        @param pCacheEntry A cache entry whose pTexture or iTexture field
-            should be set to a null value, whatever that means for the
-            rendering engine.
-    */
-    void _setNullTexture(cached_text_t* pCacheEntry) const;
-
     //! Convert a cache canvas containing rendered text into a texture.
     /*!
         @param pEventualCanvas A pointer to the rendertarget we'll be using to
@@ -278,7 +288,7 @@ protected:
     //! Free a previously-made texture of a cache entry.
     /*!
         This call should free all the resources previously allocated by a call
-        to _makeTexture().
+        to _makeTexture() and set the texture field to indicate no texture.
 
         @param pCacheEntry A cache entry previously passed to _makeTexture().
     */

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -1505,16 +1505,12 @@ bool THFreeTypeFont::_isMonochrome() const
     return true;
 }
 
-void THFreeTypeFont::_setNullTexture(cached_text_t* pCacheEntry) const
-{
-    pCacheEntry->pTexture = NULL;
-}
-
 void THFreeTypeFont::_freeTexture(cached_text_t* pCacheEntry) const
 {
     if(pCacheEntry->pTexture != NULL)
     {
         SDL_DestroyTexture(reinterpret_cast<SDL_Texture*>(pCacheEntry->pTexture));
+        pCacheEntry->pTexture = NULL;
     }
 }
 
@@ -1541,11 +1537,11 @@ void THFreeTypeFont::_makeTexture(THRenderTarget *pEventualCanvas, cached_text_t
 
 void THFreeTypeFont::_drawTexture(THRenderTarget* pCanvas, cached_text_t* pCacheEntry, int iX, int iY) const
 {
-    if(pCacheEntry->iTexture == 0)
+    if(pCacheEntry->pTexture == NULL)
         return;
 
     SDL_Rect rcDest = { iX, iY, pCacheEntry->iWidth, pCacheEntry->iHeight };
-    pCanvas->draw(reinterpret_cast<SDL_Texture*>(pCacheEntry->pTexture), NULL, &rcDest, 0);
+    pCanvas->draw(static_cast<SDL_Texture*>(pCacheEntry->pTexture), NULL, &rcDest, 0);
 }
 
 #endif // CORSIX_TH_USE_FREETYPE2


### PR DESCRIPTION
Fixes #785. Also removes unnecessary _setNullTexture function, and sets the
texture to NULL in _freeTexture as is conventional in C++.