### PR TITLE
Use a more stable variable to denote cured Kings. Fixes #1033

### DIFF
--- a/CorsixTH/Lua/rooms/psych.lua
+++ b/CorsixTH/Lua/rooms/psych.lua
@@ -97,7 +97,7 @@ function PsychRoom:commandEnteringPatient(patient)
       duration = duration - 1
     end
     if duration <= 0 then
-      if patient.diagnosed and patient.humanoid_class == "Elvis Patient" then
+      if patient.diagnosed and patient.disease.id == "king_complex" then
         -- Diagnosed patients (Elvis) need to change clothes
         obj, ox, oy = self.world:findObjectNear(patient, "screen")
         patient:walkTo(ox, oy)


### PR DESCRIPTION
After curing, the humanoid class changes, in current master (I found out while trying to get crash logs in #1033). This fix uses the disease of the patient which is a bit more stable, apparently. It fixes the double payment, and also the double "go home" message.

Don't know where this change was introduced.
