### PR TITLE
[RDY] Action parameter checking

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -30,7 +30,7 @@ local runDebugger = dofile "run_debugger"
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 111
+local SAVEGAME_VERSION = 112
 
 class "App"
 

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -339,6 +339,11 @@ function Humanoid:afterLoad(old, new)
   if old < 83 and self.humanoid_class == "Chewbacca Patient" then
     self.die_anims.extra_east = 1682
   end
+
+  for _, action in pairs(self.action_queue) do
+    -- Sometimes actions not actual instances of HumanoidAction
+    HumanoidAction.afterLoad(action, old, new)
+  end
   Entity.afterLoad(self, old, new)
 end
 
@@ -669,7 +674,7 @@ end
 
 -- Check if the humanoid is running actions intended to leave the room, as indicated by the flag
 function Humanoid:isLeaving()
-  return self.action_queue[1].is_leaving
+  return self.action_queue[1].is_leaving and true or false
 end
 
 -- Check if there is "is_leaving" action in the action queue
@@ -721,7 +726,8 @@ end
 --!param must_happen (boolean, nil) If true, then the walk action will not be
 -- interrupted.
 function Humanoid:walkTo(tile_x, tile_y, must_happen)
-  self:setNextAction(WalkAction(tile_x, tile_y):setMustHappen(must_happen))
+  self:setNextAction(WalkAction(tile_x, tile_y)
+      :setMustHappen(not not must_happen))
 end
 
 -- Stub functions for handling fatigue. These are overridden by the staff subclass,

--- a/CorsixTH/Lua/humanoid_action.lua
+++ b/CorsixTH/Lua/humanoid_action.lua
@@ -27,6 +27,8 @@ local HumanoidAction = _G["HumanoidAction"]
 --! Construct a humanoid action (base class constructor).
 --!param name (str) Name of the action.
 function HumanoidAction:HumanoidAction(name)
+  assert(type(name) == "string", "Invalid value for parameter 'name'")
+
   self.name = name
   self.count = nil -- 'nil' means 'forever' (until finished), else the number to perform.
   self.must_happen = false -- If true, action cannot be skipped.
@@ -40,6 +42,8 @@ end
 --!param count (int or nil) Set to 'nil' if 'forever', else integer count.
 --!return (action) Returning self, for daisy-chaining.
 function HumanoidAction:setCount(count)
+  assert(count == nil or type(count) == "number", "Invalid value for parameter 'count'")
+
   self.count = count
   return self
 end
@@ -48,6 +52,8 @@ end
 --!param must_happen (bool) Whether or not the action must happen.
 --!return (action) Returning self, for daisy-chaining.
 function HumanoidAction:setMustHappen(must_happen)
+  assert(type(must_happen) == "boolean", "Invalid value for parameters 'must_happen'")
+
   self.must_happen = must_happen
   return self
 end
@@ -57,6 +63,9 @@ end
 --! termination conditions.
 --!return (action) Returning self, for daisy-chaining.
 function HumanoidAction:setLoopCallback(loop_callback)
+  assert(loop_callback == nil or type(loop_callback) == "function",
+      "Invalid value for parameter 'loop_callback'")
+
   self.loop_callback = loop_callback
   return self
 end
@@ -65,6 +74,9 @@ end
 --!param after_use (func) Callback function that is called after the action ends.
 --!return (action) Returning self, for daisy-chaining.
 function HumanoidAction:setAfterUse(after_use)
+  assert(after_use == nil or type(after_use) == "function",
+      "Invalid value for parameter 'after_use'")
+
   self.after_use = after_use
   return self
 end
@@ -73,6 +85,8 @@ end
 --!param is_leaving (bool) Whether or not the humanoid is leaving. If not specified, value is true.
 --!return (action) Returning self, for daisy-chaining.
 function HumanoidAction:setIsLeaving(is_leaving)
+  assert(type(is_leaving) == "boolean", "Invalid value for parameter 'is_leaving'")
+
   self.is_leaving = is_leaving
   return self
 end

--- a/CorsixTH/Lua/humanoid_action.lua
+++ b/CorsixTH/Lua/humanoid_action.lua
@@ -29,11 +29,11 @@ local HumanoidAction = _G["HumanoidAction"]
 function HumanoidAction:HumanoidAction(name)
   self.name = name
   self.count = nil -- 'nil' means 'forever' (until finished), else the number to perform.
