### PR TITLE
Prevent a crash when rotating an object at a tile where it cannot be placed

### DIFF
--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -321,7 +321,7 @@ function GameUI:onCursorWorldPositionChange()
       -- limit to non-door objects in room
       local room = self.do_world_hit_test
       entity = entity and class.is(entity, Object) and
-          entity:getRoom() == room and entity ~= room.door
+          entity:getRoom() == room and entity ~= room.door and entity
     end
   end
   if entity ~= self.cursor_entity then


### PR DESCRIPTION
Boolean magic is too complicated for me :(
