### PR TITLE
[RDY] Remove initial warmth grace period, reduce impact of too cold/warm. Fixes #74.

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -812,19 +812,23 @@ function Humanoid:tickDay()
 
   -- If it is too hot or too cold, start to decrease happiness and
   -- show the corresponding icon. Otherwise we could get happier instead.
-  -- Let the player get into the level first though, don't decrease happiness the first year.
-  if self.attributes["warmth"] and self.hospital and not self.hospital.initial_grace then
-    -- Cold: less than 11 degrees C
-    if self.attributes["warmth"] < 0.22 then
-      self:changeAttribute("happiness", -0.02 * (0.22 - self.attributes["warmth"]) / 0.14)
+  local min_comfort_temp = 0.22 -- 11 degrees Celcius.
+  local max_comfort_temp = 0.36 -- 18 degrees Celcius.
+  local decrease_factor = 0.10
+  local increase_happiness = 0.005
+
+  if self.attributes["warmth"] and self.hospital then
+    -- Cold: less than comfortable.
+    if self.attributes["warmth"] < min_comfort_temp then
+      self:changeAttribute("happiness", -decrease_factor * (min_comfort_temp - self.attributes["warmth"]))
       self:setMood("cold", "activate")
-    -- Hot: More than 18 degrees C
-    elseif self.attributes["warmth"] > 0.36 then
-      self:changeAttribute("happiness", -0.02 * (self.attributes["warmth"] - 0.36) / 0.14)
+    -- Hot: More than comfortable.
+    elseif self.attributes["warmth"] > max_comfort_temp then
+      self:changeAttribute("happiness", -decrease_factor * (self.attributes["warmth"] - max_comfort_temp))
       self:setMood("hot", "activate")
-    -- Ideal: Between 11 and 18
+    -- Ideal: Not too cold or too warm.
     else
-      self:changeAttribute("happiness", 0.005)
+      self:changeAttribute("happiness", increase_happiness)
       self:setMood("cold", "deactivate")
       self:setMood("hot", "deactivate")
     end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -48,7 +48,6 @@ function Hospital:Hospital(world, avail_rooms, name)
   self.acc_overdraft = 0
   self.acc_heating = 0
   self.discover_autopsy_risk = 10
-  self.initial_grace = true
 
   -- The sum of all material values (tiles, rooms, objects).
   -- Initial value: hospital tile count * tile value + 20000
@@ -648,6 +647,10 @@ function Hospital:afterLoad(old, new)
     -- price distortion
     self.under_priced_threshold = -0.4
     self.over_priced_threshold = 0.3
+  end
+
+  if old < 111 then
+    self.initial_grace = nil
   end
 
   -- Update other objects in the hospital (added in version 106).

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1033,11 +1033,6 @@ function World:onTick()
         self.month = self.month + 1
         if self.month > 12 then
           self.month = 12
-          if self.year == 1 then
-            for _, hospital in ipairs(self.hospitals) do
-              hospital.initial_grace = false
-            end
-          end
           -- It is crucial that the annual report gets to initialize before onEndYear is called.
           -- Yearly statistics are reset there.
           self.ui:addWindow(UIAnnualReport(self.ui, self))


### PR DESCRIPTION
Original patch #225 aiming to fix #74 by MarkL, which seemed mostly ok, but the last fix was never done, instead the patch was closed.

Original comment:
````
To replace issue #81 and issue #121

This will allow the player to turn off the initial grace period in
config.txt.
Which is what I think issue #74 is about. Currently happiness does not
go down if it is too cold in the first year.
```

Updates done: Replaced boolean value by month count, moved grace period handling to the monthly hospital function, tuned down the happiness changes a bit (0.02 -> 0.015 factor).
