### PR TITLE
Don't crash for unreachable room

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1844,7 +1844,7 @@ function World:findRoomNear(humanoid, room_type_id, distance, mode)
     if r.built and (not room_type_id or r.room_info.id == room_type_id) and r.is_active and r.door.queue.max_size ~= 0 then
       local x, y = r:getEntranceXY(false)
       local d = self:getPathDistance(humanoid.tile_x, humanoid.tile_y, x, y)
-      if d > distance then
+      if not d or d > distance then
         break -- continue
       end
       local this_score = d


### PR DESCRIPTION
This fixes the immediate crashes caused by building a room in an unreachable
area as per issue #819 

It should be noted that this is a very small step towards supporting unreachable areas. If you actually put any staff in this area the game will still quickly crash.