### PR TITLE
[WIP] Remove any remaining litter after removing humanoids from the blue-print area

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -255,6 +255,13 @@ function UIEditRoom:confirm(force)
   end
 end
 
+--! Return whether humanoid entity is sticking around or walking into an area.
+--!param entity (Humanoid) Humanoid to check.
+--!param x1 (int) Smallest x value of the room.
+--!param x2 (int) Biggest x value of the room.
+--!param y1 (int) Smallest y value of the room.
+--!param y2 (int) Biggest y value of the room.
+--!return (bool) Whether the entity is blocking or going to block the area.
 function UIEditRoom:isHumanoidObscuringArea(entity, x1, x2, y1, y2)
   if entity.tile_x then
     if x1 <= entity.tile_x and entity.tile_x <= x2
@@ -335,6 +342,12 @@ function UIEditRoom:clearArea()
   end
 
   if next(humanoids_to_watch) == nil then
+    -- There might be litter on the floor (most likely a humanoid vomiting after
+    -- establishing the room blueprint, but before confirming).
+    -- Clear it all (ie also 'normal' litter).
+    local rect = self.blueprint_rect
+    self.world:clearLitterFromArea(rect.x, rect.y, rect.x + rect.w - 1, rect.y + rect.h - 1)
+
     -- No humanoids within the area, so continue with the room placement
     self:confirm(true)
     return

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2257,6 +2257,11 @@ function World:getObjects(x, y)
   return self.objects[index]
 end
 
+--! Get an object from a node in the world.
+--!param x (int) X position of the node to retrieve from.
+--!param y (int) Y position of the node to retrieve from.
+--!param id (string) Optional ID name of the object to retrieve (else first object is retrieved).
+--!return (object) Retrieved object, if it exists.
 function World:getObject(x, y, id)
   local objects = self:getObjects(x, y)
   if objects then
@@ -2304,6 +2309,22 @@ function World:getObjectsById(id)
   end
 
   return ret
+end
+
+--! Remove all litter from an area of the world.
+--!param x1 (int) Low x of the area to clear.
+--!param y1 (int) Low y of the area to clear.
+--!param x2 (int) High x of the area to clear.
+--!param y2 (int) High y of the area to clear.
+function World:clearLitterFromArea(x1, y1, x2, y2)
+  for x = x1, x2 do
+    for y = y1, y2 do
+      local obj = self:getObject(x, y, "litter")
+      if obj then -- Silently remove litter from the world.
+        self:removeLitter(obj, x, y)
+      end
+    end
+  end
 end
 
 --! Remove litter from a tile.


### PR DESCRIPTION
Fixes #066 at least partly.

It solves the "vomit between confirm and actual construction of room" problem, but if you test with the save game, you will notice red/blue colours of the blueprint are not properly updated until you move or resize the blueprint.

Not sure if that is supposed to be fixed here too.


I pondered about allowing overbuilding on litter, but that would mostly defeat the purpose of litter I think, so I didn't change that.