### PR TITLE
Block using a map node that is at the end of the iteration. Fixes #124

### DIFF
--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -884,7 +884,7 @@ void THMap::draw(THRenderTarget* pCanvas, int iScreenX, int iScreenY,
 
                 //check if an object in the adjacent tile above the current tile needs to be redrawn
                 //and if necessary draw it
-                pItem = (THDrawable*)(formerIterator->m_pNext);
+                pItem = formerIterator ? (THDrawable*)(formerIterator->m_pNext) : nullptr;
                 while(pItem)
                 {
                     if(pItem->getDrawingLayer() == 8)


### PR DESCRIPTION
Tried the savegame in the first comment, one from #659, and the save from #902 and they all work now.

They walk a tile in the air just outside the map now. Don't know if that is intended, but it does make them disappear completely from the window that follows them no matter in which direction they walk off-map.
