### PR TITLE
[RDY] Update Rsync filter file and use

### DIFF
--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -76,7 +76,8 @@ IF(APPLE)
   #Add an extra step at the end of the build process to copy the resources into the bundle.
   add_custom_command(TARGET CorsixTH
   					 POST_BUILD
-  					 COMMAND rsync -rv --include-from ${CMAKE_SOURCE_DIR}/CorsixTH/RequiredResources.txt ${CMAKE_SOURCE_DIR}/CorsixTH/ \${TARGET_BUILD_DIR}/\${FULL_PRODUCT_NAME}/Contents/Resources)
+					 COMMAND rsync -rv --include-from ${CMAKE_SOURCE_DIR}/CorsixTH/RequiredResources.txt ${CMAKE_SOURCE_DIR}/CorsixTH/ \${TARGET_BUILD_DIR}/\${FULL_PRODUCT_NAME}/Contents/MacOS
+					 COMMAND rsync -rv ${CMAKE_SOURCE_DIR}/CorsixTH/Icon.icns \${TARGET_BUILD_DIR}/\${FULL_PRODUCT_NAME}/Contents/Resources/)
 
   target_link_libraries(CorsixTH SDL2main)
   INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/CorsixTH/SDLMain/)

--- a/CorsixTH/RequiredResources.txt
+++ b/CorsixTH/RequiredResources.txt
@@ -2,17 +2,20 @@
 # to help with copying the required resources into the 
 # bundles for the Mac build.
 
-- .svn
+- .git/
 - .DS_Store
-- CVS
 + CorsixTH.lua
 + Lua/
 + Lua/**
 + Levels/
-+ Levels/*
++ Levels/**
 + Bitmap/
 + Bitmap/aux_ui.*
 + Bitmap/tree_ctrl.*
 + Bitmap/mainmenu1080.dat
 + Bitmap/mainmenu1080.pal
++ Campaigns/
++ Campaigns/**
++ Graphics/
++ Graphics/**
 - *


### PR DESCRIPTION
This adds the newer folders to the rsync list and changes the OS X target of the rsync to the MacOS folder where the CorsixTH executable is. It's done this way in the 0.40 release and I'm unsure why others haven't seen this problem (it's hidden if you move the app to the top folder of the repository). Only the Icon.icns is left in Resources because that sets the Finder icon, which may not be in control of CMake, my testing didn't make that clear.