### PR TITLE
[RDY] Fix #800 don't play sound effects in new scenarios if play_sounds is disabled

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -493,6 +493,9 @@ function App:loadLevel(level, ...)
   self.world = World(self)
   self.world:createMapObjects(map_objects)
 
+  -- Enable / disable SoundEffects
+  self.audio:playSoundEffects(self.config.play_sounds)
+
   -- Load UI
   self.ui = GameUI(self, self.world:getLocalPlayerHospital())
   self.world:setUI(self.ui) -- Function call allows world to set up its keyHandlers


### PR DESCRIPTION
Added audio:playSoundEffects() in App:loadLevel() to disable / enable sound effects like it is done in LoadGame() for savegames