-  self.must_happen = nil -- If true, action cannot be skipped.
+  self.must_happen = false -- If true, action cannot be skipped.
   self.loop_callback = nil -- Periodic callback to check for termination conditions.
   self.after_use = nil -- Callback for performing updates afterwards.
-  self.is_leaving = nil -- Whether the humanoid is leaving.
-  self.no_truncate = nil -- If set, disable shortening the action.
+  self.is_leaving = false -- Whether the humanoid is leaving.
+  self.no_truncate = false -- If set, disable shortening the action.
 end
 
 --! Set the number of times the action should happen.
@@ -82,4 +82,18 @@ end
 function HumanoidAction:disableTruncate()
   self.no_truncate = true
   return self
+end
+
+function HumanoidAction:afterLoad(old, new)
+  if old < 112 then
+    self.is_leaving = not not self.is_leaving
+    self.must_happen = not not self.must_happen
+    self.no_truncate = not not self.no_truncate
+    self.saved_must_happen = not not self.saved_must_happen
+    self.idle_must_happen = not not self.idle_must_happen
+
+    if self.name == "walk" then
+      self.is_entering = not not self.is_entering
+    end
+  end
 end

--- a/CorsixTH/Lua/humanoid_actions/call_checkpoint.lua
+++ b/CorsixTH/Lua/humanoid_actions/call_checkpoint.lua
@@ -24,8 +24,13 @@ class "CallCheckPointAction" (HumanoidAction)
 local CallCheckPointAction = _G["CallCheckPointAction"]
 
 function CallCheckPointAction:CallCheckPointAction(call, on_remove)
+  assert(call == nil or
+      (type(call) == "table" and type(call.key) == "string"),
+      "Invalid value for parameter 'call'")
+  assert(type(on_remove) == "function", "Invalid value for parameter 'on_remove'")
+
   self:HumanoidAction("call_checkpoint")
-  self.call = call -- Whether the humanoid is on call.
+  self.call = call -- The call the humanoid is on (humanoid.on_call) or nil
   self.on_remove = on_remove -- Interrupt handler to use.
 end
 

--- a/CorsixTH/Lua/humanoid_actions/idle.lua
+++ b/CorsixTH/Lua/humanoid_actions/idle.lua
@@ -33,6 +33,11 @@ end
 --!param direction (string) Direction of facing.
 --!return (action) Self, for daisy-chaining.
 function IdleAction:setDirection(direction)
+  assert(direction == nil or
+      direction == "north" or direction == "south" or
+      direction == "east" or direction == "west",
+      "Invalid value for parameter 'direction'")
+
   self.direction = direction
   return self
 end
@@ -41,6 +46,9 @@ end
 --!param on_interrupt (function) Function to call on interrupt.
 --!return (action) Self, for daisy-chaining.
 function IdleAction:setOnInterrupt(on_interrupt)
+  assert(on_interrupt == nil or type(on_interrupt) == "function",
+      "Invalid value for parameter 'on_interrupt'")
+
   self.on_interrupt = on_interrupt
   return self
 end

--- a/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
@@ -24,6 +24,13 @@ class "IdleSpawnAction" (HumanoidAction)
 local IdleSpawnAction = _G["IdleSpawnAction"]
 
 function IdleSpawnAction:IdleSpawnAction(anim, point_dir)
+  assert(type(anim) == "number", "Invalid value for parameter 'anim'")
+  assert(type(point_dir) == "table" and
+      type(point_dir.x) == "number" and type(point_dir.y) == "number" and
+      point_dir.direction == "north" or point_dir.direction == "south" or
+      point_dir.direction == "east" or point_dir.direction == "west",
+      "Invalid value for parameter 'point_dir'")
+
   self:HumanoidAction("idle_spawn")
   self.spawn_animation = anim
   self.point = point_dir -- x, y, direction of the spawn animation

--- a/CorsixTH/Lua/humanoid_actions/knock_door.lua
+++ b/CorsixTH/Lua/humanoid_actions/knock_door.lua
@@ -27,6 +27,11 @@ local KnockDoorAction = _G["KnockDoorAction"]
 --!param door (Object) Door to knock on.
 --!param direction (string) Direction of facing.
 function KnockDoorAction:KnockDoorAction(door, direction)
+  assert(class.is(door, Door), "Invalid value for parameter 'door'")
+  assert(direction == "north" or direction == "south" or
+      direction == "east" or direction == "west",
+      "Invalid value for parameter 'direction'")
+
   self:HumanoidAction("knock_door")
   self.door = door -- Door to knock on.
   self.direction = direction -- Direction of facing.

