### PR TITLE
[reference] Split callback functions out of the action literals.

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -261,7 +261,10 @@ function App:init()
 
     dofile "room"
     self.rooms = self:loadLuaFolder("rooms")
+
+    dofile "humanoid_action"
     self.humanoid_actions = self:loadLuaFolder("humanoid_actions")
+
     local diseases = self:loadLuaFolder("diseases")
     self.diseases = self:loadLuaFolder("diagnosis", nil, diseases)
 

--- a/CorsixTH/Lua/calls_dispatcher.lua
+++ b/CorsixTH/Lua/calls_dispatcher.lua
@@ -258,7 +258,7 @@ function CallsDispatcher.sendNurseToVaccinate(patient, nurse)
     -- The epidemic may have ended before the call can be executed
     -- so just finish the call immediately
     CallsDispatcher.queueCallCheckpointAction(nurse)
-    nurse:queueAction{name = "answer_call"}
+    nurse:queueAction(AnswerCallAction())
     nurse:finishAction()
     patient.reserved_for = nil
   end
@@ -418,11 +418,8 @@ end
 -- A interrupt handler could be supplied if special handling is needed.
 -- If not, the default would be reinsert the call into the queue
 function CallsDispatcher.queueCallCheckpointAction(humanoid, interrupt_handler)
-  return humanoid:queueAction{
-    name = "call_checkpoint",
-    call = humanoid.on_call,
-    on_remove = interrupt_handler or CallsDispatcher.actionInterruptHandler
-  }
+  return humanoid:queueAction(CallCheckPointAction():setCall(humanoid.on_call)
+      :setOnRemove(interrupt_handler or CallsDispatcher.actionInterruptHandler))
 end
 
 -- Default checkpoint interrupt handler
@@ -488,7 +485,7 @@ function CallsDispatcher.unassignCall(call)
   assert(assigned.on_call == call, "Unassigning call but the staff was not on call or a different call")
   call.assigned = nil
   assigned.on_call = nil
-  assigned:setNextAction{name = "answer_call"}
+  assigned:setNextAction(AnswerCallAction())
 end
 
 function CallsDispatcher.verifyStaffForRoom(room, attribute, staff)

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -309,7 +309,7 @@ function UIEditRoom:clearArea()
         elseif entity.action_queue[1].name == "seek_room" or (meander and meander.name == "seek_room") then
           -- Make sure that the humanoid doesn't stand idle waiting within the blueprint
           if entity.action_queue[1].name == "seek_room" then
-            entity:queueAction({name = "meander", count = 1, must_happen = true}, 0)
+            entity:queueAction(MeanderAction():setCount(1):setMustHappen(), 0)
           else
             meander.done_walk = false
           end
@@ -599,7 +599,7 @@ function UIEditRoom:returnToDoorPhase()
   local room = self.room
   room.built = false
   if room.door and room.door.queue then
-    room.door.queue:rerouteAllPatients({name = "seek_room", room_type = room.room_info.id})
+    room.door.queue:rerouteAllPatients(SeekRoomAction(room.room_info.id))
   end
 
   self.purchase_button:enable(false)

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -157,20 +157,13 @@ function UIFax:choice(choice_number)
     elseif choice == "guess_cure" then
       owner:setDiagnosed()
       if owner:agreesToPay(owner.disease.id) then
-        owner:setNextAction{
-          name = "seek_room",
-          room_type = owner.disease.treatment_rooms[1],
-          treatment_room = true,
-        }
+        owner:setNextAction(SeekRoomAction(owner.disease.treatment_rooms[1]):setIsTreatmentRoom())
       else
         owner:goHome("over_priced", owner.disease.id)
       end
     elseif choice == "research" then
       owner:setMood("idea", "activate")
-      owner:setNextAction {
-        name = "seek_room",
-        room_type = "research",
-      }
+      owner:setNextAction(SeekRoomAction("research"))
     end
   end
   local vip_ignores_refusal = math.random(1, 2)

--- a/CorsixTH/Lua/dialogs/patient.lua
+++ b/CorsixTH/Lua/dialogs/patient.lua
@@ -330,11 +330,7 @@ function UIPatient:guessDisease()
   end
   patient:setDiagnosed()
   if patient:agreesToPay(patient.disease.id) then
-    patient:setNextAction({
-      name = "seek_room",
-      room_type = patient.disease.treatment_rooms[1],
-      treatment_room = true,
-    }, 1)
+    patient:setNextAction(SeekRoomAction(patient.disease.treatment_rooms[1]):setIsTreatmentRoom(), 1)
   else
     patient:goHome("over_priced")
   end

--- a/CorsixTH/Lua/dialogs/place_staff.lua
+++ b/CorsixTH/Lua/dialogs/place_staff.lua
@@ -57,7 +57,7 @@ function UIPlaceStaff:close()
     self.staff.pickup = false
     self.staff.going_to_staffroom = nil
     self.staff.action_queue[1].window = nil
-    self.staff:setNextAction{name = "meander"}
+    self.staff:setNextAction(MeanderAction())
   elseif self.profile then
     self.ui:tutorialStep(2, {6, 7}, 1)
     self.ui:tutorialStep(4, {4, 5}, 1)

--- a/CorsixTH/Lua/dialogs/queue_dialog.lua
+++ b/CorsixTH/Lua/dialogs/queue_dialog.lua
@@ -396,7 +396,7 @@ function UIQueuePopup:draw(canvas, x, y)
 end
 
 function UIQueuePopup:sendToReception()
-  self.patient:setNextAction{name = "seek_reception"}
+  self.patient:setNextAction(SeekReceptionAction())
   self:close()
 end
 

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -314,12 +314,7 @@ end
 
 function UIStaff:placeStaff()
   self.staff.pickup = true
-  self.staff:setNextAction({
-    name = "pickup",
-    ui = self.ui,
-    todo_close = self,
-    must_happen = true,
-  }, true)
+  self.staff:setNextAction(PickupAction():setUi(self.ui):setTodoClose(self):setMustHappen(), true)
 end
 
 function UIStaff:fireStaff()

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -438,12 +438,8 @@ end
 --! Despawn the humanoid.
 function Humanoid:despawn()
   local spawn_points = self.world.spawn_points
