### PR TITLE
[rdy] Litter room fix

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -30,7 +30,7 @@ local runDebugger = dofile "run_debugger"
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 112
+local SAVEGAME_VERSION = 113
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -614,7 +614,7 @@ function UIEditRoom:returnToDoorPhase()
           break
         end
         if obj.object_type.id == "litter" then -- Silently remove litter from the world.
-          self.world:removeLitter(obj, x, y)
+          obj.remove()
           break
         end
         self.world:destroyEntity(obj)

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -488,6 +488,7 @@ function UIPlaceObjects:placeObject(dont_close_if_empty)
 
   local object = self.objects[self.active_index]
   if object.object.id == "reception_desk" then self.ui:tutorialStep(1, 4, "next") end
+
   local real_obj
   -- There might be an existing object that has been picked up.
   if object.existing_objects and #object.existing_objects > 0 then
@@ -500,6 +501,7 @@ function UIPlaceObjects:placeObject(dont_close_if_empty)
     if real_obj.orientation_before and real_obj.orientation_before ~= self.object_orientation then
       real_obj:initOrientation(self.object_orientation)
     end
+    self.world:removeAllLitterFromFootprint(real_obj.footprint, self.object_cell_x, self.object_cell_y)
     real_obj:setTile(self.object_cell_x, self.object_cell_y)
     self.world:objectPlaced(real_obj)
     if real_obj.slave then
@@ -512,6 +514,8 @@ function UIPlaceObjects:placeObject(dont_close_if_empty)
       real_obj:calculateSmoke(room)
     end
   else
+    local object_footprint = object.object.orientations[self.object_orientation].footprint
+    self.world:removeAllLitterFromFootprint(object_footprint, self.object_cell_x, self.object_cell_y)
     real_obj = self.world:newObject(object.object.id,
         self.object_cell_x, self.object_cell_y, self.object_orientation)
   end

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -481,7 +481,8 @@ function UIPlaceObjects:onMouseUp(button, x, y)
 end
 
 function UIPlaceObjects:placeObject(dont_close_if_empty)
-  if not self.place_objects then -- We don't want to place objects because we are selecting new objects for adding in a room being built/edited
+  if not self.place_objects then
+    -- We don't want to place objects because we are selecting new objects for adding in a room being built/edited
     return
   end
 
@@ -511,8 +512,8 @@ function UIPlaceObjects:placeObject(dont_close_if_empty)
       real_obj:calculateSmoke(room)
     end
   else
-    real_obj = self.world:newObject(object.object.id, self.object_cell_x,
-    self.object_cell_y, self.object_orientation)
+    real_obj = self.world:newObject(object.object.id,
+        self.object_cell_x, self.object_cell_y, self.object_orientation)
   end
   if room then
     room.objects[real_obj] = true
@@ -682,7 +683,7 @@ function UIPlaceObjects:setBlueprintCell(x, y)
     if self.object_anim and object.class ~= "SideObject" then
       if allgood then
         allgood = not world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, self.object_orientation, roomId)
- 	    end
+      end
       if ATTACH_BLUEPRINT_TO_TILE then
         self.object_anim:setTile(map, x, y)
       end

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -634,7 +634,7 @@ function UIPlaceObjects:setBlueprintCell(x, y)
       local x = x + tile[1]
       local y = y + tile[2]
       -- Check 1: Does the tile have valid map coordinates?:
-      if world:areFootprintTilesCoardinatesInvalid(x, y) then
+      if not world:isOnMap(x, y) then
         setAllGood(tile)
         x = 0
         y = 0

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -321,8 +321,7 @@ end
 
 function Patient:die()
   -- It may happen that this patient was just cured and then the room blew up.
-  -- (Hospital not set when going home)
-  local hospital = self.hospital or self.world:getLocalPlayerHospital()
+  local hospital = self.hospital
 
   if hospital.num_deaths < 1 then
     self.world.ui.adviser:say(_A.information.first_death)

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2137,11 +2137,16 @@ function Hospital:searchForHandymanTask(handyman, taskType)
   return index
 end
 
-
-function Hospital:getIndexOfTask(x, y, taskType)
+--! Find a handyman task by task type, position, and possibly the used object.
+--!param x (int) The X coordinate of the position.
+--!param y (int) The Y coordinate of the position.
+--!param taskType Type of the task.
+--!param obj (Object) If specified, the object used for doing the task.
+--! Since multiple litter objects may exist at the same tile, the object must be given when cleaning.
+function Hospital:getIndexOfTask(x, y, taskType, obj)
   local subTable = self:findHandymanTaskSubtable(taskType)
   for i, v in ipairs(subTable) do
