### PR TITLE
[RDY] Adds a user level directory

### DIFF
--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -376,6 +376,14 @@ unicode_font = nil -- [[X:\ThemeHospital\font.ttc]]
 --
 savegames = nil -- [[X:\ThemeHospital\Saves]]
 
+-------------------------------------------------------------------------------------------------------------------------
+-- Levels. By default, the "Levels" directory alongside this config file will
+-- be used for storing new maps / levels in. Should this not be suitable, then
+-- uncomment the following line, and point it to a directory which exists and
+-- is more suitable.
+--
+levels = nil -- [[X:\ThemeHospital\Levels]]
+
  ------------------------------------------------------------------------------------------------------------------------
 -- Use new graphics. Whether to use the original graphics from Theme Hospital
 -- or use new graphics created by the CorsixTH project.

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/load_map.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/load_map.lua
@@ -25,7 +25,7 @@ class "UILoadMap" (UIFileBrowser)
 local UILoadMap = _G["UILoadMap"]
 
 function UILoadMap:UILoadMap(ui, mode)
-  local path = ui.app.level_dir
+  local path = ui.app.user_level_dir
   local treenode = FilteredFileTreeNode(path, ".map")
   treenode.label = "Maps"
   self:UIFileBrowser(ui, mode, _S.load_game_window.caption:format(".map"), 295, treenode, true)
@@ -38,7 +38,7 @@ function UILoadMap:choiceMade(name)
   local app = self.ui.app
   -- Make sure there is no blue filter active.
   app.video:setBlueFilterActive(false)
-  name = name:sub(app.level_dir:len() + 1)
+  name = name:sub(app.user_level_dir:len() + 1)
   local status, err = pcall(app.loadLevel, app, name, nil, nil, nil, nil, true)
   if not status then
     err = _S.errors.load_prefix .. err

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_map.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_map.lua
@@ -45,7 +45,7 @@ local col_shadow = {
 }
 
 function UISaveMap:UISaveMap(ui)
-  local treenode = FilteredFileTreeNode(ui.app.level_dir, ".map")
+  local treenode = FilteredFileTreeNode(ui.app.user_level_dir, ".map")
   treenode.label = "Maps"
   self:UIFileBrowser(ui, "map", _S.save_map_window.caption:format(".map"), 265, treenode, true)
   -- The most probable preference of sorting is by date - what you played last
@@ -73,7 +73,7 @@ function UISaveMap:confirmName()
     self:abortName()
     return
   end
-  self:trySave(app.level_dir .. filename .. ".map")
+  self:trySave(app.user_level_dir .. filename .. ".map")
 end
 
 --! Function called by clicking button of existing save #num

--- a/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_game.lua
@@ -34,15 +34,10 @@ local col_scrollbar = {
 
 local details_width = 280
 
-function UICustomGame:UICustomGame(ui)
-
-  self.label_font = TheApp.gfx:loadFont("QData", "Font01V")
-
-  -- Supply the required list of items to UIMenuList
-  local path = ui.app.level_dir
-
-  -- Create the actual list
-  local items = {}
+--! Compile metainfo for all of the levels in the given path.
+--!param path (string) The path that should contain level files.
+--!param items (table) Table to insert the level metadata into.
+local findLevelsInDir = function(path, items)
   for file in lfs.dir(path) do
     if file:match"%.level$" then
       local level_info = TheApp:readLevelFile(file)
@@ -58,6 +53,16 @@ function UICustomGame:UICustomGame(ui)
       end
     end
   end
+end
+
+function UICustomGame:UICustomGame(ui)
+  self.label_font = TheApp.gfx:loadFont("QData", "Font01V")
+
+  -- Supply the required list of items to UIMenuList
+  -- Create the actual list
+  local items = {}
+  findLevelsInDir(TheApp.level_dir, items)
+  findLevelsInDir(TheApp.user_level_dir, items)
   self:UIMenuList(ui, "menu", _S.custom_game_window.caption, items, 10, details_width + 40)
 
   -- Create a toolbar ready to be used if the description for a level is


### PR DESCRIPTION
Similar to the savegame directory, this commit adds a user level file. By
default this uses a new Levels directory in the same path as the config. When
picking a single scenario both the users level directory and the built in level
directory are checked.

Addresses #1045 