### PR TITLE
[RDY] Machines smoke when needing repair

### DIFF
--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -491,6 +491,7 @@ function UIPlaceObjects:placeObject(dont_close_if_empty)
     real_obj = object.existing_objects[1]
     table.remove(object.existing_objects, 1)
   end
+  local room = self.room or self.world:getRoom(self.object_cell_x, self.object_cell_y)
   if real_obj then
     -- If there is such an object then we don't want to make a new one, but move this one instead.
     if real_obj.orientation_before and real_obj.orientation_before ~= self.object_orientation then
@@ -503,11 +504,14 @@ function UIPlaceObjects:placeObject(dont_close_if_empty)
     end
     -- Some objects (e.g. the plant) uses this flag to avoid doing stupid things when picked up.
     real_obj.picked_up = false
+    -- Machines may have smoke, recalculate it to ensure the animation is in the correct state
+    if real_obj.strength then
+      real_obj:calculateSmoke(room)
+    end
   else
     real_obj = self.world:newObject(object.object.id, self.object_cell_x,
     self.object_cell_y, self.object_orientation)
   end
-  local room = self.room or self.world:getRoom(self.object_cell_x, self.object_cell_y)
   if room then
     room.objects[real_obj] = true
   end

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -39,7 +39,6 @@ function Machine:Machine(world, object_type, x, y, direction, etc)
 
   -- We actually don't want any dynamic info just yet
   self:clearDynamicInfo()
-  -- TODO: Smoke, 3424
   -- Change hover cursor once the room has been finished.
   local callback
   callback = --[[persistable:machine_build_callback]] function(room)
@@ -78,43 +77,118 @@ function Machine:setCrashedAnimation()
   self:setAnimation(self.object_type.crashed_animation)
 end
 
+--! Calculates the number of times the machine can be used before crashing (unless repaired first)
+function Machine:getRemainingUses()
+  return self.strength - self.times_used
+end
+
+--! Set whether the smoke animation should be showing
+local function setSmoke(self, isSmoking)
+  -- If turning smoke on for this machine
+  if isSmoking then
+    -- If there is no smoke animation for this machine, make one
+    if not self.smokeInfo then
+      self.smokeInfo = TH.animation()
+      -- Note: Set the location of the smoke to that of the machine
+      -- rather than setting the machine to the parent so that the smoke
+      -- doesn't get hidden with the machine during use
+      self.smokeInfo:setTile(self.th:getTile())
+      -- Always show the first smoke layer
+      self.smokeInfo:setLayer(10, 2)
+      -- tick to animate over all frames
+      self.ticks = true
+    end
+    -- TODO: select the smoke icon based on the type of machine
+    self.smokeInfo:setAnimation(self.world.anims, 3424)
+  else -- Otherwise, turning smoke off
+    -- If there is currently a smoke animation, remove it
+    if self.smokeInfo then
+      self.smokeInfo:setTile(nil)
+    end
+    self.smokeInfo = nil
+  end
+end
+
+--! Call on machine use. Handles crashing the machine & queueing repairs
 function Machine:machineUsed(room)
+  -- Do nothing if the room has already crashed
   if room.crashed then
-    -- Do nothing if the room has already crashed.
     return
   end
+  -- Update dynamic info (strength & times used)
   self:updateDynamicInfo()
-  local threshold = self.strength - self.times_used
+  -- How many uses this machine has left until it explodes
+  local threshold = self:getRemainingUses()
+  -- Find a queued task for a handyman coming to repair this machine
   local taskIndex = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "repairing")
 
   -- Too late it is about to explode
   if threshold < 1 then
+    -- Clean up any task of handyman coming to repair the machine
     self.hospital:removeHandymanTask(taskIndex, "repairing")
+    -- Blow up the room
     room:crashRoom()
     self:setCrashedAnimation()
+    -- No special cursor required when hovering over the crashed room
     self.hover_cursor = nil
+    -- Clear dynamic info (tracks machine usage which is no longer required)
     self:clearDynamicInfo()
+    -- Prevent the machine from smoking, it's now just a pile of rubble
+    setSmoke(self, false)
+    -- If we have the window for this machine open, close it
     local window = self.world.ui:getWindow(UIMachine)
     if window and window.machine == self then
       window:close()
     end
