### PR TITLE
[RDY] Fix assert for use_screen action

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/use_screen.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_screen.lua
@@ -26,7 +26,9 @@ local UseScreenAction = _G["UseScreenAction"]
 --! Action to use the screen.
 --!param screen (object) Screen to use.
 function UseScreenAction:UseScreenAction(screen)
-  assert(class.is(screen, Object) and screen.object_type.id == "screen",
+  assert(class.is(screen, Object) and (
+      screen.object_type.id == "screen" or
+      screen.object_type.id == "surgeon_screen"),
       "Invalid value for parameter 'screen'")
 
   self:HumanoidAction("use_screen")


### PR DESCRIPTION
use_screen can apply to either regular screens or surgeon_screens. I missed
surgeon_screen in my earlier patch.