### PR TITLE
Fix: it's now github desktop [ci skip]

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -82,8 +82,7 @@ CONTRIBUTING CODE:
 First Time
 1. Ensure you have a GitHub account (https://github.com/signup/free)
 2. Fork CorsixTH\CorsixTH (https://github.com/CorsixTH/CorsixTH/fork)
-3. Ensure you have a git client.  (http://windows.github.com or
-http://mac.github.com)
+3. Ensure you have a git client.  (http://desktop.github.com)
 4. Clone your fork to your computer
         - If using github client, run Git Shell
         - git clone https://github.com/mygithubuser/CorsixTH.git


### PR DESCRIPTION
GitHub for Mac and GitHub for Windows were merged together to make GitHub Desktop