### PR TITLE
[RDY] Fix cure in diagnosis room

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -175,6 +175,8 @@ local function action_seek_room_no_diagnosis_room_found(action, humanoid)
     -- A patient with an undiscovered disease should never get here.
     assert(humanoid.hospital.disease_casebook[humanoid.disease.id].discovered)
     humanoid:setDiagnosed()
+    humanoid:unregisterRoomBuildCallback(action.build_callback)
+    humanoid:unregisterRoomRemoveCallback(action.remove_callback)
     if humanoid:agreesToPay(humanoid.disease.id) then
       humanoid:queueAction({
         name = "seek_room",


### PR DESCRIPTION
Remove the callbacks which would make the patient return to the diagnosis
room after it's built even though they were already diagnosed through
guess the cure.

Fixes #1108. Again thanks to Brainsample, who does all the work I keep taking credit for.