### PR TITLE
[RDY] Drug casebook price impact

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -30,7 +30,7 @@ local runDebugger = dofile "run_debugger"
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 108
+local SAVEGAME_VERSION = 109
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -136,7 +136,7 @@ function UIFax:choice(choice_number)
     owner:setMood("patient_wait", "deactivate")
     owner.message_callback = nil
     if choice == "send_home" then
-      owner:goHome()
+      owner:goHome("kicked")
       if owner.diagnosed then
         -- No treatment rooms
         owner:updateDynamicInfo(_S.dynamic_info.patient.actions.no_treatment_available)

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -156,11 +156,15 @@ function UIFax:choice(choice_number)
       end
     elseif choice == "guess_cure" then
       owner:setDiagnosed(true)
-      owner:setNextAction{
-        name = "seek_room",
-        room_type = owner.disease.treatment_rooms[1],
-        treatment_room = true,
-      }
+      if owner:agreesToPay(owner.disease.id) then
+        owner:setNextAction{
+          name = "seek_room",
+          room_type = owner.disease.treatment_rooms[1],
+          treatment_room = true,
+        }
+      else
+        owner:goHome("over_priced", owner.disease.id)
+      end
     elseif choice == "research" then
       owner:setMood("idea", "activate")
       owner:setNextAction {

--- a/CorsixTH/Lua/dialogs/patient.lua
+++ b/CorsixTH/Lua/dialogs/patient.lua
@@ -280,7 +280,7 @@ function UIPatient:goHome()
   end
   self:close()
   self.patient:playSound("sack.wav")
-  self.patient:goHome()
+  self.patient:goHome("kicked")
   self.patient:updateDynamicInfo(_S.dynamic_info.patient.actions.sent_home)
 end
 

--- a/CorsixTH/Lua/dialogs/patient.lua
+++ b/CorsixTH/Lua/dialogs/patient.lua
@@ -299,11 +299,15 @@ function UIPatient:guessDisease()
     return
   end
   patient:setDiagnosed(true)
-  patient:setNextAction({
-    name = "seek_room",
-    room_type = patient.disease.treatment_rooms[1],
-    treatment_room = true,
-  }, 1)
+  if patient:agreesToPay(patient.disease.id) then
+    patient:setNextAction({
+      name = "seek_room",
+      room_type = patient.disease.treatment_rooms[1],
+      treatment_room = true,
+    }, 1)
+  else
+    patient:goHome("over_priced")
+  end
 end
 
 function UIPatient:hitTest(x, y)

--- a/CorsixTH/Lua/dialogs/queue_dialog.lua
+++ b/CorsixTH/Lua/dialogs/queue_dialog.lua
@@ -363,7 +363,7 @@ function UIQueuePopup:UIQueuePopup(ui, x, y, patient)
   local function send_to_hospital(i)
     return --[[persistable:queue_dialog_popup_hospital_button]] function()
       -- TODO: Actually send to another hospital (when they exist)
-      self.patient:goHome()
+      self.patient:goHome("kicked")
       local str = _S.dynamic_info.patient.actions.sent_to_other_hospital
       self.patient:updateDynamicInfo(str)
       self:close()
@@ -401,6 +401,6 @@ function UIQueuePopup:sendToReception()
 end
 
 function UIQueuePopup:sendHome()
-  self.patient:goHome()
+  self.patient:goHome("kicked")
   self:close()
 end

--- a/CorsixTH/Lua/dialogs/resizables/cheats.lua
+++ b/CorsixTH/Lua/dialogs/resizables/cheats.lua
@@ -71,6 +71,8 @@ function UICheats:UICheats(ui)
     {name = "end_year",       func = self.cheatYear},
     {name = "lose_level",     func = self.cheatLose},
     {name = "win_level",      func = self.cheatWin},
+    {name = "increase_prices", func = self.cheatIncreasePrices},
+    {name = "decrease_prices", func = self.cheatDecreasePrices},
   }
 
 
@@ -214,6 +216,30 @@ end
 
 function UICheats:cheatWin()
   self.ui.app.world:winGame(1) -- TODO adjust for multiplayer
+end
+
+function UICheats:cheatIncreasePrices()
+  local hosp = self.ui.app.world.hospitals[1]
+  for _, casebook in pairs(hosp.disease_casebook) do
+    local new_price = casebook.price + 0.5
+    if new_price > 2 then
+      casebook.price = 2
+    else
+      casebook.price = new_price
+    end
+  end
+end
+
+function UICheats:cheatDecreasePrices()
+  local hosp = self.ui.app.world.hospitals[1]
+  for _, casebook in pairs(hosp.disease_casebook) do
+    local new_price = casebook.price - 0.5
+    if new_price < 0.5 then
+      casebook.price = 0.5
+    else
+      casebook.price = new_price
+    end
+  end
 end
 
 function UICheats:buttonBack()

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -253,7 +253,7 @@ moods("cold",           3994,       0,       true) -- These have no priority sin
 moods("hot",            3988,       0,       true) -- they will be shown when hovering
 moods("queue",          4568,      70)             -- no matter what other priorities.
 moods("poo",            3996,       5)
