### PR TITLE
Sshpass for Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       - luarocks
       - doxygen
       - g++-5
+      - sshpass
 
 before_install:
   # Required for LDocGen


### PR DESCRIPTION
The current script uses ~~lua 5.1 and~~ no sshpass, this adds ~~lua 5.3 (manual build as it's not in any ubuntu repo that travis containers has access to) and~~ sshpass.

Lua commit taken out.