### PR TITLE
Reset scale and print error when zoom fails

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -364,6 +364,9 @@ bool THRenderTarget::setScaleFactor(double fScale, THScaledItems eWhatToScale)
         SDL_RenderSetLogicalSize(m_pRenderer, virtWidth, virtHeight);
         if(SDL_SetRenderTarget(m_pRenderer, m_pZoomTexture) != 0)
         {
+            std::cout << "Warning: Could not render to zoom texture - " << SDL_GetError() << std::endl;
+
+            SDL_RenderSetScale(m_pRenderer, 1, 1);
             SDL_DestroyTexture(m_pZoomTexture);
             m_pZoomTexture = NULL;
             return false;


### PR DESCRIPTION
Should better handle scenario that leads to #805 and tell us why SDL_SetRenderTarget is failing.