### PR TITLE
Fixed Lua Error #133

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -30,7 +30,7 @@ local runDebugger = dofile "run_debugger"
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 102
+local SAVEGAME_VERSION = 103
 
 class "App"
 

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -257,7 +257,12 @@ local function action_seek_room_start(action, humanoid)
           end
         end
         if found then
-          action_seek_room_goto_room(room, humanoid, action.diagnosis_room)
+          -- Don't add a "go to room" action to the patient's queue if the
+          -- autopsy machine is about to kill them:
+          local current_room = humanoid:getRoom()
+          if not current_room or not (current_room.room_info.id == "research" and current_room:getStaffMember() and current_room:getStaffMember().action_queue[1].name == "multi_use_object") then
+            action_seek_room_goto_room(room, humanoid, action.diagnosis_room)
+          end
           TheApp.ui.bottom_panel:removeMessage(humanoid)
           humanoid:unregisterRoomBuildCallback(build_callback)
           humanoid:unregisterRoomRemoveCallback(remove_callback)

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2580,6 +2580,19 @@ function World:afterLoad(old, new)
     self.ui:addKeyHandler({"shift", "+"}, self, self.adjustZoom,  5)
     self.ui:addKeyHandler({"shift", "-"}, self, self.adjustZoom, -5)
   end
+
+  if old < 103 then
+    -- If a room has patients who no longer exist in its
+    -- humanoids_enroute table because of #133 remove them:
+    for _, room in pairs(self.rooms) do
+      for patient, _ in pairs(room.humanoids_enroute) do
+        if patient.tile_x == nil then
+          room.humanoids_enroute[patient] = nil
+        end
+      end
+    end
+  end
+
   -- Now let things inside the world react.
   for _, cat in pairs({self.hospitals, self.entities, self.rooms}) do
     for _, obj in pairs(cat) do


### PR DESCRIPTION
#133: Patients who ceased to exist after using the autopsy machine could still be referenced in the humanoids_enroute table for a treatment room they required when this researched treatment room was created while a patient requiring it was using an autopsy machine. This would queue an action for them to go to the created room after using the autopsy machine, adding them to its humanoids_enroute table.

This reference to a deceased patient in a room's humanoids_enroute table would cause a lua error to occur when the room was edited because the room's deactivate function would reference the patient's hospital field which was nil because the autoposy machine had made it nil.