### PR TITLE
Fix crash when window of cured patient is opened while he walks off the map

### DIFF
--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -706,8 +706,8 @@ function GameUI.limitPointToDiamond(dx, dy, visible_diamond, do_limit)
         vx, vy = -sqrt_5, -2 * sqrt_5
         d = (rx * vx + ry * vy) - (p1x * vx)
       end
-      -- In the unit vector parallel to the diamond edge, resolve the two verticies and
-      -- the point, and either move the point to the edge or to one of the two verticies.
+      -- In the unit vector parallel to the diamond edge, resolve the two vertices and
+      -- the point, and either move the point to the edge or to one of the two vertices.
       -- NB: vx, vy, p1x, p1y, p2x, p2y are set such that p1 < p2.
       local p1 = vx * p1y - vy * p1x
       local p2 = vx * p2y - vy * p2x
@@ -719,6 +719,7 @@ function GameUI.limitPointToDiamond(dx, dy, visible_diamond, do_limit)
       else--if p1 <= pd and pd <= p2 then
         dx, dy = dx - d * vx, dy - d * vy
       end
+      return math.floor(dx), math.floor(dy), true
     else
       return dx, dy, false
     end


### PR DESCRIPTION
Don't know if this should go in 0.50.

I found issue #561, which doesn't give much information, but I interpreted it as having a window on a cured patient open while he walks home. Sure enough, when he walks off the map, his px/py coordinates become floats which the C++ function doesn't want, and the drawing code crashes.

I traced the code to game_ui, where a "limit to diamond" function performs floating point arithmetic to compute the x/y position in that case. The fix was then a simple 'floor' around the returned coordinates.
I didn't change the other returns, as no computations are being done on the coordinates in those cases.
