### PR TITLE
Staff management scroll dot

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -497,7 +497,7 @@ function UIStaffManagement:scrollUp()
   if self.scroll_dot.visible and self.page > 1 then
     self.selected_staff = nil
     self.page = self.page - 1
-    self.scroll_dot.y = 168 + math_floor(83*((self.page - 1)/(#self.staff_members[self.category]-1)/10))
+    self:updateScrollDot()
   end
   self:updateTooltips()
 end
@@ -506,9 +506,15 @@ function UIStaffManagement:scrollDown()
   if self.scroll_dot.visible and self.page*10 < #self.staff_members[self.category] then
     self.selected_staff = nil
     self.page = self.page + 1
-    self.scroll_dot.y = 168 + math_floor(83*((self.page - 1)/(#self.staff_members[self.category]-1)/10))
+    self:updateScrollDot()
   end
   self:updateTooltips()
+end
+
+function UIStaffManagement:updateScrollDot()
+  local numPages = math.ceil(#self.staff_members[self.category] / 10)
+  local yOffset = math_floor(83 * ((self.page - 1) / (numPages - 1)))
+  self.scroll_dot.y = 168 + yOffset
 end
 
 function UIStaffManagement:payBonus()


### PR DESCRIPTION
On the Staff Management page, the scroll dot to the left indicating how far through the pages of staff you are was stuck at the top. 
This PR fixes that.