--- a/CorsixTH/Lua/humanoid_actions/multi_use_object.lua
+++ b/CorsixTH/Lua/humanoid_actions/multi_use_object.lua
@@ -27,6 +27,9 @@ local MultiUseObjectAction = _G["MultiUseObjectAction"]
 --!param object (Object) Object being used.
 --!param use_with (Humanoid) Fellow user of the object.
 function MultiUseObjectAction:MultiUseObjectAction(object, use_with)
+  assert(class.is(object, Object), "Invalid value for parameter 'object'")
+  assert(class.is(use_with, Humanoid), "Invalid value for parameter 'use_with'")
+
   self:HumanoidAction("multi_use_object")
   self.object = object
   self.use_with = use_with
@@ -38,6 +41,10 @@ end
 --!param span (array) Span of invisibility, {from, to}
 --!return (action) self, for daisy-chaining.
 function MultiUseObjectAction:setInvisiblePhaseSpan(span)
+  assert(type(span) == "table" and type(span[1]) == "number" and
+      type(span[2] == "number") and span[1] <= span[2],
+      "Invalid value for parameter 'span'")
+
   self.invisible_phase_span = span
   return self
 end
@@ -46,6 +53,8 @@ end
 --!param prolonged (bool) If set, enable prolonged usage of the object.
 --!return (action) self, for daisy-chaining.
 function MultiUseObjectAction:setProlongedUsage(prolonged)
+  assert(type(prolonged), "boolean", "Invalid value for parameter 'prolonged'")
+
   self.prolonged_usage = prolonged
   return self
 end
@@ -54,6 +63,8 @@ end
 --!param layer3 (int) Value to set for animation layer 3.
 --!return (action) self, for daisy-chaining.
 function MultiUseObjectAction:setLayer3(layer3)
+  assert(type(layer3) == "number", "Invalid value for parameter 'layer3'")
+
   self.layer3 = layer3
   return self
 end

--- a/CorsixTH/Lua/humanoid_actions/pickup.lua
+++ b/CorsixTH/Lua/humanoid_actions/pickup.lua
@@ -26,6 +26,8 @@ local PickupAction = _G["PickupAction"]
 -- Construct a pick-up action
 --!param ui User interface
 function PickupAction:PickupAction(ui)
+  assert(class.is(ui, UI), "Invalid value for parameter 'ui'")
+
   self:HumanoidAction("pickup")
   self.ui = ui
   self.todo_close = nil
@@ -33,6 +35,8 @@ function PickupAction:PickupAction(ui)
 end
 
 function PickupAction:setTodoClose(dialog)
+  assert(class.is(dialog, Window), "Invalid value for parameter 'dialog'")
+
   self.todo_close = dialog
   return self
 end

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -28,6 +28,10 @@ local QueueAction = _G["QueueAction"]
 --!param y Y position of the queue.
 --!param queue (Queue) Queue to join
 function QueueAction:QueueAction(x, y, queue)
+  assert(type(x) == "number", "Invalid value for parameter 'x'")
+  assert(type(y) == "number", "Invalid value for parameter 'y'")
+  assert(class.is(queue, Queue), "Invalid value for parameter 'queue'")
+
   self:HumanoidAction("queue")
   self.x = x -- Position of the queue(?)
   self.y = y
@@ -41,6 +45,8 @@ end
 --!param door (object) Object to reserve when leaving the queue.
 --!return (action) self, for daisy-chaining.
 function QueueAction:setReserveWhenDone(door)
+  assert(class.is(door, Door), "Invalid value for parameter 'door'")
+
   self.reserve_when_done = door
   return self
 end
@@ -50,6 +56,9 @@ end
 --!param face_y (int) Y coordinate of the tile to face.
 --!return (action) self, for daisy-chaining.
 function QueueAction:setFaceDirection(face_x, face_y)
+  assert(type(face_x) == "number", "Invalid value for parameter 'face_x'")
+  assert(type(face_y) == "number", "Invalid value for parameter 'face_y'")
+
   self.face_x = face_x
   self.face_y = face_y
   return self

--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -77,7 +77,7 @@ local function action_seek_reception_start(action, humanoid)
     -- immediately, so walk them closer to the desk before joining the queue
     if can_join_queue_at(humanoid, humanoid.tile_x, humanoid.tile_y, x, y) then
       local face_x, face_y = best_desk:getSecondaryUsageTile()
