### PR TITLE
Workaround SDL2 bug with ClipRect coordinates

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -237,6 +237,11 @@ protected:
     bool m_bShouldScaleBitmaps; ///< Whether bitmaps should be scaled.
     bool m_bSupportsTargetTextures;
 
+    // In SDL2 < 2.0.4 there is an issue with the y coordinates used for
+    // ClipRects in opengl and opengles.
+    // see: https://bugzilla.libsdl.org/show_bug.cgi?id=2700
+    bool m_bApplyOpenGlClipFix;
+
     void _flushZoomBuffer();
 };
 


### PR DESCRIPTION
In SDL2 2.0.3 and lower versions the y coordinates for the ClipRect is
inverted. This commit detects and handles that case.

Fixes #846