### PR TITLE
Enforce map bounds in ScreenToWorld

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1005,6 +1005,8 @@ end
 function UIEditRoom:setBlueprintRect(x, y, w, h)
   local rect = self.blueprint_rect
   local map = self.ui.app.map
+  if x < 1 then x = 1 end
+  if y < 1 then y = 1 end
   if x + w > map.width  then w = map.width  - x end
   if y + h > map.height then h = map.height - y end
 

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -90,7 +90,14 @@ function Map:ScreenToWorld(x, y)
   -- And then adjust origin from (0, 0) to (1, 1)
   y = y / 32 + 1
   x = x / 64
-  return y + x, y - x
+  local tile_x, tile_y = y + x, y - x
+  if self.width ~= nil and self.height ~= nil then
+    if tile_x < 1 then tile_x = 1 end
+    if tile_x > self.width then tile_x = self.width end
+    if tile_y < 1 then tile_y = 1 end
+    if tile_y > self.height then tile_y = self.height end
+  end
+  return tile_x, tile_y
 end
 
 local function bits(n)


### PR DESCRIPTION
Fixes some edge cases where the cursor was outside of the map causing crashes.

Fixes #384, #556 and #714