-      humanoid:setNextAction(QueueAction(x, y, best_desk.queue):setMustHappen(action.mustHappen)
+      humanoid:setNextAction(QueueAction(x, y, best_desk.queue):setMustHappen(action.must_happen)
           :setFaceDirection(face_x, face_y))
     else
       local walk = WalkAction(x, y):setMustHappen(action.must_happen)

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -26,6 +26,8 @@ local SeekRoomAction = _G["SeekRoomAction"]
 --! Find another room (and go to it).
 --!param room_type Type of the new room.
 function SeekRoomAction:SeekRoomAction(room_type)
+  assert(type(room_type) == "string", "Invalid value for parameter 'room_type'")
+
   self:HumanoidAction("seek_room")
   self.room_type = room_type
   self.treatment_room = nil -- Whether the next room is a treatment room.
@@ -40,6 +42,8 @@ function SeekRoomAction:enableTreatmentRoom()
 end
 
 function SeekRoomAction:setDiagnosisRoom(room)
+  assert(type(room) == "number", "Invalid value for parameter 'room'")
+
   self.diagnosis_room = room
   return self
 end

--- a/CorsixTH/Lua/humanoid_actions/spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/spawn.lua
@@ -27,6 +27,11 @@ local SpawnAction = _G["SpawnAction"]
 --!param mode (str) Mode of spawning: "spawn" or "despawn"
 --!param point (table x, y, optional direction) Position and optional face direction of spawning or despawning.
 function SpawnAction:SpawnAction(mode, point)
+  assert(mode == "spawn" or mode == "despawn", "Invalid value for parameter 'mode'")
+  assert(type(point) == "table" and
+    type(point.x) == "number" and type(point.y) == "number",
+    "Invalid value for parameter 'point'")
+
   self:HumanoidAction("spawn")
   self.mode = mode -- mode of spawning: "spawn" or "despawn"
   self.point = point
@@ -37,6 +42,10 @@ end
 --!param offset (table x, y) Position offset.
 --!return (action) Return self for daisy chaining.
 function SpawnAction:setOffset(offset)
+  assert(type(offset) == "table" and
+      type(offset.x) == "number" and type(offset.y) == "number",
+      "Invalid value for parameter 'offset'")
+
   self.offset = offset
   return self
 end
@@ -57,7 +66,7 @@ end)
 
 local function action_spawn_start(action, humanoid)
   assert(action.mode == "spawn" or action.mode == "despawn", "spawn action given invalid mode: " .. action.mode)
-  local x, y =  action.point.x,  action.point.y
+  local x, y = action.point.x, action.point.y
   if action.mode == "despawn" and (humanoid.tile_x ~= x or humanoid.tile_y ~= y) then
     humanoid:queueAction(WalkAction(action.point.x, action.point.y):setMustHappen(action.must_happen), 0)
     return

--- a/CorsixTH/Lua/humanoid_actions/staff_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/staff_reception.lua
@@ -26,6 +26,8 @@ local StaffReceptionAction = _G["StaffReceptionAction"]
 -- Action class for the "staff reception desk" action.
 --!param desk (object) Desk to staff.
 function StaffReceptionAction:StaffReceptionAction(desk)
+  assert(class.is(desk, ReceptionDesk), "Invalid value for parameter 'desk'")
+
   self:HumanoidAction("staff_reception")
   self.object = desk -- Reception desk object.
   self:setMustHappen(true)

--- a/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
+++ b/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
@@ -24,6 +24,8 @@ class "SweepFloorAction" (HumanoidAction)
 local SweepFloorAction = _G["SweepFloorAction"]
 
 function SweepFloorAction:SweepFloorAction(litter)
+  assert(class.is(litter, Litter), "Invalid value for parameter 'litter'")
+
   self:HumanoidAction("sweep_floor")
   self.litter = litter
 end

--- a/CorsixTH/Lua/humanoid_actions/use_object.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_object.lua
@@ -29,6 +29,8 @@ local UseObjectAction = _G["UseObjectAction"]
 --! Construct a 'use object' action.
 --!param object (Object) Object to use.
 function UseObjectAction:UseObjectAction(object)
+  assert(class.is(object, Object), "Invalid value for parameter 'object'")
+
   self:HumanoidAction("use_object")
   self.object = object
   self.watering_plant = false -- Whether the action is watering the plant.
