### PR TITLE
Fix: Avoid crash by removing litter from rooms getting edited

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -602,6 +602,10 @@ function UIEditRoom:returnToDoorPhase()
         if not obj or obj == room.door or class.is(obj, SwingDoor) then
           break
         end
+        if obj.object_type.id == "litter" then -- Silently remove litter from the world.
+          self.world:removeLitter(obj, x, y)
+          break
+        end
         self.world:destroyEntity(obj)
         if not obj.master then
           self:addObjects({{

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -187,7 +187,8 @@ function UIPlaceObjects:addObjects(object_list, pay_for)
         object.qty = object.qty + new_object.qty
         if pay_for then
           local build_cost = self.ui.hospital:getObjectBuildCost(new_object.object.id)
-          self.ui.hospital:spendMoney(new_object.qty * build_cost, _S.transactions.buy_object .. ": " .. object.object.name, new_object.qty * build_cost)
+          local msg = _S.transactions.buy_object .. ": " .. object.object.name
+          self.ui.hospital:spendMoney(new_object.qty * build_cost, msg, new_object.qty * build_cost)
         end
         -- If this is an object that has been created in the world already, add it to the
         -- associated list of objects to re-place.

--- a/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
+++ b/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
@@ -30,9 +30,7 @@ local finish = permanent"action_sweep_floor_finish"( function(humanoid)
 end)
 
 local remove_litter = permanent"action_sweep_floor_remove_litter"( function(humanoid)
-  humanoid.world:removeObjectFromTile(humanoid.user_of, humanoid.tile_x, humanoid.tile_y)
-  humanoid.world:destroyEntity(humanoid.user_of)
-  humanoid.world.map.th:setCellFlags(humanoid.tile_x, humanoid.tile_y, {buildable = true})
+  humanoid.world:removeLitter(humanoid.user_of, humanoid.tile_x, humanoid.tile_y)
   humanoid.user_of:setTile(nil)
   humanoid.user_of = nil
   humanoid:setTimer(humanoid.world:getAnimLength(animation_numbers[2]) * 2, finish)

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2257,6 +2257,16 @@ function World:getObjectsById(id)
   return ret
 end
 
+--! Remove litter from a tile.
+--!param obj (Litter) litter to remove.
+--!param x (int) X position of the tile.
+--!param y (int) Y position of the tile.
+function World:removeLitter(obj, x, y)
+  self:removeObjectFromTile(obj, x, y)
+  self:destroyEntity(obj)
+  self.map.th:setCellFlags(x, y, {buildable = true})
+end
+
 --! Get the room at a given tile location.
 --!param x X position of the queried tile.
 --!param y Y position of the queried tile.


### PR DESCRIPTION
Fixes #708 (and a few others probably).

The issue shouldn't happen at all, since people cannot drop litter or vomit inside a room.
However, until issue #147 is fixed, litter can be added just before blue-printing a room. When the user then edits the room, the litter is assumed to be part of the room contents, and the program crashes.
