### PR TITLE
[RDY] Cleanup the C++ object oriented code

### DIFF
--- a/CorsixTH/Src/iso_fs.h
+++ b/CorsixTH/Src/iso_fs.h
@@ -95,7 +95,7 @@ public:
     */
     bool getFileData(file_handle_t iFile, uint8_t *pBuffer);
 
-protected:
+private:
     struct _file_t
     {
         char *sPath;

--- a/CorsixTH/Src/persist_lua.cpp
+++ b/CorsixTH/Src/persist_lua.cpp
@@ -52,9 +52,6 @@ enum PersistTypes
     PERSIST_TCOUNT, // must equal 16 (for compatibility)
 };
 
-LuaPersistWriter::~LuaPersistWriter() {}
-LuaPersistReader::~LuaPersistReader() {}
-
 static int l_writer_mt_index(lua_State *L);
 
 template <class T> static int l_crude_gc(lua_State *L)
@@ -140,7 +137,7 @@ public:
         free(m_pData);
     }
 
-    virtual lua_State* getStack()
+    lua_State* getStack() override
     {
         return m_L;
     }
@@ -188,7 +185,7 @@ public:
         }
     }
 
-    virtual void fastWriteStackObject(int iIndex)
+    void fastWriteStackObject(int iIndex) override
     {
         lua_State *L = m_L;
 
@@ -253,7 +250,7 @@ public:
         lua_pop(L, 1);
     }
 
-    virtual void writeStackObject(int iIndex)
+    void writeStackObject(int iIndex) override
     {
         lua_State *L = m_L;
 
@@ -651,7 +648,7 @@ public:
         lua_pop(L, 2);
     }
 
-    virtual void writeByteStream(const uint8_t *pBytes, size_t iCount)
+    void writeByteStream(const uint8_t *pBytes, size_t iCount) override
     {
         if(m_bHadError)
         {
@@ -669,7 +666,7 @@ public:
         m_iDataLength += iCount;
     }
 
-    virtual void setError(const char *sError)
+    void setError(const char *sError) override
     {
         // If multiple errors occur, only record the first.
         if(m_bHadError)
@@ -704,7 +701,7 @@ public:
             return nullptr;
     }
 
-protected:
+private:
     lua_State *m_L;
     uint64_t m_iNextIndex;
     uint8_t* m_pData;
@@ -749,12 +746,12 @@ public:
         free(m_sStringBuffer);
     }
 
-    virtual lua_State* getStack()
+    lua_State* getStack() override
     {
         return m_L;
     }
 
-    virtual void setError(const char *sError)
+    void setError(const char *sError) override
     {
         m_bHadError = true;
         size_t iErrLength = std::strlen(sError) + 1;
@@ -789,7 +786,7 @@ public:
         lua_setmetatable(L, 1);
     }
 
-    virtual bool readStackObject()
+    bool readStackObject() override
     {
         uint64_t iIndex;
         if(!readVUInt(iIndex))
@@ -1187,7 +1184,7 @@ public:
         return true;
     }
 
