### PR TITLE
Fix issues with C++ standards complience

### DIFF
--- a/CorsixTH/Src/lua_sdl.h
+++ b/CorsixTH/Src/lua_sdl.h
@@ -32,13 +32,15 @@ SOFTWARE.
 #define SDL_USEREVENT_TICK (SDL_USEREVENT + 0)
 // SDL_USEREVENT_MUSIC_OVER - informs script of SDL_Mixer music finishing
 #define SDL_USEREVENT_MUSIC_OVER (SDL_USEREVENT + 1)
-// SDL_USEREVENT_CPCALL - calls lua_cpcall with SDL_Event user.data1 and data2
-#define SDL_USEREVENT_CPCALL (SDL_USEREVENT + 2)
+// SDL_USEREVENT_MUSIC_LOADED - informs script that async music is loaded
+#define SDL_USEREVENT_MUSIC_LOADED (SDL_USEREVENT + 2)
 // SDL USEREVENT_MOVIE_OVER - informs script of THMovie movie finishing
 #define SDL_USEREVENT_MOVIE_OVER (SDL_USEREVENT + 3)
 // SDL_USEREVENT_SOUND_OVER - informs script of a played sound finishing.
 #define SDL_USEREVENT_SOUND_OVER (SDL_USEREVENT + 4)
 
 int luaopen_sdl(lua_State *L);
+
+int l_load_music_async_callback(lua_State *L);
 
 #endif // CORSIX_TH_LUA_SDL_H_

--- a/CorsixTH/Src/main.cpp
+++ b/CorsixTH/Src/main.cpp
@@ -55,10 +55,6 @@ int CorsixTH_lua_main_no_eval(lua_State *L)
     }
     lua_pop(L, 1);
 
-    // registry._CLEANUP = {}
-    lua_newtable(L);
-    lua_setfield(L, LUA_REGISTRYINDEX, "_CLEANUP");
-
     // math.random* = Mersenne twister variant
     luaT_cpcall(L, luaopen_random, nullptr);
 

--- a/CorsixTH/Src/sdl_audio.cpp
+++ b/CorsixTH/Src/sdl_audio.cpp
@@ -72,7 +72,6 @@ static int l_init(lua_State *L)
     else
     {
         lua_pushboolean(L, 1);
-        luaT_addcleanup(L, Mix_CloseAudio);
         Mix_HookMusicFinished(audio_music_over_callback);
         return 1;
     }

--- a/CorsixTH/Src/sdl_audio.cpp
+++ b/CorsixTH/Src/sdl_audio.cpp
@@ -85,7 +85,7 @@ struct load_music_async_t
     char* err;
 };
 
-static int l_load_music_async_callback(lua_State *L)
+int l_load_music_async_callback(lua_State *L)
 {
     load_music_async_t *async = (load_music_async_t*)lua_touserdata(L, 1);
 
@@ -166,9 +166,8 @@ static int load_music_async_thread(void* arg)
         std::memcpy(async->err, Mix_GetError(), iLen);
     }
     SDL_Event e;
-    e.type = SDL_USEREVENT_CPCALL;
-    e.user.data1 = (void*)l_load_music_async_callback;
-    e.user.data2 = arg;
+    e.type = SDL_USEREVENT_MUSIC_LOADED;
+    e.user.data1 = arg;
     SDL_PushEvent(&e);
     return 0;
 }

--- a/CorsixTH/Src/sdl_core.cpp
+++ b/CorsixTH/Src/sdl_core.cpp
@@ -57,7 +57,6 @@ static int l_init(lua_State *L)
         return 1;
     }
 
-    luaT_addcleanup(L, SDL_Quit);
     lua_pushboolean(L, 1);
     return 1;
 }

--- a/CorsixTH/Src/sdl_core.cpp
+++ b/CorsixTH/Src/sdl_core.cpp
@@ -229,8 +229,8 @@ static int l_mainloop(lua_State *L)
                 lua_pushliteral(dispatcher, "music_over");
                 nargs = 1;
                 break;
