### PR TITLE
Fix file path for font dialog on Linux

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -308,7 +308,7 @@ function App:init()
 
       -- If a savegame was specified, load it
       if self.command_line.load then
-        local status, err = pcall(self.load, self, self.command_line.load)
+        local status, err = pcall(self.load, self, self.savegame_dir .. self.command_line.load)
         if not status then
           err = _S.errors.load_prefix .. err
           print(err)
@@ -1209,19 +1209,20 @@ function App:getVersion(version)
 end
 
 function App:save(filename)
-  return SaveGameFile(self.savegame_dir .. filename)
+  return SaveGameFile(filename)
 end
+
 -- Omit the usual file extension so this file cannot be seen from the normal load and save screen and cannot be overwritten
 function App:quickSave()
   local filename = "quicksave"
   return SaveGameFile(self.savegame_dir .. filename)
 end
 
-function App:load(filename)
+function App:load(filepath)
   if self.world then
     self:worldExited()
   end
-  return LoadGameFile(self.savegame_dir .. filename)
+  return LoadGameFile(filepath)
 end
 
 function App:quickLoad()

--- a/CorsixTH/Lua/dialogs/resizables/file_browser.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browser.lua
@@ -203,12 +203,7 @@ function UIFileBrowser:UIFileBrowser(ui, mode, title, vertical_size, root, show_
   self.control = FilteredTreeControl(root, 5, 35, h_size - 10, vertical_size, self.col_bg, self.col_scrollbar, true, show_dates)
     :setSelectCallback(--[[persistable:file_browser_select_callback]] function(node)
       if node.is_valid_file and (lfs.attributes(node.path, "mode") ~= "directory") then
-        local name = node.label
-        while (node.parent.parent) do
-          name = node.parent.label .. pathsep .. name
-          node = node.parent
-        end
-        self:choiceMade(name)
+        self:choiceMade(node.path)
       end
     end)
   self:addWindow(self.control)

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
@@ -68,11 +68,12 @@ end
 --! Function called when textbox is confirmed (e.g. by pressing enter)
 function UISaveGame:confirmName()
   local filename = self.new_savegame_textbox.text
+  local app = self.ui.app
   if filename == "" then
     self:abortName()
     return
   end
-  self:trySave(filename .. ".sav")
+  self:trySave(app.savegame_dir .. filename .. ".sav")
 end
 
 --! Function called by clicking button of existing save #num
@@ -82,7 +83,7 @@ end
 
 --! Try to save the game with given filename; if already exists, create confirmation window first.
 function UISaveGame:trySave(filename)
-  if lfs.attributes(self.ui.app.savegame_dir .. filename, "size") ~= nil then
+  if lfs.attributes(filename, "size") ~= nil then
     self.ui:addWindow(UIConfirmDialog(self.ui, _S.confirmation.overwrite_save, --[[persistable:save_game_confirmation]] function() self:doSave(filename) end))
   else
     self:doSave(filename)

--- a/CorsixTH/Lua/dialogs/resizables/main_menu.lua
+++ b/CorsixTH/Lua/dialogs/resizables/main_menu.lua
@@ -90,9 +90,7 @@ end
 function UIMainMenu:buttonContinueGame()
   local most_recent_saved_game = FileTreeNode(self.ui.app.savegame_dir):getMostRecentlyModifiedChildFile(".sav")
   if most_recent_saved_game then
-    local _, prefix_end_i = string.find(most_recent_saved_game.path, self.ui.app.savegame_dir)
-    local path = string.sub(most_recent_saved_game.path, prefix_end_i + 1, string.len(most_recent_saved_game.path))
-
+    local path = most_recent_saved_game.path
     local app = self.ui.app
     local status, err = pcall(app.load, app, path)
     if not status then


### PR DESCRIPTION
Makes the file dialog return the full path when making a choice.
Load and Save code needed to be adjusted to accomodate the change.

This PR fixes the remaining issues with #785