-    virtual bool readByteStream(uint8_t *pBytes, size_t iCount)
+    bool readByteStream(uint8_t *pBytes, size_t iCount) override
     {
         if(iCount > m_iDataBufferLength)
         {
@@ -1215,7 +1212,7 @@ public:
             return nullptr;
     }
 
-protected:
+private:
     lua_State *m_L;
     uint64_t m_iNextIndex;
     const uint8_t* m_pData;

--- a/CorsixTH/Src/persist_lua.h
+++ b/CorsixTH/Src/persist_lua.h
@@ -38,7 +38,7 @@ template <> struct LuaPersistVInt<int> {typedef unsigned int T;};
 class LuaPersistWriter
 {
 public:
-    virtual ~LuaPersistWriter();
+    virtual ~LuaPersistWriter() = default;
 
     virtual lua_State* getStack() = 0;
     virtual void writeStackObject(int iIndex) = 0;
@@ -111,7 +111,7 @@ public:
 class LuaPersistReader
 {
 public:
-    virtual ~LuaPersistReader();
+    virtual ~LuaPersistReader() = default;
 
     virtual lua_State* getStack() = 0;
     virtual bool readStackObject() = 0;

--- a/CorsixTH/Src/run_length_encoder.h
+++ b/CorsixTH/Src/run_length_encoder.h
@@ -66,7 +66,7 @@ public:
     uint32_t* getOutput(size_t *pCount) const;
     void pumpOutput(LuaPersistWriter *pWriter) const;
 
-protected:
+private:
     void _clean();
 
     //! Reduce the amount of data in the buffer
@@ -114,7 +114,7 @@ public:
     uint32_t read();
     bool isFinished() const;
 
-protected:
+private:
     void _clean();
 
     uint32_t* m_pBuffer;

--- a/CorsixTH/Src/th.h
+++ b/CorsixTH/Src/th.h
@@ -80,7 +80,7 @@ public:
     */
     const char* getString(size_t section, size_t index);
 
-protected:
+private:
     //! Section information
     std::vector<std::vector<const char *>> sections;
 

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -189,7 +189,7 @@ public:
     //! Perform a "fill to end of file" chunk (normally called by decodeChunks)
     void chunkFinish(uint8_t value);
 
-protected:
+private:
     inline bool _isDone() {return m_ptr == m_end;}
     inline void _fixNpixels(int& npixels) const;
     inline void _incrementPosition(int npixels);
@@ -360,7 +360,7 @@ public:
      */
     const AnimationStartFrames &getNamedAnimations(const std::string &sName, int iTilesize) const;
 
-protected:
+private:
 #if CORSIX_TH_USE_PACK_PRAGMAS
 #pragma pack(push)
 #pragma pack(1)
@@ -515,15 +515,12 @@ public:
 
    // bool isMultipleFrameAnimation() { return false;}
 protected:
-    void _clear();
-
     //! X position on tile (not tile x-index)
     int m_iX;
     //! Y position on tile (not tile y-index)
     int m_iY;
 
     THLayers_t m_oLayers;
-
 };
 
 class THAnimation : public THAnimationBase
@@ -559,7 +556,7 @@ public:
     void depersist(LuaPersistReader *pReader);
 
     THAnimationManager* getAnimationManager(){ return m_pManager;}
-protected:
+private:
     THAnimationManager *m_pManager;
     THAnimation* m_pMorphTarget;
     size_t m_iAnimation; ///< Animation number.
@@ -599,7 +596,7 @@ public:
     void persist(LuaPersistWriter *pWriter) const;
     void depersist(LuaPersistReader *pReader);
 
-protected:
+private:
     struct _sprite_t
     {
         size_t iSprite;

--- a/CorsixTH/Src/th_gfx_font.cpp
+++ b/CorsixTH/Src/th_gfx_font.cpp
@@ -97,14 +97,6 @@ static const char* utf8prev(const char* sString)
 }
 #endif
 
-THFont::THFont()
-{
-}
-
-THFont::~THFont()
-{
-}
-
 THBitmapFont::THBitmapFont()
 {
     m_pSpriteSheet = nullptr;

--- a/CorsixTH/Src/th_gfx_font.h
+++ b/CorsixTH/Src/th_gfx_font.h
@@ -60,8 +60,7 @@ struct THFontDrawArea
 class THFont
 {
 public:
-    THFont();
-    virtual ~THFont();
+    virtual ~THFont() = default;
 
     //! Get the size of drawn text.
     /*!
@@ -75,7 +74,7 @@ public:
             occupy. Default is INT_MAX.
     */
     virtual THFontDrawArea getTextSize(const char* sMessage, size_t iMessageLength,
-                                        int iMaxWidth = INT_MAX) const = 0;
+                                       int iMaxWidth = INT_MAX) const = 0;
 
     //! Draw a single line of text
     /*!
@@ -111,12 +110,12 @@ public:
           of text is smaller than iWidth.
     */
     virtual THFontDrawArea drawTextWrapped(THRenderTarget* pCanvas, const char* sMessage,
-                                            size_t iMessageLength, int iX, int iY,
-                                            int iWidth, int iMaxRows = INT_MAX, int iSkipRows = 0,
-                                            eTHAlign eAlign = Align_Left) const = 0;
+                                           size_t iMessageLength, int iX, int iY,
+                                           int iWidth, int iMaxRows = INT_MAX, int iSkipRows = 0,
+                                           eTHAlign eAlign = Align_Left) const = 0;
 };
 
-class THBitmapFont : public THFont
+class THBitmapFont final : public THFont
 {
 public:
     THBitmapFont();
@@ -138,18 +137,18 @@ public:
     */
     void setSeparation(int iCharSep, int iLineSep);
 
-    virtual THFontDrawArea getTextSize(const char* sMessage, size_t iMessageLength,
-                             int iMaxWidth = INT_MAX) const;
+    THFontDrawArea getTextSize(const char* sMessage, size_t iMessageLength,
+                               int iMaxWidth = INT_MAX) const override;
 
-    virtual void drawText(THRenderTarget* pCanvas, const char* sMessage,
-                          size_t iMessageLength, int iX, int iY) const;
+    void drawText(THRenderTarget* pCanvas, const char* sMessage,
+                  size_t iMessageLength, int iX, int iY) const override;
 
-    virtual THFontDrawArea drawTextWrapped(THRenderTarget* pCanvas, const char* sMessage,
-                                size_t iMessageLength, int iX, int iY,
-                                int iWidth, int iMaxRows = INT_MAX, int iSkipRows = 0,
-                                eTHAlign eAlign = Align_Left) const;
+    THFontDrawArea drawTextWrapped(THRenderTarget* pCanvas, const char* sMessage,
+                                   size_t iMessageLength, int iX, int iY,
+                                   int iWidth, int iMaxRows = INT_MAX, int iSkipRows = 0,
+                                   eTHAlign eAlign = Align_Left) const override;
 
-protected:
+private:
     THSpriteSheet* m_pSpriteSheet;
     int m_iCharSep;
     int m_iLineSep;
@@ -169,7 +168,7 @@ protected:
     THRawBitmap class, but with an alpha channel, and a single colour rather
     than a palette).
 */
-class THFreeTypeFont : public THFont
+class THFreeTypeFont final : public THFont
 {
 public:
     THFreeTypeFont();
@@ -218,18 +217,18 @@ public:
     */
     FT_Error setPixelSize(int iWidth, int iHeight);
 
-    virtual THFontDrawArea getTextSize(const char* sMessage, size_t iMessageLength,
-                                        int iMaxWidth = INT_MAX) const;
+    THFontDrawArea getTextSize(const char* sMessage, size_t iMessageLength,
+                               int iMaxWidth = INT_MAX) const override;
 
-    virtual void drawText(THRenderTarget* pCanvas, const char* sMessage,
-                          size_t iMessageLength, int iX, int iY) const;
+    void drawText(THRenderTarget* pCanvas, const char* sMessage,
+                  size_t iMessageLength, int iX, int iY) const override;
 
-    virtual THFontDrawArea drawTextWrapped(THRenderTarget* pCanvas, const char* sMessage,
-                                size_t iMessageLength, int iX, int iY,
-                                int iWidth, int iMaxRows = INT_MAX, int iSkipRows = 0,
-                                eTHAlign eAlign = Align_Left) const;
+    THFontDrawArea drawTextWrapped(THRenderTarget* pCanvas, const char* sMessage,
+                                   size_t iMessageLength, int iX, int iY,
+                                   int iWidth, int iMaxRows = INT_MAX, int iSkipRows = 0,
+                                   eTHAlign eAlign = Align_Left) const override;
 
-protected:
+private:
     struct cached_text_t
     {
         //! The text being converted to pixels

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -39,10 +39,6 @@ FullColourRenderer::FullColourRenderer(int iWidth, int iHeight) : m_iWidth(iWidt
     m_iY = 0;
 }
 
-FullColourRenderer::~FullColourRenderer()
-{
-}
-
 //! Convert a colour to an equivalent grey scale level.
 /*!
     @param iOpacity Opacity of the pixel.

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -47,7 +47,7 @@ public:
         @param iHeight Pixel height of the resulting image
     */
     FullColourRenderer(int iWidth, int iHeight);
-    virtual ~FullColourRenderer();
+    virtual ~FullColourRenderer() = default;
 
     //! Decode a 32bpp image, and push it to the storage backend.
     /*!
@@ -58,7 +58,7 @@ public:
     */
     bool decodeImage(const uint8_t* pImg, const THPalette *pPalette, uint32_t iSpriteFlags);
 
-protected:
+private:
     //! Store a decoded pixel. Use m_iX and m_iY if necessary.
     /*!
         @param pixel Pixel to store.
@@ -70,7 +70,6 @@ protected:
     int m_iX;
     int m_iY;
 
-private:
     //! Push a pixel to the storage.
     /*!
         @param iValue Pixel value to store.
@@ -99,10 +98,9 @@ class FullColourStoring : public FullColourRenderer
 public:
     FullColourStoring(uint32_t *pDest, int iWidth, int iHeight);
 
-protected:
-    virtual void storeARGB(uint32_t pixel);
+private:
+    void storeARGB(uint32_t pixel) override;
 
-protected:
     //! Pointer to the storage (not owned by this class).
     uint32_t *m_pDest;
 };
@@ -112,10 +110,9 @@ class WxStoring : public FullColourRenderer
 public:
     WxStoring(uint8_t* pRGBData, uint8_t* pAData, int iWidth, int iHeight);
 
-protected:
-    virtual void storeARGB(uint32_t pixel);
+private:
+    void storeARGB(uint32_t pixel) override;
 
-protected:
     //! Pointer to the RGB storage (not owned by this class).
     uint8_t *m_pRGBData;
 
@@ -222,7 +219,7 @@ public: // Internal (this rendering engine only) API
     void draw(SDL_Texture *pTexture, const SDL_Rect *prcSrcRect, const SDL_Rect *prcDstRect, int iFlags);
     void drawLine(THLine *pLine, int iX, int iY);
 
-protected:
+private:
     SDL_Window *m_pWindow;
     SDL_Renderer *m_pRenderer;
     SDL_Texture *m_pZoomTexture;
@@ -354,7 +351,7 @@ public: // Internal (this rendering engine only) API
         m_aColoursARGB[iEntry] = iVal;
     }
 
-protected:
+private:
     //! 32bpp palette colours associated with the 8bpp colour index.
     uint32_t m_aColoursARGB[256];
 
@@ -408,7 +405,7 @@ public:
     void draw(THRenderTarget* pCanvas, int iX, int iY, int iSrcX, int iSrcY,
               int iWidth, int iHeight);
 
-protected:
+private:
     //! Image stored in SDL format for quick rendering.
     SDL_Texture *m_pTexture;
 
@@ -541,7 +538,7 @@ public: // Internal (this rendering engine only) API
     */
     void wxDrawSprite(size_t iSprite, uint8_t* pRGBData, uint8_t* pAData);
 
-protected:
+private:
     friend class THCursor;
 #if CORSIX_TH_USE_PACK_PRAGMAS
 #pragma pack(push)
@@ -628,7 +625,7 @@ public:
     static bool setPosition(THRenderTarget* pTarget, int iX, int iY);
 
     void draw(THRenderTarget* pCanvas, int iX, int iY);
-protected:
+private:
     SDL_Surface* m_pBitmap;
     SDL_Cursor* m_pCursorHidden;
     int m_iHotspotX;
@@ -655,7 +652,7 @@ public:
     void persist(LuaPersistWriter *pWriter) const;
     void depersist(LuaPersistReader *pReader);
 
-protected:
+private:
     friend class THRenderTarget;
     void initialize();
 

--- a/CorsixTH/Src/th_map.h
+++ b/CorsixTH/Src/th_map.h
@@ -381,7 +381,7 @@ public:
 
     void setOverlay(THMapOverlay *pOverlay, bool bTakeOwnership);
 
-protected:
+private:
     THDrawable* _hitTestDrawables(THLinkList* pListStart, int iXs, int iYs,
                                   int iTestX, int iTestY) const;
     void _readTileIndex(const uint8_t* pData, int& iX, int &iY) const;
@@ -490,7 +490,7 @@ public:
     */
     inline bool isLastOnScanline() const;
 
-protected:
+private:
     // Maximum extents of the visible parts of a node (pixel distances relative
     // to the top-most corner of an isometric cell)
     // If set too low, things will disappear when near the screen edge
@@ -548,7 +548,7 @@ public:
     THMapScanlineIterator operator= (const THMapScanlineIterator &iterator);
     inline const THMapNode* getNode() {return m_pNode;}
 
-protected:
+private:
     const THMapNode* m_pNode;
     const THMapNode* m_pNodeFirst;
     const THMapNode* m_pNodeEnd;

--- a/CorsixTH/Src/th_map_overlays.cpp
+++ b/CorsixTH/Src/th_map_overlays.cpp
@@ -25,10 +25,6 @@ SOFTWARE.
 #include "th_map.h"
 #include <sstream>
 
-THMapOverlay::~THMapOverlay()
-{
-}
-
 THMapOverlayPair::THMapOverlayPair()
 {
     m_pFirst = nullptr;

--- a/CorsixTH/Src/th_map_overlays.h
+++ b/CorsixTH/Src/th_map_overlays.h
@@ -34,7 +34,7 @@ class THSpriteSheet;
 class THMapOverlay
 {
 public:
-    virtual ~THMapOverlay();
+    virtual ~THMapOverlay() = default;
 
     virtual void drawCell(THRenderTarget* pCanvas, int iCanvasX, int iCanvasY,
                           const THMap* pMap, int iNodeX, int iNodeY) = 0;
@@ -49,10 +49,10 @@ public:
     void setFirst(THMapOverlay* pOverlay, bool bTakeOwnership);
     void setSecond(THMapOverlay* pOverlay, bool bTakeOwnership);
 
-    virtual void drawCell(THRenderTarget* pCanvas, int iCanvasX, int iCanvasY,
-                          const THMap* pMap, int iNodeX, int iNodeY);
+    void drawCell(THRenderTarget* pCanvas, int iCanvasX, int iCanvasY,
+                  const THMap* pMap, int iNodeX, int iNodeY) override;
 
-protected:
+private:
     THMapOverlay *m_pFirst, *m_pSecond;
     bool m_bOwnFirst, m_bOwnSecond;
 };
@@ -71,6 +71,8 @@ protected:
 
     THSpriteSheet* m_pSprites;
     THFont* m_pFont;
+
+private:
     bool m_bOwnsSprites;
     bool m_bOwnsFont;
 };
@@ -79,6 +81,7 @@ class THMapTextOverlay : public THMapTypicalOverlay
 {
 public:
     THMapTextOverlay();
+    virtual ~THMapTextOverlay() = default;
 
     virtual void drawCell(THRenderTarget* pCanvas, int iCanvasX, int iCanvasY,
         const THMap* pMap, int iNodeX, int iNodeY);
@@ -86,28 +89,28 @@ public:
     void setBackgroundSprite(size_t iSprite);
     virtual const std::string getText(const THMap* pMap, int iNodeX, int iNodeY) = 0;
 
-protected:
+private:
     size_t m_iBackgroundSprite;
 };
 
-class THMapPositionsOverlay : public THMapTextOverlay
+class THMapPositionsOverlay final : public THMapTextOverlay
 {
 public:
-    virtual const std::string getText(const THMap* pMap, int iNodeX, int iNodeY);
+    const std::string getText(const THMap* pMap, int iNodeX, int iNodeY) override;
 };
 
-class THMapFlagsOverlay : public THMapTypicalOverlay
+class THMapFlagsOverlay final : public THMapTypicalOverlay
 {
 public:
-    virtual void drawCell(THRenderTarget* pCanvas, int iCanvasX, int iCanvasY,
-                          const THMap* pMap, int iNodeX, int iNodeY);
+    void drawCell(THRenderTarget* pCanvas, int iCanvasX, int iCanvasY,
+                  const THMap* pMap, int iNodeX, int iNodeY) override;
 };
 
-class THMapParcelsOverlay : public THMapTypicalOverlay
+class THMapParcelsOverlay final : public THMapTypicalOverlay
 {
 public:
-    virtual void drawCell(THRenderTarget* pCanvas, int iCanvasX, int iCanvasY,
-                          const THMap* pMap, int iNodeX, int iNodeY);
+    void drawCell(THRenderTarget* pCanvas, int iCanvasX, int iCanvasY,
+                  const THMap* pMap, int iNodeX, int iNodeY) override;
 };
 
 #endif

--- a/CorsixTH/Src/th_movie.h
+++ b/CorsixTH/Src/th_movie.h
@@ -142,7 +142,7 @@ public:
     //! \retval -1 Abort is in progress
     //! \retval 1 An error writing the frame
     int write(AVFrame* pFrame, double dPts);
-protected:
+private:
     static const size_t ms_pictureBufferSize = 4; ///< The number of elements to allocate in the picture queue
     bool m_fAborting; ///< Whether we are in the process of aborting
     bool m_fAllocated; ///< Whether the picture buffer has been allocated (and hasn't since been deallocated)

--- a/CorsixTH/Src/th_pathfind.h
+++ b/CorsixTH/Src/th_pathfind.h
@@ -85,6 +85,7 @@ class BasePathing
 {
 public:
     BasePathing(THPathfinder *pf);
+    virtual ~BasePathing() = default;
 
     //! Initialize the path finder.
     /*!
@@ -134,9 +135,9 @@ class PathFinder : public BasePathing
 public:
     PathFinder(THPathfinder *pf) : BasePathing(pf) { }
 
-    virtual int makeGuess(node_t *pNode);
-    virtual bool tryNode(node_t *pNode, th_map_node_flags flags,
-                         node_t *pNeighbour, int direction);
+    int makeGuess(node_t *pNode) override;
+    bool tryNode(node_t *pNode, th_map_node_flags flags,
+                 node_t *pNeighbour, int direction) override;
 
     bool findPath(const THMap *pMap, int iStartX, int iStartY, int iEndX, int iEndY);
 
@@ -149,9 +150,9 @@ class HospitalFinder : public BasePathing
 public:
     HospitalFinder(THPathfinder *pf) : BasePathing(pf) { }
 
-    virtual int makeGuess(node_t *pNode);
-    virtual bool tryNode(node_t *pNode, th_map_node_flags flags,
-                         node_t *pNeighbour, int direction);
+    int makeGuess(node_t *pNode) override;
+    bool tryNode(node_t *pNode, th_map_node_flags flags,
+                 node_t *pNeighbour, int direction) override;
 
     bool findPathToHospital(const THMap *pMap, int iStartX, int iStartY);
 };
@@ -161,9 +162,9 @@ class IdleTileFinder : public BasePathing
 public:
     IdleTileFinder(THPathfinder *pf) : BasePathing(pf) { }
 
-    virtual int makeGuess(node_t *pNode);
-    virtual bool tryNode(node_t *pNode, th_map_node_flags flags,
-                         node_t *pNeighbour, int direction);
+    int makeGuess(node_t *pNode) override;
+    bool tryNode(node_t *pNode, th_map_node_flags flags,
+                 node_t *pNeighbour, int direction) override;
 
     bool findIdleTile(const THMap *pMap, int iStartX, int iStartY, int iN);
 
@@ -178,9 +179,9 @@ class Objectsvisitor : public BasePathing
 public:
     Objectsvisitor(THPathfinder *pf) : BasePathing(pf) { }
 
-    virtual int makeGuess(node_t *pNode);
-    virtual bool tryNode(node_t *pNode, th_map_node_flags flags,
-                         node_t *pNeighbour, int direction);
+    int makeGuess(node_t *pNode) override;
+    bool tryNode(node_t *pNode, th_map_node_flags flags,
+                         node_t *pNeighbour, int direction) override;
 
     bool visitObjects(const THMap *pMap, int iStartX, int iStartY,
                       THObjectType eTHOB, int iMaxDistance,
@@ -290,7 +291,7 @@ public:
     int m_iOpenCount;
     int m_iOpenSize;
 
-protected:
+private:
     PathFinder m_oPathFinder;
     HospitalFinder m_oHospitalFinder;
     IdleTileFinder m_oIdleTileFinder;

--- a/CorsixTH/Src/th_sound.h
+++ b/CorsixTH/Src/th_sound.h
@@ -51,7 +51,7 @@ public:
     */
     SDL_RWops* loadSound(size_t iIndex);
 
-protected:
+private:
 #if CORSIX_TH_USE_PACK_PRAGMAS
 #pragma pack(push)
 #pragma pack(1)
@@ -106,7 +106,7 @@ public:
     int reserveChannel();
     void releaseChannel(int iChannel);
 
-protected:
+private:
 #ifdef CORSIX_TH_USE_SDL_MIXER
     static THSoundEffects* ms_pSingleton;
     static void _onChannelFinish(int iChannel);

--- a/CorsixTH/Src/xmi2mid.cpp
+++ b/CorsixTH/Src/xmi2mid.cpp
@@ -190,7 +190,7 @@ public:
         return m_pPointer == m_pEnd;
     }
 
-protected:
+private:
     template <class T>
     static T _byteSwap(T value)
     {


### PR DESCRIPTION
- Reduce scope of members from protected to private as allowed by current usage
- Use override keyword, not virtual, to mark overridden virtual functions on
derived classes.
- Use default virtual destructors on base classes when there were no resources
to free on the base.
- Mark derived classes as final where it is obvious that they should not be
subclassed.