### PR TITLE
[rfc] Query custom graphics with the animation number as string.

### DIFF
--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -704,10 +704,33 @@ size_t THAnimationManager::getFrameCount() const
 
 size_t THAnimationManager::getFirstFrame(size_t iAnimation) const
 {
+    size_t result = getCustomFirstFrame(iAnimation);
+    if (result > 0)
+        return result;
+
+    return getOriginalFirstFrame(iAnimation);
+}
+
+size_t THAnimationManager::getOriginalFirstFrame(size_t iAnimation) const
+{
     if(iAnimation < m_iAnimationCount)
         return m_vFirstFrames[iAnimation];
     else
         return 0;
+}
+
+size_t THAnimationManager::getCustomFirstFrame(size_t iAnimation) const
+{
+    if (iAnimation > 99999) // Number too large to fit, requested animation doesn't exist.
+        return 0;
+
+    std::string name = std::to_string(iAnimation);
+    const AnimationStartFrames &anim_frames = getNamedAnimations(name, 64);
+    if (anim_frames.iNorth > 0) return getOriginalFirstFrame(anim_frames.iNorth);
+    if (anim_frames.iEast > 0)  return getOriginalFirstFrame(anim_frames.iEast);
+    if (anim_frames.iSouth > 0) return getOriginalFirstFrame(anim_frames.iSouth);
+    if (anim_frames.iWest > 0)  return getOriginalFirstFrame(anim_frames.iWest);
+    return 0;
 }
 
 size_t THAnimationManager::getNextFrame(size_t iFrame) const

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -297,6 +297,10 @@ public:
     size_t getFrameCount() const;
 
     //! Get the index of the first frame of an animation
+    /**!
+        @param iAnimation Animation to obtain.
+        @return The first frame of the requested animation if it exists, else \c 0.
+     */
     size_t getFirstFrame(size_t iAnimation) const;
 
     //! Get the index of the frame after a given frame
@@ -493,6 +497,21 @@ private:
         @param iLength Number of frames in the animation.
      */
     void fixNextFrame(uint32_t iFirst, size_t iLength);
+
+    //! Get the index of the first frame of an original animation
+    /*!
+        @param iAnimation Animation to obtain.
+        @return The first frame of the requested animation if it exists, else \c 0.
+     */
+    size_t getOriginalFirstFrame(size_t iAnimation) const;
+
+    //! Get the index of the first frame of a custom animation
+    /*!
+        @param iAnimation Animation to obtain.
+        @return The first frame of the requested animation if it exists, else \c 0.
+     */
+    size_t getCustomFirstFrame(size_t iAnimation) const;
+
 };
 
 struct THMapNode;


### PR DESCRIPTION
This enables simple replacement of original animations by custom
graphics.
