### PR TITLE
[RDY] Fix jukebox crash

### DIFF
--- a/CorsixTH/Lua/dialogs/jukebox.lua
+++ b/CorsixTH/Lua/dialogs/jukebox.lua
@@ -163,7 +163,7 @@ function UIJukebox:draw(canvas, x, y)
       font = self.blue_font
     end
     local str = info.title
-    while font:sizeOf(str, font) > 185 do
+    while font:sizeOf(str) > 185 do
       str = string.sub(str, 1, string.len(str) - 5) .. "..."
     end
     font:draw(canvas, str, x + 24, y + 11)


### PR DESCRIPTION
The jukebox passed the font as a 3rd argument to sizeOf. This was an error that
just started causing problems as d21995e introduced an actual 3rd argument for
max width. Thanks smoke_fumus.