-    if v.tile_x == x and v.tile_y == y then
+    if v.tile_x == x and v.tile_y == y and (obj == nil or v.object == obj) then
       return i
     end
   end

--- a/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
+++ b/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
@@ -46,11 +46,10 @@ local remove_litter = permanent"action_sweep_floor_remove_litter"( function(huma
   humanoid.user_of:setTile(nil)
   humanoid.user_of = nil
   humanoid:setTimer(humanoid.world:getAnimLength(animation_numbers[2]) * 2, finish)
-  local hospital = humanoid.world.hospitals[1]
+
+  local hospital = humanoid.world:getHospital(humanoid.tile_x, humanoid.tile_y)
   local taskIndex = hospital:getIndexOfTask(humanoid.tile_x, humanoid.tile_y, "cleaning")
-  if taskIndex ~= -1 then
   hospital:removeHandymanTask(taskIndex, "cleaning")
-  end
 end)
 
 local sweep = permanent"action_sweep_floor_sweep"( function(humanoid)

--- a/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
+++ b/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
@@ -42,14 +42,10 @@ local finish = permanent"action_sweep_floor_finish"( function(humanoid)
 end)
 
 local remove_litter = permanent"action_sweep_floor_remove_litter"( function(humanoid)
-  humanoid.world:removeLitter(humanoid.user_of, humanoid.tile_x, humanoid.tile_y)
+  humanoid.user_of:remove()
   humanoid.user_of:setTile(nil)
   humanoid.user_of = nil
   humanoid:setTimer(humanoid.world:getAnimLength(animation_numbers[2]) * 2, finish)
-
-  local hospital = humanoid.world:getHospital(humanoid.tile_x, humanoid.tile_y)
-  local taskIndex = hospital:getIndexOfTask(humanoid.tile_x, humanoid.tile_y, "cleaning")
-  hospital:removeHandymanTask(taskIndex, "cleaning")
 end)
 
 local sweep = permanent"action_sweep_floor_sweep"( function(humanoid)

--- a/CorsixTH/Lua/objects/litter.lua
+++ b/CorsixTH/Lua/objects/litter.lua
@@ -62,11 +62,9 @@ function Litter:Litter(world, object_type, x, y, direction, etc)
 end
 
 function Litter:setTile(x, y)
-  local map = self.world.map.th
   Entity.setTile(self, x, y)
   if x then
     self.world:addObjectToTile(self, x, y)
-    map:setCellFlags(x, y, {buildable = false})
   end
 end
 -- Litter is an Entity and not an Object so it does not inherit this method
@@ -98,7 +96,6 @@ function Litter:remove()
   assert(self:isCleanable())
 
   self.world:removeObjectFromTile(self, self.tile_x, self.tile_y)
-  self.world.map.th:setCellFlags(self.tile_x, self.tile_y, {buildable = true})
 
   local hospital = self.world:getHospital(self.tile_x, self.tile_y)
   local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning", self)

--- a/CorsixTH/Lua/objects/litter.lua
+++ b/CorsixTH/Lua/objects/litter.lua
@@ -87,7 +87,7 @@ function Litter:setLitterType(anim_type, mirrorFlag)
       error("Unknown litter type")
     end
     if self:isCleanable() then
-      local hospital = self.world:getLocalPlayerHospital()
+      local hospital = self.world:getHospital(self.tile_x, self.tile_y)
       hospital:addHandymanTask(self, "cleaning", 1, self.tile_x, self.tile_y)
     end
   end
@@ -133,7 +133,7 @@ function Litter:afterLoad(old, new)
   end
   if old < 54 then
     if not self:isCleanable() then
-      local hospital = self.world:getLocalPlayerHospital()
+      local hospital = self.world:getHospital(self.tile_x, self.tile_y)
       local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning")
       hospital:removeHandymanTask(taskIndex, "cleaning")
     end

--- a/CorsixTH/Lua/objects/litter.lua
+++ b/CorsixTH/Lua/objects/litter.lua
@@ -101,7 +101,7 @@ function Litter:remove()
   self.world.map.th:setCellFlags(self.tile_x, self.tile_y, {buildable = true})
 
   local hospital = self.world:getHospital(self.tile_x, self.tile_y)
-  local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning")
+  local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning", self)
   hospital:removeHandymanTask(taskIndex, "cleaning")
 
   self.world:destroyEntity(self)
@@ -148,7 +148,7 @@ function Litter:afterLoad(old, new)
   if old < 54 then
     if not self:isCleanable() then
       local hospital = self.world:getHospital(self.tile_x, self.tile_y)
-      local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning")
+      local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning", self)
       hospital:removeHandymanTask(taskIndex, "cleaning")
     end
   end

--- a/CorsixTH/Lua/objects/litter.lua
+++ b/CorsixTH/Lua/objects/litter.lua
@@ -93,6 +93,20 @@ function Litter:setLitterType(anim_type, mirrorFlag)
   end
 end
 
+--! Remove the litter from the world.
+function Litter:remove()
+  assert(self:isCleanable())
+
+  self.world:removeObjectFromTile(self, self.tile_x, self.tile_y)
+  self.world.map.th:setCellFlags(self.tile_x, self.tile_y, {buildable = true})
+
+  local hospital = self.world:getHospital(self.tile_x, self.tile_y)
+  local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning")
+  hospital:removeHandymanTask(taskIndex, "cleaning")
+
+  self.world:destroyEntity(self)
+end
+
 function Litter:getDrawingLayer()
   return 0
 end

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -64,6 +64,8 @@ function Room:initRoom(x, y, w, h, door, door2)
   self.objects = {--[[a set rather than a list]]}
   -- the set of humanoids walking to this room
   self.humanoids_enroute = {--[[a set rather than a list]]}
+
+  self.world:removeAllLitterFromRectangle(self.x, self.y, self.width, self.height)
 end
 
 --! Get the tile next to the door.

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1956,7 +1956,7 @@ function World:canNonSideObjectBeSpawnedAt(x, y, objects_id, orientation, spawn_
   for _, tile in ipairs(objects_footprint) do
     local tiles_world_x = x + tile[1]
     local tiles_world_y = y + tile[2]
-    if self:areFootprintTilesCoardinatesInvalid(tiles_world_x, tiles_world_y) then
+    if not self:isOnMap(tiles_world_x, tiles_world_y) then
       return false
     end
 
@@ -1971,8 +1971,12 @@ function World:canNonSideObjectBeSpawnedAt(x, y, objects_id, orientation, spawn_
   return not self:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, orientation, spawn_rooms_id)
 end
 
-function World:areFootprintTilesCoardinatesInvalid(x, y)
-  return x < 1 or x > self.map.width or y < 1 or y > self.map.height
+--! Test whether the given coordinate is on the map.
+--!param x (int) X position of the coordinate to test.
+--!param y (int) Y position of the coordinate to test.
+--!return (boolean) Whether the provided position is on the map.
+function World:isOnMap(x, y)
+  return x >= 1 and x <= self.map.width and y >= 1 and y <= self.map.height
 end
 
 ---

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2678,6 +2678,15 @@ function World:afterLoad(old, new)
   if old < 108 then
     self.room_build_callbacks = nil
   end
+  if old < 113 then -- Make cleanable littered tiles buildable.
+    for x = 1, self.map.width do
+      for y = 1, self.map.height do
+        local litter = self:getObject(x, y, "litter")
+        if litter and litter:isCleanable() then self.map:setCellFlags(x, y, {buildable=true}) end
+      end
+    end
+  end
+
   self.savegame_version = new
 end
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2252,16 +2252,6 @@ function World:getObject(x, y, id)
   return -- nil
 end
 
---! Remove litter from a tile.
---!param obj (Litter) litter to remove.
---!param x (int) X position of the tile.
---!param y (int) Y position of the tile.
-function World:removeLitter(obj, x, y)
-  self:removeObjectFromTile(obj, x, y)
-  self:destroyEntity(obj)
-  self.map.th:setCellFlags(x, y, {buildable = true})
-end
-
 --! Get the room at a given tile location.
 --!param x (int) X position of the queried tile.
 --!param y (int) Y position of the queried tile.

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -799,8 +799,7 @@ function World:newRoom(x, y, w, h, room_info, ...)
   -- Note: Room IDs will be unique, but they may not form continuous values
   -- from 1, as IDs of deleted rooms may not be re-issued for a while
   local class = room_info.class and _G[room_info.class] or Room
-  -- TODO: Take hospital based on the owner of the plot the room is built on
-  local hospital = self.hospitals[1]
+  local hospital = self:getHospital(x, y)
   local room = class(x, y, w, h, id, room_info, self, hospital, ...)
 
   self.rooms[id] = room
@@ -2264,11 +2263,23 @@ function World:removeLitter(obj, x, y)
 end
 
 --! Get the room at a given tile location.
---!param x X position of the queried tile.
---!param y Y position of the queried tile.
+--!param x (int) X position of the queried tile.
+--!param y (int) Y position of the queried tile.
 --!return (Room) Room of the tile, or 'nil'.
 function World:getRoom(x, y)
   return self.rooms[self.map:getRoomId(x, y)]
+end
+
+--! Get the hospital at a given tile location.
+--!param x (int) X position of the queried tile.
+--!param y (int) Y position of the queried tile.
+--!return (Hospital) Hospital at the given location or 'nil'.
+function World:getHospital(x, y)
+  local th = self.map.th
+
+  local flags = th:getCellFlags(x, y)
+  if not flags.hospital then return nil end
+  return self.hospitals[flags.owner]
 end
 
 --! Returns localized name of the room, internal required staff name

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2229,11 +2229,20 @@ function World:addObjectToTile(object, x, y)
   return true
 end
 
+--! Retrieve all objects from a given position.
+--!param x (int) X position of the object to retrieve.
+--!param y (int) Y position of the object to retrieve.
 function World:getObjects(x, y)
   local index = (y - 1) * self.map.width + x
   return self.objects[index]
 end
 
+--! Retrieve one object from a given position.
+--!param x (int) X position of the object to retrieve.
+--!param y (int) Y position of the object to retrieve.
+--!param id Id to search, nil gets first object, string gets first object with
+--! that id, set of strings gets first object that matches an entry in the set.
+--!return (Object or nil) The found object, or nil if the object is not found.
 function World:getObject(x, y, id)
   local objects = self:getObjects(x, y)
   if objects then
@@ -2254,6 +2263,48 @@ function World:getObject(x, y, id)
     end
   end
   return -- nil
+end
+
+--! Remove all cleanable litter from a given tile.
+--!param x (int) X position of the tile to clean.
+--!param y (int) Y position of the tile to clean.
+function World:removeAllLitter(x, y)
+  local litters = {}
+  local objects = self:getObjects(x, y)
+  if not objects then return end
+
+  for _, obj in ipairs(objects) do
+    if obj.object_type.id == "litter" and obj:isCleanable() then
+      litters[#litters + 1] = obj
+    end
+  end
+  for _, litter in ipairs(litters) do litter:remove() end
+end
+
+--! Remove all litter from the foot print of an object.
+--!param x (int) X position of the object
+--!param y (int) Y position of the object
+function World:removeAllLitterFromFootprint(object_footprint, x, y)
+  for _, tile in ipairs(object_footprint) do
+    if tile.complete_cell then
+      self:removeAllLitter(x + tile[1], y + tile[2])
+    end
+  end
+end
+
+--! Remove all litter from a rectangular area.
+--!param x (int) Start x position of the area.
+--!param y (int) Start y position of the area.
+--!param w (int) Number of tiles in x direction.
+--!param h (int) Number of tiles in y direction.
+function World:removeAllLitterFromRectangle(x, y, w, h)
+  x = x - 1
+  y = y - 1
+  for dx = 1, w do
+    for dy = 1, h do
+      self:removeAllLitter(x + dx, y + dy)
+    end
+  end
 end
 
 --! Get the room at a given tile location.


### PR DESCRIPTION
This should solve the room litter problem once and for all. It ignores litter as cause for non-buildability for rooms, clears litter from new rooms, and removes litter from rooms in old saves.

I am however not so happy with the buildable flag. It gets treated asif there is a single cause for the tile being non-buildable, but we have several possible causes. In case of litter, there is definitely the option to have more than 1 litter object at a tile, which means setting it to true unconditionally is just wrong.

Maybe the flag should have a cause , or it should be derivable from the tile contents (which would be major +1). Ideas?

Edit: https://github.com/CorsixTH/CorsixTH/pull/381#issuecomment-68917824  says we should never have more than one litter on a tile.

_Edit: Ignore the first 2 commits, they are fixes for a more useful work environment._