### PR TITLE
[RFC] Load hospital and build flags for all tiles when in map editor

### DIFF
--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -195,7 +195,7 @@ function Map:load(level, difficulty, level_name, map_file, level_intro, map_edit
     local data
     data, errors = self:getRawData(map_file)
     if data then
-      i, objects = self.th:load(data)
+      i, objects = self.th:load(data, map_editor)
     else
       return nil, errors
     end
@@ -230,7 +230,7 @@ function Map:load(level, difficulty, level_name, map_file, level_intro, map_edit
     else
       local data, errors = self:getRawData(level)
       if data then
-        i, objects = self.th:load(data)
+        i, objects = self.th:load(data, map_editor)
       else
         return nil, errors
       end
@@ -246,7 +246,7 @@ function Map:load(level, difficulty, level_name, map_file, level_intro, map_edit
     self.map_file = map_file
     local data, errors = self:getRawData(map_file)
     if data then
-      i, objects = self.th:load(data)
+      i, objects = self.th:load(data, map_editor)
     else
       return nil, errors
     end

--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -91,9 +91,10 @@ static int l_map_load(lua_State *L)
     THMap* pMap = luaT_testuserdata<THMap>(L);
     size_t iDataLen;
     const uint8_t* pData = luaT_checkfile(L, 2, &iDataLen);
+    bool for_edit = static_cast<bool>(lua_toboolean(L, 3));
     lua_settop(L, 2);
     lua_newtable(L);
-    if(pMap->loadFromTHFile(pData, iDataLen, l_map_load_obj_cb, (void*)L))
+    if(pMap->loadFromTHFile(pData, iDataLen, l_map_load_obj_cb, (void*)L, for_edit))
         lua_pushboolean(L, 1);
     else
         lua_pushboolean(L, 0);

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -352,7 +352,7 @@ bool THMap::loadBlank()
 
 bool THMap::loadFromTHFile(const uint8_t* pData, size_t iDataLength,
                            THMapLoadObjectCallback_t fnObjectCallback,
-                           void* pCallbackToken)
+                           void* pCallbackToken, bool for_edit)
 {
     if(iDataLength < 163948 || !setSize(128, 128))
         return false;
@@ -438,7 +438,7 @@ bool THMap::loadFromTHFile(const uint8_t* pData, size_t iDataLength,
             if(!(pData[5] & 1))
             {
                 pNode->flags.passable = true;
-                if(*pParcel && !(pData[7] & 16))
+                if((*pParcel || for_edit) && !(pData[7] & 16))
                 {
                     pNode->flags.hospital = true;
                     if(!(pData[5] & 2)) {

--- a/CorsixTH/Src/th_map.h
+++ b/CorsixTH/Src/th_map.h
@@ -240,7 +240,7 @@ public:
     bool loadBlank();
     bool loadFromTHFile(const uint8_t* pData, size_t iDataLength,
                         THMapLoadObjectCallback_t fnObjectCallback,
-                        void* pCallbackToken);
+                        void* pCallbackToken, bool for_edit);
 
     void save(std::string filename);
 


### PR DESCRIPTION
Fixes #1044 

When we move towards multiplayer this may change again because there will be purchased plots that cannot be built on - we will need to check the owner as well as the flags for all builds and there will be no need to not load flags from parcel 0. In the mean time this fix is low impact.