### PR TITLE
[RDY] Add github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,40 @@
+#### Describe the issue
+
+#### Steps to Reproduce
+1. *Load save game attached to this ticket*
+
+2.
+
+3.
+
+#### Save Game
+*It is often useful for us if you have a save game from shortly before the
+issue occurs that can be used to recreate the problem. Sometimes a save that
+shows the issue happening may be useful as well. As GitHub currently only
+supports uploading of images, you will have to upload your your savegames to
+an another source such as [Google Drive](https://drive.google.com),
+[Dropbox](https://dropbox.com), or
+[SkyDrive/OneDrive](https://onedrive.live.com). Add the link to the file to
+your issue and make the file(s) public, so we can access your gamelog or
+savegame. The most important thing is to not remove these files after you
+uploaded them!*
+
+#### Expected Behavior
+
+#### System Information
+**CorsixTH Version:** *e.g. 0.50 or 7d886f35ca*
+
+**Operating System:** *e.g. Windows 10*
+
+**Theme Hospital Version:** *CD, GOG.com, Origin, or Demo*
+
+#### Gamelog.txt
+*For information about where to find gamelog.txt see:
+https://github.com/CorsixTH/CorsixTH/wiki/Frequently-Asked-Questions#where-do-i-find-the-configuration-or-the-gamelog-file*
+```
+Paste gamelog.txt output here
+```
+
+### Additional Info
+*Paste any screen shots or other additional information that might help
+illustrate the problem.*

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -13,43 +13,6 @@ And if there is no existing issue discussion for what you want to work on
 please open a new issue for it and tell other devs here that your going to/
 have started working on it.
 
-ISSUE REPORTING:
-
-GitHub currently doesn't support automatic issue templates, so follow the
-instructions below when you want to make a suggestion, bug report, or pull
-request.
-
-Please report only one bug, suggestion or pull request per issue,
-
-BUG REPORT
-
-Please answer the questions below when you want to report a bug. A bug could
-be for example an error crash, graphical glitch or unexpected behavior. Please
-copy the questions below to your issue and answer them when you want to report
-a bug:
-
-What steps will reproduce the problem?
-1.
-2.
-3.
-
-What is the expected output? What do you see instead?
-
-What version of CorsixTH are you using (e.g. "0.30", "4c66e39985")?
-
-What operating system / compile settings are you using?
-
-What level was this on (e.g. "Demo level", "Full game level 12")?
-
-Upload a saved game file (preferably an autosave from before the error) if you
-have one and it is relevant. Look at HOW TO UPLOAD GAMELOG AND/OR SAVES for how
-to do this.
-
-If possible, also upload the gamelog. Look at HOW TO UPLOAD GAMELOG AND/OR
-SAVES for how to do this.
-
-Please provide any additional information below.
-
 SUGGESTION
 
 If you want to make a suggestion, please copy the following  questions into
@@ -64,17 +27,6 @@ PULL REQUEST
 When providing a pull request ensure the description field describes the major
 changes from the request. If your pull request relates to any existing
 issues, include those issues in the description. e.g. "Fixes issue #1"
-
-HOW TO UPLOAD GAMELOG AND/OR SAVES
-
-As GitHub currently only supports uploading of images, you will have to upload
-your gamelog(.txt) and your savegames to an another source such as Google
-Drive, Dropbox, or SkyDrive/OneDrive. Add the link to the file to your issue
-and make the file(s) public, so we can access your gamelog or savegame. The
-most important thing is to not remove these files after you uploaded them!
-
-Also make sure you don't use a file hosting service which will automatically
-delete your file after a time.
 
 
 CONTRIBUTING CODE:


### PR DESCRIPTION
GitHub recently introduced support for issue templates: https://github.com/blog/2111-issue-and-pull-request-templates

Try it out at: https://github.com/TheCycoONE/issue-template-test/issues/new