### PR TITLE
[RDY] Fix luaT_register

### DIFF
--- a/CorsixTH/Src/persist_lua.cpp
+++ b/CorsixTH/Src/persist_lua.cpp
@@ -25,6 +25,7 @@ SOFTWARE.
 #include <errno.h>
 #include <cmath>
 #include <cstdio>
+#include <vector>
 #ifdef _MSC_VER
 #pragma warning(disable: 4996) // Disable "std::strcpy unsafe" warnings under MSVC
 #endif
@@ -1461,7 +1462,7 @@ static int l_errcatch(lua_State *L)
     return 1;
 }
 
-static const struct luaL_Reg persist_lib[] = {
+static const std::vector<luaL_Reg> persist_lib = {
     // Due to the various required upvalues, functions are registered
     // manually, but we still need a dummy to pass to luaL_register.
     {"errcatch", l_errcatch},

--- a/CorsixTH/Src/rnc.cpp
+++ b/CorsixTH/Src/rnc.cpp
@@ -37,6 +37,7 @@ SOFTWARE.
 #include "config.h"
 #include "rnc.h"
 #include "th_lua.h"
+#include <vector>
 
 /*! Result status values from #rnc_inpack. */
 enum class rnc_status
@@ -548,7 +549,7 @@ static int l_decompress(lua_State *L)
     return 2;
 }
 
-static const struct luaL_Reg rnclib[] = {
+static const std::vector<luaL_Reg> rnclib = {
     {"decompress", l_decompress},
     {nullptr, nullptr}
 };

--- a/CorsixTH/Src/sdl_core.cpp
+++ b/CorsixTH/Src/sdl_core.cpp
@@ -25,6 +25,7 @@ SOFTWARE.
 #include "th_lua.h"
 #include <cstring>
 #include <cstdio>
+#include <vector>
 #ifndef _MSC_VER
 #define stricmp strcasecmp
 #else
@@ -342,13 +343,13 @@ static int l_get_ticks(lua_State *L)
     return 1;
 }
 
-static const struct luaL_Reg sdllib[] = {
+static const std::vector<luaL_Reg> sdllib = {
     {"init", l_init},
     {"getTicks", l_get_ticks},
     {"getKeyModifiers", l_get_key_modifiers},
     {nullptr, nullptr}
 };
-static const struct luaL_Reg sdllib_with_upvalue[] = {
+static const std::vector<luaL_Reg> sdllib_with_upvalue = {
     {"mainloop", l_mainloop},
     {"getFPS", l_get_fps},
     {"trackFPS", l_track_fps},
@@ -371,12 +372,11 @@ int luaopen_sdl(lua_State *L)
     fps_ctrl* ctrl = (fps_ctrl*)lua_newuserdata(L, sizeof(fps_ctrl));
     ctrl->init();
     luaT_register(L, "sdl", sdllib);
-    const luaL_Reg *pUpvaluedFunctions = sdllib_with_upvalue;
-    for(; pUpvaluedFunctions->name; ++pUpvaluedFunctions)
+    for (auto reg = sdllib_with_upvalue.begin(); reg->name; ++reg)
     {
         lua_pushvalue(L, -2);
-        luaT_pushcclosure(L, pUpvaluedFunctions->func, 1);
-        lua_setfield(L, -2, pUpvaluedFunctions->name);
+        luaT_pushcclosure(L, reg->func, 1);
+        lua_setfield(L, -2, reg->name);
     }
 
     load_extra(L, "audio", luaopen_sdl_audio);

--- a/CorsixTH/Src/th_lua.h
+++ b/CorsixTH/Src/th_lua.h
@@ -25,6 +25,7 @@ SOFTWARE.
 #include "config.h"
 #include "lua.hpp"
 #include <new>
+#include <vector>
 
 int luaopen_th(lua_State *L);
 
@@ -44,12 +45,12 @@ inline int luaT_upvalueindex(int i)
 #endif
 }
 
-inline void luaT_register(lua_State *L, const char *n, const luaL_Reg *l)
+inline void luaT_register(lua_State *L, const char *n, const std::vector<luaL_Reg> &l)
 {
 #if LUA_VERSION_NUM >= 502
-    luaL_newlibtable(L, l);
+    lua_createtable(L, 0, static_cast<int>(l.size()));
     lua_pushvalue(L, luaT_environindex);
-    luaL_setfuncs(L, l, 1);
+    luaL_setfuncs(L, l.data(), 1);
     lua_pushvalue(L, -1);
     lua_setglobal(L, n);
 #else


### PR DESCRIPTION
luaL_newlibtable expected a C array to set the size of the table based on the
number of elements, but since luaT_register is a function that array is being
auto cast to a pointer where the size wasn't available. By using vectors instead
we preserve the size.