### PR TITLE
[RDY] Fix building of rooms adjacent to parcel expansions

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -399,21 +399,29 @@ function UIEditRoom:finishRoom()
     if dir == "north_window_1" then
       if x ~= rect.x then
         map:setCell(x, y, layer, flag + tiles.north)
-        map:setCell(x + 1, y, layer, flag + tiles.north)
+        if map:getCell(x + 1, y, layer) ~= 0 then
+          map:setCell(x + 1, y, layer, flag + tiles.north)
+        end
       end
     elseif dir == "north_window_2" then
       if x == rect.x then
-        map:setCell(x - 1, y, layer, flag + tiles.north)
+        if map:getCell(x - 1, y, layer) ~= 0 then
+          map:setCell(x - 1, y, layer, flag + tiles.north)
+        end
         map:setCell(x, y, layer, flag + tiles.north)
       end
     elseif dir == "west_window_1" then
       if y == rect.y then
         map:setCell(x, y, layer, flag + tiles.west)
-        map:setCell(x, y - 1, layer, flag + tiles.west)
+        if map:getCell(x, y - 1, layer) ~= 0 then
+          map:setCell(x, y - 1, layer, flag + tiles.west)
+        end
       end
     elseif dir == "west_window_2" then
       if y ~= rect.y then
-        map:setCell(x, y + 1, layer, flag + tiles.west)
+        if map:getCell(x, y + 1, layer) ~= 0 then
+          map:setCell(x, y + 1, layer, flag + tiles.west)
+        end
         map:setCell(x, y, layer, flag + tiles.west)
       end
     end

--- a/CorsixTH/Lua/walls/external.lua
+++ b/CorsixTH/Lua/walls/external.lua
@@ -24,17 +24,21 @@ wall.inside_tiles = {
   north = 122,
   north_window_1 = 124,
   north_window_2 = 126,
+  north_expansion = 144,
   west = 123,
   west_window_1 = 127,
   west_window_2 = 125,
+  west_expansion = 145,
 }
 wall.outside_tiles = {
   north = 114,
   north_window_1 = 116,
   north_window_2 = 118,
+  north_expansion = 142,
   west = 115,
   west_window_1 = 119,
   west_window_2 = 117,
+  west_expansion = 143,
 }
 wall.window_tiles = {
 }


### PR DESCRIPTION
Previously, if you built something next to an expansion wall that wall would disappear and be replaces by the room's internal one. Also, if the expansion happened to have half of a window visible an extra piece of wall would appear out of nowhere when you finished the room. Prerequisite to fix #451.