### PR TITLE
[RDY] Fix disappearing room walls next to new plots

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -749,7 +749,7 @@ end
 --!param parcel (int) Plot to change.
 --!param owner (int) New owner (may be 0).
 function World:setPlotOwner(parcel, owner)
-  self.map.th:setPlotOwner(parcel, owner)
+  self.map:setPlotOwner(parcel, owner)
   if owner ~= 0 and self.delayed_map_objects then
     for info, p in pairs(self.delayed_map_objects) do
       if p == parcel then

--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -670,6 +670,14 @@ static int l_map_updateshadows(lua_State *L)
     return 1;
 }
 
+static int l_map_updatepathfinding(lua_State *L)
+{
+    THMap* pMap = luaT_testuserdata<THMap>(L);
+    pMap->updatePathfinding();
+    lua_settop(L, 1);
+    return 1;
+}
+
 static int l_map_mark_room(lua_State *L)
 {
     THMap* pMap = luaT_testuserdata<THMap>(L);
@@ -775,8 +783,30 @@ static int l_map_get_parcel_count(lua_State *L)
 static int l_map_set_parcel_owner(lua_State *L)
 {
     THMap* pMap = luaT_testuserdata<THMap>(L);
-    pMap->setParcelOwner(static_cast<int>(luaL_checkinteger(L, 2)), static_cast<int>(luaL_checkinteger(L, 3)));
-    lua_settop(L, 1);
+    int iX = static_cast<int>(luaL_checkinteger(L, 2));
+    int iY = static_cast<int>(luaL_checkinteger(L, 3));
+    if(lua_type(L, 4) != LUA_TTABLE)
+    {
+        lua_settop(L, 3);
+        lua_newtable(L);
+    }
+    else
+    {
+        lua_settop(L, 4);
+    }
+    std::vector<std::pair<int, int>> vSplitTiles = pMap->setParcelOwner(iX, iY);
+    for (std::vector<std::pair<int, int>>::size_type i = 0; i != vSplitTiles.size(); i++)
+    {
+      lua_pushinteger(L, i + 1);
+      lua_createtable(L, 0, 2);
+      lua_pushinteger(L, 1);
+      lua_pushinteger(L, vSplitTiles[i].first + 1);
+      lua_settable(L, 6);
+      lua_pushinteger(L, 2);
+      lua_pushinteger(L, vSplitTiles[i].second + 1);
+      lua_settable(L, 6);
+      lua_settable(L, 4);
+    }
     return 1;
 }
 
@@ -929,6 +959,7 @@ void THLuaRegisterMap(const THLuaRegisterState_t *pState)
     luaT_setfunction(l_map_updatetemperature, "updateTemperatures");
     luaT_setfunction(l_map_updateblueprint, "updateRoomBlueprint", MT_Anims, MT_Anim);
     luaT_setfunction(l_map_updateshadows, "updateShadows");
+    luaT_setfunction(l_map_updatepathfinding, "updatePathfinding");
     luaT_setfunction(l_map_mark_room, "markRoom");
     luaT_setfunction(l_map_unmark_room, "unmarkRoom");
     luaT_setfunction(l_map_set_sheet, "setSheet", MT_Sheet);

--- a/CorsixTH/Src/th_map.h
+++ b/CorsixTH/Src/th_map.h
@@ -293,8 +293,10 @@ public:
             the outside, and should never have its ownership changed).
         \param iOwner The number of the player who should own the parcel, or
             zero if no player should own the parcel.
+        \return vSplitTiles A vector that contains tile coordinates where
+            iParcelId is adjacent to another part of the hospital.
     */
-    void setParcelOwner(int iParcelId, int iOwner);
+    std::vector<std::pair<int, int>> setParcelOwner(int iParcelId, int iOwner);
 
     //! Get the owner of a particular parcel of land
     /*!


### PR DESCRIPTION
One proposed solution to #451.

The actual buying of a plot needs to be done in C++ as it would be way too slow in Lua (I gave it a go). At the same time C++ doesn't know about wall types for different rooms etc, so the logic for which type of wall to add when a player buys a new plot must be done in Lua. Therefore this proposed solution makes the C++ "buying" code return which tiles inside you current hospital are adjacent to the plot you are buying, and then Lua checks whether some extra room wall needs to be placed at these now removed external expansion wall positions.