### PR TITLE
Allow use of bottom panel during pause

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -204,7 +204,7 @@ function UIBottomPanel:drawReputationMeter(canvas, x_left, y)
 end
 
 function UIBottomPanel:drawDynamicInfo(canvas, x, y)
-  if self.world:isCurrentSpeed("Pause") then
+  if self.world:isCurrentSpeed("Pause") and not self.world.user_actions_allowed then
     self.pause_font:drawWrapped(canvas, _S.misc.pause, x + 10, y + 14, 255, "center")
   elseif self.dynamic_info then
     local info = self.dynamic_info


### PR DESCRIPTION
When allow_user_actions_while_paused is enabled we don't want to block the
bottom panel buttons with the pause overlay.

Thanks Brainsample.

Patch taken from #1102