-            case SDL_USEREVENT_CPCALL:
-                if(luaT_cpcall(L, (lua_CFunction)e.user.data1, e.user.data2))
+            case SDL_USEREVENT_MUSIC_LOADED:
+                if(luaT_cpcall(L, (lua_CFunction)l_load_music_async_callback, e.user.data1))
                 {
                     SDL_RemoveTimer(timer);
                     lua_pushliteral(L, "callback");

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -552,7 +552,7 @@ public:
     void setMorphTarget(THAnimation *pMorphTarget, unsigned int iDurationFactor = 1);
     void setFrame(size_t iFrame);
 
-    void setSpeed(int iX, int iY) {m_iSpeedX = iX, m_iSpeedY = iY;}
+    void setSpeed(int iX, int iY) {speed.x = iX, speed.y = iY;}
     void setCropColumn(int iColumn) {m_iCropColumn = iColumn;}
 
     void persist(LuaPersistWriter *pWriter) const;
@@ -564,12 +564,13 @@ protected:
     THAnimation* m_pMorphTarget;
     size_t m_iAnimation; ///< Animation number.
     size_t m_iFrame;     ///< Frame number.
-    union { struct {
-        //! Amount to change m_iX per tick
-        int m_iSpeedX;
-        //! Amount to change m_iY per tick
-        int m_iSpeedY;
-    };
+    union {
+        struct {
+            //! Amount to change m_iX per tick
+            int x;
+            //! Amount to change m_iY per tick
+            int y;
+        } speed;
         //! Some animations are tied to the marker of another animation and
         //! hence have a parent rather than a speed.
         THAnimation* m_pParent;

--- a/CorsixTH/Src/th_lua.cpp
+++ b/CorsixTH/Src/th_lua.cpp
@@ -148,16 +148,6 @@ void luaT_pushcclosuretable(lua_State *L, lua_CFunction fn, int n)
     lua_setmetatable(L, -2); // .. t <top
 }
 
-void luaT_addcleanup(lua_State *L, void(*fnCleanup)(void))
-{
-    lua_checkstack(L, 2);
-    lua_getfield(L, LUA_REGISTRYINDEX, "_CLEANUP");
-    int idx = 1 + (int)lua_objlen(L, -1);
-    lua_pushlightuserdata(L, (void*)fnCleanup);
-    lua_rawseti(L, -2, idx);
-    lua_pop(L, 1);
-}
-
 //! Check for a string or userdata
 const uint8_t* luaT_checkfile(lua_State *L, int idx, size_t* pDataLen)
 {

--- a/CorsixTH/Src/th_lua.h
+++ b/CorsixTH/Src/th_lua.h
@@ -127,9 +127,6 @@ inline int luaT_resume(lua_State *L, lua_State *f, int n)
 */
 #define luaT_new(L, T) new ((T*)lua_newuserdata(L, sizeof(T))) T
 
-//! Register a function to be called after a lua_State is destroyed
-void luaT_addcleanup(lua_State *L, void(*fnCleanup)(void));
-
 //! Check that a Lua argument is a binary data blob
 /*!
     If the given argument is a string or (full) userdata, then returns a

--- a/CorsixTH/SrcUnshared/main.cpp
+++ b/CorsixTH/SrcUnshared/main.cpp
@@ -25,7 +25,9 @@ SOFTWARE.
 #include "../Src/bootstrap.h"
 #include <stack>
 #include <SDL.h>
-
+#ifdef CORSIX_TH_USE_SDL_MIXER
+#include <SDL_mixer.h>
+#endif
 // Template magic for checking type equality
 template <typename T1, typename T2>
 struct types_equal{ enum{
@@ -36,6 +38,17 @@ template <typename T1>
 struct types_equal<T1, T1>{ enum{
     result = 1,
 }; };
+
+void cleanup()
+{
+#ifdef CORSIX_TH_USE_SDL_MIXER
+    while(Mix_QuerySpec(nullptr, nullptr, nullptr))
+    {
+        Mix_CloseAudio();
+    }
+#endif
+    SDL_Quit();
+}
 
 //! Program entry point
 /*!
@@ -105,29 +118,7 @@ int main(int argc, char** argv)
         lua_getfield(L, LUA_REGISTRYINDEX, "_RESTART");
         bRun = lua_toboolean(L, -1) != 0;
 
-        // Get cleanup functions out of the Lua state (but don't run them yet)
-        std::stack<void(*)(void)> stkCleanup;
-        lua_getfield(L, LUA_REGISTRYINDEX, "_CLEANUP");
-        if(lua_type(L, -1) == LUA_TTABLE)
-        {
-            for(unsigned int i = 1; i <= lua_objlen(L, -1); ++i)
-            {
-                lua_rawgeti(L, -1, (int)i);
-                stkCleanup.push((void(*)(void))lua_touserdata(L, -1));
-                lua_pop(L, 1);
-            }
-        }
-
-        lua_close(L);
-
-        // The cleanup functions are executed _after_ the Lua state is fully
-        // closed, and in reserve order to that in which they were registered.
-        while(!stkCleanup.empty())
-        {
-            if(stkCleanup.top() != NULL)
-                stkCleanup.top()();
-            stkCleanup.pop();
-        }
+        cleanup();
 
         if(bRun)
         {


### PR DESCRIPTION
This pr replaces the cases where function pointers are cast to void*, which is explicitly undefined in the C++ spec. It also names an anonymous struct. Anonymous structs are illegal in C++ 11/14.

These are all the standards compliance issues MSVC informed me about when attempting to compile with /Za. Unfortunately we won't be able to target /Za because standard windows headers rely on non-compliant behavior.

Fixes #929