-moods("money",          4018,      30)
+moods("sad_money",      4018,      50)
 moods("patient_wait",   5006,      40)
 moods("epidemy1",       4566,      55)
 moods("epidemy2",       4570,      55)

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -560,7 +560,7 @@ local function Humanoid_startAction(self)
           -- Set these variables to increase the likelihood of the humanoid managing to get out of the hospital.
           self.going_home = false
           self.hospital = self.world:getLocalPlayerHospital()
-          self:goHome()
+          self:goHome("kicked")
         end
         if TheApp.world:isCurrentSpeed("Pause") then
         TheApp.world:setSpeed(TheApp.world.prev_speed)

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -426,19 +426,24 @@ end
 -- Set the `Hospital` which is responsible for treating or employing the
 -- `Humanoid`. In single player games, this has little effect, but it is very
 -- important in multiplayer games.
---!param hospital (Hospital, nil) The `Hospital` which should be responsible
--- for the `Humanoid`. If nil, then the `Humanoid` is despawned.
+--!param hospital (Hospital) The `Hospital` which should be responsible
+-- for the `Humanoid`.
 function Humanoid:setHospital(hospital)
   self.hospital = hospital
-  if not hospital or not hospital.is_in_world then
-    local spawn_points = self.world.spawn_points
-    self:setNextAction{
-      name = "spawn",
-      mode = "despawn",
-      point = spawn_points[math.random(1, #spawn_points)],
-      must_happen = true,
-    }
+  if not hospital.is_in_world then
+    self:despawn()
   end
+end
+
+--! Despawn the humanoid.
+function Humanoid:despawn()
+  local spawn_points = self.world.spawn_points
+  self:setNextAction{
+    name = "spawn",
+    mode = "despawn",
+    point = spawn_points[math.random(1, #spawn_points)],
+    must_happen = true,
+  }
 end
 
 -- Function to activate/deactivate moods of a humanoid.

--- a/CorsixTH/Lua/entities/inspector.lua
+++ b/CorsixTH/Lua/entities/inspector.lua
@@ -45,7 +45,7 @@ function Inspector:goHome()
 
   self:unregisterCallbacks()
   self.going_home = true
-  self:setHospital(nil)
+  self:despawn()
 end
 
 --[[ Called when the inspector has left the map ]]

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -214,6 +214,24 @@ function Patient:setHospital(hospital)
   end
 end
 
+--! Decide the ID of the disease or treatment that the patient is paying for.
+--!return (string or nil) Id of the disease or treatment, or nil if the Id could
+--! not be decided.
+function Patient:getTreatmentDiseaseId()
+  if self.diagnosed then
+    return self.disease.id
+  else
+    local room_info = self:getRoom()
+    if not room_info then
+      print("Warning: Trying to receive money for treated patient who is "..
+          "not in a room")
+      return nil
+    end
+    room_info = room_info.room_info
+    return "diag_" .. room_info.id
+  end
+end
+
 function Patient:treated() -- If a drug was used we also need to pay for this
   local hospital = self.hospital
   local amount = self.hospital.disease_casebook[self.disease.id].drug_cost or 0

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -487,11 +487,11 @@ end
 
 function Patient:goHome(cured)
   local hosp = self.hospital
-  if not hosp and self.going_home then
+  if self.going_home then
     -- The patient should be going home already! Anything related to the hospital
     -- will not be updated correctly, but we still want to try to get the patient to go home.
     TheApp.world:gameLog("Warning: goHome called when the patient is already going home")
-    self:setHospital(nil)
+    self:despawn()
     return
   end
   if not cured then
@@ -525,7 +525,7 @@ function Patient:goHome(cured)
   if room then
     room:makeHumanoidLeave(self)
   end
-  self:setHospital(nil)
+  self:despawn()
 end
 
 -- This function handles changing of the different attributes of the patient.

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -516,6 +516,25 @@ function Patient:tapFoot()
   end
 end
 
+-- Increments "cures" statistics
+function Patient:incrementCuredCounts()
+  local hosp = self.hospital
+  hosp.num_cured = hosp.num_cured + 1
+  hosp.num_cured_ty = hosp.num_cured_ty + 1
+  local casebook = hosp.disease_casebook[self.disease.id]
+  casebook.recoveries = casebook.recoveries + 1
+  if self.is_emergency then
+    hosp.emergency.cured_emergency_patients = hosp.emergency.cured_emergency_patients + 1
+  end
+end
+
+-- Increment "not_cured" statistics
+function Patient:incrementNotCuredCounts()
+  local hosp = self.hospital
+  hosp.not_cured = hosp.not_cured + 1
+  hosp.not_cured_ty = hosp.not_cured_ty + 1
+end
+
 --! Make the patient leave the hospital. This function also handles some
 --! statistics (number of cured/kicked out patients, etc.)
 --! The mood icon is updated accordingly. Reputation is impacted accordingly.
@@ -544,21 +563,14 @@ function Patient:goHome(reason)
     if hosp.num_cured < 1 then
       self.world.ui.adviser:say(_A.information.first_cure)
     end
-    hosp.num_cured = hosp.num_cured + 1
-    hosp.num_cured_ty = hosp.num_cured_ty + 1
-    local casebook = hosp.disease_casebook[self.disease.id]
-    casebook.recoveries = casebook.recoveries + 1
-    if self.is_emergency then
-      hosp.emergency.cured_emergency_patients = hosp.emergency.cured_emergency_patients + 1
-    end
+    self:incrementCuredCounts()
     self:updateDynamicInfo(_S.dynamic_info.patient.actions.cured)
     self.hospital:msgCured()
   elseif reason == "kicked" then
     self:setMood("exit", "activate")
     if not self.is_debug then
       hosp:changeReputation("kicked", self.disease)
-      hosp.not_cured = hosp.not_cured + 1
-      hosp.not_cured_ty = hosp.not_cured_ty + 1
+      self:incrementNotCuredCounts()
       local casebook = hosp.disease_casebook[self.disease.id]
       casebook.turned_away = casebook.turned_away + 1
     end

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -269,14 +269,7 @@ function Patient:treated() -- If a drug was used we also need to pay for this
   hospital:updatePercentages()
 
   if self.is_emergency then
-    local killed = hospital.emergency.killed_emergency_patients
-    local cured = hospital.emergency.cured_emergency_patients
-    if killed + cured >= hospital.emergency.victims then
-      local window = hospital.world.ui:getWindow(UIWatch)
-      if window then
-        window:onCountdownEnd()
-      end
-    end
+    hospital:checkEmergencyOver()
   end
 end
 

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -263,12 +263,7 @@ end
 
 function Patient:treated() -- If a drug was used we also need to pay for this
   local hospital = self.hospital
-  local amount = self.hospital.disease_casebook[self.disease.id].drug_cost or 0
   hospital:receiveMoneyForTreatment(self)
-  if amount ~= 0 then
-    local str = _S.drug_companies[math.random(1 , 5)]
-    hospital:spendMoney(amount, _S.transactions.drug_cost .. ": " .. str)
-  end
 
   -- Either the patient is no longer sick, or he/she dies.
   if self:isTreatmentEffective() then
@@ -280,7 +275,7 @@ function Patient:treated() -- If a drug was used we also need to pay for this
   end
 
   hospital:updatePercentages()
-
+  hospital:paySupplierForDrug(self)
   if self.is_emergency then
     hospital:checkEmergencyOver()
   end

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -232,13 +232,42 @@ function Patient:getTreatmentDiseaseId()
   end
 end
 
+--! Estimate the subjective perceived distortion between the price level the
+--! patient might expect considering the reputation and the cure effectiveness
+--! of a given treatment and the staff internal state.
+--!param casebook (table): casebook entry for the treatment.
+--!return (float) [-1, 1]. The smaller the value is, the more the patient
+--! considers the bill to be under-priced. The bigger the value is, the more
+--! the patient patient considers the bill to be over-priced.
+function Patient:getPriceDistortion(casebook)
+  -- weights
+  local happiness_weight = 0.1
+  local reputation_weight = 0.6
+  local effectiveness_weight = 0.3
+
+  -- map the different variables to [0-1] and merge them
+  local reputation = casebook.reputation or self.hospital.reputation
+  local effectiveness = casebook.cure_effectiveness
+
+  local weighted_happiness = happiness_weight * self.attributes.happiness
+  local weighted_reputation = reputation_weight * (reputation / 1000)
+  local weighted_effectiveness = effectiveness_weight * (effectiveness / 100)
+
+  local expected_price_level = weighted_happiness + weighted_reputation + weighted_effectiveness
+
+  -- map to [0-1]
+  local price_level = ((casebook.price - 0.5) / 3) * 2
+
+  return price_level - expected_price_level
+end
+
 function Patient:treated() -- If a drug was used we also need to pay for this
   local hospital = self.hospital
   local amount = self.hospital.disease_casebook[self.disease.id].drug_cost or 0
   hospital:receiveMoneyForTreatment(self)
   if amount ~= 0 then
-  local str = _S.drug_companies[math.random(1 , 5)]
-  hospital:spendMoney(amount, _S.transactions.drug_cost .. ": " .. str)
+    local str = _S.drug_companies[math.random(1 , 5)]
+    hospital:spendMoney(amount, _S.transactions.drug_cost .. ": " .. str)
   end
 
   -- Either the patient is no longer sick, or he/she dies.

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -261,7 +261,12 @@ function Patient:getPriceDistortion(casebook)
   return price_level - expected_price_level
 end
 
-function Patient:treated() -- If a drug was used we also need to pay for this
+--! Handle attempting to treat this patient
+--!
+--! If the treatment is effective the patient will be sent home, otherwise they
+--! will die. The patient may or may not agree to pay for the treatment
+--! depending on whether they consider the price reasonable.
+function Patient:treatDisease()
   local hospital = self.hospital
   hospital:receiveMoneyForTreatment(self)
 

--- a/CorsixTH/Lua/entities/staff.lua
+++ b/CorsixTH/Lua/entities/staff.lua
@@ -990,5 +990,20 @@ function Staff:getDrawingLayer()
   end
 end
 
+--! Estimate staff service quality based on skills, fatigue and happiness.
+--!return (float) between [0-1] indicating quality of the service.
+function Staff:getServiceQuality()
+  -- weights
+  local skill_weight = 0.7
+  local fatigue_weight = 0.2
+  local happiness_weight = 0.1
+
+  local weighted_skill = skill_weight * self.profile.skill
+  local weighted_fatigue = fatigue_weight * self.attributes["fatigue"]
+  local weighted_happiness = happiness_weight * self.attributes["happiness"]
+
+  return weighted_skill + weighted_fatigue + weighted_happiness
+end
+
 -- Dummy callback for savegame compatibility
 local callbackNewRoom = --[[persistable:staff_build_staff_room_callback]] function(room) end

--- a/CorsixTH/Lua/entities/staff.lua
+++ b/CorsixTH/Lua/entities/staff.lua
@@ -371,7 +371,7 @@ function Staff:fire()
   self:setDynamicInfoText(_S.dynamic_info.staff.actions.fired)
   self.fired = true
   self.hospital:changeReputation("kicked")
-  self:setHospital(nil)
+  self:despawn()
   self.hover_cursor = nil
   self.attributes["fatigue"] = nil
   self:leaveAnnounce()
@@ -385,7 +385,7 @@ function Staff:fire()
 end
 
 function Staff:die()
-  self:setHospital(nil)
+  self:despawn()
   if self.task then
     -- If the staff member had a task outstanding, unassigning them from that task.
     -- Tasks with no handyman assigned will be eligible for reassignment by the hospital.

--- a/CorsixTH/Lua/entities/vip.lua
+++ b/CorsixTH/Lua/entities/vip.lua
@@ -119,7 +119,7 @@ function Vip:goHome()
   self.going_home = true
   -- save self.hospital so we can reference it in self:onDestroy
   self.last_hospital = self.hospital
-  self:setHospital(nil)
+  self:despawn()
 end
 
 -- called when the vip is out of the hospital grounds

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1569,15 +1569,18 @@ function Hospital:receiveMoneyForTreatment(patient)
       reason = _S.transactions.cure_colon .. " " .. casebook.disease.name
     end
     local amount = self:getTreatmentPrice(disease_id)
-    casebook.money_earned = casebook.money_earned + amount
-    patient.world:newFloatingDollarSign(patient, amount)
+
     -- 25% of the payments now go through insurance
     if patient.insurance_company then
       self:addInsuranceMoney(patient.insurance_company, amount)
     else
+      -- patient is paying normally (but still, he could feel like it's
+      -- under- or over-priced and it could impact happiness and reputation)
       self:computePriceLevelImpact(patient, casebook)
       self:receiveMoney(amount, reason)
     end
+    casebook.money_earned = casebook.money_earned + amount
+    patient.world:newFloatingDollarSign(patient, amount)
   end
 end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1529,33 +1529,23 @@ end
 ]]
 function Hospital:receiveMoneyForTreatment(patient)
   if not self.world.free_build_mode then
-    local disease_id
+    local disease_id = patient:getTreatmentDiseaseId()
+    if disease_id == nil then return end
+    local casebook = self.disease_casebook[disease_id]
     local reason
-    if not self.world.free_build_mode then
-      if patient.diagnosed then
-        disease_id = patient.disease.id
-        reason = _S.transactions.cure_colon .. " " .. patient.disease.name
-      else
-        local room_info = patient:getRoom()
-        if not room_info then
-          print("Warning: Trying to receieve money for treated patient who is "..
-              "not in a room")
-          return
-        end
-        room_info = room_info.room_info
-        disease_id = "diag_" .. room_info.id
-        reason = _S.transactions.treat_colon .. " " .. room_info.name
-      end
-     local casebook = self.disease_casebook[disease_id]
-     local amount = self:getTreatmentPrice(disease_id)
-      casebook.money_earned = casebook.money_earned + amount
-      patient.world:newFloatingDollarSign(patient, amount)
-      -- 25% of the payments now go through insurance
-      if patient.insurance_company then
-        self:addInsuranceMoney(patient.insurance_company, amount)
-      else
-        self:receiveMoney(amount, reason)
-      end
+    if casebook.pseudo then
+      reason = _S.transactions.treat_colon .. " " .. casebook.disease.name
+    else
+      reason = _S.transactions.cure_colon .. " " .. casebook.disease.name
+    end
+    local amount = self:getTreatmentPrice(disease_id)
+    casebook.money_earned = casebook.money_earned + amount
+    patient.world:newFloatingDollarSign(patient, amount)
+    -- 25% of the payments now go through insurance
+    if patient.insurance_company then
+      self:addInsuranceMoney(patient.insurance_company, amount)
+    else
+      self:receiveMoney(amount, reason)
     end
   end
 end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1279,6 +1279,19 @@ function Hospital:resolveEmergency()
   self.world:nextEmergency()
 end
 
+--! Determine if all of the patients in the emergency have been cured or killed.
+--! If they have end the emergency timer.
+function Hospital:checkEmergencyOver()
+  local killed = self.emergency.killed_emergency_patients
+  local cured = self.emergency.cured_emergency_patients
+  if killed + cured >= self.emergency.victims then
+    local window = self.world.ui:getWindow(UIWatch)
+    if window then
+      window:onCountdownEnd()
+    end
+  end
+end
+
 -- Creates VIP and sends a FAX to query the user.
 function Hospital:createVip()
   local vipName =  _S.vip_names[math.random(1,10)]

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1788,7 +1788,9 @@ function Hospital:changeReputation(reason, disease, valueChange)
   else
     amount = reputation_changes[reason]
   end
-  self.reputation = self.reputation + amount
+  if self:isReputationChangeAllowed(amount) then
+    self.reputation = self.reputation + amount
+  end
   if disease then
     local casebook = self.disease_casebook[disease.id]
     casebook.reputation = casebook.reputation + amount
@@ -1811,6 +1813,42 @@ function Hospital:checkReputation()
     return
   end
   self.reputation_above_threshold = false
+end
+
+--! Decide whether a reputation change is effective or not. As we approach 1000,
+--! a gain is less likely. As we approach 0, a loss is less likely.
+--! Under 500, a gain is always effective.  Over 500, a loss is always effective.
+--!param amount (int): The amount of reputation change.
+function Hospital:isReputationChangeAllowed(amount)
+  if (amount > 0 and self.reputation <= 500) or (amount < 0 and self.reputation >= 500) or (amount == 0) then
+    return true
+  else
+    return math.random() <= self:getReputationChangeLikelihood()
+  end
+end
+
+--! Compute the likelihood for a reputation change to be effective.
+--! Likelihood gets smaller as hospital reputation gets closer to extreme values.
+--!return (float) Likelihood of a reputation change.
+function Hospital:getReputationChangeLikelihood()
+  -- The result follows a quadratic function, for a curved and smooth evolution.
+  -- If reputation == 500, the result is 100%.
+  -- Between [380-720], the result is still over 80%.
+  -- At 100 or 900, it's under 40%.
+  -- At 0 or 1000, it's 0%.
+  --
+  -- The a, b and c coefficients have been computed to include points
+  -- (x=0, y=1), (x=500, y=0) and (x=1000, y=1) where x is the current
+  -- reputation and y the likelihood of the reputation change to be
+  -- refused, based a discriminant (aka "delta") == 0
+  local a = 0.000004008
+  local b = 0.004008
+  local c = 1
+
+  local x = self.reputation
+
+  -- The result is "reversed" for more readability
+  return 1 - (a * x * x - b * x + c)
 end
 
 function Hospital:updatePercentages()

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1604,6 +1604,16 @@ function Hospital:receiveMoneyForProduct(patient, amount, reason)
   self:receiveMoney(amount, reason)
 end
 
+--! Pay drug if drug has been purshased to treat a patient
+--!param patient(patient); the patient who's been treated with the drug
+function Hospital:paySupplierForDrug(patient)
+  local drug_amount = patient.hospital.disease_casebook[patient.disease.id].drug_cost or 0
+  if drug_amount ~= 0 then
+    local str = _S.drug_companies[math.random(1, 5)]
+    patient.hospital:spendMoney(drug_amount, _S.transactions.drug_cost .. ": " .. str)
+  end
+end
+
 --[[ Add a transaction to the hospital's transaction log.
 !param transaction (table) A table containing a string field called `desc`, and
 at least one of the following integer fields: `spend`, `receive`.

--- a/CorsixTH/Lua/humanoid_actions/die.lua
+++ b/CorsixTH/Lua/humanoid_actions/die.lua
@@ -54,7 +54,7 @@ local action_die_tick; action_die_tick = permanent"action_die_tick"( function(hu
     humanoid:setAnimation(humanoid.die_anims.fly_east, mirror)
     humanoid:setTilePositionSpeed(humanoid.tile_x, humanoid.tile_y, nil, nil, 0, -4)
   else
-    humanoid:setHospital(nil)
+    humanoid:despawn()
     humanoid.world:destroyEntity(humanoid)
   end
 end)

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -175,11 +175,15 @@ local function action_seek_room_no_diagnosis_room_found(action, humanoid)
     -- A patient with an undiscovered disease should never get here.
     assert(humanoid.hospital.disease_casebook[humanoid.disease.id].discovered)
     humanoid:setDiagnosed(true)
-    humanoid:queueAction({
-      name = "seek_room",
-      room_type = humanoid.disease.treatment_rooms[1],
-      treatment_room = true,
-    }, 1)
+    if humanoid:agreesToPay(humanoid.disease.id) then
+      humanoid:queueAction({
+        name = "seek_room",
+        room_type = humanoid.disease.treatment_rooms[1],
+        treatment_room = true,
+      }, 1)
+    else
+      humanoid:goHome("over_priced", humanoid.disease.id)
+    end
     humanoid:finishAction()
   end
 end

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -142,7 +142,7 @@ local function action_seek_room_no_diagnosis_room_found(action, humanoid)
   -- Otherwise, depending on hospital policy three things can happen:
   if humanoid.diagnosis_progress < humanoid.hospital.policies["send_home"] then
     -- Send home automatically
-    humanoid:goHome()
+    humanoid:goHome("kicked")
     humanoid:updateDynamicInfo(_S.dynamic_info.patient.actions.no_diagnoses_available)
   elseif humanoid.diagnosis_progress < humanoid.hospital.policies["guess_cure"] or
       not humanoid.hospital.disease_casebook[humanoid.disease.id].discovered then

--- a/CorsixTH/Lua/humanoid_actions/spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/spawn.lua
@@ -27,7 +27,7 @@ local orient_opposite = {
 
 local action_spawn_despawn = permanent"action_spawn_despawn"( function(humanoid)
   if humanoid.hospital then
-    humanoid:setHospital(nil)
+    humanoid:despawn()
   end
   humanoid.world:destroyEntity(humanoid)
 end)

--- a/CorsixTH/Lua/humanoid_actions/use_object.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_object.lua
@@ -319,7 +319,7 @@ action_use_object_tick = permanent"action_use_object_tick"( function(humanoid)
       end
 
       if action.destroy_user_after_use then
-        humanoid:setHospital(nil)
+        humanoid:despawn()
         humanoid.world:destroyEntity(humanoid)
       else
         humanoid:finishAction(action)

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -595,6 +595,8 @@ cheats_window = {
     end_year = "End of Year",
     lose_level = "Lose Level",
     win_level = "Win Level",
+    increase_prices = "Increase prices",
+    decrease_prices = "Decrease prices",
   },
   close = "Close",
 }
@@ -614,6 +616,8 @@ tooltip.cheats_window = {
     end_year = "Jumps to the end of the year.",
     lose_level = "Lose the current level.",
     win_level = "Win the current level.",
+    increase_prices = "Increase all prices by 50% (max. 200%)",
+    decrease_prices = "Decrease all prices by 50% (min. 50%)",
   }
 }
 

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -198,6 +198,9 @@ adviser = {
     researcher_needs_desk_3 = "Each Researcher needs to have his own desk to work from.",
     nurse_needs_desk_1 = "Each Nurse needs to have her own desk to work from.",
     nurse_needs_desk_2 = "Your Nurse is pleased that you have allowed her to have a break. If you were intending to have more than one working in the ward, then you need to provide them each with a desk to work from.",
+    low_prices = "You're charging too little for %s. This will bring people to your hospital, but you won't make a lot of profit from each one.",
+    high_prices = "Your charges for %s are high. This will make big profits in the short-term, but ultimately you'll start to drive people away.",
+    fair_prices = "Your charges for %s seem fair and balanced.",
   },
   cheats = {
     th_cheat = "Congratulations, you have unlocked cheats!",

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -201,6 +201,7 @@ adviser = {
     low_prices = "You're charging too little for %s. This will bring people to your hospital, but you won't make a lot of profit from each one.",
     high_prices = "Your charges for %s are high. This will make big profits in the short-term, but ultimately you'll start to drive people away.",
     fair_prices = "Your charges for %s seem fair and balanced.",
+    patient_not_paying = "A patient left without paying for %s because it's too expensive!",
   },
   cheats = {
     th_cheat = "Congratulations, you have unlocked cheats!",

--- a/CorsixTH/Lua/languages/french.lua
+++ b/CorsixTH/Lua/languages/french.lua
@@ -639,6 +639,10 @@ adviser = {
     researcher_needs_desk_3 = "Un chercheur a toujours besoin d'un bureau.",
     nurse_needs_desk_1 = "Chaque infirmière a besoin de son propre bureau.",
     nurse_needs_desk_2 = "Votre infirmière est heureuse d'avoir une pause. Si vous comptez y faire travailler plusieurs personnes en même temps, vous devez leur construire un bureau à chacune.",
+    low_prices = "Vous facturez trop peu pour %s. Ça va amener des gens dans votre hôpital, mais vous ne ferez pas beaucoup de profit sur chacun d'eux.",
+    high_prices = "Votre tarif pour %s est trop élevé. Ça va générer plus de profit sur le court-terme, mais à la longue les gens vont fuir.",
+    fair_prices = "Le prix pour %s semble juste et équilibré.",
+    patient_not_paying = "Un patient est parti sans payer pour %s parce que c'est trop cher !",
   },
   cheats = {
     th_cheat = "Félicitations, vous avez débloqué les triches !",

--- a/CorsixTH/Lua/objects/reception_desk.lua
+++ b/CorsixTH/Lua/objects/reception_desk.lua
@@ -119,7 +119,11 @@ function ReceptionDesk:tick()
             end
             -- VIP has his own list, don't add the gp office twice
           elseif queue_front.humanoid_class ~= "VIP" then
-            queue_front:queueAction{name = "seek_room", room_type = "gp"}
+            if queue_front:agreesToPay("diag_gp") then
+              queue_front:queueAction{name = "seek_room", room_type = "gp"}
+            else
+              queue_front:goHome("over_priced", "diag_gp")
+            end
           else
             -- the VIP will realise that he is idle, and start going round rooms
             queue_front:queueAction{name = "idle"}

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -185,7 +185,7 @@ function Room:dealtWithPatient(patient)
         patient:queueAction{name = "seek_room", room_type = next_room}
       else
         -- Patient is "done" at the hospital
-        patient:treated()
+        patient:treatDisease()
       end
     end
   else

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -987,3 +987,26 @@ function Room:isDiagnosisRoomForPatient(patient)
   end
 end
 
+
+--! Get the average service quality of the staff members in the room.
+--!return (float) [0-1] Average staff service quality.
+function Room:getStaffServiceQuality()
+  local quality = 0.5
+
+  if self.staff_member_set then
+    -- For rooms with multiple staff member (like operating theatre)
+    quality = 0
+    local count = 0
+    for member, _ in pairs(self.staff_member_set) do
+      quality = quality + member:getServiceQuality()
+      count = count + 1
+    end
+
+    quality = quality / count
+  elseif self.staff_member then
+    -- For rooms with one staff member
+    quality = self.staff_member:getServiceQuality()
+  end
+
+  return quality
+end

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -167,24 +167,26 @@ function Room:dealtWithPatient(patient)
     self:setStaffMembersAttribute("dealing_with_patient", false)
   end
 
-  if patient.disease and not patient.diagnosed then
-    -- Patient not yet diagnosed, hence just been in a diagnosis room.
-    -- Increment diagnosis_progress, and send patient back to GP.
+  if patient.disease then
+    if not patient.diagnosed then
+      -- Patient not yet diagnosed, hence just been in a diagnosis room.
+      -- Increment diagnosis_progress, and send patient back to GP.
 
-    patient:completeDiagnosticStep(self)
-    patient:queueAction{name = "seek_room", room_type = "gp"}
-    self.hospital:receiveMoneyForTreatment(patient)
-  elseif patient.disease and patient.diagnosed then
-    -- Patient just been in a cure room, so either patient now cured, or needs
-    -- to move onto next cure room.
-    patient.cure_rooms_visited = patient.cure_rooms_visited + 1
-    local next_room = patient.disease.treatment_rooms[patient.cure_rooms_visited + 1]
-    if next_room then
-      -- Do not say that it is a treatment room here, since that check should already have been made.
-      patient:queueAction{name = "seek_room", room_type = next_room}
+      patient:completeDiagnosticStep(self)
+      patient:queueAction{name = "seek_room", room_type = "gp"}
+      self.hospital:receiveMoneyForTreatment(patient)
     else
-      -- Patient is "done" at the hospital
-      patient:treated()
+      -- Patient just been in a cure room, so either patient now cured, or needs
+      -- to move onto next cure room.
+      patient.cure_rooms_visited = patient.cure_rooms_visited + 1
+      local next_room = patient.disease.treatment_rooms[patient.cure_rooms_visited + 1]
+      if next_room then
+        -- Do not say that it is a treatment room here, since that check should already have been made.
+        patient:queueAction{name = "seek_room", room_type = next_room}
+      else
+        -- Patient is "done" at the hospital
+        patient:treated()
+      end
     end
   else
     patient:queueAction{name = "meander", count = 2}

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -173,8 +173,12 @@ function Room:dealtWithPatient(patient)
       -- Increment diagnosis_progress, and send patient back to GP.
 
       patient:completeDiagnosticStep(self)
-      patient:queueAction{name = "seek_room", room_type = "gp"}
       self.hospital:receiveMoneyForTreatment(patient)
+      if patient:agreesToPay("diag_gp") then
+        patient:queueAction{name = "seek_room", room_type = "gp"}
+      else
+        patient:goHome("over_priced", "diag_gp")
+      end
     else
       -- Patient just been in a cure room, so either patient now cured, or needs
       -- to move onto next cure room.
@@ -986,7 +990,6 @@ function Room:isDiagnosisRoomForPatient(patient)
     return true
   end
 end
-
 
 --! Get the average service quality of the staff members in the room.
 --!return (float) [0-1] Average staff service quality.

--- a/CorsixTH/Lua/rooms/gp.lua
+++ b/CorsixTH/Lua/rooms/gp.lua
@@ -163,7 +163,7 @@ function GPRoom:sendPatientToNextDiagnosisRoom(patient)
   if #patient.available_diagnosis_rooms == 0 then
     -- The very rare case where the patient has visited all his/her possible diagnosis rooms
     -- There's not much to do then... Send home
-    patient:goHome()
+    patient:goHome("kicked")
     patient:updateDynamicInfo(_S.dynamic_info.patient.actions.no_diagnoses_available)
   else
     self.staff_member:setMood("reflexion", "activate") -- Show the uncertainty mood over the doctor

--- a/CorsixTH/Lua/rooms/gp.lua
+++ b/CorsixTH/Lua/rooms/gp.lua
@@ -130,11 +130,14 @@ function GPRoom:dealtWithPatient(patient)
     patient.needs_redirecting = false
   elseif patient.disease and not patient.diagnosed then
     self.hospital:receiveMoneyForTreatment(patient)
-
     patient:completeDiagnosticStep(self)
     if patient.diagnosis_progress >= self.hospital.policies["stop_procedure"] then
       patient:setDiagnosed(true)
-      patient:queueAction{name = "seek_room", room_type = patient.disease.treatment_rooms[1], treatment_room = true}
+      if patient:agreesToPay(patient.disease.id) then
+        patient:queueAction{name = "seek_room", room_type = patient.disease.treatment_rooms[1], treatment_room = true}
+      else
+        patient:goHome("over_priced", patient.disease.id)
+      end
 
       self.staff_member:setMood("idea3", "activate") -- Show the light bulb over the doctor
       -- Check if this disease has just been discovered
@@ -167,12 +170,17 @@ function GPRoom:sendPatientToNextDiagnosisRoom(patient)
     patient:updateDynamicInfo(_S.dynamic_info.patient.actions.no_diagnoses_available)
   else
     self.staff_member:setMood("reflexion", "activate") -- Show the uncertainty mood over the doctor
-    local next_room = math.random(1, #patient.available_diagnosis_rooms)
-    patient:queueAction{
-      name = "seek_room",
-      room_type = patient.available_diagnosis_rooms[next_room],
-      diagnosis_room = next_room,
-    }
+    local next_room_id = math.random(1, #patient.available_diagnosis_rooms)
+    local next_room = patient.available_diagnosis_rooms[next_room_id]
+    if patient:agreesToPay("diag_" .. next_room) then
+      patient:queueAction{
+        name = "seek_room",
+        room_type = next_room,
+        diagnosis_room = next_room_id,
+      }
+    else
+      patient:goHome("over_priced", "diag_" .. next_room)
+    end
   end
 end
 

--- a/CorsixTH/Lua/rooms/research.lua
+++ b/CorsixTH/Lua/rooms/research.lua
@@ -185,10 +185,7 @@ function ResearchRoom:commandEnteringPatient(patient)
         self.hospital.discover_autopsy_risk = self.hospital.discover_autopsy_risk + 10
       end
       if patient.hospital then
-        -- NB: Do not use patient:setHospital(nil) as that also causes despawning, which
-        -- has some bad effects if the autopsy machine is directly next to the room's door
         hosp:removePatient(patient)
-        patient.hospital = nil
       end
       patient.world:destroyEntity(patient)
     end,


### PR DESCRIPTION
A cleanup of the patch queue from #971
There are few changes from the code in #971 rebased onto the latest master.

The pull request does a few things:
1. It introduces a response to drug casebook prices, patients will go home without paying if prices are too high and reputation is affected.
2. Makes hospital reputation impact the number of patients spawned
3. Fixes the death rate for under diagnosed patients
4. Refactors patient treatment, of particular note patient.hospital is now never nil.