@@ -46,6 +48,9 @@ end
 --!param prolonged (bool or nil) If set, enable prolonged usage of the object.
 --!return (action) self, for daisy-chaining.
 function UseObjectAction:setProlongedUsage(prolonged)
+  assert(prolonged == nil or type(prolonged) == "boolean",
+      "Invalid value for parameter 'prolonged'")
+
   self.prolonged_usage = prolonged
   return self
 end

--- a/CorsixTH/Lua/humanoid_actions/use_screen.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_screen.lua
@@ -26,6 +26,9 @@ local UseScreenAction = _G["UseScreenAction"]
 --! Action to use the screen.
 --!param screen (object) Screen to use.
 function UseScreenAction:UseScreenAction(screen)
+  assert(class.is(screen, Object) and screen.object_type.id == "screen",
+      "Invalid value for parameter 'screen'")
+
   self:HumanoidAction("use_screen")
   self.object = screen
 end

--- a/CorsixTH/Lua/humanoid_actions/vaccinate.lua
+++ b/CorsixTH/Lua/humanoid_actions/vaccinate.lua
@@ -27,6 +27,9 @@ local VaccinateAction = _G["VaccinateAction"]
 --!param patient (Patient) Patient to vaccinate.
 --!param fee Amount of money to pay.
 function VaccinateAction:VaccinateAction(patient, fee)
+  assert(class.is(patient, Patient), "Invalid value for parameter 'patient'")
+  assert(type(fee) == "number", "Invalid value for parameter 'fee'")
+
   self:HumanoidAction("vaccinate")
   self.patient = patient -- Patient to vaccinate.
   self.vaccination_fee = fee -- Money to get from the patient.

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -27,6 +27,9 @@ local WalkAction = _G["WalkAction"]
 --!param x (int) X coordinate of the destination tile.
 --!param y (int) Y coordinate of the destination tile.
 function WalkAction:WalkAction(x, y)
+  assert(type(x) == "number", "Invalid value for parameter 'x'")
+  assert(type(y) == "number", "Invalid value for parameter 'y'")
+
   self:HumanoidAction("walk")
   self.x = x
   self.y = y
@@ -51,6 +54,8 @@ end
 --!param entering (bool) If set or nil, set the flag of entering the room.
 --!return (action) self, for daisy-chaining.
 function WalkAction:setIsEntering(entering)
+  assert(type(entering) == "boolean", "Invalid value for parameter 'entering'")
+
   self.is_entering = entering
   return self
 end

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -32,7 +32,7 @@ function WalkAction:WalkAction(x, y)
   self.y = y
   self.truncate_only_on_high_priority = false
   self.walking_to_vaccinate = false -- Nurse walking with the intention to vaccinate
-  self.is_entering = nil -- Whether the walk enters a room.
+  self.is_entering = false -- Whether the walk enters a room.
 end
 
 function WalkAction:truncateOnHighPriority()

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -111,7 +111,7 @@ function Room:createEnterAction(humanoid_entering, callback)
     self.humanoids_enroute[humanoid_entering] = {callback = callback}
   end
 
-  return WalkAction(x, y):setIsEntering(humanoid_entering and self or true)
+  return WalkAction(x, y):setIsEntering(true)
 end
 
 --! Get a patient in the room.

--- a/CorsixTH/Lua/rooms/operating_theatre.lua
+++ b/CorsixTH/Lua/rooms/operating_theatre.lua
@@ -80,6 +80,8 @@ function OperatingTheatreRoom:roomFinished()
 end
 
 local function wait_for_object(humanoid, obj, must_happen)
+  assert(type(must_happen) == "boolean", "must happen must be true or false")
+
   local loop_callback_wait = --[[persistable:operatring_theatre_wait]] function(action)
     if action.todo_interrupt or not obj.user then
       humanoid:finishAction(action)
@@ -106,7 +108,7 @@ function OperatingTheatreRoom:commandEnteringStaff(staff)
   -- Put surgeon outfit on
   local screen, screen_x, screen_y = self.world:findObjectNear(staff, "surgeon_screen")
   staff:walkTo(screen_x, screen_y)
-  staff:queueAction(wait_for_object(staff, screen))
+  staff:queueAction(wait_for_object(staff, screen, false))
   staff:queueAction(UseScreenAction(screen))
 
   -- Resume operation if already ongoing


### PR DESCRIPTION
The primary purpose of this pr is to add type checking to the action queue and enforce consistent types for given properties to make errors easier to trace.

During the process I also found a typo which is corrected in the first commit.