### PR TITLE
On loading a savegame, first remove all object-thobs, then add them again. Fixes #1063

### DIFF
--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -680,8 +680,11 @@ function Object:onClick(ui, button, data)
   end
 end
 
-function Object:resetAnimation()
+function Object:eraseObject()
   self.world.map.th:eraseObjectTypes(self.tile_x, self.tile_y)
+end
+
+function Object:resetAnimation()
   self.world.map.th:setCellFlags(self.tile_x, self.tile_y, {thob = self.object_type.thob})
   self.th:setDrawingLayer(self:getDrawingLayer())
   self.th:setTile(self.world.map.th, self:getRenderAttachTile())

--- a/CorsixTH/Lua/entity.lua
+++ b/CorsixTH/Lua/entity.lua
@@ -348,6 +348,11 @@ function Entity:playAfterLoadSound()
   end
 end
 
+--! Stub to be extended in subclasses, if needed.
+function Entity:eraseObject()
+  -- Give entity the chance to clear itself from the map before resetAnimation gets called.
+end
+
 function Entity:resetAnimation()
   self.th:setDrawingLayer(self:getDrawingLayer())
   local x, y = self.tile_x, self.tile_y

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2313,6 +2313,11 @@ end
 --! Because the save file only saves one thob per tile if they are more that information
 -- will be lost. To solve this after a load we need to set again all the thobs on each tile.
 function World:resetAnimations()
+  -- Erase entities from the map if they want.
+  for _, entity in ipairs(self.entities) do
+    entity:eraseObject()
+  end
+  -- Add them again.
   for _, entity in ipairs(self.entities) do
     entity:resetAnimation()
   end


### PR DESCRIPTION
This prevents missing objects when two or more objects share a tile while loading a savegame.
Before this patch, the second object to add would remove the first added
object, causing path finding failures when looking for the first object.

Many thanks go to TheCycoONE for his pathfinder bug hunting and finding
about the missing objects.