### PR TITLE
[RDY] Don't copy pngs in NSIS install script

### DIFF
--- a/WindowsInstaller/Win32Script.nsi
+++ b/WindowsInstaller/Win32Script.nsi
@@ -265,7 +265,6 @@ Section "MainSection" SEC01
   File /r /x .svn ..\CorsixTH\Bitmap\*.pal
   File /r /x .svn ..\CorsixTH\Bitmap\*.dat
   File /r /x .svn ..\CorsixTH\Bitmap\*.tab
-  File /r /x .svn ..\CorsixTH\Bitmap\*.png
 
   SetOutPath "$INSTDIR\Levels"
   File /r /x .svn ..\CorsixTH\Levels\*.*


### PR DESCRIPTION
There are no longer any pngs in this folder so this line causes the install to
fail.