### PR TITLE
typos

### DIFF
--- a/AnimView/th.cpp
+++ b/AnimView/th.cpp
@@ -309,7 +309,7 @@ bool THAnimations::loadFrameFile(wxString sFilename)
     /*
       256 is a common flag - could be x-flip.
       The lower byte can also take non-zero values - could be ghost palette
-      indicies.
+      indices.
     */
     /*
     FILE *f = fopen("E:\\list.txt", "wt");

--- a/AnimView/tinystr.h
+++ b/AnimView/tinystr.h
@@ -279,7 +279,7 @@ TiXmlString operator + (const char* a, const TiXmlString & b);
 
 /*
    TiXmlOutStream is an emulation of std::ostream. It is based on TiXmlString.
-   Only the operators that we need for TinyXML have been developped.
+   Only the operators that we need for TinyXML have been developed.
 */
 class TiXmlOutStream : public TiXmlString
 {

--- a/AnimView/tinyxml.h
+++ b/AnimView/tinyxml.h
@@ -256,7 +256,7 @@ public:
                                 TiXmlParsingData* data,
                                 TiXmlEncoding encoding /*= TIXML_ENCODING_UNKNOWN */ ) = 0;
 
-    /** Expands entities in a string. Note this should not contian the tag's '<', '>', etc,
+    /** Expands entities in a string. Note this should not contain the tag's '<', '>', etc,
         or they will be transformed into entities!
     */
     static void EncodeString( const TIXML_STRING& str, TIXML_STRING* out );
@@ -576,7 +576,7 @@ public:
     #endif
 
     /** Add a new node related to this. Adds a child past the LastChild.
-        Returns a pointer to the new object or NULL if an error occured.
+        Returns a pointer to the new object or NULL if an error occurred.
     */
     TiXmlNode* InsertEndChild( const TiXmlNode& addThis );
 
@@ -593,17 +593,17 @@ public:
     TiXmlNode* LinkEndChild( TiXmlNode* addThis );
 
     /** Add a new node related to this. Adds a child before the specified child.
-        Returns a pointer to the new object or NULL if an error occured.
+        Returns a pointer to the new object or NULL if an error occurred.
     */
     TiXmlNode* InsertBeforeChild( TiXmlNode* beforeThis, const TiXmlNode& addThis );
 
     /** Add a new node related to this. Adds a child after the specified child.
-        Returns a pointer to the new object or NULL if an error occured.
+        Returns a pointer to the new object or NULL if an error occurred.
     */
     TiXmlNode* InsertAfterChild(  TiXmlNode* afterThis, const TiXmlNode& addThis );
 
     /** Replace a child of this node.
-        Returns a pointer to the new object or NULL if an error occured.
+        Returns a pointer to the new object or NULL if an error occurred.
     */
     TiXmlNode* ReplaceChild( TiXmlNode* replaceThis, const TiXmlNode& withThis );
 
@@ -1475,7 +1475,7 @@ public:
         @sa SetTabSize, Row, Column
     */
     int ErrorRow() const    { return errorLocation.row+1; }