+    -- Clear the icon showing a handyman is coming to repair the machine
     self:setRepairing(nil)
     return true
-    -- Urgent repair needed
+  -- Else if urgent repair needed
   elseif threshold < 4 then
-    -- TODO: Smoke, up to three animations per machine
-    -- i.e. < 4 one plume, < 3 two plumes or < 2 three plumes of smoke
+    -- If the job of repairing the machine isn't queued, queue it now (higher priority)
     if taskIndex == -1 then
       local call = self.world.dispatcher:callForRepair(self, true, false, true)
       self.hospital:addHandymanTask(self, "repairing", 2, self.tile_x, self.tile_y, call)
-    else
+    else -- Otherwise the task is already queued. Increase the priority to above that of machines with at least 4 uses left
       self.hospital:modifyHandymanTaskPriority(taskIndex, 2, "repairing")
     end
+  -- Else if repair is needed, but not urgently
   elseif threshold < 6 then
-    -- Not urgent
+    -- If the job of repairing the machine isn't queued, queue it now (low priority)
     if taskIndex == -1 then
       local call = self.world.dispatcher:callForRepair(self)
       self.hospital:addHandymanTask(self, "repairing", 1, self.tile_x, self.tile_y, call)
+    end
+  end
+  
+  -- Update whether smoke gets displayed for this machine (and if so, how much)
+  self:calculateSmoke(room)
+end
+
+--! Calculates whether smoke gets displayed for this machine (and if so, how much)
+function Machine:calculateSmoke(room)
+  -- Do nothing if the room has already crashed
+  if room.crashed then
+    return
+  end
+  
+  -- How many uses this machine has left until it explodes
+  local threshold = self:getRemainingUses()
+  
+  -- If now exploding, clear any smoke
+  if threshold < 1 then
+    setSmoke(self, false)
+  -- Else if urgent repair needed
+  elseif threshold < 4 then
+    -- Display smoke, up to three animations per machine
+    -- i.e. < 4 one plume, < 3 two plumes or < 2 three plumes of smoke
+    setSmoke(self, true)
+    -- turn on additional layers of the animation for extra smoke plumes, depending on how damaged the machine is
+    if threshold < 3 then
+      self.smokeInfo:setLayer(11, 2)
+    end
+    if threshold < 2 then
+      self.smokeInfo:setLayer(12, 2)
     end
   end
 end
@@ -188,6 +262,7 @@ function Machine:machineRepaired(room)
   end
   self.times_used = 0
   self:setRepairing(nil)
+  setSmoke(self, false)
 
   local taskIndex = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "repairing")
   self.hospital:removeHandymanTask(taskIndex, "repairing")
@@ -277,6 +352,10 @@ function Machine:onDestroy()
   if index ~= -1 then
     self.hospital:removeHandymanTask(index, "repairing")
   end
+  
+  -- Stop this machine from smoking
+  setSmoke(self, false)
+  
   Object.onDestroy(self)
 end
 
@@ -297,4 +376,13 @@ function Machine:afterLoad(old, new)
     end
   end
   return Object.afterLoad(self, old, new)
+end
+
+function Machine:tick()
+  -- Tick any smoke animation
+  if self.smokeInfo then
+    self.smokeInfo:tick()
+  end
+  
+  return Object.tick(self)
 end

--- a/CorsixTH/Lua/entity.lua
+++ b/CorsixTH/Lua/entity.lua
@@ -204,6 +204,7 @@ function Entity:tick()
   else
     self:_tick()
   end
+  -- Tick any mood animation
   if self.mood_info then
     self.mood_info:tick()
   end


### PR DESCRIPTION
Machines will now smoke when they are need of repair.
Shows 1-3 plumes of smoke depending on how badly it needs repairing.
3 plumes: use again & it will blow up
2 plumes: 1 use left
1 plume: 2 uses left

Smoke will still be displayed whilst the machine is in use, and whilst the repair icon is showing, disappearing once the machine is repaired or blows up.

Ideally, different animations should be displayed for each machine (& maybe orientation?). The smoke animations seem to occupy the range 3424-3472. 
As working out which smoke animation goes with which machine could end up being quite laborious I've just used 3424 for every machine, but if I (or anyone else) have the time to work out which animation goes with which machine, it will be straight forward to change this to use an id specified on the class rather than the hard-coded one.