### PR TITLE
[rdy] Avoid infinite looping if there are no viable diseases for new patients. Fixes issue #732

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -479,6 +479,10 @@ end
 --!param hospital (Hospital) Hospital that the new patient should visit.
 --!return (Patient entity) The spawned patient, or 'nil' if no patient spawned.
 function World:spawnPatient(hospital)
+  if not hospital then
+    hospital = self:getLocalPlayerHospital()
+  end
+
   -- The level might not contain any diseases
   if #self.available_diseases < 1 then
     self.ui:addWindow(UIInformation(self.ui, {"There are no diseases on this level! Please add some to your level."}))
@@ -488,22 +492,21 @@ function World:spawnPatient(hospital)
     self.ui:addWindow(UIInformation(self.ui, {"Could not spawn patient because no spawn points are available. Please place walkable tiles on the edge of your level."}))
     return
   end
-  if not hospital then
-    hospital = self:getLocalPlayerHospital()
-  end
 
   if not hospital:hasStaffedDesk() then return nil end
 
-  local spawn_point = self.spawn_points[math.random(1, #self.spawn_points)]
-  local patient = self:newEntity("Patient", 2)
+  -- Construct disease.
   local disease = self.available_diseases[math.random(1, #self.available_diseases)]
   while not isDiseaseUsableForNewPatient(self, disease, hospital) do
     disease = self.available_diseases[math.random(1, #self.available_diseases)]
   end
+
+  -- Construct patient.
+  local spawn_point = self.spawn_points[math.random(1, #self.spawn_points)]
+  local patient = self:newEntity("Patient", 2)
   patient:setDisease(disease)
   patient:setNextAction{name = "spawn", mode = "spawn", point = spawn_point}
   patient:setHospital(hospital)
-
   return patient
 end
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -468,9 +468,8 @@ function World:spawnPatient(hospital)
   --!param disease (disease) Disease to test.
   --!return (boolean) Whether the disease is visible and available.
   local function isVisualDiseaseAvailable(disease)
-    if not disease.visuals_id then
-      return true
-    end
+    if disease.only_emergency then return false end
+    if not disease.visuals_id then return true end
 
     local current_month = (self.year - 1) * 12 + self.month
 
@@ -496,7 +495,7 @@ function World:spawnPatient(hospital)
     local spawn_point = self.spawn_points[math.random(1, #self.spawn_points)]
     local patient = self:newEntity("Patient", 2)
     local disease = self.available_diseases[math.random(1, #self.available_diseases)]
-    while disease.only_emergency or not isVisualDiseaseAvailable(disease) do
+    while not isVisualDiseaseAvailable(disease) do
       disease = self.available_diseases[math.random(1, #self.available_diseases)]
     end
     patient:setDisease(disease)

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -467,7 +467,7 @@ function World:spawnPatient(hospital)
   --! Function to determine whether a given disease is visible and available.
   --!param disease (disease) Disease to test.
   --!return (boolean) Whether the disease is visible and available.
-  local function isVisualDiseaseAvailable(disease)
+  local function isDiseaseUsableForNewPatient(disease)
     if disease.only_emergency then return false end
     if not disease.visuals_id then return true end
 
@@ -495,7 +495,7 @@ function World:spawnPatient(hospital)
     local spawn_point = self.spawn_points[math.random(1, #self.spawn_points)]
     local patient = self:newEntity("Patient", 2)
     local disease = self.available_diseases[math.random(1, #self.available_diseases)]
-    while not isVisualDiseaseAvailable(disease) do
+    while not isDiseaseUsableForNewPatient(disease) do
       disease = self.available_diseases[math.random(1, #self.available_diseases)]
     end
     patient:setDisease(disease)

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -476,8 +476,9 @@ function World:spawnPatient(hospital)
 
     --! level files can delay visuals to a given month
     --! and / or until a given number of patients have arrived
-    local hold_visual_months = self.map.level_config.gbv.HoldVisualMonths
-    local hold_visual_peep_count = self.map.level_config.gbv.HoldVisualPeepCount
+    local level_config = self.map.level_config
+    local hold_visual_months = level_config.gbv.HoldVisualMonths
+    local hold_visual_peep_count = level_config.gbv.HoldVisualPeepCount
 
     --! if the month is greater than either of these values then visuals will not appear in the game
     if hold_visual_months and hold_visual_months > current_month or
@@ -485,7 +486,6 @@ function World:spawnPatient(hospital)
       return false
     end
     --! the value against #visuals_available determines from which month a disease can appear. 0 means it can show up anytime.
-    local level_config = self.map.level_config
     if level_config.visuals_available[disease.visuals_id].Value >= current_month then
       return false
     end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -464,10 +464,12 @@ function World:spawnPatient(hospital)
     hospital = self:getLocalPlayerHospital()
   end
 
-  --! Function to determine whether a given disease is visible and available.
+  --! Function to determine whether a given disease is available for new patients.
+  --!param self (World) World object.
   --!param disease (disease) Disease to test.
+  --!param hospital (Hospital) Hospital that needs a new patient.
   --!return (boolean) Whether the disease is visible and available.
-  local function isDiseaseUsableForNewPatient(disease)
+  local function isDiseaseUsableForNewPatient(self, disease, hospital)
     if disease.only_emergency then return false end
     if not disease.visuals_id then return true end
 
@@ -495,7 +497,7 @@ function World:spawnPatient(hospital)
     local spawn_point = self.spawn_points[math.random(1, #self.spawn_points)]
     local patient = self:newEntity("Patient", 2)
     local disease = self.available_diseases[math.random(1, #self.available_diseases)]
-    while not isDiseaseUsableForNewPatient(disease) do
+    while not isDiseaseUsableForNewPatient(self, disease, hospital) do
       disease = self.available_diseases[math.random(1, #self.available_diseases)]
     end
     patient:setDisease(disease)

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -495,10 +495,20 @@ function World:spawnPatient(hospital)
 
   if not hospital:hasStaffedDesk() then return nil end
 
-  -- Construct disease.
+  -- Construct disease, take a random guess first, as a quick clear-sky attempt.
   local disease = self.available_diseases[math.random(1, #self.available_diseases)]
-  while not isDiseaseUsableForNewPatient(self, disease, hospital) do
-    disease = self.available_diseases[math.random(1, #self.available_diseases)]
+  if not isDiseaseUsableForNewPatient(self, disease, hospital) then
+    -- Lucky shot failed, do a proper calculation.
+    local usable_diseases = {}
+    for _, d in ipairs(self.available_diseases) do
+      if isDiseaseUsableForNewPatient(self, d, hospital) then
+        usable_diseases[#usable_diseases + 1] = d
+      end
+    end
+
+    if #usable_diseases == 0 then return nil end
+
+    disease = usable_diseases[math.random(1, #usable_diseases)]
   end
 
   -- Construct patient.

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -463,12 +463,7 @@ function World:spawnPatient(hospital)
   if not hospital then
     hospital = self:getLocalPlayerHospital()
   end
-  --! What is the current month?
-  local current_month = (self.year - 1) * 12 + self.month
-  --! level files can delay visuals to a given month
-  --! and / or until a given number of patients have arrived
-  local hold_visual_months = self.map.level_config.gbv.HoldVisualMonths
-  local hold_visual_peep_count = self.map.level_config.gbv.HoldVisualPeepCount
+
   --! Function to determine whether a given disease is visible and available.
   --!param disease (disease) Disease to test.
   --!return (boolean) Whether the disease is visible and available.
@@ -476,6 +471,14 @@ function World:spawnPatient(hospital)
     if not disease.visuals_id then
       return true
     end
+
+    local current_month = (self.year - 1) * 12 + self.month
+
+    --! level files can delay visuals to a given month
+    --! and / or until a given number of patients have arrived
+    local hold_visual_months = self.map.level_config.gbv.HoldVisualMonths
+    local hold_visual_peep_count = self.map.level_config.gbv.HoldVisualPeepCount
+
     --! if the month is greater than either of these values then visuals will not appear in the game
     if hold_visual_months and hold_visual_months > current_month or
     hold_visual_peep_count and hold_visual_peep_count > hospital.num_visitors then

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -451,29 +451,28 @@ end
 --!param self (World) World object.
 --!param disease (disease) Disease to test.
 --!param hospital (Hospital) Hospital that needs a new patient.
---!return (boolean) Whether the disease is visible and available.
+--!return (boolean) Whether the disease is usable for new spawned patients.
 local function isDiseaseUsableForNewPatient(self, disease, hospital)
   if disease.only_emergency then return false end
   if not disease.visuals_id then return true end
 
   local current_month = (self.year - 1) * 12 + self.month
 
-  --! level files can delay visuals to a given month
-  --! and / or until a given number of patients have arrived
+  -- level files can delay visuals to a given month
+  -- and / or until a given number of patients have arrived
   local level_config = self.map.level_config
   local hold_visual_months = level_config.gbv.HoldVisualMonths
   local hold_visual_peep_count = level_config.gbv.HoldVisualPeepCount
 
-  --! if the month is greater than either of these values then visuals will not appear in the game
-  if hold_visual_months and hold_visual_months > current_month or
-  hold_visual_peep_count and hold_visual_peep_count > hospital.num_visitors then
+  -- if the month is greater than either of these values then visuals will not appear in the game
+  if (hold_visual_months and hold_visual_months > current_month) or
+      (hold_visual_peep_count and hold_visual_peep_count > hospital.num_visitors) then
     return false
   end
-  --! the value against #visuals_available determines from which month a disease can appear. 0 means it can show up anytime.
-  if level_config.visuals_available[disease.visuals_id].Value >= current_month then
-    return false
-  end
-  return true
+
+  -- The value against #visuals_available determines from which month a disease can appear.
+  -- 0 means it can show up anytime.
+  return level_config.visuals_available[disease.visuals_id].Value < current_month
 end
 
 --! Spawn a patient from a spawn point for the given hospital.
@@ -493,19 +492,19 @@ function World:spawnPatient(hospital)
     hospital = self:getLocalPlayerHospital()
   end
 
-  if hospital:hasStaffedDesk() then
-    local spawn_point = self.spawn_points[math.random(1, #self.spawn_points)]
-    local patient = self:newEntity("Patient", 2)
-    local disease = self.available_diseases[math.random(1, #self.available_diseases)]
-    while not isDiseaseUsableForNewPatient(self, disease, hospital) do
-      disease = self.available_diseases[math.random(1, #self.available_diseases)]
-    end
-    patient:setDisease(disease)
-    patient:setNextAction{name = "spawn", mode = "spawn", point = spawn_point}
-    patient:setHospital(hospital)
+  if not hospital:hasStaffedDesk() then return nil end
 
-    return patient
+  local spawn_point = self.spawn_points[math.random(1, #self.spawn_points)]
+  local patient = self:newEntity("Patient", 2)
+  local disease = self.available_diseases[math.random(1, #self.available_diseases)]
+  while not isDiseaseUsableForNewPatient(self, disease, hospital) do
+    disease = self.available_diseases[math.random(1, #self.available_diseases)]
   end
+  patient:setDisease(disease)
+  patient:setNextAction{name = "spawn", mode = "spawn", point = spawn_point}
+  patient:setHospital(hospital)
+
+  return patient
 end
 
 --A VIP is invited (or he invited himself) to the player hospital.


### PR DESCRIPTION
If a level file only has visible diseases, and these are postponed until the future by the level file, the unfixed code would loop forever.