### PR TITLE
[WIP|RFC] Cpp11 font

### DIFF
--- a/CorsixTH/Src/th_gfx_font.cpp
+++ b/CorsixTH/Src/th_gfx_font.cpp
@@ -209,7 +209,7 @@ void THBitmapFont::drawText(THRenderTarget* pCanvas, const char* sMessage, size_
 
 THFontDrawArea THBitmapFont::drawTextWrapped(THRenderTarget* pCanvas, const char* sMessage,
                         size_t iMessageLength, int iX, int iY, int iWidth,
-                        int iMaxRows, int iSkipRows, eTHAlign eAlign) const
+                        int iMaxRows, int iSkipRows, text_align text_align) const
 {
     THFontDrawArea oDrawArea = {};
     int iSkippedRows = 0;
@@ -274,7 +274,7 @@ THFontDrawArea THBitmapFont::drawTextWrapped(THRenderTarget* pCanvas, const char
                 {
                     int iXOffset = 0;
                     if(iMsgBreakWidth < iWidth)
-                        iXOffset = (iWidth - iMsgBreakWidth) * static_cast<int>(eAlign) / 2;
+                        iXOffset = (iWidth - iMsgBreakWidth) * static_cast<int>(text_align) / 2;
                     drawText(pCanvas, sMessage, sBreakPosition - sMessage, iX + iXOffset, iY);
                 }
                 iY += static_cast<int>(iTallest) + m_iLineSep;
@@ -329,7 +329,7 @@ THFreeTypeFont::THFreeTypeFont()
         pEntry->sMessage = nullptr;
         pEntry->iMessageLength = 0;
         pEntry->iMessageBufferLength = 0;
-        pEntry->eAlign = Align_Left;
+        pEntry->text_align = text_align::left;
         pEntry->iWidth = 0;
         pEntry->iHeight = 0;
         pEntry->iWidestLine = 0;
@@ -516,7 +516,7 @@ struct codepoint_glyph_t
 
 THFontDrawArea THFreeTypeFont::drawTextWrapped(THRenderTarget* pCanvas, const char* sMessage,
                                 size_t iMessageLength, int iX, int iY,
-                                int iWidth, int iMaxRows, int iSkipRows, eTHAlign eAlign) const
+                                int iWidth, int iMaxRows, int iSkipRows, text_align text_align) const
 {
     THFontDrawArea oDrawArea = {};
     int iNumRows = 0;
@@ -527,7 +527,7 @@ THFontDrawArea THFreeTypeFont::drawTextWrapped(THRenderTarget* pCanvas, const ch
         + (static_cast<size_t>(iMaxRows) << (ms_CacheSizeLog2 / 8))
         + (static_cast<size_t>(iSkipRows) << (ms_CacheSizeLog2 / 4))
         + (static_cast<size_t>(iWidth) << (ms_CacheSizeLog2 / 2))
-        + (static_cast<size_t>(eAlign) << ms_CacheSizeLog2);
+        + (static_cast<size_t>(text_align) << ms_CacheSizeLog2);
     for(size_t i = 0; i < iMessageLength; ++i)
         iHash ^= (iHash << 5) + (iHash >> 2) + static_cast<size_t>(sMessage[i]);
     iHash &= (1 << ms_CacheSizeLog2) - 1;
@@ -535,7 +535,7 @@ THFontDrawArea THFreeTypeFont::drawTextWrapped(THRenderTarget* pCanvas, const ch
     cached_text_t* pEntry = m_aCache + iHash;
     if(pEntry->iMessageLength != iMessageLength || pEntry->iWidth > iWidth
         || (iWidth != INT_MAX && pEntry->iWidth < iWidth)
-        || pEntry->eAlign != eAlign || !pEntry->bIsValid
+        || pEntry->text_align != text_align || !pEntry->bIsValid
         || std::memcmp(pEntry->sMessage, sMessage, iMessageLength) != 0)
     {
         // Cache entry does not match the message being drawn, so discard the
@@ -555,7 +555,7 @@ THFontDrawArea THFreeTypeFont::drawTextWrapped(THRenderTarget* pCanvas, const ch
         std::memcpy(pEntry->sMessage, sMessage, iMessageLength);
         pEntry->iMessageLength = iMessageLength;
         pEntry->iWidth = iWidth;
-        pEntry->eAlign = eAlign;
+        pEntry->text_align = text_align;
 
         // Split the message into lines, and determine the position within the
         // line for each character.
@@ -702,7 +702,7 @@ THFontDrawArea THFreeTypeFont::drawTextWrapped(THRenderTarget* pCanvas, const ch
             if((iLineWidth >> 6) < iWidth)
             {
                 iAlignDelta = ((iWidth * 64 - iLineWidth) *
-                    static_cast<int>(eAlign)) / 2;
+                    static_cast<int>(text_align)) / 2;
             }
             if(iLineWidth > iWidestLine)
                 iWidestLine = iLineWidth;

--- a/CorsixTH/Src/th_gfx_font.h
+++ b/CorsixTH/Src/th_gfx_font.h
@@ -28,11 +28,11 @@ SOFTWARE.
 #include FT_FREETYPE_H
 #endif
 
-enum eTHAlign
+enum class text_align
 {
-    Align_Left = 0,
-    Align_Center = 1,
-    Align_Right = 2,
+    left,
+    center,
+    right
 };
 
 /** Structure for the bounds of a text string that is rendered to the screen. */
@@ -107,13 +107,13 @@ public:
         @param iWidth The maximum width of each line of text.
         @param iMaxRows The maximum number of rows to draw. Default is INT_MAX.
         @param iSkipRows Start rendering text after skipping this many rows.
-        @param eAlign How to align each line of text if the width of the line
+        @param text_align How to align each line of text if the width of the line
           of text is smaller than iWidth.
     */
     virtual THFontDrawArea drawTextWrapped(THRenderTarget* pCanvas, const char* sMessage,
                                             size_t iMessageLength, int iX, int iY,
                                             int iWidth, int iMaxRows = INT_MAX, int iSkipRows = 0,
-                                            eTHAlign eAlign = Align_Left) const = 0;
+                                            text_align text_align = text_align::left) const = 0;
 };
 
 class THBitmapFont : public THFont
@@ -147,7 +147,7 @@ public:
     virtual THFontDrawArea drawTextWrapped(THRenderTarget* pCanvas, const char* sMessage,
                                 size_t iMessageLength, int iX, int iY,
                                 int iWidth, int iMaxRows = INT_MAX, int iSkipRows = 0,
-                                eTHAlign eAlign = Align_Left) const;
+                                text_align text_align = text_align::left) const;
 
 protected:
     THSpriteSheet* m_pSpriteSheet;
@@ -227,7 +227,7 @@ public:
     virtual THFontDrawArea drawTextWrapped(THRenderTarget* pCanvas, const char* sMessage,
                                 size_t iMessageLength, int iX, int iY,
                                 int iWidth, int iMaxRows = INT_MAX, int iSkipRows = 0,
-                                eTHAlign eAlign = Align_Left) const;
+                                text_align text_align = text_align::left) const;
 
 protected:
     struct cached_text_t
@@ -263,7 +263,7 @@ protected:
         int iNumRows;
 
         //! Alignment of the message in the box
-        eTHAlign eAlign;
+        text_align text_align;
 
         //! True when the pData reflects the sMessage given the size constraints
         bool bIsValid;

--- a/CorsixTH/Src/th_gfx_font.h
+++ b/CorsixTH/Src/th_gfx_font.h
@@ -27,6 +27,7 @@ SOFTWARE.
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #endif
+#include <string>
 
 enum class text_align
 {
@@ -153,6 +154,21 @@ protected:
     THSpriteSheet* m_pSpriteSheet;
     int m_iCharSep;
     int m_iLineSep;
+
+    //! Draw a single line of text between two u32string iterators
+    /*!
+    @param pCanvas The render target to draw onto.
+    @param start The beginning of the text to write.
+    @param end The end of the text to write.
+    @param iX The X coordinate of the top-left corner of the bounding
+    rectangle for the drawn text.
+    @param iY The Y coordinate of the top-left corner of the bounding
+    rectangle for the drawn text.
+    */
+    void drawUcs4Substring(THRenderTarget *pCanvas,
+        std::u32string::iterator start,
+        std::u32string::iterator end,
+        int iX, int iY) const;
 };
 
 #ifdef CORSIX_TH_USE_FREETYPE2

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -330,19 +330,19 @@ static int l_font_draw(lua_State *L)
     const char* sMsg = luaT_checkstring(L, 3, &iMsgLen);
     int iX = static_cast<int>(luaL_checkinteger(L, 4));
     int iY = static_cast<int>(luaL_checkinteger(L, 5));
-    eTHAlign eAlign = Align_Center;
+    text_align text_align = text_align::center;
     if(!lua_isnoneornil(L, 8))
     {
         const char* sAlign = luaL_checkstring(L, 8);
         if(std::strcmp(sAlign, "right") == 0)
-            eAlign = Align_Right;
+            text_align = text_align::right;
         else if(std::strcmp(sAlign, "left") == 0)
-            eAlign = Align_Left;
+            text_align = text_align::left;
         else if(std::strcmp(sAlign, "center") == 0
              || std::strcmp(sAlign, "centre") == 0
              || std::strcmp(sAlign, "middle") == 0)
         {
-            eAlign = Align_Center;
+            text_align = text_align::center;
         }
         else
             return luaL_error(L, "Invalid alignment: \"%s\"", sAlign);
@@ -353,8 +353,8 @@ static int l_font_draw(lua_State *L)
     {
         int iW = static_cast<int>(luaL_checkinteger(L, 6));
         int iH = static_cast<int>(luaL_checkinteger(L, 7));
-        if(iW > oDrawArea.iEndX && eAlign != Align_Left)
-            iX += (iW - oDrawArea.iEndX) / ((eAlign == Align_Center) ? 2 : 1);
+        if(iW > oDrawArea.iEndX && text_align != text_align::left)
+            iX += (iW - oDrawArea.iEndX) / ((text_align == text_align::center) ? 2 : 1);
         if(iH > oDrawArea.iEndY)
             iY += (iH - oDrawArea.iEndY) / 2;
     }
@@ -381,19 +381,19 @@ static int l_font_draw_wrapped(lua_State *L)
     int iX = static_cast<int>(luaL_checkinteger(L, 4));
     int iY = static_cast<int>(luaL_checkinteger(L, 5));
     int iW = static_cast<int>(luaL_checkinteger(L, 6));
-    eTHAlign eAlign = Align_Left;
+    text_align text_align = text_align::left;
     if(!lua_isnoneornil(L, 7))
     {
         const char* sAlign = luaL_checkstring(L, 7);
         if(std::strcmp(sAlign, "right") == 0)
-            eAlign = Align_Right;
+            text_align = text_align::right;
         else if(std::strcmp(sAlign, "left") == 0)
-            eAlign = Align_Left;
+            text_align = text_align::left;
         else if(std::strcmp(sAlign, "center") == 0
              || std::strcmp(sAlign, "centre") == 0
              || std::strcmp(sAlign, "middle") == 0)
         {
-            eAlign = Align_Center;
+            text_align = text_align::center;
         }
         else
             return luaL_error(L, "Invalid alignment: \"%s\"", sAlign);
@@ -411,7 +411,7 @@ static int l_font_draw_wrapped(lua_State *L)
     }
 
     THFontDrawArea oDrawArea = pFont->drawTextWrapped(pCanvas, sMsg, iMsgLen, iX, iY,
-                                              iW, iMaxRows, iSkipRows, eAlign);
+                                              iW, iMaxRows, iSkipRows, text_align);
     lua_pushinteger(L, oDrawArea.iEndY);
     lua_pushinteger(L, oDrawArea.iEndX);
     lua_pushinteger(L, oDrawArea.iNumRows);


### PR DESCRIPTION
The second commit is the more ambitious and problematic one. I switched from our own utf8next function which is a bit of macro soup to the C++11 standard library unicode functionality.

Unfortunately there are a few problems with this approach.
1. In my tests (using visual studio 2013) it's very slow. It needs to convert/copy the characters to a u32string, which at least in that implementation led to extreme lag even on a modern gaming PC, when viewing the debug overlays.
2. It's currently broken in the latest Visual Studio 2015 (https://connect.microsoft.com/VisualStudio/feedback/details/1403302/unresolved-external-when-using-codecvt-utf8)
3. As with our current solution, this does not handle decomposed unicode characters (NFD form). (See https://en.wikipedia.org/wiki/Unicode_equivalence)

I have done some research and found that a lot of people use a library called ICU (http://site.icu-project.org/) for character set conversion. It appears to be well maintained, extensive, and capable of converting not just utf-8, but also the ibm-437 code page used for sprites. Unfortunately it requires that all strings be stored as unicodeStrings, so it may not avoid the performance issues I mentioned in point 1.

Does anyone have any thoughts on where to go with this?

To reiterate, ideally we want:
1. Correct results
2. Performance (enough to not slow the game down noticeably)
3. Clean macro-free code (that doesn't reinvent the wheel).