-  self:setNextAction{
-    name = "spawn",
-    mode = "despawn",
-    point = spawn_points[math.random(1, #spawn_points)],
-    must_happen = true,
-  }
+  self:setNextAction(SpawnAction():setMode("despawn")
+      :setPoint(spawn_points[math.random(1, #spawn_points)]):setMustHappen())
 end
 
 -- Function to activate/deactivate moods of a humanoid.
@@ -523,11 +519,11 @@ local function Humanoid_startAction(self)
     end
     -- Is it a member of staff, grim or a patient?
     if class.is(self, Staff) then
-      self:queueAction({name = "meander"})
+      self:queueAction(MeanderAction())
     elseif class.is(self,GrimReaper) then
-      self:queueAction({name = "idle"})
+      self:queueAction(IdleAction())
     else
-      self:queueAction({name = "seek_reception"})
+      self:queueAction(SeekReceptionAction())
     end
     -- Open the dialog of the humanoid.
     local ui = self.world.ui
@@ -703,7 +699,7 @@ function Humanoid:setType(humanoid_class)
   self.pee_anim = pee_animations[humanoid_class]
   self.humanoid_class = humanoid_class
   if #self.action_queue == 0 then
-    self:setNextAction {name = "idle"}
+    self:setNextAction(IdleAction())
   end
 
   self.th:setPartialFlag(self.permanent_flags or 0, false)
@@ -726,12 +722,12 @@ end
 --!param must_happen (boolean, nil) If true, then the walk action will not be
 -- interrupted.
 function Humanoid:walkTo(tile_x, tile_y, must_happen)
-  self:setNextAction {
-    name = "walk",
-    x = tile_x,
-    y = tile_y,
-    must_happen = must_happen,
-  }
+  local action = WalkAction(tile_x, tile_y)
+  if must_happen then
+    action:setMustHappen(must_happen)
+  end
+
+  self:setNextAction(action)
 end
 
 -- Stub functions for handling fatigue. These are overridden by the staff subclass,
@@ -749,9 +745,9 @@ end
 function Humanoid:handleRemovedObject(object)
   local replacement_action
   if self.humanoid_class and self.humanoid_class == "Receptionist" then
-    replacement_action = {name = "meander"}
+    replacement_action = MeanderAction()
   elseif object.object_type.id == "bench" or object.object_type.id == "drinks_machine" then
-    replacement_action = {name = "idle", must_happen = true}
+    replacement_action = IdleAction():setMustHappen()
   end
 
   for i, action in ipairs(self.action_queue) do

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -723,10 +723,7 @@ end
 -- interrupted.
 function Humanoid:walkTo(tile_x, tile_y, must_happen)
   local action = WalkAction(tile_x, tile_y)
-  if must_happen then
-    action:setMustHappen(must_happen)
-  end
-
+  action:setMustHappen(must_happen or false)
   self:setNextAction(action)
 end
 

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -209,20 +209,24 @@ function Machine:createHandymanActions(handyman)
   self.repairing = handyman
   self:setRepairingMode()
 
-  local --[[persistable:handyman_repair_after_use]] function after_use()
+  local --[[persistable:handyman_repair_after_use]] function repair_after_use()
     handyman:setCallCompleted()
     handyman:setDynamicInfoText("")
     self:machineRepaired(self:getRoom())
   end
+
   local action = {name = "walk", x = ux, y = uy, is_entering = this_room and true or false}
+
+  local repair_loop_callback = --[[persistable:handyman_repair_loop_callback]] function()
+    action_use.prolonged_usage = false
+  end
+
   local repair_action = {
     name = "use_object",
     object = self,
     prolonged_usage = false,
-    loop_callback = --[[persistable:handyman_repair_loop_callback]] function()
-      action_use.prolonged_usage = false
-    end,
-    after_use = after_use,
+    loop_callback = repair_loop_callback,
+    after_use = repair_after_use,
     min_length = 20,
   }
   if handyman_room and handyman_room ~= this_room then
@@ -231,19 +235,22 @@ function Machine:createHandymanActions(handyman)
   else
     handyman:setNextAction(action)
   end
+
+  local meander_loop_callback = --[[persistable:handyman_meander_repair_loop_callback]] function()
+    if not self.user then
+      -- The machine is ready to be repaired.
+      -- The following statement will finish the meander action in the handyman's
+      -- action queue.
+      handyman:finishAction()
+    end
+    -- Otherwise do nothing and let the meandering continue.
+  end
+
   -- Before the actual repair action, insert a meander action to wait for the machine
   -- to become free for use.
   handyman:queueAction({
     name = "meander",
-    loop_callback = --[[persistable:handyman_meander_repair_loop_callback]] function()
-      if not self.user then
-        -- The machine is ready to be repaired.
-        -- The following statement will finish the meander action in the handyman's
-        -- action queue.
-        handyman:finishAction()
-      end
-      -- Otherwise do nothing and let the meandering continue.
-    end,
+    loop_callback = meander_loop_callback,
   })
   -- The last one is another walk action to the repair tile. If the handymand goes directly
   -- to repair it will simply complete in an instant.

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -215,20 +215,16 @@ function Machine:createHandymanActions(handyman)
     self:machineRepaired(self:getRoom())
   end
 
-  local action = {name = "walk", x = ux, y = uy, is_entering = this_room and true or false}
+  local action = WalkAction(ux, uy):setIsEntering(this_room and true or false)
 
   local repair_loop_callback = --[[persistable:handyman_repair_loop_callback]] function()
     action_use.prolonged_usage = false
   end
 
-  local repair_action = {
-    name = "use_object",
-    object = self,
-    prolonged_usage = false,
-    loop_callback = repair_loop_callback,
-    after_use = repair_after_use,
-    min_length = 20,
-  }
+  local repair_action = UseObjectAction(self):setProlongedUsage(false)
+      :setLoopCallback(repair_loop_callback):setAfterUse(repair_after_use)
+  repair_action.min_length = 20
+
   if handyman_room and handyman_room ~= this_room then
     handyman:setNextAction(handyman_room:createLeaveAction())
     handyman:queueAction(action)
@@ -248,16 +244,14 @@ function Machine:createHandymanActions(handyman)
 
   -- Before the actual repair action, insert a meander action to wait for the machine
   -- to become free for use.
-  handyman:queueAction({
-    name = "meander",
-    loop_callback = meander_loop_callback,
-  })
-  -- The last one is another walk action to the repair tile. If the handymand goes directly
+  handyman:queueAction(MeanderAction():setLoopCallback(meander_loop_callback))
+
+  -- The last one is another walk action to the repair tile. If the handyman goes directly
   -- to repair it will simply complete in an instant.
   handyman:queueAction(action)
   handyman:queueAction(repair_action)
   CallsDispatcher.queueCallCheckpointAction(handyman)
-  handyman:queueAction{name = "answer_call"}
+  handyman:queueAction(AnswerCallAction())
   handyman:setDynamicInfoText(_S.dynamic_info.staff.actions.going_to_repair
     :format(self.object_type.name))
 end

--- a/CorsixTH/Lua/entities/staff.lua
+++ b/CorsixTH/Lua/entities/staff.lua
@@ -649,9 +649,9 @@ function Staff:goToStaffRoom()
   if room then
     room.staff_leaving = true
     self:setNextAction(room:createLeaveAction())
-    self:queueAction(SeekStaffRoom())
+    self:queueAction(SeekStaffRoomAction())
   else
-    self:setNextAction(SeekStaffRoom())
+    self:setNextAction(SeekStaffRoomAction())
   end
 end
 

--- a/CorsixTH/Lua/entities/staff.lua
+++ b/CorsixTH/Lua/entities/staff.lua
@@ -339,7 +339,7 @@ function Staff:updateSkill(consultant, trait, amount)
       self.world.ui.adviser:say(_A.information.promotion_to_consultant)
       if self:getRoom().room_info.id == "training" then
         self:setNextAction(self:getRoom():createLeaveAction())
-        self:queueAction{name = "meander"}
+        self:queueAction(MeanderAction())
         self.last_room = nil
       end
       self:updateStaffTitle()
@@ -428,7 +428,7 @@ function Staff:onClick(ui, button)
     end
   elseif button == "right" then
     self.pickup = true
-    self:setNextAction({name = "pickup", ui = ui, must_happen = true}, true)
+    self:setNextAction(PickupAction():setUi(ui):setMustHappen(), true)
   end
   Humanoid.onClick(self, ui, button)
 end
@@ -649,9 +649,9 @@ function Staff:goToStaffRoom()
   if room then
     room.staff_leaving = true
     self:setNextAction(room:createLeaveAction())
-    self:queueAction{name = "seek_staffroom", must_happen = true}
+    self:queueAction(SeekStaffRoom())
   else
-    self:setNextAction{name = "seek_staffroom", must_happen = true}
+    self:setNextAction(SeekStaffRoom())
   end
 end
 
@@ -669,7 +669,7 @@ function Staff:onPlaceInCorridor()
     self.task = nil
   end
   self:updateSpeed()
-  self:setNextAction{name = "meander"}
+  self:setNextAction(MeanderAction())
   if self.humanoid_class == "Receptionist" then
     world:findObjectNear(self, "reception_desk", nil, function(x, y)
       local obj = world:getObject(x, y, "reception_desk")
@@ -912,7 +912,7 @@ function Staff:interruptHandymanTask()
     self.on_call = nil
   end
   self.task = nil
-  self:setNextAction{name = "answer_call"}
+  self:setNextAction(AnswerCallAction())
 end
 
 function Staff:searchForHandymanTask()
@@ -960,7 +960,7 @@ function Staff:searchForHandymanTask()
     if self:getRoom() then
       self:queueAction(self:getRoom():createLeaveAction())
     end
-    self:queueAction({name = "meander"})
+    self:queueAction(MeanderAction())
   end
   return assignedTask
 end
@@ -972,12 +972,12 @@ function Staff:assignHandymanTask(taskIndex, taskType)
   if taskType == "cleaning" then
     if self:getRoom() then
       self:setNextAction(self:getRoom():createLeaveAction())
-      self:queueAction{name = "walk", x = task.tile_x, y = task.tile_y}
+      self:queueAction(WalkAction(task.tile_x, task.tile_y))
     else
-      self:setNextAction{name = "walk", x = task.tile_x, y = task.tile_y}
+      self:setNextAction(WalkAction(task.tile_x, task.tile_y))
     end
-    self:queueAction{name = "sweep_floor", litter = task.object}
-    self:queueAction{name = "answer_call"}
+    self:queueAction(SweepFloorAction():setLitter(task.object))
+    self:queueAction(AnswerCallAction())
   else
     if task.call.dropped then
       task.call.dropped = nil

--- a/CorsixTH/Lua/entities/vip.lua
+++ b/CorsixTH/Lua/entities/vip.lua
@@ -70,7 +70,7 @@ function Vip:tickDay()
       while self.next_room and not self.next_room.is_active do
         self.next_room_no, self.next_room = next(self.world.rooms, self.next_room_no)
       end
-      self:setNextAction{name = "vip_go_to_next_room"}
+      self:setNextAction(VipGoToNextRoomAction())
     end
   end
 
@@ -456,7 +456,7 @@ end
 function Vip:afterLoad(old, new)
   if old < 50 then
     self.num_visited_rooms = 0
-    self:setNextAction{name = "idle"}
+    self:setNextAction(IdleAction())
     self.waiting = 1
     for _, room in pairs(self.world.rooms) do
       if room.door.reserved_for == self then

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -535,12 +535,8 @@ function Epidemic:evacuateHospital()
       patient:clearDynamicInfo()
       patient:setDynamicInfo('text', {_S.dynamic_info.patient.actions.epidemic_sent_home})
       patient:setMood("exit","activate")
-      patient:setNextAction{
-        name = "spawn",
-        mode = "despawn",
-        point = self.world.spawn_points[math.random(1, #self.world.spawn_points)],
-        must_happen = true,
-      }
+      patient:setNextAction(SpawnAction():setMode("despawn"):setMustHappen()
+          :setPoint(self.world.spawn_points[math.random(1, #self.world.spawn_points)]))
     end
   end
 end
@@ -560,9 +556,9 @@ function Epidemic:spawnInspector()
   inspector:setType("Inspector")
 
   local spawn_point = self.world.spawn_points[math.random(1, #self.world.spawn_points)]
-  inspector:setNextAction{name = "spawn", mode = "spawn", point = spawn_point}
+  inspector:setNextAction(SpawnAction():setMode("spawn"):setPoint(spawn_point))
   inspector:setHospital(self.hospital)
-  inspector:queueAction{name = "seek_reception"}
+  inspector:queueAction(SeekReceptionAction())
 end
 
 --[[ Is the patient "still" either idle queuing or sitting on a bench
@@ -599,7 +595,7 @@ function Epidemic:createVaccinationActions(patient,nurse)
   if not x or not y then
     nurse:setCallCompleted()
     patient.reserved_for = nil
-    nurse:setNextAction({name = "meander"})
+    nurse:setNextAction(MeanderAction())
     patient:removeVaccinationCandidateStatus()
   else
     -- Give selected patient the cursor with the arrow once they are next
@@ -607,12 +603,8 @@ function Epidemic:createVaccinationActions(patient,nurse)
     patient:giveVaccinationCandidateStatus()
     local level_config = self.world.map.level_config
     local fee = level_config.gbv.VacCost or 50
-    nurse:setNextAction({name = "walk", x = x, y = y,
-                        must_happen = true,
-                        walking_to_vaccinate = true})
-    nurse:queueAction({name ="vaccinate",
-                      vaccination_fee = fee,
-                      patient = patient, must_happen = true})
+    nurse:setNextAction(WalkAction(x, y):setMustHappen():setWalkingToVaccinate())
+    nurse:queueAction(VaccinateAction():setFee(fee):setPatient(patient):setMustHappen())
   end
 end
 

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -521,7 +521,7 @@ function GameUI:onMouseUp(code, x, y)
     local patient = (window and window.patient.is_debug and window.patient) or self.hospital:getDebugPatient()
     if patient then
       patient:walkTo(highlight_x, highlight_y)
-      patient:queueAction{name = "idle"}
+      patient:queueAction(IdleAction())
     end
   end
 

--- a/CorsixTH/Lua/humanoid_action.lua
+++ b/CorsixTH/Lua/humanoid_action.lua
@@ -1,0 +1,89 @@
+--[[ Copyright (c) 2016 Albert "Alberth" Hofkamp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. --]]
+
+--! Humanoid action base class.
+class "HumanoidAction"
+
+---@type HumanoidAction
+local HumanoidAction = _G["HumanoidAction"]
+
+--! Construct a humanoid action (base class constructor).
+--!param name (str) Name of the action.
+function HumanoidAction:HumanoidAction(name)
+  self.name = name
+  self.count = nil -- 'nil' means 'forever' (until finished), else the number to perform.
+  self.must_happen = false -- If set, action cannot be skipped.
+  self.loop_callback = nil -- Periodic callback to check for termination conditions.
+  self.after_use = nil -- Callback for performing updates afterwards.
+  self.is_leaving = nil -- Whether the humanoid is leaving.
+  self.no_truncate = nil -- If set, disable shortening the action.
+end
+
+--! Set the number of times the action should happen.
+--!param count (int or nil) Set to 'nil' if 'forever', else integer count.
+--!return (action) Returning self, for daisy-chaining.
+function HumanoidAction:setCount(count)
+  self.count = count
+  return self
+end
+
+--! Set the 'must happen' flag (that is, action cannot be skipped).
+--!param must_happen (bool) Whether or not the action must happen. If not specified, value is true.
+--!return (action) Returning self, for daisy-chaining.
+function HumanoidAction:setMustHappen(must_happen)
+  if must_happen == nil then must_happen = true end
+
+  self.must_happen = true
+  return self
+end
+
+--! Set the callback for checking termination conditions.
+--!param loop_callback (func) Callback function that is called each iteration to check for
+--! termination conditions.
+--!return (action) Returning self, for daisy-chaining.
+function HumanoidAction:setLoopCallback(loop_callback)
+  self.loop_callback = loop_callback
+  return self
+end
+
+--! Set the callback for performing updates afterwards.
+--!param after_use (func) Callback function that is called after the action ends.
+--!return (action) Returning self, for daisy-chaining.
+function HumanoidAction:setAfterUse(after_use)
+  self.after_use = after_use
+  return self
+end
+
+--! Set whether the humanoid is leaving.
+--!param is_leaving (bool) Whether or not the humanoid is leaving. If not specified, value is true.
+--!return (action) Returning self, for daisy-chaining.
+function HumanoidAction:setIsLeaving(is_leaving)
+  if is_leaving == nil then is_leaving = true end
+
+  self.is_leaving = is_leaving
+  return self
+end
+
+--! Do not allow truncating the action.
+--!return (action) Returning self, for daisy-chaining.
+function HumanoidAction:setNoTruncate()
+  self.no_truncate = true
+  return self
+end

--- a/CorsixTH/Lua/humanoid_actions/answer_call.lua
+++ b/CorsixTH/Lua/humanoid_actions/answer_call.lua
@@ -18,6 +18,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "AnswerCallAction" (HumanoidAction)
+
+---@type AnswerCallAction
+local AnswerCallAction = _G["AnswerCallAction"]
+
+function AnswerCallAction:AnswerCallAction()
+  self:HumanoidAction("answer_call")
+end
+
 local function action_answer_call_start(action, humanoid)
   action.must_happen = true
   CallsDispatcher.onCheckpointCompleted(action, humanoid)

--- a/CorsixTH/Lua/humanoid_actions/answer_call.lua
+++ b/CorsixTH/Lua/humanoid_actions/answer_call.lua
@@ -35,7 +35,7 @@ local function action_answer_call_start(action, humanoid)
     if room then
       humanoid:queueAction(room:createLeaveAction())
     end
-    humanoid:queueAction({name = "meander"})
+    humanoid:queueAction(MeanderAction())
   end
   humanoid:finishAction(action)
 end

--- a/CorsixTH/Lua/humanoid_actions/call_checkpoint.lua
+++ b/CorsixTH/Lua/humanoid_actions/call_checkpoint.lua
@@ -18,6 +18,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "CallCheckPointAction" (HumanoidAction)
+
+---@type CallCheckPointAction
+local CallCheckPointAction = _G["CallCheckPointAction"]
+
+function CallCheckPointAction:CallCheckPointAction()
+  self:HumanoidAction("call_checkpoint")
+  self.call = nil -- Whether the humanoid is on call.
+  self.on_remove = nil -- Interrupt handler to use.
+end
+
+--! Set whether the humanoid is on call.
+--!param call (bool) If set, humanoid is on call.
+--!return (action) Returning self, for daisy-chaining.
+function CallCheckPointAction:setCall(call)
+  self.call = call
+  return self
+end
+
+--! Set the interrupt handler.
+--!param handler (function) Interrupt handler to use.
+--!return (action) Returning self, for daisy-chaining.
+function CallCheckPointAction:setOnRemove(handler)
+  self.on_remove = handler
+  return self
+end
+
 local function action_call_checkpoint_start(action, humanoid)
   action.must_happen = true
   CallsDispatcher.onCheckpointCompleted(action.call)

--- a/CorsixTH/Lua/humanoid_actions/check_watch.lua
+++ b/CorsixTH/Lua/humanoid_actions/check_watch.lua
@@ -17,6 +17,17 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
+
+class "CheckWatchAction" (HumanoidAction)
+
+---@type CheckWatchAction
+local CheckWatchAction = _G["CheckWatchAction"]
+
+function CheckWatchAction:CheckWatchAction()
+  self:HumanoidAction("check_watch")
+  self:setMustHappen()
+end
+
 local action_check_watch_end = permanent"action_check_watch_end"( function(humanoid)
   humanoid:finishAction()
 end)

--- a/CorsixTH/Lua/humanoid_actions/die.lua
+++ b/CorsixTH/Lua/humanoid_actions/die.lua
@@ -163,12 +163,9 @@ local action_die_tick_reaper; action_die_tick_reaper = permanent"action_die_tick
     --Spawn the grim reaper and the lava hole:
     local lava_hole = humanoid.world:newObject("gates_to_hell", hole_x, hole_y, holes_orientation)
     local grim_reaper = humanoid.world:newEntity("GrimReaper", 1660)
-    grim_reaper:setNextAction({name = "idle_spawn",
-                               count = 40,
-                               spawn_animation = 1660,
-                               point = { x = grim_x,
-                                         y = grim_y,
-                                         direction=grim_spawn_idle_direction}})
+    grim_reaper:setNextAction(IdleSpawnAction():setCount(40):setAnimation(1660)
+        :setPoint({x = grim_x, y = grim_y, direction = grim_spawn_idle_direction}))
+
     --Initialise the grim reaper:
     grim_reaper:setHospital(humanoid.world:getLocalPlayerHospital())
     grim_reaper.lava_hole = lava_hole
@@ -187,18 +184,14 @@ local action_die_tick_reaper; action_die_tick_reaper = permanent"action_die_tick
     action.phase = 4
     local grim = humanoid.grim_reaper
     if grim.tile_x ~= grim.use_tile_x or grim.tile_y ~= grim.use_tile_y then
-      grim:queueAction({name = "walk",
-                        x = grim.use_tile_x,
-                        y = grim.use_tile_y,
-                        no_truncate = true})
+      grim:queueAction(WalkAction(grim.use_tile_x, grim.use_tile_y):setNoTruncate())
     end
 
     local loop_callback_wait = --[[persistable:reaper_wait]]function()
       grim:setAnimation(1002, grim.mirror)
       action_die_tick_reaper(humanoid)
     end
-
-    grim:queueAction({name = "idle", loop_callback = loop_callback_wait})
+    grim:queueAction(IdleAction():setLoopCallback(loop_callback_wait))
 
   --4: There will be a brief pause before the patient stands up:
   elseif phase == 4 then
@@ -220,18 +213,13 @@ local action_die_tick_reaper; action_die_tick_reaper = permanent"action_die_tick
     local loop_callback_swipe =--[[persistable:reaper_swipe]]function()
       grim:setAnimation(1670, grim.mirror)
     end
-
-    grim:queueAction({name = "idle",
-                      count = grim.world:getAnimLength(1670),
-                      loop_callback = loop_callback_swipe})
+    grim:queueAction(IdleAction():setCount(grim.world:getAnimLength(1670)):setLoopCallback(loop_callback_swipe))
 
     local loop_callback_leave =--[[persistable:reaper_leave]]function()
       grim:setAnimation(1678, grim.mirror)
     end
 
-    grim:queueAction({name = "idle",
-                      count = grim.world:getAnimLength(1678),
-                      loop_callback = loop_callback_leave})
+    grim:queueAction(IdleAction():setCount(grim.world:getAnimLength(1678)):setLoopCallback(loop_callback_leave))
 
     local lava_destroy = --[[persistable:lava_destroy]]function()
       humanoid.world:destroyEntity(lava_hole)
@@ -243,8 +231,7 @@ local action_die_tick_reaper; action_die_tick_reaper = permanent"action_die_tick
       grim.world:destroyEntity(grim)
     end
 
-    grim:queueAction({name = "idle",
-                      loop_callback = loop_callback_destroy})
+    grim:queueAction(IdleAction():setLoopCallback(loop_callback_destroy))
 
     --The patient's final actions:
     humanoid:walkTo(humanoid.hole_use_tile_x, humanoid.hole_use_tile_y, true)
@@ -253,10 +240,10 @@ local action_die_tick_reaper; action_die_tick_reaper = permanent"action_die_tick
       grim:finishAction()
     end
 
-    humanoid:queueAction({name = "use_object",
-                          object = lava_hole,
-                          destroy_user_after_use = true,
-                          after_walk_in = post_walk_into})
+    local use_action = UseObjectAction(lava_hole)
+    use_action.destroy_user_after_use = true
+    use_action.after_walk_in = post_walk_into
+    humanoid:queueAction(use_action)
     humanoid:finishAction()
   end
 end)
@@ -310,7 +297,7 @@ local function action_die_start(action, humanoid)
       else
         humanoid:walkTo(humanoid.tile_x, humanoid.tile_y - 1)
       end
-      humanoid:queueAction({name = "die"})
+      humanoid:queueAction(DieAction())
       humanoid:finishAction()
       return
     end

--- a/CorsixTH/Lua/humanoid_actions/die.lua
+++ b/CorsixTH/Lua/humanoid_actions/die.lua
@@ -18,6 +18,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "DieAction" (HumanoidAction)
+
+---@type DieAction
+local DieAction = _G["DieAction"]
+
+function DieAction:DieAction()
+  self:HumanoidAction("die")
+end
+
 local action_die_tick; action_die_tick = permanent"action_die_tick"( function(humanoid)
   local action = humanoid.action_queue[1]
   local phase = action.phase

--- a/CorsixTH/Lua/humanoid_actions/falling.lua
+++ b/CorsixTH/Lua/humanoid_actions/falling.lua
@@ -18,6 +18,16 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "FallingAction" (HumanoidAction)
+
+---@type FallingAction
+local FallingAction = _G["FallingAction"]
+
+function FallingAction:FallingAction()
+  self:HumanoidAction("falling")
+  self.must_happen = true
+end
+
 local action_falling_end = permanent"action_falling_end"( function(humanoid)
   humanoid:finishAction()
 end)

--- a/CorsixTH/Lua/humanoid_actions/get_up.lua
+++ b/CorsixTH/Lua/humanoid_actions/get_up.lua
@@ -18,6 +18,16 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "GetUpAction" (HumanoidAction)
+
+---@type GetUpAction
+local GetUpAction = _G["GetUpAction"]
+
+function GetUpAction:GetUpAction()
+  self:HumanoidAction("get_up")
+  self.must_happen = true
+end
+
 local action_get_up_end = permanent"action_get_up_end"( function(humanoid)
   humanoid:finishAction()
 end)

--- a/CorsixTH/Lua/humanoid_actions/idle.lua
+++ b/CorsixTH/Lua/humanoid_actions/idle.lua
@@ -18,6 +18,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "IdleAction" (HumanoidAction)
+
+---@type IdleAction
+local IdleAction = _G["IdleAction"]
+
+function IdleAction:IdleAction()
+  self:HumanoidAction("idle")
+  self.direction = nil -- Direction of standing idle.
+  self.on_interrupt = nil -- Function to call at an interrupt.
+end
+
+--! Set the direction of facing while standing idle.
+--!param direction (string) Direction of facing.
+--!return (action) Self, for daisy-chaining.
+function IdleAction:setDirection(direction)
+  self.direction = direction
+  return self
+end
+
+--! Set the function to call on interrupt.
+--!param on_interrupt (function) Function to call on interrupt.
+--!return (action) Self, for daisy-chaining.
+function IdleAction:setOnInterrupt(on_interrupt)
+  self.on_interrupt = on_interrupt
+  return self
+end
+
 local action_idle_interrupt = permanent"action_idle_interrupt"( function(action, humanoid)
   humanoid:setTimer(1, humanoid.finishAction)
 end)

--- a/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
@@ -24,11 +24,14 @@ local function action_idle_spawn_start(action, humanoid)
   humanoid:setTilePositionSpeed(action.point.x,action.point.y)
 
   if action.spawn_animation then
+    local loop_callback_spawn =--[[persistable:idle_spawn_animation]] function()
+      if action.spawn_sound then humanoid:playSound(action.spawn_sound) end
+      humanoid:setAnimation(action.spawn_animation)
+    end
+
     humanoid:queueAction({name="idle",count = humanoid.world:getAnimLength(action.spawn_animation),
-                                      loop_callback=--[[persistable:idle_spawn_animation]] function()
-                                        if action.spawn_sound then humanoid:playSound(action.spawn_sound) end
-                                        humanoid:setAnimation(action.spawn_animation)
-                                      end})
+                                      loop_callback = loop_callback_spawn})
+
   elseif action.spawn_sound then
     humanoid:playSound(action.spawn_sound)
   end

--- a/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
@@ -17,6 +17,34 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
+
+class "IdleSpawnAction" (HumanoidAction)
+
+---@type IdleSpawnAction
+local IdleSpawnAction = _G["IdleSpawnAction"]
+
+function IdleSpawnAction:IdleSpawnAction()
+  self:HumanoidAction("idle_spawn")
+  self.spawn_animation = nil
+  self.point = nil -- x, y, direction of the spawn animation
+end
+
+--! Set the animation.
+--!param anim (int) Animation to play.
+--!return (action) Return self for daisy chaining.
+function IdleSpawnAction:setAnimation(anim)
+  self.spawn_animation = anim
+  return self
+end
+
+--! Set the position and direction of the animation.
+--!param point (table x, y, direction) Position and direction.
+--!return (action) Return self for daisy chaining.
+function IdleSpawnAction:setPoint(point)
+  self.point = point
+  return self
+end
+
 local function action_idle_spawn_start(action, humanoid)
   action.must_happen = true
 

--- a/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
@@ -57,14 +57,14 @@ local function action_idle_spawn_start(action, humanoid)
       humanoid:setAnimation(action.spawn_animation)
     end
 
-    humanoid:queueAction({name="idle",count = humanoid.world:getAnimLength(action.spawn_animation),
-                                      loop_callback = loop_callback_spawn})
+    humanoid:queueAction(IdleAction():setCount(humanoid.world:getAnimLength(action.spawn_animation))
+        :setLoopCallback(loop_callback_spawn))
 
   elseif action.spawn_sound then
     humanoid:playSound(action.spawn_sound)
   end
 
-  humanoid:queueAction({name="idle",count = action.count,loop_callback = action.loop_callback})
+  humanoid:queueAction(IdleAction():setCount(action.count):setLoopCallback(action.loop_callback))
   humanoid:finishAction()
 end
 

--- a/CorsixTH/Lua/humanoid_actions/knock_door.lua
+++ b/CorsixTH/Lua/humanoid_actions/knock_door.lua
@@ -18,6 +18,21 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "KnockDoorAction" (HumanoidAction)
+
+---@type KnockDoorAction
+local KnockDoorAction = _G["KnockDoorAction"]
+
+--! Constructor for knocking on the door action.
+--!param door (Object) Door to knock on.
+--!param direction (string) Direction of facing.
+function KnockDoorAction:KnockDoorAction(door, direction)
+  self:HumanoidAction("knock_door")
+  self:setMustHappen()
+  self.door = door -- Door to knock on.
+  self.direction = direction -- Direction of facing.
+end
+
 local action_knock_door_tick = permanent"action_knock_door_tick"( function(humanoid)
   local door = humanoid.user_of
   door:removeUser(humanoid)

--- a/CorsixTH/Lua/humanoid_actions/meander.lua
+++ b/CorsixTH/Lua/humanoid_actions/meander.lua
@@ -18,6 +18,16 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "MeanderAction" (HumanoidAction)
+
+---@type MeanderAction
+local MeanderAction = _G["MeanderAction"]
+
+function MeanderAction:MeanderAction()
+  self:HumanoidAction("meander")
+  self.can_idle = false -- If set, humanoid can do next action.
+end
+
 local function meander_action_start(action, humanoid)
   local room = humanoid:getRoom()
   -- Answering call queue

--- a/CorsixTH/Lua/humanoid_actions/meander.lua
+++ b/CorsixTH/Lua/humanoid_actions/meander.lua
@@ -72,7 +72,7 @@ local function meander_action_start(action, humanoid)
   if x == humanoid.tile_x and y == humanoid.tile_y then
     -- Nowhere to walk to - go idle instead, or go onto the next action
     if #humanoid.action_queue == 1 then
-      humanoid:queueAction{name = "idle"}
+      humanoid:queueAction(IdleAction())
     end
     humanoid:finishAction()
     return
@@ -94,14 +94,14 @@ local function meander_action_start(action, humanoid)
       return
     end
   end
+
   local procrastination
   if action.can_idle and math.random(1, 3) == 1 then
-    procrastination = {name = "idle", count = math.random(25, 40)}
+    procrastination = IdleAction():setCount(math.random(25, 40)):setMustHappen(action.must_happen)
   else
     action.can_idle = true
-    procrastination = {name = "walk", x = x, y = y}
+    procrastination = WalkAction(x, y):setMustHappen(action.must_happen)
   end
-  procrastination.must_happen = action.must_happen
   humanoid:queueAction(procrastination, 0)
 end
 

--- a/CorsixTH/Lua/humanoid_actions/meander.lua
+++ b/CorsixTH/Lua/humanoid_actions/meander.lua
@@ -97,10 +97,10 @@ local function meander_action_start(action, humanoid)
 
   local procrastination
   if action.can_idle and math.random(1, 3) == 1 then
-    procrastination = IdleAction():setCount(math.random(25, 40)):setMustHappen(action.must_happen)
+    procrastination = IdleAction():setCount(math.random(25, 40)):setMustHappen(action.must_happen or false)
   else
     action.can_idle = true
-    procrastination = WalkAction(x, y):setMustHappen(action.must_happen)
+    procrastination = WalkAction(x, y):setMustHappen(action.must_happen or false)
   end
   humanoid:queueAction(procrastination, 0)
 end

--- a/CorsixTH/Lua/humanoid_actions/multi_use_object.lua
+++ b/CorsixTH/Lua/humanoid_actions/multi_use_object.lua
@@ -322,7 +322,7 @@ local function action_multi_use_object_start(action, humanoid)
     end
   end
   if use_with.action_queue[1].name ~= "idle" then
-    humanoid:queueAction({name = "idle", count = 2}, 0)
+    humanoid:queueAction(IdleAction():setCount(2), 0)
     return
   else
     action.idle_interrupt = use_with.action_queue[1].on_interrupt

--- a/CorsixTH/Lua/humanoid_actions/multi_use_object.lua
+++ b/CorsixTH/Lua/humanoid_actions/multi_use_object.lua
@@ -18,7 +18,41 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "MultiUseObjectAction" (HumanoidAction)
+
+---@type MultiUseObjectAction
+local MultiUseObjectAction = _G["MultiUseObjectAction"]
+
+--! Construct a multi-use object action.
+--!param object (Object) Object being used.
+--!param use_with (Humanoid) Fellow user of the object.
+function MultiUseObjectAction:MultiUseObjectAction(object, use_with)
+  self:HumanoidAction("multi_use_object")
+  self.object = object
+  self.use_with = use_with
+  self.prolonged_usage = nil -- If true, the usage is prolonged.
+end
+
+--! Set the invisibility span.
+--!param span (array) Span of invisibility, {from, to}
+--!return (action) self, for daisy-chaining.
+function MultiUseObjectAction:setInvisiblePhaseSpan(span)
+  self.invisible_phase_span = span
+  return self
+end
+
+--! Set prolonged usage of the object.
+--!param prolonged (bool or nil) If nil or true, enable prolonged usage of the object.
+--!return (action) self, for daisy-chaining.
+function MultiUseObjectAction:setProlongedUsage(prolonged)
+  if prolonged == nil then prolonged = true end
+
+  self.prolonged_usage = prolonged
+  return self
+end
+
 local TH = require "TH"
+
 local orient_mirror = {
   north = "west",
   west = "north",

--- a/CorsixTH/Lua/humanoid_actions/on_ground.lua
+++ b/CorsixTH/Lua/humanoid_actions/on_ground.lua
@@ -18,6 +18,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "OnGroundAction" (HumanoidAction)
+
+---@type OnGroundAction
+local OnGroundAction = _G["OnGroundAction"]
+
+function OnGroundAction:OnGroundAction()
+  self:HumanoidAction("on_ground")
+end
+
 local action_on_ground_end = permanent"action_on_ground_end"( function(humanoid)
   humanoid:finishAction()
 end)

--- a/CorsixTH/Lua/humanoid_actions/pee.lua
+++ b/CorsixTH/Lua/humanoid_actions/pee.lua
@@ -18,6 +18,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "PeeAction" (HumanoidAction)
+
+---@type PeeAction
+local PeeAction = _G["PeeAction"]
+
+function PeeAction:PeeAction()
+  self:HumanoidAction("pee")
+end
+
 local action_pee_end = permanent"action_pee_end"( function(humanoid)
   local litter = humanoid.world:newObject("litter", humanoid.tile_x, humanoid.tile_y)
   litter:setLitterType("pee", humanoid.last_move_direction == "south" and 0 or 1)

--- a/CorsixTH/Lua/humanoid_actions/pickup.lua
+++ b/CorsixTH/Lua/humanoid_actions/pickup.lua
@@ -18,6 +18,27 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "PickupAction" (HumanoidAction)
+
+---@type PickupAction
+local PickupAction = _G["PickupAction"]
+
+function PickupAction:PickupAction()
+  self:HumanoidAction("pickup")
+  self.ui = nil
+  self.todo_close = nil
+end
+
+function PickupAction:setUi(ui)
+  self.ui = ui
+  return self
+end
+
+function PickupAction:setTodoClose(dialog)
+  self.todo_close = dialog
+  return self
+end
+
 local action_pickup_interrupt = permanent"action_pickup_interrupt"( function(action, humanoid)
   if action.window then
     action.window:close()

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -223,17 +223,8 @@ local action_queue_on_change_position = permanent"action_queue_on_change_positio
         num_actions_prior = action_queue_leave_bench(action, humanoid)
       end
       action.current_bench_distance = dist
-      humanoid:queueAction({
-        name = "walk",
-        x = bx,
-        y = by,
-        must_happen = true,
-      }, num_actions_prior)
-      humanoid:queueAction({
-        name = "use_object",
-        object = bench,
-        must_happen = true,
-      }, num_actions_prior + 1)
+      humanoid:queueAction(WalkAction(bx, by):setMustHappen(), num_actions_prior)
+      humanoid:queueAction(UseObjectAction(bench):setMustHappen(), num_actions_prior + 1)
       bench.reserved_for = humanoid
       return
     elseif not action:isStanding() then
@@ -275,26 +266,13 @@ local action_queue_on_change_position = permanent"action_queue_on_change_positio
       end
     end
     humanoid.action_queue[idle_index].direction = idle_direction
-    humanoid:queueAction({
-      name = "walk",
-      x = ix,
-      y = iy,
-      must_happen = true,
-    }, idle_index - 1)
+    humanoid:queueAction(WalkAction(ix, iy):setMustHappen(), idle_index - 1)
   else
     action.current_bench_distance = nil
     local num_actions_prior = action_queue_leave_bench(action, humanoid)
-    humanoid:queueAction({
-      name = "walk",
-      x = ix,
-      y = iy,
-      must_happen = true,
-    }, num_actions_prior)
-    humanoid:queueAction({
-      name = "idle",
-      direction = idle_direction,
-      must_happen = true,
-    }, num_actions_prior + 1)
+    humanoid:queueAction(WalkAction(ix, iy):setMustHappen(), num_actions_prior)
+    humanoid:queueAction(IdleAction():setDirection(idle_direction):setMustHappen(),
+        num_actions_prior + 1)
   end
 end)
 
@@ -333,28 +311,15 @@ function(action, humanoid, machine, mx, my, fun_after_use)
     -- change_position can do its work.
     -- Note that it is inserted after the currently executing use_object action.
     if action.is_in_queue then
-      humanoid:queueAction({
-        name = "idle",
-        --direction = machine,
-        must_happen = true,
-      }, 1)
+      humanoid:queueAction(IdleAction():setMustHappen(), 1)
       action_queue_on_change_position(action, humanoid)
     end
   end
 
   -- Walk to the machine and then use it.
-  humanoid:queueAction({
-    name = "walk",
-    x = mx,
-    y = my,
-    must_happen = true,
-  }, num_actions_prior)
-  humanoid:queueAction({
-    name = "use_object",
-    object = machine,
-    after_use = after_use,
-    must_happen = true,
-  }, num_actions_prior + 1)
+  humanoid:queueAction(WalkAction(mx, my):setMustHappen(), num_actions_prior)
+  humanoid:queueAction(UseObjectAction(machine):setAfterUse(after_use)
+      :setMustHappen(), num_actions_prior + 1)
   machine:addReservedUser(humanoid)
 
   -- Make sure no one thinks we're sitting down anymore.
@@ -401,11 +366,7 @@ local function action_queue_start(action, humanoid)
       humanoid:updateDynamicInfo(_S.dynamic_info.patient.actions.queueing_for:format(door.room.room_info.name))
     end
   end
-  humanoid:queueAction({
-    name = "idle",
-    is_leaving = humanoid:isLeaving(),
-    must_happen = true,
-  }, 0)
+  humanoid:queueAction(IdleAction():setMustHappen():setIsLeaving(humanoid:isLeaving()), 0)
   action:onChangeQueuePosition(humanoid)
 
   if queue.same_room_priority then

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -18,6 +18,43 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "QueueAction" (HumanoidAction)
+
+---@type QueueAction
+local QueueAction = _G["QueueAction"]
+
+--! Queue for something (door or reception desk).
+--!param x X position of the queue.
+--!param y Y position of the queue.
+--!param queue (Queue) Queue to join
+function QueueAction:QueueAction(x, y, queue)
+  self:HumanoidAction("queue")
+  self.x = x -- Position of the queue(?)
+  self.y = y
+  self.face_x = nil -- Tile to turn the face to.
+  self.face_y = nil
+  self.queue = queue
+  self.reserve_when_done = nil -- Object to reserve when leaving the queue.
+end
+
+--! Set the object to reserve when queueing is done.
+--!param door (object) Object to reserve when leaving the queue.
+--!return (action) self, for daisy-chaining.
+function QueueAction:setReserveWhenDone(door)
+  self.reserve_when_done = door
+  return self
+end
+
+--! Set the tile to face.
+--!param face_x (int) X coordinate of the tile to face.
+--!param face_y (int) Y coordinate of the tile to face.
+--!return (action) self, for daisy-chaining.
+function QueueAction:setFaceDirection(face_x, face_y)
+  self.face_x = face_x
+  self.face_y = face_y
+  return self
+end
+
 local function get_direction(x, y, facing_x, facing_y)
   if facing_y < y then
     return "north"

--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -74,17 +74,10 @@ local function action_seek_reception_start(action, humanoid)
     -- immediately, so walk them closer to the desk before joining the queue
     if can_join_queue_at(humanoid, humanoid.tile_x, humanoid.tile_y, x, y) then
       local face_x, face_y = best_desk:getSecondaryUsageTile()
-      humanoid:setNextAction{
-        name = "queue",
-        x = x,
-        y = y,
-        queue = best_desk.queue,
-        face_x = face_x,
-        face_y = face_y,
-        must_happen = action.must_happen,
-      }
+      local q_action = QueueAction(x, y, best_desk.queue):setMustHappen()
+      humanoid:setNextAction(q_action:setFaceDirection(face_x, face_y))
     else
-      local walk = {name = "walk", x = x, y = y, must_happen = action.must_happen}
+      local walk = WalkAction(x, y):setMustHappen(action.must_happen)
       humanoid:queueAction(walk, 0)
 
       -- Trim the walk to finish once it is possible to join the queue
@@ -102,16 +95,15 @@ local function action_seek_reception_start(action, humanoid)
     -- the hospital, so either walk to the hospital, or walk around the hospital.
     local procrastination
     if world.map.th:getCellFlags(humanoid.tile_x, humanoid.tile_y).hospital then
-      procrastination = {name = "meander", count = 1}
+      procrastination = MeanderAction():setCount(1):setMustHappen(action.must_happen)
       if not humanoid.waiting then
         -- Eventually people are going to get bored and leave.
         humanoid.waiting = 5
       end
     else
       local _, hosp_x, hosp_y = world.pathfinder:isReachableFromHospital(humanoid.tile_x, humanoid.tile_y)
-      procrastination = {name = "walk", x = hosp_x, y = hosp_y}
+      procrastination = WalkAction(hosp_x, hosp_y):setMustHappen(action.must_happen)
     end
-    procrastination.must_happen = action.must_happen
     humanoid:queueAction(procrastination, 0)
   end
 end

--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -77,7 +77,7 @@ local function action_seek_reception_start(action, humanoid)
       local q_action = QueueAction(x, y, best_desk.queue):setMustHappen()
       humanoid:setNextAction(q_action:setFaceDirection(face_x, face_y))
     else
-      local walk = WalkAction(x, y):setMustHappen(action.must_happen)
+      local walk = WalkAction(x, y):setMustHappen(action.must_happen or false)
       humanoid:queueAction(walk, 0)
 
       -- Trim the walk to finish once it is possible to join the queue
@@ -95,14 +95,14 @@ local function action_seek_reception_start(action, humanoid)
     -- the hospital, so either walk to the hospital, or walk around the hospital.
     local procrastination
     if world.map.th:getCellFlags(humanoid.tile_x, humanoid.tile_y).hospital then
-      procrastination = MeanderAction():setCount(1):setMustHappen(action.must_happen)
+      procrastination = MeanderAction():setCount(1):setMustHappen(action.must_happen or false)
       if not humanoid.waiting then
         -- Eventually people are going to get bored and leave.
         humanoid.waiting = 5
       end
     else
       local _, hosp_x, hosp_y = world.pathfinder:isReachableFromHospital(humanoid.tile_x, humanoid.tile_y)
-      procrastination = WalkAction(hosp_x, hosp_y):setMustHappen(action.must_happen)
+      procrastination = WalkAction(hosp_x, hosp_y):setMustHappen(action.must_happen or false)
     end
     humanoid:queueAction(procrastination, 0)
   end

--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -18,6 +18,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "SeekReceptionAction" (HumanoidAction)
+
+---@type SeekReceptionAction
+local SeekReceptionAction = _G["SeekReceptionAction"]
+
+function SeekReceptionAction:SeekReceptionAction()
+  self:HumanoidAction("seek_reception")
+end
+
 local function can_join_queue_at(humanoid, x, y, use_x, use_y)
   local flag_cache = humanoid.world.map.th:getCellFlags(x, y)
   return flag_cache.hospital and not flag_cache.room

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -235,7 +235,7 @@ local function action_seek_room_start(action, humanoid)
   end
   -- Seeking for toilets is a special case with its own action.
   if action.room_type == "toilets" then
-    humanoid:queueAction({name = "seek_toilets"}, 1)
+    humanoid:queueAction(SeekToiletsAction(), 1)
     humanoid:finishAction()
     return
   end
@@ -330,7 +330,7 @@ local function action_seek_room_start(action, humanoid)
       end
       if action_still_valid then
         action.done_walk = true
-        humanoid:queueAction({name = "meander", count = 1, must_happen = true}, 0)
+        humanoid:queueAction(MeanderAction():setCount(1):setMustHappen(), 0)
       end
     else
       -- Make sure the patient stands in a correct way as he/she is waiting.

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -18,6 +18,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "SeekRoomAction" (HumanoidAction)
+
+---@type SeekRoomAction
+local SeekRoomAction = _G["SeekRoomAction"]
+
+--! Find another room (and go to it).
+--!param room_type Type of the new room.
+function SeekRoomAction:SeekRoomAction(room_type)
+  self:HumanoidAction("seek_room")
+  self.room_type = room_type
+  self.treatment_room = nil -- Whether the next room is a treatment room.
+  self.diagnosis_room = nil
+end
+
+--! Denote that the room being looked for is a treatment room.
+--!return (action) self, for daisy-chaining.
+function SeekRoomAction:setIsTreatmentRoom()
+  self.treatment_room = true
+  return self
+end
+
+function SeekRoomAction:setDiagnosisRoom(room)
+  self.diagnosis_room = room
+  return self
+end
+
 local function action_seek_room_find_room(action, humanoid)
   local room_type = action.room_type
   if action.diagnosis_room then

--- a/CorsixTH/Lua/humanoid_actions/seek_staffroom.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_staffroom.lua
@@ -49,7 +49,7 @@ local function seek_staffroom_action_start(action, humanoid)
     -- This should happen only in rare cases, e.g. if the target staff room was removed while heading there and none other exists
     print("No staff room found in seek_staffroom action")
     humanoid.going_to_staffroom = nil
-    humanoid:queueAction({name = "meander"})
+    humanoid:queueAction(MeanderAction())
     humanoid:finishAction()
   end
 end

--- a/CorsixTH/Lua/humanoid_actions/seek_staffroom.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_staffroom.lua
@@ -18,6 +18,16 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "SeekStaffRoomAction" (HumanoidAction)
+
+---@type SeekStaffRoomAction
+local SeekStaffRoomAction = _G["SeekStaffRoomAction"]
+
+function SeekStaffRoomAction:SeekStaffRoomAction()
+  self:HumanoidAction("seek_staffroom")
+  self:setMustHappen()
+end
+
 local function seek_staffroom_action_start(action, humanoid)
   -- Mechanism for clearing the going_to_staffroom flag when this action is
   -- interrupted (due to entering the staff room, being picked up, etc.)

--- a/CorsixTH/Lua/humanoid_actions/seek_toilets.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_toilets.lua
@@ -59,9 +59,9 @@ local function seek_toilets_action_start(action, humanoid)
     -- removed while heading there and none other exists. In that case, go back
     -- to the previous room or go to the reception.
     if humanoid.next_room_to_visit then
-      humanoid:setNextAction{name = "seek_room", room_type = humanoid.next_room_to_visit.room_info.id}
+      humanoid:setNextAction(SeekRoomAction(humanoid.next_room_to_visit.room_info.id))
     else
-      humanoid:queueAction{name = "seek_reception"}
+      humanoid:queueAction(SeekReceptionAction())
     end
     humanoid.going_to_toilet = "no"
     humanoid:finishAction()

--- a/CorsixTH/Lua/humanoid_actions/seek_toilets.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_toilets.lua
@@ -19,6 +19,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "SeekToiletsAction" (HumanoidAction)
+
+---@type SeekToiletsAction
+local SeekToiletsAction = _G["SeekToiletsAction"]
+
+function SeekToiletsAction:SeekToiletsAction()
+  self:HumanoidAction("seek_toilets")
+end
+
 local function seek_toilets_action_start(action, humanoid)
   -- Mechanism for clearing the going_to_toilets flag when this action is
   -- interrupted.

--- a/CorsixTH/Lua/humanoid_actions/shake_fist.lua
+++ b/CorsixTH/Lua/humanoid_actions/shake_fist.lua
@@ -18,6 +18,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "ShakeFistAction" (HumanoidAction)
+
+---@type ShakeFistAction
+local ShakeFistAction = _G["ShakeFistAction"]
+
+function ShakeFistAction:ShakeFistAction()
+  self:HumanoidAction("shake_fist")
+end
+
 local action_shake_fist_end = permanent"action_shake_fist_end"( function(humanoid)
   humanoid:finishAction()
 end)

--- a/CorsixTH/Lua/humanoid_actions/spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/spawn.lua
@@ -18,6 +18,42 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "SpawnAction" (HumanoidAction)
+
+---@type SpawnAction
+local SpawnAction = _G["SpawnAction"]
+
+function SpawnAction:SpawnAction()
+  self:HumanoidAction("spawn")
+  self.point = nil -- x, y, direction
+  self.mode = nil -- mode of spawaning: "spawn" or "despawn"
+  self.offset = nil -- Offset in position??
+end
+
+--! Set the position and direction of the spawn point.
+--!param point (table: x, y, direction) point Position and direction.
+--!return (action) Return self for daisy chaining.
+function SpawnAction:setPoint(point)
+  self.point = point
+  return self
+end
+
+--! Set the mode of spawning (spawn or despawn).
+--!param mode (str) Spawning mode.
+--!return (action) Return self for daisy chaining.
+function SpawnAction:setMode(mode)
+  self.mode = mode
+  return self
+end
+
+--! Set the offset of spawning.
+--!param offset (table x, y) Position offset.
+--!return (action) Return self for daisy chaining.
+function SpawnAction:setOffset(offset)
+  self.offset = offset
+  return self
+end
+
 local orient_opposite = {
   north = "south",
   west = "east",

--- a/CorsixTH/Lua/humanoid_actions/spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/spawn.lua
@@ -72,7 +72,7 @@ local function action_spawn_start(action, humanoid)
   assert(action.mode == "spawn" or action.mode == "despawn", "spawn action given invalid mode: " .. action.mode)
   local x, y =  action.point.x,  action.point.y
   if action.mode == "despawn" and (humanoid.tile_x ~= x or humanoid.tile_y ~= y) then
-    humanoid:queueAction(WalkAction(action.point.x, action.point.y):setMustHappen(action.must_happen), 0)
+    humanoid:queueAction(WalkAction(action.point.x, action.point.y):setMustHappen(action.must_happen or false), 0)
     return
   end
   action.must_happen = true

--- a/CorsixTH/Lua/humanoid_actions/spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/spawn.lua
@@ -72,12 +72,7 @@ local function action_spawn_start(action, humanoid)
   assert(action.mode == "spawn" or action.mode == "despawn", "spawn action given invalid mode: " .. action.mode)
   local x, y =  action.point.x,  action.point.y
   if action.mode == "despawn" and (humanoid.tile_x ~= x or humanoid.tile_y ~= y) then
-    humanoid:queueAction({
-      name = "walk",
-      x = action.point.x,
-      y = action.point.y,
-      must_happen = action.must_happen,
-    }, 0)
+    humanoid:queueAction(WalkAction(action.point.x, action.point.y):setMustHappen(action.must_happen), 0)
     return
   end
   action.must_happen = true

--- a/CorsixTH/Lua/humanoid_actions/staff_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/staff_reception.lua
@@ -18,6 +18,21 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "StaffReceptionAction" (HumanoidAction)
+
+---@type StaffReceptionAction
+local StaffReceptionAction = _G["StaffReceptionAction"]
+
+function StaffReceptionAction:StaffReceptionAction()
+  self:HumanoidAction("staff_reception")
+  self.object = nil -- Reception desk object.
+end
+
+function StaffReceptionAction:setObject(desk)
+  self.object = desk
+  return self
+end
+
 local action_staff_reception_interrupt = permanent"action_staff_reception_interrupt"( function(action, humanoid, high_priority)
   local object = action.object
   object.receptionist = nil

--- a/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
+++ b/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
@@ -18,6 +18,20 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "SweepFloorAction" (HumanoidAction)
+
+---@type SweepFloorAction
+local SweepFloorAction = _G["SweepFloorAction"]
+
+function SweepFloorAction:SweepFloorAction()
+  self:HumanoidAction("sweep_floor")
+end
+
+function SweepFloorAction:setLitter(litter)
+  self.litter = litter
+  return self
+end
+
 -- Set markers for all animations involved.
 local animation_numbers = {
   1874,

--- a/CorsixTH/Lua/humanoid_actions/tap_foot.lua
+++ b/CorsixTH/Lua/humanoid_actions/tap_foot.lua
@@ -17,10 +17,20 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
+
+class "TapFootAction" (HumanoidAction)
+
+---@type TapFootAction
+local TapFootAction = _G["TapFootAction"]
+
+function TapFootAction:TapFootAction()
+  self:HumanoidAction("tap_foot")
+  self:setMustHappen()
+end
+
 local action_tap_foot_end = permanent"action_tap_foot_end"( function(humanoid)
   humanoid:finishAction()
 end)
-
 
 local function action_tap_foot_start(action, humanoid)
   if math.random(0, 1) == 1 then

--- a/CorsixTH/Lua/humanoid_actions/use_object.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_object.lua
@@ -20,6 +20,41 @@ SOFTWARE. --]]
 
 local TH = require "TH"
 
+
+class "UseObjectAction" (HumanoidAction)
+
+---@type UseObjectAction
+local UseObjectAction = _G["UseObjectAction"]
+
+--! Construct a 'use object' action.
+--!param object (Object) Object to use.
+function UseObjectAction:UseObjectAction(object)
+  self:HumanoidAction("use_object")
+  self.object = object
+  self.watering_plant = false -- Whether the action is watering the plant.
+  self.prolonged_usage = nil -- If true, the usage is prolonged.
+end
+
+--! Set the 'watering plant' flag.
+--!param watering (boolean) New value of the flag, flag is set when nil or true is given.
+--!return (action) self, for daisy chaining.
+function UseObjectAction:setWateringPlant(watering)
+  if watering == nil then watering = true end
+
+  self.watering_plant = watering
+  return self
+end
+
+--! Set prolonged usage of the object.
+--!param prolonged (bool or nil) If nil or true, enable prolonged usage of the object.
+--!return (action) self, for daisy-chaining.
+function UseObjectAction:setProlongedUsage(prolonged)
+  if prolonged == nil then prolonged = true end
+
+  self.prolonged_usage = prolonged
+  return self
+end
+
 local orient_mirror = {
   north = "west",
   west = "north",

--- a/CorsixTH/Lua/humanoid_actions/use_screen.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_screen.lua
@@ -18,6 +18,18 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "UseScreenAction" (HumanoidAction)
+
+---@type UseScreenAction
+local UseScreenAction = _G["UseScreenAction"]
+
+--! Action to use the screen.
+--!param screen (object) Screen to use.
+function UseScreenAction:UseScreenAction(screen)
+  self:HumanoidAction("use_screen")
+  self.object = screen
+end
+
 local finish = permanent"action_use_screen_finish"( function(humanoid)
   local screen = humanoid.user_of
   humanoid.user_of = nil

--- a/CorsixTH/Lua/humanoid_actions/use_staffroom.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_staffroom.lua
@@ -18,6 +18,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "UseStaffRoomAction" (HumanoidAction)
+
+---@type UseStaffRoomAction
+local UseStaffRoomAction = _G["UseStaffRoomAction"]
+
+function UseStaffRoomAction:UseStaffRoomAction()
+  self:HumanoidAction("use_staffroom")
+end
+
 -- decide on the next source of relaxation the humanoid will go to
 -- returns target_obj, ox, oy, new_type
 -- the function will always return a value for new_type, depending on what type was chosen,

--- a/CorsixTH/Lua/humanoid_actions/use_staffroom.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_staffroom.lua
@@ -96,7 +96,7 @@ local function use_staffroom_action_start(action, humanoid)
 
   -- If no target was found, then walk around for a bit and try again later
   if not action.target_obj then
-    humanoid:queueAction({name = "meander", count = 2}, 0)
+    humanoid:queueAction(MeanderAction():setCount(2), 0)
     return
   end
 
@@ -122,7 +122,7 @@ local function use_staffroom_action_start(action, humanoid)
         humanoid:setDynamicInfoText(_S.dynamic_info.staff.actions.heading_for:format(room.room_info.name))
       else
         -- Send the staff out of the room
-        humanoid:queueAction{name = "meander"}
+        humanoid:queueAction(MeanderAction())
       end
     else
       obj_use_time = obj_use_time - 1
@@ -143,13 +143,10 @@ local function use_staffroom_action_start(action, humanoid)
     end
   end
 
-  local obj_action = {
-    name = "use_object",
-    prolonged_usage = true,
-    object = action.target_obj,
-    loop_callback = loop_callback_use
-  }
-  humanoid:queueAction({name = "walk", x = action.ox, y = action.oy}, 0)
+  local obj_action = UseObjectAction(action.target_obj):setProlongedUsage()
+      :setLoopCallback(loop_callback_use)
+
+  humanoid:queueAction(WalkAction(action.ox, action.oy), 0)
   humanoid:queueAction(obj_action, 1)
 end
 

--- a/CorsixTH/Lua/humanoid_actions/vaccinate.lua
+++ b/CorsixTH/Lua/humanoid_actions/vaccinate.lua
@@ -99,7 +99,7 @@ local function vaccinate(action, nurse)
     -- Check if they STILL are in an adjacent square
     if is_in_adjacent_square(nurse, patient) then
       CallsDispatcher.queueCallCheckpointAction(nurse)
-      nurse:queueAction{name = "answer_call"}
+      nurse:queueAction(AnswerCallAction())
       -- Disable either vaccination icon that may be present (edge case)
       patient:setMood("epidemy2", "deactivate")
       patient:setMood("epidemy3", "deactivate")
@@ -112,24 +112,21 @@ local function vaccinate(action, nurse)
       patient:setMood("epidemy2", "activate")
       -- Drop it they may not even be the vacc candidate anymore
       CallsDispatcher.queueCallCheckpointAction(nurse)
-      nurse:queueAction{name = "answer_call"}
+      nurse:queueAction(AnswerCallAction())
       patient.reserved_for = nil
     end
   end
 
-  if is_in_adjacent_square(nurse,patient) then
-    local face_direction = find_face_direction(nurse,patient)
-    nurse:queueAction({name="idle",
-                       direction=face_direction,
-                       count=5,
-                       after_use=perform_vaccination,
-                       on_interrupt=interrupt_vaccination,
-                       must_happen=true})
+  if is_in_adjacent_square(nurse, patient) then
+    local face_direction = find_face_direction(nurse, patient)
+    nurse:queueAction(IdleAction():setDirection(face_direction):setCount(5)
+        :setAfterUse(perform_vaccination):setOnInterrupt(interrupt_vaccination):setMustHappen())
+
   else
     patient:removeVaccinationCandidateStatus()
     nurse:setCallCompleted()
     patient.reserved_for = nil
-    nurse:queueAction({name="meander"})
+    nurse:queueAction(MeanderAction())
   end
   nurse:finishAction()
 end

--- a/CorsixTH/Lua/humanoid_actions/vaccinate.lua
+++ b/CorsixTH/Lua/humanoid_actions/vaccinate.lua
@@ -18,6 +18,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "VaccinateAction" (HumanoidAction)
+
+---@type VaccinateAction
+local VaccinateAction = _G["VaccinateAction"]
+
+function VaccinateAction:VaccinateAction()
+  self:HumanoidAction("vaccinate")
+  self.patient = nil -- Patient to vaccinate.
+  self.vaccination_fee = nil -- Money to get from the patient.
+end
+
+--! Set the patient to vaccinate.
+--!param patient (Patient) Patient to vaccinate.
+--!return (action) Self, for daisy-chaining.
+function VaccinateAction:setPatient(patient)
+  self.patient = patient
+  return self
+end
+
+--! Set the amount of money to pay for vaccinating.
+--!param fee Amount of money to pay.
+--!return (action) Self, for daisy-chaining.
+function VaccinateAction:setFee(fee)
+  self.vaccination_fee = fee
+end
+
 local is_in_adjacent_square = permanent"vacc_adjacent_square"(
 function (patient,nurse)
   local x1, y1 = patient.tile_x, patient.tile_y

--- a/CorsixTH/Lua/humanoid_actions/vip_go_to_next_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/vip_go_to_next_room.lua
@@ -17,6 +17,16 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
+
+class "VipGoToNextRoomAction" (HumanoidAction)
+
+---@type VipGoToNextRoomAction
+local VipGoToNextRoomAction = _G["VipGoToNextRoomAction"]
+
+function VipGoToNextRoomAction:VipGoToNextRoomAction()
+  self:HumanoidAction("vip_go_to_next_room")
+end
+
 local action_vip_go_to_next_room_end = permanent"action_next_room_end"( function(humanoid)
   humanoid:finishAction()
 end)

--- a/CorsixTH/Lua/humanoid_actions/vip_go_to_next_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/vip_go_to_next_room.lua
@@ -31,7 +31,6 @@ local action_vip_go_to_next_room_end = permanent"action_next_room_end"( function
   humanoid:finishAction()
 end)
 
-
 local function action_vip_go_to_next_room_start(action, humanoid)
   if humanoid.next_room_no == nil then
     -- This vip is done here.
@@ -40,10 +39,10 @@ local function action_vip_go_to_next_room_start(action, humanoid)
     -- Walk to the entrance of the room and stay there for a while.
     local x, y = humanoid.next_room:getEntranceXY()
     local callback = --[[persistable:vip_next_room_enroute_cancel]] function()
-      humanoid:setNextAction({name = "idle"})
+      humanoid:setNextAction(IdleAction())
       humanoid.waiting = 1;
     end
-    humanoid:queueAction{name = "walk", x = x, y = y}
+    humanoid:queueAction(WalkAction(x, y))
     -- What happens if the room disappears:
     humanoid.next_room.humanoids_enroute[humanoid] = {callback = callback}
 
@@ -67,11 +66,7 @@ local function action_vip_go_to_next_room_start(action, humanoid)
         dir = "east"
       end
     end
-    humanoid:queueAction{
-      name = "idle",
-      loop_callback = evaluate,
-      direction = dir,
-    }
+    humanoid:queueAction(IdleAction():setLoopCallback(evaluate):setDirection(dir))
 
     -- Finish this action and start the above sequence.
     humanoid:finishAction()

--- a/CorsixTH/Lua/humanoid_actions/vomit.lua
+++ b/CorsixTH/Lua/humanoid_actions/vomit.lua
@@ -18,6 +18,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "VomitAction" (HumanoidAction)
+
+---@type VomitAction
+local VomitAction = _G["VomitAction"]
+
+function VomitAction:VomitAction()
+  self:HumanoidAction("vomit")
+end
+
 local action_vomit_end = permanent"action_vomit_end"( function(humanoid)
   local litter = humanoid.world:newObject("litter", humanoid.tile_x, humanoid.tile_y)
   litter:setLitterType("puke", humanoid.last_move_direction == "south" and 0 or 1)  --For some reason the vomit is inverted.

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -18,6 +18,50 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+class "WalkAction" (HumanoidAction)
+
+---@type WalkAction
+local WalkAction = _G["WalkAction"]
+
+--! Action to walk to a given position.
+--!param x (int) X coordinate of the destination tile.
+--!param y (int) Y coordinate of the destination tile.
+function WalkAction:WalkAction(x, y)
+  self:HumanoidAction("walk")
+  self.x = x
+  self.y = y
+  self.truncate_only_on_high_priority = false
+  self.walking_to_vaccinate = false -- Nurse walking with the intention to vaccinate
+  self.is_entering = false -- Whether the walk enters a room.
+end
+
+function WalkAction:setTruncateOnHighPriority(allow_truncate)
+  if allow_truncate == nil then allow_truncate = true end
+
+  self.truncate_only_on_high_priority = allow_truncate
+  return self
+end
+
+--! Nurse is walking with the intention to vaccinate.
+--!param wtv (boolean or nil) If set or nil, set the walking_to_vaccinate flag.
+--!return (action) self, for daisy-chaining.
+function WalkAction:setWalkingToVaccinate(wtv)
+  if wtv == nil then wtv = true end
+
+  self.walking_to_vaccinate = wtv
+  return self
+end
+
+--! Set a flag whether the walk enters a room.
+--!param entering (bool) If set or nil, set the flag of entering the room.
+--!return (action) self, for daisy-chaining.
+function WalkAction:setIsEntering(entering)
+  if entering == nil then entering = true end
+
+  self.is_entering = entering
+  return self
+end
+
 local action_walk_interrupt
 action_walk_interrupt = permanent"action_walk_interrupt"( function(action, humanoid, high_priority)
   if action.truncate_only_on_high_priority and not high_priority then

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -279,10 +279,10 @@ navigateDoor = function(humanoid, x1, y1, dir)
     -- A member of staff is entering, but is maybe no longer needed
     -- in this room?
     if not room.is_active or not room:staffFitsInRoom(humanoid) then
-      humanoid:queueAction({name = "idle"},0)
+      humanoid:queueAction(IdleAction(), 0)
       humanoid:setTilePositionSpeed(x1, y1)
-      humanoid:setNextAction({name = "idle", count = 10},0)
-      humanoid:queueAction{name = "meander"}
+      humanoid:setNextAction(IdleAction():setCount(10), 0)
+      humanoid:queueAction(MeanderAction())
       return
     end
   end
@@ -303,21 +303,11 @@ navigateDoor = function(humanoid, x1, y1, dir)
     if is_entering_room and queue:size() == 0 and not room:getPatient() and
         not door.user and not door.reserved_for and humanoid.should_knock_on_doors and
         room.room_info.required_staff and not swinging then
-      humanoid:queueAction({
-        name = "knock_door",
-        door = door,
-        direction = dir,
-      }, action_index)
+      humanoid:queueAction(KnockDoorAction(door, dir), action_index)
       action_index = action_index + 1
     end
-    humanoid:queueAction({
-      name = "queue",
-      is_leaving = humanoid:isLeaving(),
-      x = x1,
-      y = y1,
-      queue = queue,
-      reserve_when_done = door,
-    }, action_index)
+    local q_action = QueueAction(x1, y1, queue):setIsLeaving(humanoid:isLeaving())
+    humanoid:queueAction(q_action:setReserveWhenDone(door), action_index)
     action.must_happen = action.saved_must_happen
     action.reserve_on_resume = door
     return
@@ -328,11 +318,7 @@ navigateDoor = function(humanoid, x1, y1, dir)
   elseif is_entering_room and not action.done_knock and humanoid.should_knock_on_doors and
       room.room_info.required_staff and not swinging then
     humanoid:setTilePositionSpeed(x1, y1)
-    humanoid:queueAction({
-      name = "knock_door",
-      door = door,
-      direction = dir,
-    }, 0)
+    humanoid:queueAction(KnockDoorAction(door, dir), 0)
     action.reserve_on_resume = door
     action.done_knock = true
     return

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -35,20 +35,15 @@ function WalkAction:WalkAction(x, y)
   self.is_entering = false -- Whether the walk enters a room.
 end
 
-function WalkAction:setTruncateOnHighPriority(allow_truncate)
-  if allow_truncate == nil then allow_truncate = true end
-
-  self.truncate_only_on_high_priority = allow_truncate
+function WalkAction:setTruncateOnHighPriority()
+  self.truncate_only_on_high_priority = true
   return self
 end
 
 --! Nurse is walking with the intention to vaccinate.
---!param wtv (boolean or nil) If set or nil, set the walking_to_vaccinate flag.
 --!return (action) self, for daisy-chaining.
-function WalkAction:setWalkingToVaccinate(wtv)
-  if wtv == nil then wtv = true end
-
-  self.walking_to_vaccinate = wtv
+function WalkAction:setWalkingToVaccinate()
+  self.walking_to_vaccinate = true
   return self
 end
 

--- a/CorsixTH/Lua/humanoid_actions/yawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/yawn.lua
@@ -17,10 +17,20 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
+
+class "YawnAction" (HumanoidAction)
+
+---@type YawnAction
+local YawnAction = _G["YawnAction"]
+
+function YawnAction:YawnAction()
+  self:HumanoidAction("yawn")
+  self:setMustHappen()
+end
+
 local action_yawn_end = permanent"action_yawn_end"( function(humanoid)
   humanoid:finishAction()
 end)
-
 
 local function action_yawn_start(action, humanoid)
 

--- a/CorsixTH/Lua/objects/door.lua
+++ b/CorsixTH/Lua/objects/door.lua
@@ -145,7 +145,7 @@ end
 
 function Door:closeDoor()
   if self.queue then
-    self.queue:rerouteAllPatients({name = "seek_room", room_type = self:getRoom().room_info.id})
+    self.queue:rerouteAllPatients(SeekRoomAction(self:getRoom().room_info.id))
     self.queue = nil
   end
   self:clearDynamicInfo(nil)

--- a/CorsixTH/Lua/objects/helicopter.lua
+++ b/CorsixTH/Lua/objects/helicopter.lua
@@ -87,17 +87,12 @@ function Helicopter:spawnPatient()
   patient.is_emergency = self.spawned_patients
   hospital.emergency_patients[#hospital.emergency_patients + 1] = patient
   local x, y = hospital:getHeliportSpawnPosition()
-  patient:setNextAction{
-    name = "spawn",
-    mode = "spawn",
-    point = {x = x, y = y},
-    offset = {y = 1},
-  }
+  patient:setNextAction(SpawnAction():setMode("spawn"):setPoint({x = x, y = y}):setOffset({y = 1}))
   patient:setHospital(hospital)
-  -- TODO: If new combinated diseases are added this will not work correctly anymore.
+  -- TODO: If new combined diseases are added this will not work correctly anymore.
   patient.cure_rooms_visited = #patient.disease.treatment_rooms - 1
   local no_of_rooms = #patient.disease.treatment_rooms
-  patient:queueAction{name = "seek_room", room_type = patient.disease.treatment_rooms[no_of_rooms]}
+  patient:queueAction(SeekRoomAction(patient.disease.treatment_rooms[no_of_rooms]))
 end
 
 return object

--- a/CorsixTH/Lua/objects/plant.lua
+++ b/CorsixTH/Lua/objects/plant.lua
@@ -208,28 +208,24 @@ function Plant:createHandymanActions(handyman)
     handyman:setCallCompleted()
     if handyman_room then
       handyman:setNextAction(handyman_room:createLeaveAction())
-      handyman:queueAction{name = "meander"}
+      handyman:queueAction(MeanderAction())
     else
-      handyman:setNextAction{name = "meander"}
+      handyman:setNextAction(MeanderAction())
     end
     return
   end
   self.reserved_for = handyman
-  local action = {name = "walk", x = ux, y = uy, is_entering = this_room and true or false}
-  local water_action = {
-    name = "use_object",
-    object = self,
-    watering_plant = true,
-  }
+  local walk_action = WalkAction(ux, uy):setIsEntering(this_room and true or false)
+  local water_action = UseObjectAction(self):setWateringPlant()
   if handyman_room and handyman_room ~= this_room then
     handyman:setNextAction(handyman_room:createLeaveAction())
-    handyman:queueAction(action)
+    handyman:queueAction(walk_action)
   else
-    handyman:setNextAction(action)
+    handyman:setNextAction(walk_action)
   end
   handyman:queueAction(water_action)
   CallsDispatcher.queueCallCheckpointAction(handyman)
-  handyman:queueAction{name = "answer_call"}
+  handyman:queueAction(AnswerCallAction())
 end
 
 --! When a handyman should go to the plant he should approach it from the closest reachable tile.

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -298,14 +298,14 @@ end
 function Queue:rerouteAllPatients(action)
   for i, humanoid in ipairs(self) do
     -- slight delay so the desk is really destroyed before rerouting
-    humanoid:setNextAction({name = "idle", count = 1})
+    humanoid:setNextAction(IdleAction():setCount(1))
     -- Don't queue the same action table, but clone it for each patient.
     local clone = {}
     for k, v in pairs(action) do clone[k] = v end
     humanoid:queueAction(clone)
   end
   for humanoid in pairs(self.expected) do
-    humanoid:setNextAction({name = "idle", count = 1})
+    humanoid:setNextAction(IdleAction():setCount(1))
     humanoid:queueAction(action)
     self:unexpect(humanoid)
   end

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -86,7 +86,7 @@ end
 --!return Action to move to the tile just outside the room.
 function Room:createLeaveAction()
   local x, y = self:getEntranceXY(false)
-  return WalkAction(x, y):setIsLeaving():setTruncateOnHighPriority(true)
+  return WalkAction(x, y):setIsLeaving():setTruncateOnHighPriority()
 end
 
 function Room:createEnterAction(humanoid_entering, callback)

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -86,13 +86,7 @@ end
 --!return Action to move to the tile just outside the room.
 function Room:createLeaveAction()
   local x, y = self:getEntranceXY(false)
-  return {
-    name = "walk",
-    x = x,
-    y = y,
-    is_leaving = true,
-    truncate_only_on_high_priority = true,
-  }
+  return WalkAction(x, y):setIsLeaving():setTruncateOnHighPriority(true)
 end
 
 function Room:createEnterAction(humanoid_entering, callback)
@@ -100,16 +94,16 @@ function Room:createEnterAction(humanoid_entering, callback)
   if not callback then
     if class.is(humanoid_entering, Patient) then
       callback = --[[persistable:room_patient_enroute_cancel]] function()
-        humanoid_entering:setNextAction({name = "seek_room", room_type = self.room_info.id})
+        humanoid_entering:setNextAction(SeekRoomAction(self.room_info.id))
       end
     elseif class.is(humanoid_entering, Vip) then
       callback = --[[persistable:room_vip_enroute_cancel]] function()
-        humanoid_entering:setNextAction({name = "idle"})
+        humanoid_entering:setNextAction(IdleAction())
         humanoid_entering.waiting = 1;
       end
     else
       callback = --[[persistable:room_humanoid_enroute_cancel]] function()
-        humanoid_entering:setNextAction({name = "meander"})
+        humanoid_entering:setNextAction(MeanderAction())
       end
     end
   end
@@ -117,8 +111,7 @@ function Room:createEnterAction(humanoid_entering, callback)
     self.humanoids_enroute[humanoid_entering] = {callback = callback}
   end
 
-  return {name = "walk", x = x, y = y,
-    is_entering = humanoid_entering and self or true}
+  return WalkAction(x, y):setIsEntering()
 end
 
 --! Get a patient in the room.
@@ -175,7 +168,7 @@ function Room:dealtWithPatient(patient)
       patient:completeDiagnosticStep(self)
       self.hospital:receiveMoneyForTreatment(patient)
       if patient:agreesToPay("diag_gp") then
-        patient:queueAction{name = "seek_room", room_type = "gp"}
+        patient:queueAction(SeekRoomAction("gp"))
       else
         patient:goHome("over_priced", "diag_gp")
       end
@@ -186,15 +179,15 @@ function Room:dealtWithPatient(patient)
       local next_room = patient.disease.treatment_rooms[patient.cure_rooms_visited + 1]
       if next_room then
         -- Do not say that it is a treatment room here, since that check should already have been made.
-        patient:queueAction{name = "seek_room", room_type = next_room}
+        patient:queueAction(SeekRoomAction(next_room))
       else
         -- Patient is "done" at the hospital
         patient:treatDisease()
       end
     end
   else
-    patient:queueAction{name = "meander", count = 2}
-    patient:queueAction{name = "idle"}
+    patient:queueAction(MeanderAction():setCount(2))
+    patient:queueAction(IdleAction())
   end
 
   if self.dealt_patient_callback then
@@ -307,10 +300,10 @@ function Room:onHumanoidEnter(humanoid)
     self.humanoids[humanoid] = true
     if class.is(humanoid, Patient) then
       self:makeHumanoidLeave(humanoid)
-      humanoid:queueAction({name = "seek_room", room_type = self.room_info.id})
+      humanoid:queueAction(SeekRoomAction(self.room_info.id))
     else
       humanoid:setNextAction(self:createLeaveAction())
-      humanoid:queueAction({name = "meander"})
+      humanoid:queueAction(MeanderAction())
     end
     return
   end
@@ -323,7 +316,7 @@ function Room:onHumanoidEnter(humanoid)
       assert(humanoid.on_call.object:getRoom() == self, "Handyman arrived is on call but not arriving to the designated room")
     else
       -- If the handyman was not assigned for the job (e.g. drop by manual pickup), do answer a call
-      humanoid:setNextAction{name = "answer_call"}
+      humanoid:setNextAction(AnswerCallAction())
     end
     return
   end
@@ -351,7 +344,7 @@ function Room:onHumanoidEnter(humanoid)
           end
         if not staff_member.dealing_with_patient then
           staff_member:setNextAction(self:createLeaveAction())
-          staff_member:queueAction{name = "meander"}
+          staff_member:queueAction(MeanderAction())
           self.staff_member = humanoid
           humanoid:setCallCompleted()
           self:commandEnteringStaff(humanoid)
@@ -359,16 +352,16 @@ function Room:onHumanoidEnter(humanoid)
           if self.waiting_staff_member then
             self.waiting_staff_member.waiting_on_other_staff = nil
             self.waiting_staff_member:setNextAction(self:createLeaveAction())
-            self.waiting_staff_member:queueAction{name = "meander"}
+            self.waiting_staff_member:queueAction(MeanderAction())
           end
           self:createDealtWithPatientCallback(humanoid)
           humanoid.waiting_on_other_staff = true
-          humanoid:setNextAction{name = "meander"}
+          humanoid:setNextAction(MeanderAction())
         end
       else
         self.humanoids[humanoid] = true
         humanoid:setNextAction(self:createLeaveAction())
-        humanoid:queueAction{name = "meander"}
+        humanoid:queueAction(MeanderAction())
         humanoid:adviseWrongPersonForThisRoom()
       end
     else
@@ -389,7 +382,7 @@ function Room:onHumanoidEnter(humanoid)
         not self:isDiagnosisRoomForPatient(humanoid) then
       humanoid:queueAction(self:createLeaveAction())
       humanoid.needs_redirecting = true
-      humanoid:queueAction({name = "seek_room", room_type = "gp"})
+      humanoid:queueAction(SeekRoomAction("gp"))
       return
     end
     -- Check if the staff requirements are still fulfilled (the staff might have left / been picked up meanwhile)
@@ -413,7 +406,7 @@ function Room:createDealtWithPatientCallback(humanoid)
     local staff_member = self:getStaffMember()
     if staff_member then
       staff_member:setNextAction(self:createLeaveAction())
-      staff_member:queueAction{name = "meander"}
+      staff_member:queueAction(MeanderAction())
       staff_member:setMood("staff_wait", "deactivate")
       staff_member:setDynamicInfoText("")
     end
@@ -471,7 +464,7 @@ end
 function Room:commandEnteringStaff(humanoid, already_initialized)
   if not already_initialized then
     self.staff_member = humanoid
-    humanoid:setNextAction{name = "meander"}
+    humanoid:setNextAction(MeanderAction())
   end
   self:tryToFindNearbyPatients()
   humanoid:setDynamicInfoText("")
@@ -772,9 +765,9 @@ function Room:crashRoom()
     local person = self.door.reserved_for
     if not person:isLeaving() then
       if class.is(person, Patient) then
-        --Delay so that room is destroyed before the seek_room search.
-        person:queueAction({name = "idle", count = 1})
-        person:queueAction({name = "seek_room", room_type = self.room_info.id})
+        --Delay so that room is destroyed before the SeekRoom search.
+        person:queueAction(IdleAction():setCount(1))
+        person:queueAction(SeekRoomAction(self.room_info.id))
       end
     end
     person:finishAction()
@@ -782,7 +775,7 @@ function Room:crashRoom()
   end
 
   local remove_humanoid = function(humanoid)
-    humanoid:queueAction({name = "idle"}, 1)
+    humanoid:queueAction(IdleAction(), 1)
     humanoid.user_of = nil
     -- Make sure any emergency list is not messed up.
     -- Note that these humanoids might just have been kicked. (No hospital set)
@@ -884,12 +877,7 @@ function Room:makeHumanoidDressIfNecessaryAndThenLeave(humanoid)
     end
 
     local screen, sx, sy = self.world:findObjectNear(humanoid, "screen")
-    local use_screen = {
-      name = "use_screen",
-      object = screen,
-      must_happen = true,
-      is_leaving = true
-    }
+    local use_screen = UseScreenAction(screen):setMustHappen():setIsLeaving()
 
     --Make old saved game action queues compatible with the changes made by the #293 fix commit:
     for actions_index, action in ipairs(humanoid.action_queue) do
@@ -908,14 +896,7 @@ function Room:makeHumanoidDressIfNecessaryAndThenLeave(humanoid)
       humanoid.action_queue[1].after_use = nil
       humanoid:setNextAction(use_screen)
     else
-      humanoid:setNextAction{
-        name = "walk",
-        x = sx,
-        y = sy,
-        must_happen = true,
-        no_truncate = true,
-        is_leaving = true
-      }
+      humanoid:setNextAction(WalkAction(sx, sy):setMustHappen():setNoTruncate():setIsLeaving())
       humanoid:queueAction(use_screen)
     end
 
@@ -946,10 +927,10 @@ function Room:tryToEdit()
     if not humanoid:isLeaving() then
       if class.is(humanoid, Patient) then
         self:makeHumanoidLeave(humanoid)
-        humanoid:queueAction({name = "seek_room", room_type = self.room_info.id})
+        humanoid:queueAction(SeekRoomAction(self.room_info.id))
       else
         humanoid:setNextAction(self:createLeaveAction())
-        humanoid:queueAction({name = "meander"})
+        humanoid:queueAction(MeanderAction())
       end
     end
     i = i + 1

--- a/CorsixTH/Lua/rooms/blood_machine_room.lua
+++ b/CorsixTH/Lua/rooms/blood_machine_room.lua
@@ -56,9 +56,9 @@ function BloodMachineRoom:commandEnteringPatient(patient)
   local orientation = machine.object_type.orientations[machine.direction]
   local pat_x, pat_y = machine:getSecondaryUsageTile()
 
-  staff:setNextAction{name = "walk", x = stf_x, y = stf_y}
-  patient:setNextAction{name = "walk", x = pat_x, y = pat_y}
-  patient:queueAction{name = "idle", direction = machine.direction == "north" and "west" or "north"}
+  staff:setNextAction(WalkAction(stf_x, stf_y))
+  patient:setNextAction(WalkAction(pat_x, pat_y))
+  patient:queueAction(IdleAction():setDirection(machine.direction == "north" and "west" or "north"))
 
   local length = math.random(2, 4)
   local loop_callback = --[[persistable:blood_machine_loop_callback]] function(action)
@@ -69,19 +69,12 @@ function BloodMachineRoom:commandEnteringPatient(patient)
   end
 
   local after_use = --[[persistable:blood_machine_after_use]] function()
-    staff:setNextAction{name = "meander"}
+    staff:setNextAction(MeanderAction())
     self:dealtWithPatient(patient)
   end
 
-  staff:queueAction{
-    name = "multi_use_object",
-    object = machine,
-    use_with = patient,
-    prolonged_usage = true,
-    invisible_phase_span = {-3, 3},
-    loop_callback = loop_callback,
-    after_use = after_use,
-  }
+  staff:queueAction(MultiUseObjectAction(machine, patient):setProlongedUsage()
+      :setInvisiblePhaseSpan({-3, 3}):setLoopCallback(loop_callback):setAfterUse(after_use))
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/rooms/cardiogram.lua
+++ b/CorsixTH/Lua/rooms/cardiogram.lua
@@ -53,71 +53,82 @@ end
 function CardiogramRoom:commandEnteringPatient(patient)
   local screen, sx, sy = self.world:findObjectNear(patient, "screen")
   patient:walkTo(sx, sy)
+
+  local screen_after_use = --[[persistable:cardiogram_screen_after_use1]] function()
+    local staff = self.staff_member
+    local cardio, cx, cy = self.world:findObjectNear(patient, "cardio")
+    staff:walkTo(cardio:getSecondaryUsageTile())
+    local staff_idle = {name = "idle"}
+    staff:queueAction(staff_idle)
+    patient:walkTo(cx, cy)
+
+    local timer = 6
+    local phase = -2
+    local cardio_loop_callback = --[[persistable:cardiogram_cardio_loop_callback]] function(action)
+      if not action.on_interrupt then
+        action.prolonged_usage = false
+        patient.num_animation_ticks = 1
+        return
+      end
+      timer = timer - 1
+      if timer == 0 then
+        phase = phase + 1
+        if phase == 3 then
+          action.prolonged_usage = false
+        else
+          patient.num_animation_ticks = 3 - math.abs(phase)
+        end
+        timer = 6
+      else
+        action.secondary_anim = 1030
+      end
+    end
+
+    local cardio_after_use = --[[persistable:cardiogram_cardio_after_use]] function()
+      if #staff.action_queue == 1 then
+        staff:setNextAction{name = "meander"}
+      else
+        staff:finishAction(staff_idle)
+      end
+    end
+
+    patient:queueAction{
+      name = "multi_use_object",
+      object = cardio,
+      use_with = staff,
+      must_happen = false,
+      prolonged_usage = true,
+      loop_callback = cardio_loop_callback,
+      after_use = cardio_after_use,
+    }
+    patient:queueAction{
+      name = "walk",
+      x = sx,
+      y = sy,
+      is_leaving = true,
+      must_happen = false,
+      no_truncate = true,
+    }
+
+    local leaving_after_use = --[[persistable:cardiogram_screen_after_use2]] function()
+      if #patient.action_queue == 1 then
+        self:dealtWithPatient(patient)
+      end
+    end
+
+    patient:queueAction{
+      name = "use_screen",
+      object = screen,
+      is_leaving = true,
+      must_happen = true,
+      after_use = leaving_after_use,
+    }
+  end
+
   patient:queueAction{
     name = "use_screen",
     object = screen,
-    after_use = --[[persistable:cardiogram_screen_after_use1]] function()
-      local staff = self.staff_member
-      local cardio, cx, cy = self.world:findObjectNear(patient, "cardio")
-      staff:walkTo(cardio:getSecondaryUsageTile())
-      local staff_idle = {name = "idle"}
-      staff:queueAction(staff_idle)
-      patient:walkTo(cx, cy)
-      local timer = 6
-      local phase = -2
-      patient:queueAction{
-        name = "multi_use_object",
-        object = cardio,
-        use_with = staff,
-        must_happen = false,
-        prolonged_usage = true,
-        loop_callback = --[[persistable:cardiogram_cardio_loop_callback]] function(action)
-          if not action.on_interrupt then
-            action.prolonged_usage = false
-            patient.num_animation_ticks = 1
-            return
-          end
-          timer = timer - 1
-          if timer == 0 then
-            phase = phase + 1
-            if phase == 3 then
-              action.prolonged_usage = false
-            else
-              patient.num_animation_ticks = 3 - math.abs(phase)
-            end
-            timer = 6
-          else
-            action.secondary_anim = 1030
-          end
-        end,
-        after_use = --[[persistable:cardiogram_cardio_after_use]] function()
-          if #staff.action_queue == 1 then
-            staff:setNextAction{name = "meander"}
-          else
-            staff:finishAction(staff_idle)
-          end
-        end,
-      }
-      patient:queueAction{
-        name = "walk",
-        x = sx,
-        y = sy,
-        is_leaving = true,
-        must_happen = false,
-        no_truncate = true,
-      }
-      patient:queueAction{
-        name = "use_screen",
-        object = screen,
-        is_leaving = true,
-        must_happen = true,
-        after_use = --[[persistable:cardiogram_screen_after_use2]] function()
-          if #patient.action_queue == 1 then
-            self:dealtWithPatient(patient)
-          end
-        end,
-      }
-    end,
+    after_use = screen_after_use,
   }
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/rooms/decontamination.lua
+++ b/CorsixTH/Lua/rooms/decontamination.lua
@@ -52,7 +52,7 @@ end
 
 function DecontaminationRoom:commandEnteringStaff(staff)
   self.staff_member = staff
-  staff:setNextAction{name = "meander"}
+  staff:setNextAction(MeanderAction())
   return Room.commandEnteringStaff(self, staff)
 end
 
@@ -69,24 +69,19 @@ function DecontaminationRoom:commandEnteringPatient(patient)
   end
 
   staff:walkTo(stf_x, stf_y)
-  staff:queueAction{
-    name = "idle",
-    direction = console.direction == "north" and "west" or "north",
-    loop_callback = loop_callback,
-    shower_ready = true,
-  }
-  staff:queueAction{
-    name = "use_object",
-    object = console,
-  }
+
+  local idle_action = IdleAction():setDirection(console.direction == "north" and "west" or "north")
+      :setLoopCallback(loop_callback)
+  idle_action.shower_ready = true
+  staff:queueAction(idle_action)
+  staff:queueAction(UseObjectAction(console))
 
   patient:walkTo(pat_x, pat_y)
-  patient:queueAction{
-    name = "idle",
-    direction = shower.direction == "north" and "north" or "west",
-    loop_callback = loop_callback,
-    shower_ready = true,
-  }
+
+  idle_action = IdleAction():setDirection(shower.direction == "north" and "north" or "west")
+      :setLoopCallback(loop_callback)
+  idle_action.shower_ready = true
+  patient:queueAction(idle_action)
 
   local prolonged = true
   local length = math.random() * 3 - staff.profile.skill
@@ -107,19 +102,14 @@ function DecontaminationRoom:commandEnteringPatient(patient)
     if not self.staff_member then
       return
     end
-    self.staff_member:setNextAction{name = "meander"}
+    self.staff_member:setNextAction(MeanderAction())
     if not patient.going_home then
       self:dealtWithPatient(patient)
     end
   end
 
-  patient:queueAction{
-    name = "use_object",
-    object = shower,
-    prolonged_usage = prolonged,
-    loop_callback = shower_loop_callback,
-    after_use = shower_after_use,
-  }
+  patient:queueAction(UseObject(shower):setProlongedUsage(prolonged)
+      :setLoopCallback(shower_loop_callback):setAfterUse(shower_after_use))
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/rooms/dna_fixer.lua
+++ b/CorsixTH/Lua/rooms/dna_fixer.lua
@@ -65,34 +65,21 @@ function DNAFixerRoom:commandEnteringPatient(patient)
 
       local fixer_after_use = --[[persistable:dna_fixer_after_use]] function()
         self:dealtWithPatient(patient)
-        staff:setNextAction{name = "meander"}
+        staff:setNextAction(MeanderAction())
       end
-      patient:setNextAction{
-        name = "use_object",
-        object = dna_fixer,
-        prolonged_usage = false,
-        after_use = fixer_after_use,
-      }
 
-      staff:setNextAction{
-        name = "use_object",
-        object = console,
-      }
+      patient:setNextAction(UseObjectAction(dna_fixer):setProlongedUsage():setAfterUse(fixer_after_use))
+      staff:setNextAction(UseObjectAction(console))
     end
   end
   -- As soon as one starts to idle the callback is called to see if the other one is already idling.
   patient:walkTo(pat_x, pat_y)
-  patient:queueAction{
-    name = "idle",
-    direction = dna_fixer.direction == "north" and "north" or "west",
-    loop_callback = loop_callback,
-  }
+  patient:queueAction(IdleAction():setDirection(dna_fixer.direction == "north" and "north" or "west")
+      :setLoopCallback(loop_callback))
+
   staff:walkTo(stf_x, stf_y)
-  staff:queueAction{
-    name = "idle",
-    direction = console.direction == "north" and "north" or "west",
-    loop_callback = loop_callback,
-  }
+  staff:queueAction(IdleAction():setDirection(console.direction == "north" and "north" or "west")
+      :setLoopCallback(loop_callback))
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/rooms/dna_fixer.lua
+++ b/CorsixTH/Lua/rooms/dna_fixer.lua
@@ -62,14 +62,16 @@ function DNAFixerRoom:commandEnteringPatient(patient)
       -- We need to change to another type before starting, to be able
       -- to have different animations depending on gender.
       patient:setType(patient.change_into)
+
+      local fixer_after_use = --[[persistable:dna_fixer_after_use]] function()
+        self:dealtWithPatient(patient)
+        staff:setNextAction{name = "meander"}
+      end
       patient:setNextAction{
         name = "use_object",
         object = dna_fixer,
         prolonged_usage = false,
-        after_use = --[[persistable:dna_fixer_after_use]] function()
-          self:dealtWithPatient(patient)
-          staff:setNextAction{name = "meander"}
-        end,
+        after_use = fixer_after_use,
       }
 
       staff:setNextAction{

--- a/CorsixTH/Lua/rooms/electrolysis.lua
+++ b/CorsixTH/Lua/rooms/electrolysis.lua
@@ -87,35 +87,23 @@ function ElectrolysisRoom:commandEnteringPatient(patient)
 
       local after_electrolysis = --[[persistable:electrolysis_after_use]] function()
         self:dealtWithPatient(patient)
-        staff:setNextAction{name = "meander"}
+        staff:setNextAction(MeanderAction())
       end
 
-      patient:setNextAction{
-        name = "use_object",
-        object = electrolyser,
-        loop_callback = loop_callback_electrolysis,
-        after_use = after_electrolysis
-      }
+      local use_action = UseObjectAction(electrolyser):setLoopCallback(loop_callback_electrolysis)
+      patient:setNextAction(use_action:setAfterUse(after_electrolysis))
 
-      staff:setNextAction{
-        name = "use_object",
-        object = console,
-      }
+      staff:setNextAction(UseObjectAction(console))
     end
   end
   -- As soon as one starts to idle the callback is called to see if the other one is already idling.
   patient:walkTo(pat_x, pat_y)
-  patient:queueAction{
-    name = "idle",
-    direction = electrolyser.direction == "north" and "east" or "south",
-    loop_callback = loop_callback,
-  }
+  patient:queueAction(IdleAction():setDirection(electrolyser.direction == "north" and "east" or "south")
+      :setLoopCallback(loop_callback))
+
   staff:walkTo(stf_x, stf_y)
-  staff:queueAction{
-    name = "idle",
-    direction = console.direction == "north" and "east" or "south",
-    loop_callback = loop_callback,
-  }
+  staff:queueAction(IdleAction():setDirection(console.direction == "north" and "east" or "south")
+      :setLoopCallback(loop_callback))
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/rooms/fracture_clinic.lua
+++ b/CorsixTH/Lua/rooms/fracture_clinic.lua
@@ -57,24 +57,19 @@ function FractureRoom:commandEnteringPatient(patient)
   local stf_x, stf_y = cast:getSecondaryUsageTile()
 
   staff:walkTo(stf_x, stf_y)
-  staff:queueAction{name = "idle", direction = cast.direction == "north" and "west" or "north"}
+  staff:queueAction(IdleAction():setDirection(cast.direction == "north" and "west" or "north"))
+
   patient:walkTo(pat_x, pat_y)
 
   local after_fracture = --[[persistable:fracture_clinic_after_use]] function()
     patient:setLayer(2, 0) -- Remove casts
     patient:setLayer(3, 0)
     patient:setLayer(4, 0)
-    staff:setNextAction{name = "meander"}
+    staff:setNextAction(MeanderAction())
     self:dealtWithPatient(patient)
   end
 
-  patient:queueAction{
-    name = "multi_use_object",
-    object = cast,
-    use_with = staff,
-    after_use = after_fracture
-  }
-
+  patient:queueAction(MultiUseObjectAction(cast, staff):setAfterUse(after_fracture))
   return Room.commandEnteringPatient(self, patient)
 end
 

--- a/CorsixTH/Lua/rooms/fracture_clinic.lua
+++ b/CorsixTH/Lua/rooms/fracture_clinic.lua
@@ -59,17 +59,20 @@ function FractureRoom:commandEnteringPatient(patient)
   staff:walkTo(stf_x, stf_y)
   staff:queueAction{name = "idle", direction = cast.direction == "north" and "west" or "north"}
   patient:walkTo(pat_x, pat_y)
+
+  local after_fracture = --[[persistable:fracture_clinic_after_use]] function()
+    patient:setLayer(2, 0) -- Remove casts
+    patient:setLayer(3, 0)
+    patient:setLayer(4, 0)
+    staff:setNextAction{name = "meander"}
+    self:dealtWithPatient(patient)
+  end
+
   patient:queueAction{
     name = "multi_use_object",
     object = cast,
     use_with = staff,
-    after_use = --[[persistable:fracture_clinic_after_use]] function()
-      patient:setLayer(2, 0) -- Remove casts
-      patient:setLayer(3, 0)
-      patient:setLayer(4, 0)
-      staff:setNextAction{name = "meander"}
-      self:dealtWithPatient(patient)
-    end,
+    after_use = after_fracture
   }
 
   return Room.commandEnteringPatient(self, patient)

--- a/CorsixTH/Lua/rooms/general_diag.lua
+++ b/CorsixTH/Lua/rooms/general_diag.lua
@@ -53,38 +53,25 @@ function GeneralDiagRoom:commandEnteringPatient(patient)
   local screen, sx, sy = self.world:findObjectNear(patient, "screen")
   patient:walkTo(sx, sy)
 
-  local after_use_screen = --[[persistable:general_diag_screen_after_use1]] function()
+  local after_use_screen1 = --[[persistable:general_diag_screen_after_use1]] function()
     local staff = self.staff_member
     local trolley, cx, cy = self.world:findObjectNear(patient, "crash_trolley")
     staff:walkTo(trolley:getSecondaryUsageTile())
-    local staff_idle = {name = "idle"}
+    local staff_idle = IdleAction()
     staff:queueAction(staff_idle)
     patient:walkTo(cx, cy, true)
 
     local after_use_trolley = --[[persistable:general_diag_trolley_after_use]] function()
       if #staff.action_queue == 1 then
-        staff:setNextAction{name = "meander"}
+        staff:setNextAction(MeanderAction())
       else
         staff:finishAction(staff_idle)
       end
     end
 
-    patient:queueAction{
-      name = "multi_use_object",
-      object = trolley,
-      use_with = staff,
-      must_happen = false,
-      prolonged_usage = false,
-      after_use = after_use_trolley
-    }
-    patient:queueAction{
-      name = "walk",
-      x = sx,
-      y = sy,
-      is_leaving = true,
-      must_happen = false,
-      no_truncate = true,
-    }
+    patient:queueAction(MultiUseObjectAction(trolley, staff):setMustHappen()
+        :setProlongedUsage(false):setAfterUse(after_use_trolley))
+    patient:queueAction(WalkAction(sx, sy):setIsLeaving():setMustHappen(false):setNoTruncate())
 
     local after_use_screen2 = --[[persistable:general_diag_screen_after_use2]] function()
       if #patient.action_queue == 1 then
@@ -92,20 +79,11 @@ function GeneralDiagRoom:commandEnteringPatient(patient)
       end
     end
 
-    patient:queueAction{
-      name = "use_screen",
-      object = screen,
-      is_leaving = true,
-      must_happen = true,
-      after_use = after_use_screen2
-    }
+    patient:queueAction(UseScreenAction(screen):setIsLeaving():setMustHappen()
+        :setAfterUse(after_use_screen2))
   end
 
-  patient:queueAction{
-    name = "use_screen",
-    object = screen,
-    after_use = after_use_screen
-  }
+  patient:queueAction(UseScreenAction(screen):setAfterUse(after_use_screen1))
   return Room.commandEnteringPatient(self, patient)
 end
 

--- a/CorsixTH/Lua/rooms/hair_restoration.lua
+++ b/CorsixTH/Lua/rooms/hair_restoration.lua
@@ -63,35 +63,24 @@ function HairRestorationRoom:commandEnteringPatient(patient)
 
       local after_use_restore = --[[persistable:hair_restoration_after_use]] function()
         patient:setLayer(0, patient.layers[0] + 2) -- Change to normal hair
-        staff:setNextAction{name = "meander"}
+        staff:setNextAction(MeanderAction())
         self:dealtWithPatient(patient)
       end
 
-      patient:setNextAction{
-        name = "use_object",
-        object = hair_restorer,
-        loop_callback = loop_callback_restore,
-        after_use = after_use_restore,
-      }
-      staff:setNextAction{
-        name = "use_object",
-        object = console,
-      }
+      patient:setNextAction(UseObjectAction(hair_restorer)
+          :setLoopCallback(loop_callback_restore):setAfterUse(after_use_restore))
+
+      staff:setNextAction(UseObjectAction(console))
     end
   end
 
   patient:walkTo(pat_x, pat_y)
-  patient:queueAction{
-    name = "idle",
-    direction = hair_restorer.direction == "north" and "east" or "south",
-    loop_callback = loop_callback,
-  }
+  patient:queueAction(IdleAction():setDirection(hair_restorer.direction == "north" and "east" or "south")
+      :setLoopCallback(loop_callback))
+
   staff:walkTo(stf_x, stf_y)
-  staff:queueAction{
-    name = "idle",
-    direction = console.direction == "north" and "east" or "south",
-    loop_callback = loop_callback,
-  }
+  staff:queueAction(IdleAction():setDirection(console.direction == "north" and "east" or "south")
+      :setLoopCallback(loop_callback))
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/rooms/hair_restoration.lua
+++ b/CorsixTH/Lua/rooms/hair_restoration.lua
@@ -57,17 +57,21 @@ function HairRestorationRoom:commandEnteringPatient(patient)
 
   local --[[persistable:hair_restoration_shared_loop_callback]] function loop_callback()
     if staff.action_queue[1].name == "idle" and patient.action_queue[1].name == "idle" then
+      local loop_callback_restore = --[[persistable:hair_restoration_loop_callback]] function(action)
+        action.prolonged_usage = false
+      end
+
+      local after_use_restore = --[[persistable:hair_restoration_after_use]] function()
+        patient:setLayer(0, patient.layers[0] + 2) -- Change to normal hair
+        staff:setNextAction{name = "meander"}
+        self:dealtWithPatient(patient)
+      end
+
       patient:setNextAction{
         name = "use_object",
         object = hair_restorer,
-        loop_callback = --[[persistable:hair_restoration_loop_callback]] function(action)
-          action.prolonged_usage = false
-        end,
-        after_use = --[[persistable:hair_restoration_after_use]] function()
-          patient:setLayer(0, patient.layers[0] + 2) -- Change to normal hair
-          staff:setNextAction{name = "meander"}
-          self:dealtWithPatient(patient)
-        end,
+        loop_callback = loop_callback_restore,
+        after_use = after_use_restore,
       }
       staff:setNextAction{
         name = "use_object",

--- a/CorsixTH/Lua/rooms/inflation.lua
+++ b/CorsixTH/Lua/rooms/inflation.lua
@@ -56,22 +56,18 @@ function InflationRoom:commandEnteringPatient(patient)
   local orientation = inflator.object_type.orientations[inflator.direction]
   local stf_x, stf_y = inflator:getSecondaryUsageTile()
 
-  staff:setNextAction{name = "walk", x = stf_x, y = stf_y}
-  staff:queueAction{name = "idle", direction = inflator.direction == "north" and "east" or "south"}
-  patient:setNextAction{name = "walk", x = pat_x, y = pat_y}
+  staff:setNextAction(WalkAction(stf_x, stf_y))
+  staff:queueAction(IdleAction():setDirection(inflator.direction == "north" and "east" or "south"))
+
+  patient:setNextAction(WalkAction(pat_x, pat_y))
 
   local inflation_after_use = --[[persistable:inflation_after_use]] function()
     patient:setLayer(0, patient.layers[0] - 10) -- Change to normal head
-    staff:setNextAction{name = "meander"}
+    staff:setNextAction(MeanderAction())
     self:dealtWithPatient(patient)
   end
 
-  patient:queueAction{
-    name = "multi_use_object",
-    object = inflator,
-    use_with = staff,
-    after_use = inflation_after_use,
-  }
+  patient:queueAction(MultiUseObjectAction(inflator, staff):setAfterUse(inflation_after_use))
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/rooms/inflation.lua
+++ b/CorsixTH/Lua/rooms/inflation.lua
@@ -59,15 +59,18 @@ function InflationRoom:commandEnteringPatient(patient)
   staff:setNextAction{name = "walk", x = stf_x, y = stf_y}
   staff:queueAction{name = "idle", direction = inflator.direction == "north" and "east" or "south"}
   patient:setNextAction{name = "walk", x = pat_x, y = pat_y}
+
+  local inflation_after_use = --[[persistable:inflation_after_use]] function()
+    patient:setLayer(0, patient.layers[0] - 10) -- Change to normal head
+    staff:setNextAction{name = "meander"}
+    self:dealtWithPatient(patient)
+  end
+
   patient:queueAction{
     name = "multi_use_object",
     object = inflator,
     use_with = staff,
-    after_use = --[[persistable:inflation_after_use]] function()
-      patient:setLayer(0, patient.layers[0] - 10) -- Change to normal head
-      staff:setNextAction{name = "meander"}
-      self:dealtWithPatient(patient)
-    end,
+    after_use = inflation_after_use,
   }
 
   return Room.commandEnteringPatient(self, patient)

--- a/CorsixTH/Lua/rooms/jelly_vat.lua
+++ b/CorsixTH/Lua/rooms/jelly_vat.lua
@@ -56,22 +56,18 @@ function JellyVatRoom:commandEnteringPatient(patient)
   local orientation = moulder.object_type.orientations[moulder.direction]
   local pat_x, pat_y = moulder:getSecondaryUsageTile()
 
-  staff:setNextAction{name = "walk", x = stf_x, y = stf_y}
+  staff:setNextAction(WalkAction(stf_x, stf_y))
 
   local jellyvat_after_use = --[[persistable:jelly_vat_after_use]] function()
-    staff:setNextAction{name = "meander"}
+    staff:setNextAction(MeanderAction())
     self:dealtWithPatient(patient)
   end
 
-  staff:queueAction{
-    name = "multi_use_object",
-    object = moulder,
-    use_with = patient,
-    invisible_phase_span = {-3, 4},
-    after_use = jellyvat_after_use,
-  }
-  patient:setNextAction{name = "walk", x = pat_x, y = pat_y}
-  patient:queueAction{name = "idle", direction = moulder.direction == "north" and "west" or "north"}
+  staff:queueAction(MultiUseObjectAction(moulder, patient):setInvisiblePhaseSpan({-3, 4})
+      :setAfterUse(jellyvat_after_use))
+
+  patient:setNextAction(WalkAction(pat_x, pat_y))
+  patient:queueAction(IdleAction():setDirection(moulder.direction == "north" and "west" or "north"))
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/rooms/jelly_vat.lua
+++ b/CorsixTH/Lua/rooms/jelly_vat.lua
@@ -57,15 +57,18 @@ function JellyVatRoom:commandEnteringPatient(patient)
   local pat_x, pat_y = moulder:getSecondaryUsageTile()
 
   staff:setNextAction{name = "walk", x = stf_x, y = stf_y}
+
+  local jellyvat_after_use = --[[persistable:jelly_vat_after_use]] function()
+    staff:setNextAction{name = "meander"}
+    self:dealtWithPatient(patient)
+  end
+
   staff:queueAction{
     name = "multi_use_object",
     object = moulder,
     use_with = patient,
     invisible_phase_span = {-3, 4},
-    after_use = --[[persistable:jelly_vat_after_use]] function()
-      staff:setNextAction{name = "meander"}
-      self:dealtWithPatient(patient)
-    end,
+    after_use = jellyvat_after_use,
   }
   patient:setNextAction{name = "walk", x = pat_x, y = pat_y}
   patient:queueAction{name = "idle", direction = moulder.direction == "north" and "west" or "north"}

--- a/CorsixTH/Lua/rooms/operating_theatre.lua
+++ b/CorsixTH/Lua/rooms/operating_theatre.lua
@@ -84,19 +84,11 @@ local function wait_for_object(humanoid, obj, must_happen)
     if action.todo_interrupt or not obj.user then
       humanoid:finishAction(action)
     else
-      humanoid:queueAction({
-        name = "idle",
-        count = 5,
-        must_happen = must_happen,
-      }, 0)
+      humanoid:queueAction(IdleAction():setCount(5):setMustHappen(), 0)
     end
   end
 
-  return {
-    name = "idle",
-    must_happen = must_happen,
-    loop_callback = loop_callback_wait
-  }
+  return IdleAction():setMustHappen(must_happen):setLoopCallback(loop_callback_wait)
 end
 
 --! Returns true if an operation is ongoing
@@ -115,10 +107,7 @@ function OperatingTheatreRoom:commandEnteringStaff(staff)
   local screen, screen_x, screen_y = self.world:findObjectNear(staff, "surgeon_screen")
   staff:walkTo(screen_x, screen_y)
   staff:queueAction(wait_for_object(staff, screen))
-  staff:queueAction{
-    name = "use_screen",
-    object = screen
-  }
+  staff:queueAction(UseScreenAction(screen))
 
   -- Resume operation if already ongoing
   if self:isOperating() then
@@ -128,7 +117,7 @@ function OperatingTheatreRoom:commandEnteringStaff(staff)
 
     local table, table_x, table_y = self.world:findObjectNear(staff, "operating_table_b")
     self:queueWashHands(staff)
-    staff:queueAction({name = "walk", x = table_x, y = table_y})
+    staff:queueAction(WalkAction(table_x, table_y))
     staff:queueAction(self:buildTableAction2(ongoing_action, table))
   end
 
@@ -139,22 +128,12 @@ function OperatingTheatreRoom:commandEnteringStaff(staff)
     self.staff_member_set[staff] = "ready"
     self:tryAdvanceQueue()
   end
-
-  local meander = {name = "meander", must_happen = true,
-    loop_callback = loop_callback_more_patients
-  }
-  staff:queueAction(meander)
+  staff:queueAction(MeanderAction():setMustHappen():setLoopCallback(loop_callback_more_patients))
 
   -- Ensure that surgeons turn back into doctors when they leave
-  staff:queueAction{
-    name = "walk",
-    x = screen_x,
-    y = screen_y,
-    must_happen = true,
-    truncate_only_on_high_priority = true,
-    is_leaving = true,
-  }
-  staff:queueAction{name = "use_screen", object = screen, must_happen = true, is_leaving = true}
+  local walk_action = WalkAction(screen_x, screen_y):setMustHappen()
+  staff:queueAction(walk_action:setIsLeaving():setTruncateOnHighPriority())
+  staff:queueAction(UseScreenAction(screen):setMustHappen():setIsLeaving())
 
   return Room.commandEnteringStaff(self, staff, true)
 end
@@ -204,16 +183,9 @@ function OperatingTheatreRoom:buildTableAction1(surgeon1, patient, operation_tab
     end
   end
 
-  return {
-    name = "multi_use_object",
-    object = operation_table,
-    use_with = patient,
-    prolonged_usage = true,
-    loop_callback = loop_callback_multi_use,
-    after_use = after_use_table,
-    must_happen = true,
-    no_truncate = true,
-  }
+  return MultiUseObjectAction(operation_table, patient):setProlongedUsage()
+      :setLoopCallback(loop_callback_multi_use):setAfterUse(after_use_table)
+      :setMustHappen():setNoTruncate()
 end
 
 --! Builds the second operation action (i.e. with the surgeon whose we
@@ -236,14 +208,8 @@ function OperatingTheatreRoom:buildTableAction2(multi_use, operation_table_b)
     multi_use.prolonged_usage = false
   end
 
-  return {
-    name = "use_object",
-    object = operation_table_b,
-    loop_callback = loop_callback_use_object,
-    after_use = after_use_use_object,
-    must_happen = true,
-    no_truncate = true,
-  }
+  return UseObjectAction(operation_table_b):setLoopCallback(loop_callback_use_object)
+      :setAfterUse(after_use_use_object):setMustHappen():setNoTruncate()
 end
 
 --! Sends the surgeon to the nearest operation sink ("op_sink1")
@@ -253,9 +219,9 @@ end
 --! Default value is true.
 function OperatingTheatreRoom:queueWashHands(surgeon, at_front)
   local sink, sink_x, sink_y = self.world:findObjectNear(surgeon, "op_sink1")
-  local walk = {name = "walk", x = sink_x, y = sink_y, must_happen = true, no_truncate = true}
+  local walk = WalkAction(sink_x, sink_y):setMustHappen():setNoTruncate()
   local wait = wait_for_object(surgeon, sink, true)
-  local wash = {name = "use_object", object = sink, must_happen = true}
+  local wash = UseObjectAction(sink):setMustHappen()
 
   for pos, action in pairs({walk, wait, wash}) do
     if (at_front) then
@@ -286,7 +252,7 @@ function OperatingTheatreRoom:commandEnteringPatient(patient)
   -- Patient changes into surgical gown
   local screen, sx, sy = self.world:findObjectNear(patient, "surgeon_screen")
   patient:walkTo(sx, sy)
-  patient:queueAction{name = "use_screen", object = screen}
+  patient:queueAction(UseScreenAction(screen))
 
   -- Meanwhile, surgeons wash their hands
   -- TODO: They sometimes overlap each other when doing that. Can we avoid that?
@@ -344,28 +310,22 @@ function OperatingTheatreRoom:commandEnteringPatient(patient)
   --
   -- first surgeon walk over to the operating table
   local obj, ox, oy = self.world:findObjectNear(surgeon1, "operating_table")
-  surgeon1:queueAction({name = "walk", x = ox, y = oy, must_happen = true, no_truncate = true}, 4)
-  surgeon1:queueAction({name = "idle", loop_callback = operation_standby, must_happen = true}, 5)
+  surgeon1:queueAction(WalkAction(ox, oy):setMustHappen():setNoTruncate(), 4)
+  surgeon1:queueAction(IdleAction():setLoopCallback(operation_standby):setMustHappen(), 5)
 
   -- Patient walk to the side of the operating table
   ox, oy = obj:getSecondaryUsageTile()
-  patient:queueAction{name = "walk", x = ox, y = oy, must_happen = true, no_truncate = true}
-  patient:queueAction{name = "idle", loop_callback = operation_standby, must_happen = true}
+  patient:queueAction(WalkAction(ox, oy):setMustHappen():setNoTruncate())
+  patient:queueAction(IdleAction():setLoopCallback(operation_standby):setMustHappen())
 
   -- Patient changes out of the gown afterwards
-  patient:queueAction{
-    name = "walk",
-    x = sx,
-    y = sy,
-    must_happen = true,
-    no_truncate = true,
-  }
-  patient:queueAction{name = "use_screen", object = screen, must_happen = true}
+  patient:queueAction(WalkAction(sx, sy):setMustHappen():setNoTruncate())
+  patient:queueAction(UseScreenAction(screen):setMustHappen())
 
   -- Meanwhile, second surgeon walks over to other side of operating table
   obj, ox, oy = self.world:findObjectNear(surgeon1, "operating_table_b")
-  surgeon2:queueAction({name = "walk", x = ox, y = oy, must_happen = true, no_truncate = true}, 4)
-  surgeon2:queueAction({name = "idle", loop_callback = operation_standby, must_happen = true}, 5)
+  surgeon2:queueAction(WalkAction(ox, oy):setMustHappen():setNoTruncate(), 4)
+  surgeon2:queueAction(IdleAction():setLoopCallback(operation_standby):setMustHappen(), 5)
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/rooms/operating_theatre.lua
+++ b/CorsixTH/Lua/rooms/operating_theatre.lua
@@ -88,7 +88,7 @@ local function wait_for_object(humanoid, obj, must_happen)
     end
   end
 
-  return IdleAction():setMustHappen(must_happen):setLoopCallback(loop_callback_wait)
+  return IdleAction():setMustHappen(must_happen or false):setLoopCallback(loop_callback_wait)
 end
 
 --! Returns true if an operation is ongoing

--- a/CorsixTH/Lua/rooms/pharmacy.lua
+++ b/CorsixTH/Lua/rooms/pharmacy.lua
@@ -76,24 +76,28 @@ function PharmacyRoom:commandEnteringPatient(patient)
 
   patient:setNextAction{name = "walk", x = pat_x, y = pat_y}
   patient:queueAction{name = "idle", direction = cabinet.direction == "north" and "east" or "south"}
+
   staff:setNextAction{name = "walk", x = stf_x, y = stf_y}
+
+  local after_use_pharmacy = --[[persistable:pharmacy_after_use]] function()
+    --if we haven't tried to edit the room while she's animating, meander
+    if #staff.action_queue == 1 then
+      staff:setNextAction{name = "meander"}
+    end
+    if patient_class == "Invisible Patient" or patient_class == "Transparent Male Patient" then
+      patient:setType "Standard Male Patient"
+    elseif patient_class == "Transparent Female Patient" then
+      patient:setType "Standard Female Patient"
+    end
+    self:dealtWithPatient(patient)
+  end
+
   staff:queueAction{
     name = "multi_use_object",
     object = cabinet,
     use_with = patient,
     layer3 = layer3,
-    after_use = --[[persistable:pharmacy_after_use]] function()
-      --if we haven't tried to edit the room while she's animating, meander
-      if #staff.action_queue == 1 then
-        staff:setNextAction{name = "meander"}
-      end
-      if patient_class == "Invisible Patient" or patient_class == "Transparent Male Patient" then
-        patient:setType "Standard Male Patient"
-      elseif patient_class == "Transparent Female Patient" then
-        patient:setType "Standard Female Patient"
-      end
-      self:dealtWithPatient(patient)
-    end,
+    after_use = after_use_pharmacy
   }
 
   return Room.commandEnteringPatient(self, patient)

--- a/CorsixTH/Lua/rooms/pharmacy.lua
+++ b/CorsixTH/Lua/rooms/pharmacy.lua
@@ -74,15 +74,15 @@ function PharmacyRoom:commandEnteringPatient(patient)
     layer3 = math.random(0, 2) * 2
   end
 
-  patient:setNextAction{name = "walk", x = pat_x, y = pat_y}
-  patient:queueAction{name = "idle", direction = cabinet.direction == "north" and "east" or "south"}
+  patient:setNextAction(WalkAction(pat_x, pat_y))
+  patient:queueAction(IdleAction():setDirection(cabinet.direction == "north" and "east" or "south"))
 
-  staff:setNextAction{name = "walk", x = stf_x, y = stf_y}
+  staff:setNextAction(WalkAction(stf_x, stf_y))
 
   local after_use_pharmacy = --[[persistable:pharmacy_after_use]] function()
     --if we haven't tried to edit the room while she's animating, meander
     if #staff.action_queue == 1 then
-      staff:setNextAction{name = "meander"}
+      staff:setNextAction(MeanderAction())
     end
     if patient_class == "Invisible Patient" or patient_class == "Transparent Male Patient" then
       patient:setType "Standard Male Patient"
@@ -92,13 +92,9 @@ function PharmacyRoom:commandEnteringPatient(patient)
     self:dealtWithPatient(patient)
   end
 
-  staff:queueAction{
-    name = "multi_use_object",
-    object = cabinet,
-    use_with = patient,
-    layer3 = layer3,
-    after_use = after_use_pharmacy
-  }
+  local multiuse_action = MultiUseObjectAction(cabinet, patient):setAfterUse(after_use_pharmacy)
+  multiuse_action.layer3 = layer3
+  staff:queueAction(multiuse_action)
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/rooms/psych.lua
+++ b/CorsixTH/Lua/rooms/psych.lua
@@ -62,10 +62,10 @@ function PsychRoom:commandEnteringStaff(staff)
   self.staff_member = staff
   local obj, ox, oy = self.world:findFreeObjectNearToUse(staff, "bookcase", "near")
   if not obj then
-    staff:setNextAction{name = "meander"}
+    staff:setNextAction(MeanderAction())
   else
     staff:walkTo(ox, oy)
-    staff:queueAction{name = "use_object", object = obj}
+    staff:queueAction(UseObjectAction(obj))
     local num_meanders = math.random(2, 8)
     local loop_callback_meanders = --[[persistable:psych_meander_loop_callback]] function(action)
       num_meanders = num_meanders - 1
@@ -73,10 +73,7 @@ function PsychRoom:commandEnteringStaff(staff)
         self:commandEnteringStaff(staff)
       end
     end
-    staff:queueAction{
-      name = "meander",
-      loop_callback = loop_callback_meanders
-    }
+    staff:queueAction(MeanderAction():setLoopCallback(loop_callback_meanders))
   end
   return Room.commandEnteringStaff(self, staff, true)
 end
@@ -86,7 +83,7 @@ function PsychRoom:commandEnteringPatient(patient)
 
   local obj, ox, oy = self.world:findObjectNear(patient, "couch")
   patient:walkTo(ox, oy)
-  patient:queueAction{name = "use_object", object = obj}
+  patient:queueAction(UseObjectAction(obj))
 
   local duration = math.random(16, 72)
   local bookcase, bx, by
@@ -102,21 +99,17 @@ function PsychRoom:commandEnteringPatient(patient)
         -- Diagnosed patients (Elvis) need to change clothes
         local after_use_screen = --[[persistable:psych_screen_after_use]] function()
           if self:getStaffMember() then
-            self:getStaffMember():setNextAction{name = "meander"}
+            self:getStaffMember():setNextAction(MeanderAction())
           end
           self:dealtWithPatient(patient)
         end
 
         obj, ox, oy = self.world:findObjectNear(patient, "screen")
         patient:walkTo(ox, oy)
-        patient:queueAction{
-          name = "use_screen",
-          object = obj,
-          after_use = after_use_screen
-        }
+        patient:queueAction(UseScreenAction(obj):setAfterUse(after_use_screen))
       else
         if self:getStaffMember() then
-          self:getStaffMember():setNextAction{name = "meander"}
+          self:getStaffMember():setNextAction(MeanderAction())
         end
         self:dealtWithPatient(patient)
       end
@@ -124,23 +117,15 @@ function PsychRoom:commandEnteringPatient(patient)
     end
     if bookcase and (duration % 10) == 0 and math.random(1, 2) == 1 then
       staff:walkTo(bx, by)
-      staff:queueAction{name = "use_object", object = bookcase}
-      staff:queueAction{name = "walk", x = ox, y = oy}
-      staff:queueAction{
-        name = "use_object",
-        object = obj,
-        loop_callback = loop_callback,
-      }
+      staff:queueAction(UseObjectAction(bookcase))
+      staff:queueAction(WalkAction(ox, oy))
+      staff:queueAction(UseObjectAction(obj):setLoopCallback(loop_callback))
       duration = math.max(8, duration - 72)
     end
   end
   obj, ox, oy = self.world:findObjectNear(staff, "comfortable_chair")
   staff:walkTo(ox, oy)
-  staff:queueAction{
-    name = "use_object",
-    object = obj,
-    loop_callback = loop_callback,
-  }
+  staff:queueAction(UseObjectAction(obj):setLoopCallback(loop_callback))
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/rooms/research.lua
+++ b/CorsixTH/Lua/rooms/research.lua
@@ -86,12 +86,8 @@ function ResearchRoom:doStaffUseCycle(staff, previous_object)
         self.hospital.research:addResearchPoints(100)
       end
 
-      staff:queueAction {
-        name = "use_object",
-        object = obj,
-        loop_callback = loop_callback_desk,
-        after_use = after_use_desk
-      }
+      staff:queueAction(UseObjectAction(obj):setLoopCallback(loop_callback_desk)
+          :setAfterUse(after_use_desk))
     else
       local after_use_obj = --[[persistable:research_obj_after_use]] function()
         if obj.object_type.id == "computer" then
@@ -102,11 +98,7 @@ function ResearchRoom:doStaffUseCycle(staff, previous_object)
         end
       end
 
-      staff:queueAction {
-        name = "use_object",
-        object = obj,
-        after_use = after_use_obj
-      }
+      staff:queueAction(UseObjectAction(obj):setAfterUse(after_use_obj))
     end
   end
 
@@ -118,10 +110,7 @@ function ResearchRoom:doStaffUseCycle(staff, previous_object)
     end
   end
 
-  staff:queueAction {
-    name = "meander",
-    loop_callback = loop_callback_meander
-  }
+  staff:queueAction(MeanderAction():setLoopCallback(loop_callback_meander))
 end
 
 function ResearchRoom:roomFinished()
@@ -146,8 +135,7 @@ function ResearchRoom:roomFinished()
   end
   -- Also check if it would be good to hire a researcher.
   if not self.hospital:hasStaffOfCategory("Researcher") then
-    self.world.ui.adviser:say(_A.room_requirements
-    .research_room_need_researcher)
+    self.world.ui.adviser:say(_A.room_requirements.research_room_need_researcher)
   end
   return Room.roomFinished(self)
 end
@@ -168,7 +156,7 @@ function ResearchRoom:commandEnteringPatient(patient)
   local orientation = autopsy.object_type.orientations[autopsy.direction]
   local pat_x, pat_y = autopsy:getSecondaryUsageTile()
   patient:walkTo(pat_x, pat_y)
-  patient:queueAction{name = "idle", direction = "east"}
+  patient:queueAction(IdleAction():setDirection("east"))
   staff:walkTo(stf_x, stf_y)
 
   local after_use_autopsy = --[[persistable:autopsy_after_use]] function()
@@ -195,12 +183,7 @@ function ResearchRoom:commandEnteringPatient(patient)
     patient.world:destroyEntity(patient)
   end
 
-  staff:queueAction{
-    name = "multi_use_object",
-    object = autopsy,
-    use_with = patient,
-    after_use = after_use_autopsy
-  }
+  staff:queueAction(MultiUseObjectAction(autopsy, patient):setAfterUse(after_use_autopsy))
   return Room.commandEnteringPatient(self, patient)
 end
 

--- a/CorsixTH/Lua/rooms/slack_tongue.lua
+++ b/CorsixTH/Lua/rooms/slack_tongue.lua
@@ -56,10 +56,10 @@ function SlackTongueRoom:commandEnteringPatient(patient)
   local orientation = slicer.object_type.orientations[slicer.direction]
   local stf_x, stf_y = slicer:getSecondaryUsageTile()
 
-  staff:setNextAction{name = "walk", x = stf_x, y = stf_y}
-  staff:queueAction{name = "idle", direction = slicer.direction == "north" and "east" or "south"}
+  staff:setNextAction(WalkAction(stf_x, stf_y))
+  staff:queueAction(IdleAction():setDirection(slicer.direction == "north" and "east" or "south"))
 
-  patient:setNextAction{name = "walk", x = pat_x, y = pat_y}
+  patient:setNextAction(WalkAction(pat_x, pat_y))
 
   local after_use_slack_tongue = --[[persistable:slack_tongue_after_use]] function()
     if patient.humanoid_class == "Slack Male Patient" then
@@ -67,17 +67,11 @@ function SlackTongueRoom:commandEnteringPatient(patient)
     else
       patient:setLayer(0, patient.layers[0] - 8) -- Change to normal head
     end
-    staff:setNextAction{name = "meander"}
+    staff:setNextAction(MeanderAction())
     self:dealtWithPatient(patient)
   end
 
-  patient:queueAction{
-    name = "multi_use_object",
-    object = slicer,
-    use_with = staff,
-    after_use = after_use_slack_tongue
-  }
-
+  patient:queueAction(MultiUseObjectAction(slicer, staff):setAfterUse(after_use_slack_tongue))
   return Room.commandEnteringPatient(self, patient)
 end
 

--- a/CorsixTH/Lua/rooms/slack_tongue.lua
+++ b/CorsixTH/Lua/rooms/slack_tongue.lua
@@ -58,20 +58,24 @@ function SlackTongueRoom:commandEnteringPatient(patient)
 
   staff:setNextAction{name = "walk", x = stf_x, y = stf_y}
   staff:queueAction{name = "idle", direction = slicer.direction == "north" and "east" or "south"}
+
   patient:setNextAction{name = "walk", x = pat_x, y = pat_y}
+
+  local after_use_slack_tongue = --[[persistable:slack_tongue_after_use]] function()
+    if patient.humanoid_class == "Slack Male Patient" then
+      patient:setType "Standard Male Patient" -- Change to normal head
+    else
+      patient:setLayer(0, patient.layers[0] - 8) -- Change to normal head
+    end
+    staff:setNextAction{name = "meander"}
+    self:dealtWithPatient(patient)
+  end
+
   patient:queueAction{
     name = "multi_use_object",
     object = slicer,
     use_with = staff,
-    after_use = --[[persistable:slack_tongue_after_use]] function()
-      if patient.humanoid_class == "Slack Male Patient" then
-        patient:setType "Standard Male Patient" -- Change to normal head
-      else
-        patient:setLayer(0, patient.layers[0] - 8) -- Change to normal head
-      end
-      staff:setNextAction{name = "meander"}
-      self:dealtWithPatient(patient)
-    end,
+    after_use = after_use_slack_tongue
   }
 
   return Room.commandEnteringPatient(self, patient)

--- a/CorsixTH/Lua/rooms/staff_room.lua
+++ b/CorsixTH/Lua/rooms/staff_room.lua
@@ -53,7 +53,7 @@ function StaffRoom:onHumanoidEnter(humanoid)
     -- Receptionists cannot enter, so we do not have to worry about them
     -- If it is a handyman and he is here to do a job, let him pass
     if not humanoid.on_call then
-      humanoid:setNextAction({name = "use_staffroom"})
+      humanoid:setNextAction(UseStaffRoomAction())
       self.door.queue.visitor_count = self.door.queue.visitor_count + 1
     end
   else

--- a/CorsixTH/Lua/rooms/training.lua
+++ b/CorsixTH/Lua/rooms/training.lua
@@ -120,7 +120,7 @@ end
 
 function TrainingRoom:doStaffUseCycle(humanoid)
   local projector, ox, oy = self.world:findObjectNear(humanoid, "projector")
-  humanoid:queueAction{name = "walk", x = ox, y = oy}
+  humanoid:queueAction(WalkAction(ox, oy))
   local projector_use_time = math.random(6,20)
   local loop_callback_training = --[[persistable:training_loop_callback]] function()
     projector_use_time = projector_use_time - 1
@@ -131,12 +131,12 @@ function TrainingRoom:doStaffUseCycle(humanoid)
       if skeleton then
         humanoid:walkTo(sox, soy)
         for i = 1, math.random(3, 10) do
-          humanoid:queueAction{name = "use_object", object = skeleton}
+          humanoid:queueAction(UseObjectAction(skeleton))
         end
       elseif bookcase then
         humanoid:walkTo(box, boy)
         for i = 1, math.random(3, 10) do
-          humanoid:queueAction{name = "use_object", object = bookcase}
+          humanoid:queueAction(UseObjectAction(bookcas))
         end
       end
       -- go back to the projector
@@ -148,10 +148,7 @@ function TrainingRoom:doStaffUseCycle(humanoid)
     end
   end
 
-  humanoid:queueAction{name = "use_object",
-    object = projector,
-    loop_callback = loop_callback_training
-  }
+  humanoid:queueAction(UseObjectAction(projector):setLoopCallback(loop_callback_training))
 end
 
 function TrainingRoom:onHumanoidEnter(humanoid)
@@ -188,13 +185,13 @@ function TrainingRoom:commandEnteringStaff(humanoid)
           local staff = self.waiting_staff_member
           staff.waiting_on_other_staff = nil
           staff:setNextAction(self:createLeaveAction())
-          staff:queueAction{name = "meander"}
+          staff:queueAction(MeanderAction())
         end
         humanoid.waiting_on_other_staff = true
-        humanoid:setNextAction{name = "meander"}
+        humanoid:setNextAction(MeanderAction())
         self.waiting_staff_member = humanoid
         self.staff_member:setNextAction(self:createLeaveAction())
-        self.staff_member:queueAction{name = "meander"}
+        self.staff_member:queueAction(MeanderAction())
       else
         if obj then
           obj.reserved_for = humanoid
@@ -203,7 +200,7 @@ function TrainingRoom:commandEnteringStaff(humanoid)
           self:setStaffMember(humanoid)
         else
           humanoid:setNextAction(self:createLeaveAction())
-          humanoid:queueAction{name = "meander"}
+          humanoid:queueAction(MeanderAction())
         end
       end
     else
@@ -211,11 +208,11 @@ function TrainingRoom:commandEnteringStaff(humanoid)
       if obj then
         obj.reserved_for = humanoid
         humanoid:walkTo(ox, oy)
-        humanoid:queueAction{name = "use_object", object = obj}
-        humanoid:queueAction{name = "meander"}
+        humanoid:queueAction(UseObjectAction(obj))
+        humanoid:queueAction(MeanderAction())
       else
         humanoid:setNextAction(self:createLeaveAction())
-        humanoid:queueAction{name = "meander"}
+        humanoid:queueAction(MeanderAction())
         humanoid.last_room = nil
       end
     end
@@ -223,7 +220,7 @@ function TrainingRoom:commandEnteringStaff(humanoid)
     self.world.ui.adviser:say(_A.staff_place_advice.only_doctors_in_room
     :format(_S.rooms_long.training_room))
     humanoid:setNextAction(self:createLeaveAction())
-    humanoid:queueAction{name = "meander"}
+    humanoid:queueAction(MeanderAction())
     return
   end
 

--- a/CorsixTH/Lua/rooms/training.lua
+++ b/CorsixTH/Lua/rooms/training.lua
@@ -122,33 +122,35 @@ function TrainingRoom:doStaffUseCycle(humanoid)
   local projector, ox, oy = self.world:findObjectNear(humanoid, "projector")
   humanoid:queueAction{name = "walk", x = ox, y = oy}
   local projector_use_time = math.random(6,20)
+  local loop_callback_training = --[[persistable:training_loop_callback]] function()
+    projector_use_time = projector_use_time - 1
+    if projector_use_time == 0 then
+      local skeleton, sox, soy = self.world:findFreeObjectNearToUse(humanoid, "skeleton", "near")
+      local bookcase, box, boy = self.world:findFreeObjectNearToUse(humanoid, "bookcase", "near")
+      if math.random(0, 1) == 0 and bookcase then skeleton = nil end -- choose one
+      if skeleton then
+        humanoid:walkTo(sox, soy)
+        for i = 1, math.random(3, 10) do
+          humanoid:queueAction{name = "use_object", object = skeleton}
+        end
+      elseif bookcase then
+        humanoid:walkTo(box, boy)
+        for i = 1, math.random(3, 10) do
+          humanoid:queueAction{name = "use_object", object = bookcase}
+        end
+      end
+      -- go back to the projector
+      self:doStaffUseCycle(humanoid)
+    elseif projector_use_time < 0 then
+      -- reset variable to avoid potential overflow (over a VERY long
+      -- period of time)
+      projector_use_time = 0
+    end
+  end
+
   humanoid:queueAction{name = "use_object",
     object = projector,
-    loop_callback = --[[persistable:training_loop_callback]] function()
-      projector_use_time = projector_use_time - 1
-      if projector_use_time == 0 then
-        local skeleton, sox, soy = self.world:findFreeObjectNearToUse(humanoid, "skeleton", "near")
-        local bookcase, box, boy = self.world:findFreeObjectNearToUse(humanoid, "bookcase", "near")
-        if math.random(0, 1) == 0 and bookcase then skeleton = nil end -- choose one
-        if skeleton then
-          humanoid:walkTo(sox, soy)
-          for i = 1, math.random(3, 10) do
-            humanoid:queueAction{name = "use_object", object = skeleton}
-          end
-        elseif bookcase then
-          humanoid:walkTo(box, boy)
-          for i = 1, math.random(3, 10) do
-            humanoid:queueAction{name = "use_object", object = bookcase}
-          end
-        end
-        -- go back to the projector
-        self:doStaffUseCycle(humanoid)
-      elseif projector_use_time < 0 then
-        -- reset variable to avoid potential overflow (over a VERY long
-        -- period of time)
-        projector_use_time = 0
-      end
-    end,
+    loop_callback = loop_callback_training
   }
 end
 

--- a/CorsixTH/Lua/rooms/ultrascan.lua
+++ b/CorsixTH/Lua/rooms/ultrascan.lua
@@ -56,22 +56,17 @@ function UltrascanRoom:commandEnteringPatient(patient)
   local orientation = ultrascan.object_type.orientations[ultrascan.direction]
   local stf_x, stf_y = ultrascan:getSecondaryUsageTile()
 
-  staff:setNextAction{name = "walk", x = stf_x, y = stf_y}
-  staff:queueAction{name = "idle", direction = ultrascan.direction == "north" and "west" or "north"}
+  staff:setNextAction(WalkAction(stf_x, stf_y))
+  staff:queueAction(IdleAction():setDirection(ultrascan.direction == "north" and "west" or "north"))
 
-  patient:setNextAction{name = "walk", x = pat_x, y = pat_y}
+  patient:setNextAction(WalkAction(pat_x, pat_y))
 
   local after_use_scan = --[[persistable:ultrascan_after_use]] function()
-    staff:setNextAction{name = "meander"}
+    staff:setNextAction(MeanderAction())
     self:dealtWithPatient(patient)
   end
 
-  patient:queueAction{
-    name = "multi_use_object",
-    object = ultrascan,
-    use_with = staff,
-    after_use = after_use_scan
-  }
+  patient:queueAction(MultiUseObjectAction(ultrascan, staff):setAfterUse(after_use_scan))
   return Room.commandEnteringPatient(self, patient)
 end
 

--- a/CorsixTH/Lua/rooms/ultrascan.lua
+++ b/CorsixTH/Lua/rooms/ultrascan.lua
@@ -58,17 +58,20 @@ function UltrascanRoom:commandEnteringPatient(patient)
 
   staff:setNextAction{name = "walk", x = stf_x, y = stf_y}
   staff:queueAction{name = "idle", direction = ultrascan.direction == "north" and "west" or "north"}
+
   patient:setNextAction{name = "walk", x = pat_x, y = pat_y}
+
+  local after_use_scan = --[[persistable:ultrascan_after_use]] function()
+    staff:setNextAction{name = "meander"}
+    self:dealtWithPatient(patient)
+  end
+
   patient:queueAction{
     name = "multi_use_object",
     object = ultrascan,
     use_with = staff,
-    after_use = --[[persistable:ultrascan_after_use]] function()
-      staff:setNextAction{name = "meander"}
-      self:dealtWithPatient(patient)
-    end,
+    after_use = after_use_scan
   }
-
   return Room.commandEnteringPatient(self, patient)
 end
 

--- a/CorsixTH/Lua/rooms/ward.lua
+++ b/CorsixTH/Lua/rooms/ward.lua
@@ -95,11 +95,8 @@ end
 function WardRoom:doStaffUseCycle(humanoid)
   local meander_time = math.random(4, 10)
   local desk_use_time = math.random(8, 16)
+  humanoid:setNextAction(MeanderAction():setCount(meander_time))
 
-  humanoid:setNextAction{
-    name = "meander",
-    count = meander_time,
-  }
   local obj, ox, oy = self.world:findFreeObjectNearToUse(humanoid, "desk")
   if obj then
     obj.reserved_for = humanoid
@@ -113,11 +110,7 @@ function WardRoom:doStaffUseCycle(humanoid)
         end
       end
 
-      humanoid:queueAction {
-        name = "use_object",
-        object = obj,
-        loop_callback = desk_loop
-      }
+      humanoid:queueAction(UseObjectAction(obj):setLoopCallback(desk_loop))
     end
   end
 
@@ -128,10 +121,7 @@ function WardRoom:doStaffUseCycle(humanoid)
       self:doStaffUseCycle(humanoid)
     end
   end
-  humanoid:queueAction {
-    name = "meander",
-    loop_callback = meanders_loop
-  }
+  humanoid:queueAction(MeanderAction():setLoopCallback(meanders_loop))
 end
 
 
@@ -160,13 +150,8 @@ function WardRoom:commandEnteringPatient(patient)
       self:dealtWithPatient(patient)
     end
     patient:walkTo(pat_x, pat_y)
-    patient:queueAction{
-      name = "use_object",
-      object = bed,
-      prolonged_usage = true,
-      loop_callback = loop_callback,
-      after_use = after_use,
-    }
+    local beduse_action = UseObjectAction(bed):setProlongedUsage()
+    patient:queueAction(beduse_action:setLoopCallback(loop_callback):setAfterUse(after_use))
   end
 
   return Room.commandEnteringPatient(self, patient)
@@ -265,7 +250,7 @@ function WardRoom:afterLoad(old, new)
     local nurse = self.staff_member
     if nurse then
       nurse:setNextAction(self:createLeaveAction())
-      nurse:queueAction({name = "meander"})
+      nurse:queueAction(MeanderAction())
     end
   end
   Room.afterLoad(self, old, new)

--- a/CorsixTH/Lua/rooms/ward.lua
+++ b/CorsixTH/Lua/rooms/ward.lua
@@ -106,28 +106,31 @@ function WardRoom:doStaffUseCycle(humanoid)
     humanoid:walkTo(ox, oy)
     if obj.object_type.id == "desk" then
       local desk_use_time = math.random(7, 14)
+      local desk_loop = --[[persistable:ward_desk_loop_callback]] function()
+        desk_use_time = desk_use_time - 1
+        if desk_use_time == 0 then
+          self:doStaffUseCycle(humanoid)
+        end
+      end
+
       humanoid:queueAction {
         name = "use_object",
         object = obj,
-    loop_callback = --[[persistable:ward_desk_loop_callback]] function()
-      desk_use_time = desk_use_time - 1
-      if desk_use_time == 0 then
-        self:doStaffUseCycle(humanoid)
-      end
-    end,
-  }
+        loop_callback = desk_loop
+      }
+    end
   end
 
-  end
   local num_meanders = math.random(2, 4)
+  local meanders_loop = --[[persistable:ward_meander_loop_callback]] function(action)
+    num_meanders = num_meanders - 1
+    if num_meanders == 0 then
+      self:doStaffUseCycle(humanoid)
+    end
+  end
   humanoid:queueAction {
     name = "meander",
-    loop_callback = --[[persistable:ward_meander_loop_callback]] function(action)
-      num_meanders = num_meanders - 1
-      if num_meanders == 0 then
-        self:doStaffUseCycle(humanoid)
-      end
-    end
+    loop_callback = meanders_loop
   }
 end
 

--- a/CorsixTH/Lua/rooms/x_ray_room.lua
+++ b/CorsixTH/Lua/rooms/x_ray_room.lua
@@ -58,20 +58,24 @@ function XRayRoom:commandEnteringPatient(patient)
   local --[[persistable:x_ray_shared_loop_callback]] function loop_callback()
     if staff.action_queue[1].name == "idle" and patient.action_queue[1].name == "idle" then
 
-    local length = math.random(2, 4) * (2 - staff.profile.skill)
+      local length = math.random(2, 4) * (2 - staff.profile.skill)
+      local loop_callback_xray = --[[persistable:x_ray_loop_callback]] function(action)
+        if length <= 0 then
+          action.prolonged_usage = false
+        end
+        length = length - 1
+      end
+
+      local after_use_xray = --[[persistable:x_ray_after_use]] function()
+        staff:setNextAction{name = "meander"}
+        self:dealtWithPatient(patient)
+      end
+
       patient:setNextAction{
         name = "use_object",
         object = x_ray,
-        loop_callback = --[[persistable:x_ray_loop_callback]] function(action)
-          if length <= 0 then
-            action.prolonged_usage = false
-          end
-          length = length - 1
-        end,
-        after_use = --[[persistable:x_ray_after_use]] function()
-          staff:setNextAction{name = "meander"}
-          self:dealtWithPatient(patient)
-        end,
+        loop_callback = loop_callback_xray,
+        after_use = after_use_xray
       }
       staff:setNextAction{
         name = "use_object",

--- a/CorsixTH/Lua/rooms/x_ray_room.lua
+++ b/CorsixTH/Lua/rooms/x_ray_room.lua
@@ -67,35 +67,23 @@ function XRayRoom:commandEnteringPatient(patient)
       end
 
       local after_use_xray = --[[persistable:x_ray_after_use]] function()
-        staff:setNextAction{name = "meander"}
+        staff:setNextAction(MeanderAction())
         self:dealtWithPatient(patient)
       end
 
-      patient:setNextAction{
-        name = "use_object",
-        object = x_ray,
-        loop_callback = loop_callback_xray,
-        after_use = after_use_xray
-      }
-      staff:setNextAction{
-        name = "use_object",
-        object = console,
-      }
+      patient:setNextAction(UseObjectAction(x_ray):setLoopCallback(loop_callback_xray)
+          :setAfterUse(after_use_xray))
+      staff:setNextAction(UseObjectAction(console))
     end
   end
 
   patient:walkTo(pat_x, pat_y)
-  patient:queueAction{
-    name = "idle",
-    direction = x_ray.direction == "north" and "east" or "south",
-    loop_callback = loop_callback,
-  }
+  patient:queueAction(IdleAction():setDirection(x_ray.direction == "north" and "east" or "south")
+      :setLoopCallback(loop_callback))
+
   staff:walkTo(stf_x, stf_y)
-  staff:queueAction{
-    name = "idle",
-    direction = console.direction == "north" and "east" or "south",
-    loop_callback = loop_callback,
-  }
+  staff:queueAction(IdleAction():setDirection(console.direction == "north" and "east" or "south")
+      :setLoopCallback(loop_callback))
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -515,7 +515,7 @@ function World:spawnPatient(hospital)
   local spawn_point = self.spawn_points[math.random(1, #self.spawn_points)]
   local patient = self:newEntity("Patient", 2)
   patient:setDisease(disease)
-  patient:setNextAction{name = "spawn", mode = "spawn", point = spawn_point}
+  patient:setNextAction(SpawnAction():setMode("spawn"):setPoint(spawn_point))
   patient:setHospital(hospital)
   return patient
 end
@@ -535,11 +535,11 @@ function World:spawnVIP(name)
   vip.enter_explosions = hospital.num_explosions
 
   local spawn_point = self.spawn_points[math.random(1, #self.spawn_points)]
-  vip:setNextAction{name = "spawn", mode = "spawn", point = spawn_point}
+  vip:setNextAction(SpawnAction():setMode("spawn"):setPoint(spawn_point))
   vip:setHospital(hospital)
   vip:updateDynamicInfo()
   hospital.announce_vip = hospital.announce_vip + 1
-  vip:queueAction{name = "seek_reception"}
+  vip:queueAction(SeekReceptionAction())
 end
 
 function World:createEarthquake()


### PR DESCRIPTION
Seemingly big rewrites, bust mostly just shifting lines. Should be better if you ignore white space.