### PR TITLE
[RDY] Use travis containers and g++ 5 in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,38 @@
 language: cpp
+compiler: gcc
+sudo: false
+addons:
+  apt:
+    packages:
+      - cmake
+      - p7zip-full
+      - build-essential
+      - sshpass
+      - lua5.1
+      - luarocks
+      - doxygen
+      - g++-mingw-w64
+      - gcc-mingw-w64
+      - g++-mingw-w64-i686
+      - gcc-mingw-w64-i686
+      - binutils-mingw-w64-i686
+      - g++-mingw-w64-x86-64
+      - gcc-mingw-w64-x86-64
+      - binutils-mingw-w64-x86-64
+
 before_install:
-  # Get build dependencies
-  - sudo apt-get -qq update
-  - sudo apt-get -q install cmake p7zip-full build-essential sshpass lua5.1 luarocks doxygen
   # Required for LDocGen
-  - sudo luarocks install lpeg
-  - sudo luarocks install luafilesystem
+  - luarocks --local install lpeg
+  - luarocks --local install luafilesystem
   # Required for lua unit tests
-  - sudo luarocks install busted
-  # Install the mingw-w64 packages.
-  - sudo apt-get -q install g++-mingw-w64 gcc-mingw-w64 g++-mingw-w64-i686 gcc-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686 binutils-mingw-w64-i686 g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 binutils-mingw-w64-x86-64
-  # The packages in ubuntu's repositories seem a little broken
-  # so use a bleeding edge version
-  - wget http://ftp.jp.debian.org/debian/pool/main/m/mingw-w64/mingw-w64_3.2.0-2_all.deb
-  - sudo dpkg -i mingw-w64_3.2.0-2_all.deb
+  - luarocks --local install busted
   - mkdir libs
-  - cd libs
+  - pushd libs
   # Get FFmpeg
   - wget http://ffmpeg.zeranoe.com/builds/win32/dev/ffmpeg-2.5.2-win32-dev.7z
   - wget http://ffmpeg.zeranoe.com/builds/win32/shared/ffmpeg-2.5.2-win32-shared.7z
-  - /usr/bin/7za x ffmpeg-2.5.2-win32-dev.7z
-  - /usr/bin/7za x ffmpeg-2.5.2-win32-shared.7z
+  - 7za x ffmpeg-2.5.2-win32-dev.7z
+  - 7za x ffmpeg-2.5.2-win32-shared.7z
   - mv ffmpeg-2.5.2-win32-dev ffmpeg-dev
   - mv ffmpeg-2.5.2-win32-shared ffmpeg-bin
   # Get freetype
@@ -35,16 +47,9 @@ before_install:
   - wget https://raw.githubusercontent.com/CorsixTH/deps/master/travisci-mingw/patches/SDL_mingw_build_fix.patch
   - tar xfz SDL2-devel-2.0.3-mingw.tar.gz
   - patch -p2 -d SDL2-2.0.3/i686-w64-mingw32/include/SDL2 < SDL_mingw_build_fix.patch
