### PR TITLE
Replace all usage of non-standard malloc.h / alloc.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,6 @@ ENDIF(MSVC)
 
 # Environment handling
 
-CHECK_INCLUDE_FILES(malloc.h CORSIX_TH_HAS_MALLOC_H)
-CHECK_INCLUDE_FILES(alloca.h CORSIX_TH_HAS_ALLOCA_H)
 CHECK_INCLUDE_FILES(inttypes.h CORSIX_TH_HAS_INTTYPES_H)
 
 # Include individual projects

--- a/CorsixTH/Src/config.h.in
+++ b/CorsixTH/Src/config.h.in
@@ -71,8 +71,6 @@ SOFTWARE.
 #ifndef __STDC_CONSTANT_MACROS
 #  define __STDC_CONSTANT_MACROS
 #endif
-#cmakedefine CORSIX_TH_HAS_MALLOC_H
-#cmakedefine CORSIX_TH_HAS_ALLOCA_H
 #include <cstddef>
 #include <cstdint>
 

--- a/CorsixTH/Src/iso_fs.cpp
+++ b/CorsixTH/Src/iso_fs.cpp
@@ -24,12 +24,7 @@ SOFTWARE.
 #include <cstring>
 #include <cstdarg>
 #include <cstdlib>
-#ifdef CORSIX_TH_HAS_MALLOC_H
-#include <malloc.h> // for alloca
-#endif
-#ifdef CORSIX_TH_HAS_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <vector>
 #include <algorithm>
 
 IsoFilesystem::IsoFilesystem()
@@ -332,7 +327,7 @@ void IsoFilesystem::visitDirectoryFiles(const char* sPath,
                              void* pCallbackData) const
 {
     size_t iLen = std::strlen(sPath) + 1;
-    char *sNormedPath = (char*)alloca(iLen);
+    std::vector<char> sNormedPath(iLen);
     for(size_t i = 0; i < iLen; ++i)
         sNormedPath[i] = _normalise(sPath[i]);
 
@@ -341,7 +336,7 @@ void IsoFilesystem::visitDirectoryFiles(const char* sPath,
     for(size_t i = 0; i < m_iNumFiles; ++i)
     {
         const char *sName = m_pFiles[i].sPath;
-        if(std::strlen(sName) >= iLen && std::memcmp(sNormedPath, sName, iLen - 1) == 0)
+        if(std::strlen(sName) >= iLen && std::memcmp(sNormedPath.data(), sName, iLen - 1) == 0)
         {
             sName += iLen - 1;
             if(*sName == m_cPathSeparator)
@@ -355,7 +350,7 @@ void IsoFilesystem::visitDirectoryFiles(const char* sPath,
 IsoFilesystem::file_handle_t IsoFilesystem::findFile(const char* sPath) const
 {
     size_t iLen = std::strlen(sPath) + 1;
-    char *sNormedPath = (char*)alloca(iLen);
+    std::vector<char> sNormedPath(iLen);
     for(size_t i = 0; i < iLen; ++i)
         sNormedPath[i] = _normalise(sPath[i]);
 
@@ -364,7 +359,7 @@ IsoFilesystem::file_handle_t IsoFilesystem::findFile(const char* sPath) const
     while(iLower != iUpper)
     {
         int iMid = (iLower + iUpper) / 2;
-        int iComp = std::strcmp(sNormedPath, m_pFiles[iMid].sPath);
+        int iComp = std::strcmp(sNormedPath.data(), m_pFiles[iMid].sPath);
         if(iComp == 0)
             return iMid + 1;
         else if(iComp < 0)

--- a/CorsixTH/Src/persist_lua.cpp
+++ b/CorsixTH/Src/persist_lua.cpp
@@ -26,6 +26,7 @@ SOFTWARE.
 #include <cmath>
 #include <cstdio>
 #include <vector>
+#include <cstdlib>
 #ifdef _MSC_VER
 #pragma warning(disable: 4996) // Disable "std::strcpy unsafe" warnings under MSVC
 #endif
@@ -131,7 +132,7 @@ public:
         : m_L(L)
     {
         m_iDataBufferLength = 1024;
-        m_pData = (uint8_t*)malloc(m_iDataBufferLength);
+        m_pData = static_cast<uint8_t*>(std::malloc(m_iDataBufferLength));
     }
 
     ~LuaPersistBasicWriter()
@@ -740,7 +741,7 @@ public:
         : m_L(L)
     {
         m_iStringBufferLength = 32;
-        m_sStringBuffer = (char*)malloc(m_iStringBufferLength);
+        m_sStringBuffer = static_cast<char*>(std::malloc(m_iStringBufferLength));
     }
 
     ~LuaPersistBasicReader()

--- a/CorsixTH/Src/persist_lua.h
+++ b/CorsixTH/Src/persist_lua.h
@@ -24,13 +24,8 @@ SOFTWARE.
 #define CORSIX_TH_PERSIST_LUA_H_
 #include "config.h"
 #include "th_lua.h"
+#include <vector>
 #include <cstdlib>
-#ifdef CORSIX_TH_HAS_MALLOC_H
-#include <malloc.h> // for alloca
-#endif
-#ifdef CORSIX_TH_HAS_ALLOCA_H
-#include <alloca.h>
-#endif
 
 template <class T> struct LuaPersistVInt {};
 template <> struct LuaPersistVInt<int> {typedef unsigned int T;};
@@ -72,14 +67,14 @@ public:
         }
         else
         {
-            uint8_t *pBytes = (uint8_t*)alloca(iNumBytes);
-            pBytes[iNumBytes - 1] = 0x7F & (uint8_t)(tValue);
+            std::vector<uint8_t> bytes(iNumBytes);
+            bytes[iNumBytes - 1] = 0x7F & (uint8_t)(tValue);
             for(int i = 1; i < iNumBytes; ++i)
             {
                 tValue /= (T)0x80;
-                pBytes[iNumBytes - 1 - i] = 0x80 | (0x7F & (uint8_t)tValue);
+                bytes[iNumBytes - 1 - i] = 0x80 | (0x7F & (uint8_t)tValue);
             }
-            writeByteStream(pBytes, iNumBytes);
+            writeByteStream(bytes.data(), iNumBytes);
         }
     }
 


### PR DESCRIPTION
Calls to alloc have been replaced with C++ vectors. malloc.h is not available
on some OSX machines as per #961