-    int ErrorCol() const    { return errorLocation.col+1; }    ///< The column where the error occured. See ErrorRow()
+    int ErrorCol() const    { return errorLocation.col+1; }    ///< The column where the error occurred. See ErrorRow()
 
     /** SetTabSize() allows the error reporting functions (ErrorRow() and ErrorCol())
         to report the correct values for row and column. It does not change the output

--- a/AnimView/tinyxmlerror.cpp
+++ b/AnimView/tinyxmlerror.cpp
@@ -24,7 +24,7 @@ distribution.
 
 #include "tinyxml.h"
 
-// The goal of the seperate error file is to make the first
+// The goal of the separate error file is to make the first
 // step towards localization. tinyxml (currently) only supports
 // english error messages, but the could now be translated.
 //

--- a/AnimView/tinyxmlparser.cpp
+++ b/AnimView/tinyxmlparser.cpp
@@ -836,7 +836,7 @@ TiXmlNode* TiXmlNode::Identify( const char* p, TiXmlEncoding encoding )
     // - Elements start with a letter or underscore, but xml is reserved.
     // - Comments: <!--
     // - Decleration: <?xml
-    // - Everthing else is unknown to tinyxml.
+    // - Everything else is unknown to tinyxml.
     //
 
     const char* xmlHeader = { "<?xml" };

--- a/CMake/FindSDL2_mixer.cmake
+++ b/CMake/FindSDL2_mixer.cmake
@@ -5,7 +5,7 @@
 #  SDL_MIXER_FOUND, if false, do not try to link against
 #  SDL_MIXER_VERSION_STRING - human-readable string containing the version of SDL_mixer
 #
-# For backward compatiblity the following variables are also set:
+# For backward compatibility the following variables are also set:
 #  SDLMIXER_LIBRARY (same value as SDL_MIXER_LIBRARIES)
 #  SDLMIXER_INCLUDE_DIR (same value as SDL_MIXER_INCLUDE_DIRS)
 #  SDLMIXER_FOUND (same value as SDL_MIXER_FOUND)
@@ -81,7 +81,7 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL_mixer
                                   REQUIRED_VARS SDL_MIXER_LIBRARIES SDL_MIXER_INCLUDE_DIRS
                                   VERSION_VAR SDL_MIXER_VERSION_STRING)
 
-# for backward compatiblity
+# for backward compatibility
 set(SDLMIXER_LIBRARY ${SDL_MIXER_LIBRARIES})
 set(SDLMIXER_INCLUDE_DIR ${SDL_MIXER_INCLUDE_DIRS})
 set(SDLMIXER_FOUND ${SDL_MIXER_FOUND})

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -7,7 +7,7 @@ ENDIF(CORSIX_TH_DONE_TOP_LEVEL_CMAKE)
 # Project Declaration
 PROJECT(CorsixTH)
 
-# Basic platform dependant stuff
+# Basic platform dependent stuff
 IF(UNIX)
   IF(APPLE)
     # fruit goes here
@@ -94,7 +94,7 @@ IF(SDL_FOUND)
     message(FATAL_ERROR "Error: SDL was found but SDLmain was not")
     message("Make sure the path is correctly defined or set the environment variable SDLDIR to the correct location")
   ENDIF(SDLMAIN_LIBRARY STREQUAL "")
-  # No need to specify sdlmain seperately, the FindSDL.cmake file will take care of that. If not we get an error about it
+  # No need to specify sdlmain separately, the FindSDL.cmake file will take care of that. If not we get an error about it
   TARGET_LINK_LIBRARIES(CorsixTH ${SDL_LIBRARY})
   message("  SDL found")
 ELSE(SDL_FOUND)

--- a/CorsixTH/Levels/st.peter's.level
+++ b/CorsixTH/Levels/st.peter's.level
@@ -18,7 +18,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-This level file and map have been put together with epidemics in mind.  Whereever there are values
+This level file and map have been put together with epidemics in mind.  Wherever there are values
 that have not been used previously there are some notes to assist map makers.
 
 ---------------------- General Information -------------------------

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -756,7 +756,7 @@ function App:checkMissingStringsInLanguage(dir, language)
 end
 
 function App:fixConfig()
-  -- Fill in default values for things which dont exist
+  -- Fill in default values for things which don't exist
   local _, config_defaults = dofile "config_finder"
   for k, v in pairs(config_defaults) do
     if self.config[k] == nil then
@@ -1124,7 +1124,7 @@ function App:checkInstallFolder()
 
     if #corrupt ~= 0 then
       table.insert(corrupt, 1, "There appears to be corrupt files in your Theme Hospital folder, " ..
-      "so don't be suprised if CorsixTH crashes. At least the following files are wrong:")
+      "so don't be surprised if CorsixTH crashes. At least the following files are wrong:")
       table.insert(corrupt, message)
     end
   end

--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -198,7 +198,7 @@ function Audio:initSpeech(speech_file)
   end
   local archive_data, err = load_sound_file(speech_file)
 
-  -- If sound file not found and language choosen is not English,
+  -- If sound file not found and language chosen is not English,
   -- maybe we can have more chance loading English sounds
   if not archive_data and speech_file ~= "Sound-0.dat" and self.app.good_install_folder then
     if self.speech_file_name == "Sound-0.dat" then

--- a/CorsixTH/Lua/base_config.lua
+++ b/CorsixTH/Lua/base_config.lua
@@ -470,11 +470,11 @@ local configuration = {
     EmergencyAward = 90,
     -- <x Percentage - to win the award MIN 0 MAX 100
     EmergencyPoor = 50,
-    -- >x Percentage - to win the award MIN 0 MAX 100 - staff mean happiness thoughout the year
+    -- >x Percentage - to win the award MIN 0 MAX 100 - staff mean happiness throughout the year
     StaffHappinessAward = 75,
     -- <x Percentage - to win the award MIN 0 MAX 100
     StaffHappinessPoor = 25,
-    -- >x Percentage - to win the award MIN 0 MAX 100 - peeps mean happiness thoughout the year
+    -- >x Percentage - to win the award MIN 0 MAX 100 - peeps mean happiness throughout the year
     PeepHappinessAward = 75,
     -- <x Percentage - to win the award MIN 0 MAX 100
     PeepHappinessPoor = 25,

--- a/CorsixTH/Lua/calls_dispatcher.lua
+++ b/CorsixTH/Lua/calls_dispatcher.lua
@@ -433,7 +433,7 @@ function CallsDispatcher.actionInterruptHandler(action, humanoid)
   end
 end
 
--- Called when a call is completed sucessfully
+-- Called when a call is completed successfully
 function CallsDispatcher.onCheckpointCompleted(call)
   if not call.dropped and call.assigned then
     if debug then CallsDispatcher.dumpCall(call, "completed") end

--- a/CorsixTH/Lua/dialogs/furnish_corridor.lua
+++ b/CorsixTH/Lua/dialogs/furnish_corridor.lua
@@ -60,7 +60,7 @@ function UIFurnishCorridor:UIFurnishCorridor(ui, objects, edit_dialog)
   }
   if objects then
     for _, object in pairs(objects) do
-      self.objects[#self.objects + 1] = {object = object.object, start_qty = object.qty, qty = object.qty, min_qty = object.min_qty} -- Had to make a copy of objects list. Otherwise, we will modify the original variable (Opening dialog twice keeps memory of previously choosen quantities)
+      self.objects[#self.objects + 1] = {object = object.object, start_qty = object.qty, qty = object.qty, min_qty = object.min_qty} -- Had to make a copy of objects list. Otherwise, we will modify the original variable (Opening dialog twice keeps memory of previously chosen quantities)
     end
   else
     for _, object in ipairs(app.objects) do

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -45,7 +45,7 @@ function UIMenuBar:UIMenuBar(ui, map_editor)
   -- The list of top-level menus, from left to right
   self.menus = {}
   -- The menu which the cursor was most recently over
-  -- This should be present in self.open_menus, else it wont be drawn
+  -- This should be present in self.open_menus, else it won't be drawn
   self.active_menu = false
   -- The list of menus which should be displayed
   -- This list satifies: open_menus[x] == nil or open_menus[x].level == x

--- a/CorsixTH/Lua/dialogs/resizables/file_browser.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browser.lua
@@ -78,7 +78,7 @@ function FilteredFileTreeNode:getLabel()
   return label
 end
 
---! A sortable tree control that accomodates a certain file type and also possibly shows
+--! A sortable tree control that accommodates a certain file type and also possibly shows
 --  their last modification dates.
 class "FilteredTreeControl" (TreeControl)
 

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -260,7 +260,7 @@ function UIStaff:onMouseDown(button, x, y)
   return Window.onMouseDown(self, button, x, y)
 end
 
--- Helper function to faciliate humanoid_class comparison wrt. Surgeons
+-- Helper function to facilitate humanoid_class comparison wrt. Surgeons
 local function surg_compat(class)
   return class == "Surgeon" and "Doctor" or class
 end

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -34,7 +34,7 @@ function Patient:Patient(...)
   self.action_string = ""
   self.cured = false
   self.infected = false
-  -- To distingish between actually being dead and having a nil hospital
+  -- To distinguish between actually being dead and having a nil hospital
   self.dead = false
   -- Is the patient reserved for a particular nurse when being vaccinated
   self.reserved_for = false
@@ -624,7 +624,7 @@ function Patient:tickDay()
   -- Vomitings.
   if self.vomit_anim and not self:getRoom() and not self.action_queue[1].is_leaving and not self.action_queue[1].is_entering then
     --Nausea level is based on health then proximity to vomit is used as a multiplier.
-    --Only a patient with a health value of less than 0.8 can be the inital vomiter, however :)
+    --Only a patient with a health value of less than 0.8 can be the initial vomiter, however :)
     local initialVomitMult = 0.002   --The initial chance of vomiting.
     local proximityVomitMult = 1.5  --The multiplier used when in proximity to vomit.
     local nausea = (1.0 - self.attributes["health"]) * initialVomitMult

--- a/CorsixTH/Lua/entities/staff.lua
+++ b/CorsixTH/Lua/entities/staff.lua
@@ -387,7 +387,7 @@ function Staff:die()
   self:setHospital(nil)
   if self.task then
     -- If the staff member had a task outstanding, unassigning them from that task.
-    -- Tasks with no handyman assigned will be eligable for reassignment by the hospital.
+    -- Tasks with no handyman assigned will be eligible for reassignment by the hospital.
     self.task.assignedHandyman = nil
     self.task = nil
   end

--- a/CorsixTH/Lua/entity.lua
+++ b/CorsixTH/Lua/entity.lua
@@ -240,7 +240,7 @@ end
 --[[ Register a function (related to the entity) to be called at a later time.
 ! Each `Entity` can have a single timer associated with it, and due to this
 limit of one, it is almost always the case that the currently active humanoid
-action is the only thing wich calls `setTimer`.
+action is the only thing which calls `setTimer`.
 If self.slow_animation is set then all timers will be doubled as animation
 length will be doubled.
 !param tick_count (integer) If 0, then `f` will be called during the entity's

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -172,8 +172,8 @@ function Hospital:Hospital(world, avail_rooms, name)
   -- A list of how much each insurance company owes you. The first entry for
   -- each company is the current month's dept, the second the previous
   -- month and the third the month before that.
-  -- All payment that goes through an insurance company a given month is payed two
-  -- months later. For example diagnoses in April are payed the 1st of July
+  -- All payment that goes through an insurance company a given month is paid two
+  -- months later. For example diagnoses in April are paid the 1st of July
   self.insurance_balance = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}}
 
   -- Initialize diseases
@@ -1075,7 +1075,7 @@ function Hospital:onEndMonth()
 
   -- TODO: do you get interest on the balance owed?
   for i, company in ipairs(self.insurance_balance) do
-    -- Get the amount that is about to be payed to the player
+    -- Get the amount that is about to be paid to the player
     local payout_amount = company[3]
     if payout_amount > 0 then
       local str = _S.transactions.insurance_colon .. " " .. self.insurance[i]

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -319,7 +319,7 @@ function(action, humanoid, machine, mx, my, fun_after_use)
     must_happen = true,
   }, num_actions_prior + 1)
   machine:addReservedUser(humanoid)
-  -- Make sure noone thinks we're sitting down anymore.
+  -- Make sure no one thinks we're sitting down anymore.
   action.current_bench_distance = nil
 end)
 

--- a/CorsixTH/Lua/languages/original_strings.lua
+++ b/CorsixTH/Lua/languages/original_strings.lua
@@ -961,7 +961,7 @@ insurance_companies = {
 -- Menu strings are a little complicated: Different versions of the original
 -- game have slightly different menu strings. The strings are also organised
 -- by more levels than traditional strings. For the most part, this extra
--- organisation can be use to offset the differences in menu string indicies.
+-- organisation can be use to offset the differences in menu string indices.
 local M = {{}}
 do
   local i = 2

--- a/CorsixTH/Lua/objects/desk.lua
+++ b/CorsixTH/Lua/objects/desk.lua
@@ -37,7 +37,7 @@ object.usage_animations = {
       Nurse  = 3240,
     },
     in_use = {
-      -- Note: 72 (normal usage) should happen alot more often than 718 (head
+      -- Note: 72 (normal usage) should happen a lot more often than 718 (head
       -- scratching), hence it appears in the list many times.
       Doctor = {72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 72, 718},
       Nurse  = 3256,

--- a/CorsixTH/Lua/rooms/operating_theatre.lua
+++ b/CorsixTH/Lua/rooms/operating_theatre.lua
@@ -283,7 +283,7 @@ function OperatingTheatreRoom:commandEnteringPatient(patient)
 
   local num_ready = {0}
   ----- BEGIN Save game compatibility -----
-  -- These function are merely for save game compability.
+  -- These function are merely for save game compatibility.
   -- And they does not participate in the current game logic.
   -- Do not move or edit
   local --[[persistable:operatring_theatre_wait_for_ready]] function wait_for_ready(action)

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -600,7 +600,7 @@ local function utf8char(c)
   end
   codepoint = codepoint + (c:byte(1) % 2^(7 - #c)) * multiplier
   -- If the utf-8 character is a combining diacritical mark, merge it with the
-  -- preceeding normal character
+  -- preceding normal character
   if prechar and (0x300 <= codepoint and codepoint < 0x370) then
     if combine_diacritical_marks[prechar] then
       if combine_diacritical_marks[prechar][codepoint] then
@@ -619,7 +619,7 @@ end
 
 utf8conv = function(s)
   -- Pull out each individual utf-8 character and pass it through utf8char
-  -- [\1-\127] picks up a preceeding ASCII character to combine diacritics
+  -- [\1-\127] picks up a preceding ASCII character to combine diacritics
   -- [\192-\253] picks up the first byte of a utf-8 character (technically
   --   only 194 through 244 should be used)
   -- [\128-\191] picks up the remaining bytes of a utf-8 character

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -640,7 +640,7 @@ function World:tickEarthquake()
       self.ui.tick_scroll_amount = {x = self.randomX, y = self.randomY}
 
       local hospital = self:getLocalPlayerHospital()
-      -- loop through the patients and allow the possibilty for them to fall over
+      -- loop through the patients and allow the possibility for them to fall over
       for _, patient in ipairs(hospital.patients) do
         local current = patient.action_queue[1]
 

--- a/CorsixTH/Src/persist_lua.cpp
+++ b/CorsixTH/Src/persist_lua.cpp
@@ -395,7 +395,7 @@ public:
                     writeStackObject(-2);
                     // The naive thing to do now would be writeStackObject(-1)
                     // but this can easily lead to Lua's C call stack limit
-                    // being hit. To reduce the likelyhood of this happening,
+                    // being hit. To reduce the likelihood of this happening,
                     // we check to see if about to write another table.
                     if(lua_type(L, -1) == LUA_TTABLE)
                     {

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -261,11 +261,11 @@ public:
     //! Load original animations.
     /*!
         setSpriteSheet() must be called before calling this.
-        @param pStartData Animation first frame indicies (e.g. VSTART-1.ANI)
+        @param pStartData Animation first frame indices (e.g. VSTART-1.ANI)
         @param iStartDataLength Length of \a pStartData.
         @param pFrameData Frame details (e.g. VFRA-1.ANI)
         @param iFrameDataLength Length of \a pFrameData
-        @param pListData Element indicies list (e.g. VLIST-1.ANI)
+        @param pListData Element indices list (e.g. VLIST-1.ANI)
         @param iListDataLength Length of \a pListData
         @param pElementData Element details (e.g. VELE-1.ANI)
         @param iElementDataLength Length of \a pElementData
@@ -322,7 +322,7 @@ public:
         @param pCanvas The render target to draw onto.
         @param iFrame The frame index to draw (should be in range [0, getFrameCount() - 1])
         @param oLayers Information to decide what to draw on each layer.
-            An animation is comprised of upto thirteen layers, numbered 0
+            An animation is comprised of up to thirteen layers, numbered 0
             through 12. Some animations will have different options for what to
             render on each layer. For example, patient animations generally
             have the different options on layer 1 as different clothes, so if

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -985,7 +985,7 @@ void THMap::draw(THRenderTarget* pCanvas, int iScreenX, int iScreenY,
         THMapScanlineIterator itrNode(itrNode2, ScanlineForward, iCanvasX, iCanvasY);
         if(!bFirst) {
             //since the scanline count from one THMapScanlineIterator to another can differ
-            //syncronization between the current iterator and the former one is neeeded
+            //synchronization between the current iterator and the former one is neeeded
              if(itrNode.x() < -64)
                  ++itrNode;
              while(formerIterator.x() < itrNode.x())

--- a/CorsixTH/Src/th_map.h
+++ b/CorsixTH/Src/th_map.h
@@ -202,9 +202,9 @@ struct THMapNode : public THLinkList
     uint16_t iRoomId;
 
     //! A value between 0 (extreme cold) and 65535 (extreme heat) representing
-    //! the temperature of the tile. To allow efficent calculation of a tile's
+    //! the temperature of the tile. To allow efficient calculation of a tile's
     //! heat based on the previous tick's heat of the surrounding tiles, the
-    //! previous temperature is also stored, with the array indicies switching
+    //! previous temperature is also stored, with the array indices switching
     //! every tick.
     uint16_t aiTemperature[2];
 

--- a/CorsixTH/changelog.txt
+++ b/CorsixTH/changelog.txt
@@ -519,7 +519,7 @@ changelog for version 0.10 below.
   
 -- User Interface --
 
-* Enchancement: Since consultants are unable to learn new skills icons for 
+* Enhancement: Since consultants are unable to learn new skills icons for
   not yet fully learned skills are now removed when a doctor is promoted.
 * Fix: Disabling background music no longer disables sound effects on Windows.
 * Fix: Checking if a sound exists crashed the game if there was no sound 
@@ -816,7 +816,7 @@ Version Beta 6 - released 2011-03-24
 * Fix: Various tweaks to the operating theatre logic.
 * Fix: Don't crash if the staff window of a leaving staff member
   is open when he/she leaves the world.
-* Fix: Persistant data (salary, built rooms etc) are no longer lost
+* Fix: Persistent data (salary, built rooms etc) are no longer lost
   after restarting a level.
 
 -- User Interface --
@@ -992,7 +992,7 @@ Version Beta 2 - released 2010-03-24
 * Feature: Tooltips are displayed when hovering over buttons for some time.
 * Feature: Emergencies may happen every now and then.
 * Feature: Hospital reputation system.
-* Feature: Humurous disease description faxes are now shown when a disease is
+* Feature: Humorous disease description faxes are now shown when a disease is
   first diagnosed.
 * Feature: Room blueprints can be resized during the build process.
 

--- a/DoxyGen/animview.doxygen
+++ b/DoxyGen/animview.doxygen
@@ -1935,7 +1935,7 @@ PREDEFINED             =
 EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
-# remove all refrences to function-like macros that are alone on a line, have an
+# remove all references to function-like macros that are alone on a line, have an
 # all uppercase name, and do not end with a semicolon. Such function macros are
 # typically used for boiler-plate code, and will confuse the parser if not
 # removed.

--- a/DoxyGen/corsixth_engine.doxygen
+++ b/DoxyGen/corsixth_engine.doxygen
@@ -1935,7 +1935,7 @@ PREDEFINED             =
 EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
-# remove all refrences to function-like macros that are alone on a line, have an
+# remove all references to function-like macros that are alone on a line, have an
 # all uppercase name, and do not end with a semicolon. Such function macros are
 # typically used for boiler-plate code, and will confuse the parser if not
 # removed.

--- a/DoxyGen/leveledit.doxygen
+++ b/DoxyGen/leveledit.doxygen
@@ -1935,7 +1935,7 @@ PREDEFINED             =
 EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
-# remove all refrences to function-like macros that are alone on a line, have an
+# remove all references to function-like macros that are alone on a line, have an
 # all uppercase name, and do not end with a semicolon. Such function macros are
 # typically used for boiler-plate code, and will confuse the parser if not
 # removed.

--- a/LDocGen/output/main.css
+++ b/LDocGen/output/main.css
@@ -147,7 +147,7 @@ table.class_list td {
   padding-left: 8px;
 }
 
-/* Content - indicies */
+/* Content - indices */
 
 ul.index_letters {
   display: block;

--- a/LevelEdit/src/com/corsixth/leveledit/ReaderWriter.java
+++ b/LevelEdit/src/com/corsixth/leveledit/ReaderWriter.java
@@ -623,7 +623,7 @@ public class ReaderWriter {
             // whitespaces
             // result: "#town", "StartCash", "InterestRate", "100000", "300"
             // we check the position of each parameter, so we know which value
-            // belongs to which paramter.
+            // belongs to which parameter.
             if ((line.split("[\\.\\s+]")[i]).matches(parameter))
                 if (variable != "interest") {
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Not a programmer? Don't know another language? Well you can still help! come vis
 
 ## More
 
-Our [wiki](https://github.com/CorsixTH/CorsixTH/wiki) is a good place to start, if you cant find what you are looking for feel free to contact us using one of the methods below.
+Our [wiki](https://github.com/CorsixTH/CorsixTH/wiki) is a good place to start, if you can't find what you are looking for feel free to contact us using one of the methods below.
 
 ## Contact
 


### PR DESCRIPTION
This doesn't impact translated strings at all;
mostly code comments/README/& one error message.

But now the next time someone runs "codespell"
he'll find important typos faster.