### PR TITLE
Add Lua version to window caption

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -161,6 +161,8 @@ function App:init()
   local caption_descs = {self.video:getRendererDetails()}
   if compile_opts.jit then
     caption_descs[#caption_descs + 1] = compile_opts.jit
+  else
+    caption_descs[#caption_descs + 1] = _VERSION
   end
   if compile_opts.arch_64 then
     caption_descs[#caption_descs + 1] = "64 bit"


### PR DESCRIPTION
Maybe it is useful to add the Lua version to the window caption if CorsixTH supports several Lua versions like it does now

tested with Luajit 2.0.3, Lua 5.1 and Lua 5.2