### PR TITLE
[RDY] Use release build for appveyor so it can be run without VS

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,20 +8,21 @@ environment:
   - GENERATOR: Visual Studio 14 2015 Win64
     CMAKE_LIBRARY_PATH: c:/deps/win_x64_msvc14/lib
     CMAKE_INCLUDE_PATH: c:/deps/win_x64_msvc14
+configuration: Release
 before_build:
 - cmake -G "%GENERATOR%" -DCMAKE_LIBRARY_PATH="%CMAKE_LIBRARY_PATH%" -DCMAKE_INCLUDE_PATH="%CMAKE_INCLUDE_PATH%"
 build:
   project: CorsixTH_Top_Level.sln
   verbosity: minimal
 after_build:
-- cp %CMAKE_LIBRARY_PATH%/*.dll %APPVEYOR_BUILD_FOLDER%/CorsixTH/Debug/
-- cp -R %CMAKE_LIBRARY_PATH%/mime %APPVEYOR_BUILD_FOLDER%/CorsixTH/Debug/mime
-- cp -R %CMAKE_LIBRARY_PATH%/socket %APPVEYOR_BUILD_FOLDER%/CorsixTH/Debug/socket
-- cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Lua %APPVEYOR_BUILD_FOLDER%/CorsixTH/Debug/Lua
-- cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Bitmap %APPVEYOR_BUILD_FOLDER%/CorsixTH/Debug/Bitmap
-- cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Levels %APPVEYOR_BUILD_FOLDER%/CorsixTH/Debug/Levels
-- cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Campaigns %APPVEYOR_BUILD_FOLDER%/CorsixTH/Debug/Campaigns
-- cp %APPVEYOR_BUILD_FOLDER%/CorsixTH/CorsixTH.lua %APPVEYOR_BUILD_FOLDER%/CorsixTH/Debug/
+- cp %CMAKE_LIBRARY_PATH%/*.dll %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/
+- cp -R %CMAKE_LIBRARY_PATH%/mime %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/mime
+- cp -R %CMAKE_LIBRARY_PATH%/socket %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/socket
+- cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Lua %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/Lua
+- cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Bitmap %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/Bitmap
+- cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Levels %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/Levels
+- cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Campaigns %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/Campaigns
+- cp %APPVEYOR_BUILD_FOLDER%/CorsixTH/CorsixTH.lua %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/
 artifacts:
-- path: CorsixTH/Debug/
+- path: CorsixTH/Release/
   name: CorsixTH


### PR DESCRIPTION
The debug build cannot be distributed. This changes to a release configuration so that people can run our AppVeyor builds without having Visual Studio installed.