-  - sudo mkdir /usr/i686-w64-mingw32/bin/
-  - sudo cp SDL2-2.0.3/i686-w64-mingw32/bin/* /usr/i686-w64-mingw32/bin/
-  - sudo cp -r SDL2-2.0.3/i686-w64-mingw32/include/SDL2/* /usr/i686-w64-mingw32/include/
-  - sudo cp -r SDL2-2.0.3/i686-w64-mingw32/lib/* /usr/i686-w64-mingw32/lib/
-  - sudo chmod +x /usr/i686-w64-mingw32/bin/sdl2-config
   # Get SDL Mixer
   - wget http://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.0-mingw.tar.gz
   - tar xfz SDL2_mixer-devel-2.0.0-mingw.tar.gz
-  - sudo cp -r SDL2_mixer-2.0.0/i686-w64-mingw32/include/SDL2/* /usr/i686-w64-mingw32/include/
-  - sudo cp -r SDL2_mixer-2.0.0/i686-w64-mingw32/lib/* /usr/i686-w64-mingw32/lib/
   - mkdir lua
   # Get LUA
   - wget http://sourceforge.net/projects/mingw/files/MinGW/Extension/lua/lua-5.1.4-4/lua-5.1.4-4-mingw32-dll-51.tar.xz
@@ -75,10 +80,11 @@ before_install:
   - make PLAT=mingw LUAINC_mingw=$TRAVIS_BUILD_DIR/libs/lua/include LUALIB_mingw=$TRAVIS_BUILD_DIR/libs/lua/bin/lua51.dll CC_mingw=i686-w64-mingw32-gcc LD_mingw=i686-w64-mingw32-gcc prefix=$TRAVIS_BUILD_DIR/libs/luasocket LUAV=5.1
   - make PLAT=mingw LUAINC_mingw=$TRAVIS_BUILD_DIR/libs/lua/include LUALIB_mingw=$TRAVIS_BUILD_DIR/libs/lua/bin/lua51.dll CC_mingw=i686-w64-mingw32-gcc LD_mingw=i686-w64-mingw32-gcc prefix=$TRAVIS_BUILD_DIR/libs/luasocket LUAV=5.1 install
   - mkdir $TRAVIS_BUILD_DIR/LevelEdit/bin
+  - popd
 install:
   - cd $TRAVIS_BUILD_DIR
   # Create unix makefiles
-  - cmake -DLUA_PROGRAM_PATH=`which lua` -DCMAKE_TOOLCHAIN_FILE=build_files/toolchain-mingw.cmake -DWITH_AUDIO=ON -DWITH_MOVIES=ON -DSDL_LIBRARY="$TRAVIS_BUILD_DIR/libs/SDL2-2.0.3/i686-w64-mingw32/lib/libSDL2main.a;$TRAVIS_BUILD_DIR/libs/SDL2-2.0.3/i686-w64-mingw32/lib/libSDL2.dll.a;-lmingw32;-lSDL2main;-lSDL2" -DSDL_INCLUDE_DIR=libs/SDL2-2.0.3/i686-w64-mingw32/include/SDL2 -DSDLMAIN_LIBRARY=libs/SDL2-2.0.3/i686-w64-mingw32/lib/libSDL2main.a -DSDLMIXER_INCLUDE_DIR=$TRAVIS_BUILD_DIR/libs/SDL2_mixer-2.0.0/i686-w64-mingw32/include/SDL2 -DSDLMIXER_LIBRARY=$TRAVIS_BUILD_DIR/libs/SDL2_mixer-2.0.0/i686-w64-mingw32/lib/libSDL2_mixer.dll.a -DLUA_LIBRARY=libs/lua/lib/liblua.dll.a -DLUA_INCLUDE_DIR=libs/lua/include -DFREETYPE_INCLUDE_DIR_freetype2=libs/freetype/include/freetype2 -DFREETYPE_INCLUDE_DIR_ft2build=libs/freetype/include -DFREETYPE_LIBRARY=libs/freetype/lib/libfreetype.dll.a -DFFMPEG_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVFORMAT_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVUTIL_INCLUDE_DIRS=libs/ffmpeg-dev/include -DSWSCALE_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVCODEC_INCLUDE_DIRS=libs/ffmpeg-dev/include -DSWRESAMPLE_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVFORMAT_LIBRARIES=libs/ffmpeg-dev/lib/avformat.lib -DAVCODEC_LIBRARIES=libs/ffmpeg-dev/lib/avcodec.lib -DAVUTIL_LIBRARIES=libs/ffmpeg-dev/lib/avutil.lib -DSWSCALE_LIBRARIES=libs/ffmpeg-dev/lib/swscale.lib -DSWRESAMPLE_LIBRARIES=libs/ffmpeg-dev/lib/swresample.lib -Bfresh -H. --debug-output
+  - cmake -DLUA_PROGRAM_PATH=`which lua` -DCMAKE_TOOLCHAIN_FILE=build_files/toolchain-mingw.cmake -DWITH_AUDIO=ON -DWITH_MOVIES=ON -DSDL_LIBRARY="-lmingw32;$TRAVIS_BUILD_DIR/libs/SDL2-2.0.3/i686-w64-mingw32/lib/libSDL2main.a;$TRAVIS_BUILD_DIR/libs/SDL2-2.0.3/i686-w64-mingw32/lib/libSDL2.dll.a" -DSDL_INCLUDE_DIR=libs/SDL2-2.0.3/i686-w64-mingw32/include/SDL2 -DSDLMAIN_LIBRARY=libs/SDL2-2.0.3/i686-w64-mingw32/lib/libSDL2main.a -DSDLMIXER_INCLUDE_DIR=$TRAVIS_BUILD_DIR/libs/SDL2_mixer-2.0.0/i686-w64-mingw32/include/SDL2 -DSDLMIXER_LIBRARY=$TRAVIS_BUILD_DIR/libs/SDL2_mixer-2.0.0/i686-w64-mingw32/lib/libSDL2_mixer.dll.a -DLUA_LIBRARY=libs/lua/lib/liblua.dll.a -DLUA_INCLUDE_DIR=libs/lua/include -DFREETYPE_INCLUDE_DIR_freetype2=libs/freetype/include/freetype2 -DFREETYPE_INCLUDE_DIR_ft2build=libs/freetype/include -DFREETYPE_LIBRARY=libs/freetype/lib/libfreetype.dll.a -DFFMPEG_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVFORMAT_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVUTIL_INCLUDE_DIRS=libs/ffmpeg-dev/include -DSWSCALE_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVCODEC_INCLUDE_DIRS=libs/ffmpeg-dev/include -DSWRESAMPLE_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVFORMAT_LIBRARIES=libs/ffmpeg-dev/lib/avformat.lib -DAVCODEC_LIBRARIES=libs/ffmpeg-dev/lib/avcodec.lib -DAVUTIL_LIBRARIES=libs/ffmpeg-dev/lib/avutil.lib -DSWSCALE_LIBRARIES=libs/ffmpeg-dev/lib/swscale.lib -DSWRESAMPLE_LIBRARIES=libs/ffmpeg-dev/lib/swresample.lib -Bfresh -H. --debug-output
 before_script:
   # Don't ask for confirmation when using scp
   - echo -e "Host armedpineapple.co.uk\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
@@ -97,8 +103,8 @@ script:
   - (LUA_FAILURE=0; for file in `find CorsixTH -name '*.lua' -not -path "CorsixTH/Lua/languages/*"`; do luac -p $file; if [ $? != 0 ]; then LUA_FAILURE=1; fi; done; exit $LUA_FAILURE)
   # Run lua unit tests
   - cd $TRAVIS_BUILD_DIR/CorsixTH/Luatest
-  - eval `luarocks path`
-  - LUA_PATH="../Lua/?.lua;$LUA_PATH" busted
+  - eval `luarocks --local path`
+  - LUA_PATH="../Lua/?.lua;$LUA_PATH" /home/travis/.luarocks/bin/busted
   # Build LevelEdit
   - cd $TRAVIS_BUILD_DIR/LevelEdit && ant dist
   # Build documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ compiler: gcc
 sudo: false
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
       - libssl-dev
       - luarocks
       - doxygen
+      - g++-5
 
 before_install:
   # Required for LDocGen
@@ -27,7 +30,7 @@ install:
   - cd $TRAVIS_BUILD_DIR
   # Create unix makefiles
   - cp $HOME/deps/travisci/cmake/FindFreetype.cmake CMake/FindFreetype.cmake
-  - cmake -DLUA_PROGRAM_PATH=`which lua` -DWITH_AUDIO=ON -DWITH_MOVIES=ON -DWITH_LUAJIT=OFF -DCMAKE_INCLUDE_PATH="$CMAKE_INCLUDE_PATH;$CMAKE_INCLUDE_PATH/SDL2" -DCMAKE_LIBRARY_PATH="$CMAKE_LIBRARY_PATH" -DLUA_LIBRARY="$CMAKE_LIBRARY_PATH/liblua.so" -Bfresh -H. --debug-output
+  - cmake -DCMAKE_CXX_COMPILER="g++-5" -DLUA_PROGRAM_PATH=`which lua` -DWITH_AUDIO=ON -DWITH_MOVIES=ON -DWITH_LUAJIT=OFF -DCMAKE_INCLUDE_PATH="$CMAKE_INCLUDE_PATH;$CMAKE_INCLUDE_PATH/SDL2" -DCMAKE_LIBRARY_PATH="$CMAKE_LIBRARY_PATH" -DLUA_LIBRARY="$CMAKE_LIBRARY_PATH/liblua.so" -Bfresh -H. --debug-output
 before_script:
   # Don't ask for confirmation when using scp
   - echo -e "Host armedpineapple.co.uk\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,87 +4,30 @@ sudo: false
 addons:
   apt:
     packages:
-      - cmake
-      - p7zip-full
-      - build-essential
-      - sshpass
-      - lua5.1
+      - libssl-dev
       - luarocks
       - doxygen
-      - g++-mingw-w64
-      - gcc-mingw-w64
-      - g++-mingw-w64-i686
-      - gcc-mingw-w64-i686
-      - binutils-mingw-w64-i686
-      - g++-mingw-w64-x86-64
-      - gcc-mingw-w64-x86-64
-      - binutils-mingw-w64-x86-64
 
 before_install:
   # Required for LDocGen
   - luarocks --local install lpeg
   - luarocks --local install luafilesystem
+  - luarocks --local install luasocket  
   # Required for lua unit tests
+  - luarocks --local install luasec OPENSSL_DIR=/usr OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu/
   - luarocks --local install busted
+  - git clone --depth=1 https://github.com/CorsixTH/deps.git $HOME/deps
   - mkdir libs
   - pushd libs
-  # Get FFmpeg
-  - wget http://ffmpeg.zeranoe.com/builds/win32/dev/ffmpeg-2.5.2-win32-dev.7z
-  - wget http://ffmpeg.zeranoe.com/builds/win32/shared/ffmpeg-2.5.2-win32-shared.7z
-  - 7za x ffmpeg-2.5.2-win32-dev.7z
-  - 7za x ffmpeg-2.5.2-win32-shared.7z
-  - mv ffmpeg-2.5.2-win32-dev ffmpeg-dev
-  - mv ffmpeg-2.5.2-win32-shared ffmpeg-bin
-  # Get freetype
-  - wget https://github.com/CorsixTH/deps/raw/master/travisci-mingw/freetype-2.3.5-1-lib.zip
-  - wget https://github.com/CorsixTH/deps/raw/master/travisci-mingw/freetype-2.3.5-1-bin.zip
-  - wget https://github.com/CorsixTH/deps/raw/master/travisci-mingw/freetype-2.3.5-1-dep.zip
-  - unzip -n freetype-2.3.5-1-lib.zip -d freetype
-  - unzip -n freetype-2.3.5-1-bin.zip -d freetype
-  - unzip -n freetype-2.3.5-1-dep.zip -d freetype
-  # Get SDL
-  - wget http://libsdl.org/release/SDL2-devel-2.0.3-mingw.tar.gz
-  - wget https://raw.githubusercontent.com/CorsixTH/deps/master/travisci-mingw/patches/SDL_mingw_build_fix.patch
-  - tar xfz SDL2-devel-2.0.3-mingw.tar.gz
-  - patch -p2 -d SDL2-2.0.3/i686-w64-mingw32/include/SDL2 < SDL_mingw_build_fix.patch
-  # Get SDL Mixer
-  - wget http://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.0-mingw.tar.gz
-  - tar xfz SDL2_mixer-devel-2.0.0-mingw.tar.gz
-  - mkdir lua
-  # Get LUA
-  - wget http://sourceforge.net/projects/mingw/files/MinGW/Extension/lua/lua-5.1.4-4/lua-5.1.4-4-mingw32-dll-51.tar.xz
-  - tar xJf lua-5.1.4-4-mingw32-dll-51.tar.xz -C lua
-  - wget http://sourceforge.net/projects/mingw/files/MinGW/Extension/lua/lua-5.1.4-4/lua-5.1.4-4-mingw32-dev.tar.xz
-  - tar xJf lua-5.1.4-4-mingw32-dev.tar.xz -C lua
-  # Get LuaFileSystem
-  - wget http://github.com/keplerproject/luafilesystem/archive/v_1_6_3.tar.gz
-  - tar xzf v_1_6_3.tar.gz
-  - pushd luafilesystem-v_1_6_3
-  - i686-w64-mingw32-gcc -O2 -c -o src/lfs.o src/lfs.c -I../lua/include
-  - i686-w64-mingw32-gcc -shared -o lfs.dll src/lfs.o ../lua/bin/lua51.dll
-  - popd
-  # Get LPeg
-  - wget http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-0.12.1.tar.gz
-  - tar xzf lpeg-0.12.1.tar.gz
-  - pushd lpeg-0.12.1
-  - i686-w64-mingw32-gcc -std=c99 -O2 -I../lua/include -c -o lpcap.o lpcap.c
-  - i686-w64-mingw32-gcc -std=c99 -O2 -I../lua/include -c -o lpcode.o lpcode.c
-  - i686-w64-mingw32-gcc -std=c99 -O2 -I../lua/include -c -o lpprint.o lpprint.c
-  - i686-w64-mingw32-gcc -std=c99 -O2 -I../lua/include -c -o lptree.o lptree.c
-  - i686-w64-mingw32-gcc -std=c99 -O2 -I../lua/include -c -o lpvm.o lpvm.c
-  - i686-w64-mingw32-gcc -shared -o lpeg.dll lpcap.o lpcode.o lpprint.o lptree.o lpvm.o ../lua/bin/lua51.dll
-  - popd
-  - git clone https://github.com/diegonehab/luasocket.git luasocket
-  - pushd luasocket
-  - git checkout 5edf093
-  - make PLAT=mingw LUAINC_mingw=$TRAVIS_BUILD_DIR/libs/lua/include LUALIB_mingw=$TRAVIS_BUILD_DIR/libs/lua/bin/lua51.dll CC_mingw=i686-w64-mingw32-gcc LD_mingw=i686-w64-mingw32-gcc prefix=$TRAVIS_BUILD_DIR/libs/luasocket LUAV=5.1
-  - make PLAT=mingw LUAINC_mingw=$TRAVIS_BUILD_DIR/libs/lua/include LUALIB_mingw=$TRAVIS_BUILD_DIR/libs/lua/bin/lua51.dll CC_mingw=i686-w64-mingw32-gcc LD_mingw=i686-w64-mingw32-gcc prefix=$TRAVIS_BUILD_DIR/libs/luasocket LUAV=5.1 install
   - mkdir $TRAVIS_BUILD_DIR/LevelEdit/bin
   - popd
 install:
+  - CMAKE_INCLUDE_PATH=$HOME/deps/gnu-linux-x64/include
+  - CMAKE_LIBRARY_PATH=$HOME/deps/gnu-linux-x64/lib
   - cd $TRAVIS_BUILD_DIR
   # Create unix makefiles
-  - cmake -DLUA_PROGRAM_PATH=`which lua` -DCMAKE_TOOLCHAIN_FILE=build_files/toolchain-mingw.cmake -DWITH_AUDIO=ON -DWITH_MOVIES=ON -DSDL_LIBRARY="-lmingw32;$TRAVIS_BUILD_DIR/libs/SDL2-2.0.3/i686-w64-mingw32/lib/libSDL2main.a;$TRAVIS_BUILD_DIR/libs/SDL2-2.0.3/i686-w64-mingw32/lib/libSDL2.dll.a" -DSDL_INCLUDE_DIR=libs/SDL2-2.0.3/i686-w64-mingw32/include/SDL2 -DSDLMAIN_LIBRARY=libs/SDL2-2.0.3/i686-w64-mingw32/lib/libSDL2main.a -DSDLMIXER_INCLUDE_DIR=$TRAVIS_BUILD_DIR/libs/SDL2_mixer-2.0.0/i686-w64-mingw32/include/SDL2 -DSDLMIXER_LIBRARY=$TRAVIS_BUILD_DIR/libs/SDL2_mixer-2.0.0/i686-w64-mingw32/lib/libSDL2_mixer.dll.a -DLUA_LIBRARY=libs/lua/lib/liblua.dll.a -DLUA_INCLUDE_DIR=libs/lua/include -DFREETYPE_INCLUDE_DIR_freetype2=libs/freetype/include/freetype2 -DFREETYPE_INCLUDE_DIR_ft2build=libs/freetype/include -DFREETYPE_LIBRARY=libs/freetype/lib/libfreetype.dll.a -DFFMPEG_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVFORMAT_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVUTIL_INCLUDE_DIRS=libs/ffmpeg-dev/include -DSWSCALE_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVCODEC_INCLUDE_DIRS=libs/ffmpeg-dev/include -DSWRESAMPLE_INCLUDE_DIRS=libs/ffmpeg-dev/include -DAVFORMAT_LIBRARIES=libs/ffmpeg-dev/lib/avformat.lib -DAVCODEC_LIBRARIES=libs/ffmpeg-dev/lib/avcodec.lib -DAVUTIL_LIBRARIES=libs/ffmpeg-dev/lib/avutil.lib -DSWSCALE_LIBRARIES=libs/ffmpeg-dev/lib/swscale.lib -DSWRESAMPLE_LIBRARIES=libs/ffmpeg-dev/lib/swresample.lib -Bfresh -H. --debug-output
+  - cp $HOME/deps/travisci/cmake/FindFreetype.cmake CMake/FindFreetype.cmake
+  - cmake -DLUA_PROGRAM_PATH=`which lua` -DWITH_AUDIO=ON -DWITH_MOVIES=ON -DWITH_LUAJIT=OFF -DCMAKE_INCLUDE_PATH="$CMAKE_INCLUDE_PATH;$CMAKE_INCLUDE_PATH/SDL2" -DCMAKE_LIBRARY_PATH="$CMAKE_LIBRARY_PATH" -DLUA_LIBRARY="$CMAKE_LIBRARY_PATH/liblua.so" -Bfresh -H. --debug-output
 before_script:
   # Don't ask for confirmation when using scp
   - echo -e "Host armedpineapple.co.uk\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
@@ -110,30 +53,6 @@ script:
   # Build documentation
   - cd ${TRAVIS_BUILD_DIR}/fresh && make doc
 after_success:
-  - mkdir -p $TRAVIS_BUILD_DIR/fresh/CorsixTH
-  - cd $TRAVIS_BUILD_DIR
-  # Package LevelEdit
-  - cp LevelEdit/dist/LevelEdit.jar fresh/CorsixTH/
-  # Copy required DLLs
-  - cp libs/SDL2-2.0.3/i686-w64-mingw32/bin/*.dll fresh/CorsixTH/
-  - cp libs/SDL2_mixer-2.0.0/i686-w64-mingw32/bin/*.dll fresh/CorsixTH/
-  - cp libs/ffmpeg-bin/bin/*.dll fresh/CorsixTH/
-  - cp libs/freetype/bin/*.dll fresh/CorsixTH/
-  - cp libs/lua/bin/*.dll fresh/CorsixTH/
-  - cp libs/luafilesystem-v_1_6_3/lfs.dll fresh/CorsixTH/
-  - cp libs/lpeg-0.12.1/lpeg.dll fresh/CorsixTH/
-  - cp -r libs/luasocket/lua/5.1/* fresh/CorsixTH/
-  # Copy CTH
-  - cd CorsixTH/
-  - cp -r * ../fresh/CorsixTH/
-  - cd ../fresh/CorsixTH
-  # Prepare ZIP archive
-  - ZIPNAME=CTH-`date +"%Y%m%d"`-$TRAVIS_BRANCH-${TRAVIS_COMMIT:0:10}.zip
-  - if [ $TRAVIS_PULL_REQUEST != "false" ]; then ZIPNAME=CTH-pull-$TRAVIS_PULL_REQUEST-`date +"%Y%m%d"`-${TRAVIS_COMMIT:0:10}.zip; fi;
-  - zip -r $ZIPNAME *
-  - chmod 666 $ZIPNAME
-  # Upload to server
-  - if [ $TRAVIS_REPO_SLUG == "CorsixTH/CorsixTH" ]; then sshpass -p "$SCP_PASS" scp -v -P12349 $ZIPNAME cthbuilder@server2.armedpineapple.co.uk:/home/cthbuilder/builds/; fi;
   # Upload new docs
   - if [ $TRAVIS_REPO_SLUG == "CorsixTH/CorsixTH" -a $TRAVIS_BRANCH == "master" ]; then sshpass -p "$SCP_PASS" scp -r -v -P12349 $TRAVIS_BUILD_DIR/fresh/doc/* cthbuilder@server2.armedpineapple.co.uk:/home/cthbuilder/docs/; fi;
 env:


### PR DESCRIPTION
Travis is moving to new container system with faster start times. You can read about it here: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

As a restriction we can't run sudo.

Additionally we are moving towards C++11, which is not while supported by Travis' built in g++-4.6. This pull request abandons the mingw builds (Windows builds are now handled natively by appveyor) and moves to native g++-5.