### PR TITLE
[WIP] Rename Room's 'room_info' member variable to 'data'.

### DIFF
--- a/CorsixTH/Lua/calls_dispatcher.lua
+++ b/CorsixTH/Lua/calls_dispatcher.lua
@@ -59,7 +59,7 @@ function CallsDispatcher:callForStaff(room)
       self:callForStaffEachRoom(room, attribute, attribute .. i)
     end
   end
-  local sound = room.room_info.call_sound
+  local sound = room.data.call_sound
   if anyone_missed and sound and not room.sound_played then
     room.world.ui:playAnnouncement(sound)
     room.sound_played = true
@@ -73,7 +73,7 @@ function CallsDispatcher:callForStaffEachRoom(room, attribute, key)
   local new_call = self:enqueue(
     room,
     key,
-    _S.calls_dispatcher.staff:format(room.room_info.name, attribute),
+    _S.calls_dispatcher.staff:format(room.data.name, attribute),
     --[[persistable:call_dispatcher_staff_verification]] function(staff)
       return CallsDispatcher.verifyStaffForRoom(room, attribute, staff)
     end,
@@ -118,7 +118,7 @@ function CallsDispatcher:callForRepair(object, urgent, manual, lock_room)
 
   if not manual and urgent then
     local room = object:getRoom()
-    local sound = room.room_info.handyman_call_sound
+    local sound = room.data.handyman_call_sound
     if sound then
       ui:playAnnouncement(sound)
       ui:playSound("machwarn.wav")
@@ -407,7 +407,7 @@ function CallsDispatcher.dumpCall(call, message)
   if(class.is(call_obj,Humanoid)) then
     print(call.key .. '@' .. position .. message)
   else
-    print((call_obj.room_info and call_obj.room_info.id or call_obj.object_type.id) ..
+    print((call_obj.data and call_obj.data.id or call_obj.object_type.id) ..
         '-' .. call.key .. '@' .. position .. message)
   end
 end
@@ -543,7 +543,7 @@ function CallsDispatcher.sendStaffToRoom(room, staff)
     staff:setNextAction(room:createEnterAction(staff))
     CallsDispatcher.queueCallCheckpointAction(staff, CallsDispatcher.staffActionInterruptHandler)
   end
-  staff:setDynamicInfoText(_S.dynamic_info.staff.actions.heading_for:format(room.room_info.name))
+  staff:setDynamicInfoText(_S.dynamic_info.staff.actions.heading_for:format(room.data.name))
 end
 
 function CallsDispatcher.staffActionInterruptHandler(action, humanoid, high_priority)

--- a/CorsixTH/Lua/dialogs/queue_dialog.lua
+++ b/CorsixTH/Lua/dialogs/queue_dialog.lua
@@ -202,12 +202,12 @@ function UIQueue:onMouseUp(button, x, y)
 
     -- The new room must be of the same class as the current one
     local this_room = self.dragged.patient.next_room_to_visit
-    if this_room and room and room ~= this_room and room.room_info.id == this_room.room_info.id then
+    if this_room and room and room ~= this_room and room.data.id == this_room.data.id then
       -- Move to another room
       local patient = self.dragged.patient
       patient:setNextAction(room:createEnterAction(patient))
       patient.next_room_to_visit = room
-      patient:updateDynamicInfo(_S.dynamic_info.patient.actions.on_my_way_to:format(room.room_info.name))
+      patient:updateDynamicInfo(_S.dynamic_info.patient.actions.on_my_way_to:format(room.data.name))
       room.door.queue:expect(patient)
       room.door:updateDynamicInfo()
     end

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -226,14 +226,14 @@ function Patient:getTreatmentDiseaseId()
   if self.diagnosed then
     return self.disease.id
   else
-    local room_info = self:getRoom()
-    if not room_info then
+    local data = self:getRoom()
+    if not data then
       print("Warning: Trying to receive money for treated patient who is "..
           "not in a room")
       return nil
     end
-    room_info = room_info.room_info
-    return "diag_" .. room_info.id
+    data = data.data
+    return "diag_" .. data.id
   end
 end
 
@@ -938,7 +938,7 @@ end
 
 function Patient:notifyNewRoom(room)
   Humanoid.notifyNewRoom(self, room)
-  if self.going_to_toilet == "no-toilets" and room.room_info.id == "toilets" then
+  if self.going_to_toilet == "no-toilets" and room.data.id == "toilets" then
     self.going_to_toilet = "no" -- Patient can try again going to the loo.
   end
 end

--- a/CorsixTH/Lua/entities/staff.lua
+++ b/CorsixTH/Lua/entities/staff.lua
@@ -254,7 +254,7 @@ function Staff:isTiring()
   local room = self:getRoom()
   -- Being in a staff room is actually quite refreshing, as long as you're not a handyman watering plants.
   if room then
-    if room.room_info.id == "staff_room" and not self.on_call then
+    if room.data.id == "staff_room" and not self.on_call then
       tiring = false
     end
   elseif self.humanoid_class ~= "Handyman" then
@@ -272,7 +272,7 @@ end
 function Staff:isResting()
   local room = self:getRoom()
 
-  if room and room.room_info.id == "staff_room" and not self.on_call then
+  if room and room.data.id == "staff_room" and not self.on_call then
     return true
   else
     return false
@@ -284,7 +284,7 @@ function Staff:isResearching()
   local room = self:getRoom()
 
   -- Staff is in research lab, is qualified, and is not leaving the hospital.
-  return room and room.room_info.id == "research" and
+  return room and room.data.id == "research" and
       self.humanoid_class == "Doctor" and self.profile.is_researcher >= 1.0 and self.hospital
 end
 
@@ -293,7 +293,7 @@ function Staff:isLearning()
   local room = self:getRoom()
 
   -- Staff is in training room, the training room has a consultant, and  is using lecture chair.
-  return room and room.room_info.id == "training" and room.staff_member and
+  return room and room.data.id == "training" and room.staff_member and
       self.action_queue[1].name == "use_object" and
       self.action_queue[1].object.object_type.id == "lecture_chair"
 end
@@ -302,8 +302,8 @@ function Staff:isLearningOnTheJob()
   local room = self:getRoom()
 
   -- Staff is in room but not training room, staff room, or toilets; is a doctor; and is using something
-  return room and room.room_info.id ~= "training" and
-      room.room_info.id ~= "staff_room" and room.room_info.id ~= "toilets" and
+  return room and room.data.id ~= "training" and
+      room.data.id ~= "staff_room" and room.data.id ~= "toilets" and
       self.humanoid_class == "Doctor" and self.action_queue[1].name == "use_object"
 end
 
@@ -337,7 +337,7 @@ function Staff:updateSkill(consultant, trait, amount)
       self:updateStaffTitle()
     elseif not old_profile.is_consultant and self.profile.is_consultant then
       self.world.ui.adviser:say(_A.information.promotion_to_consultant)
-      if self:getRoom().room_info.id == "training" then
+      if self:getRoom().data.id == "training" then
         self:setNextAction(self:getRoom():createLeaveAction())
         self:queueAction(MeanderAction())
         self.last_room = nil
@@ -444,7 +444,7 @@ function Staff:dump()
   print("Busy: ", (self:isIdle() and "idle" or "busy") .. (self.pickup and " and picked up" or ''))
   if self.going_to_staffroom then print("Going to staffroom") end
   if self.last_room then
-      print("Last room: ", self.last_room.room_info.id .. '@' .. self.last_room.x ..','.. self.last_room.y)
+      print("Last room: ", self.last_room.data.id .. '@' .. self.last_room.x ..','.. self.last_room.y)
   end
 
   if self.humanoid_class == "Handyman" then
@@ -540,7 +540,7 @@ function Staff:updateSpeed()
     level = 3
   end
   local room = self:getRoom()
-  if room and room.room_info.id == "training" then
+  if room and room.data.id == "training" then
     level = 1
   elseif self.attributes["fatigue"] then
     if self.attributes["fatigue"] >= 0.8 then
@@ -614,7 +614,7 @@ function Staff:checkIfNeedRest()
 end
 
 function Staff:notifyNewRoom(room)
-  if room.room_info.id == "staff_room" then
+  if room.data.id == "staff_room" then
     self.waiting_for_staffroom = false
   end
 end
@@ -719,13 +719,13 @@ end
 
 function Staff:adviseWrongPersonForThisRoom()
   local room = self:getRoom()
-  local room_name = room.room_info.long_name
-  local required = (room.room_info.maximum_staff or room.room_info.required_staff)
-  if self.humanoid_class == "Doctor" and room.room_info.id == "toilets" then
+  local room_name = room.data.long_name
+  local required = (room.data.maximum_staff or room.data.required_staff)
+  if self.humanoid_class == "Doctor" and room.data.id == "toilets" then
     self.world.ui.adviser:say(_A.staff_place_advice.doctors_cannot_work_in_room:format(room_name))
   elseif self.humanoid_class == "Nurse" then
     self.world.ui.adviser:say(_A.staff_place_advice.nurses_cannot_work_in_room:format(room_name))
-  elseif self.humanoid_class == "Doctor" and not room.room_info.id == "training" then
+  elseif self.humanoid_class == "Doctor" and not room.data.id == "training" then
     self.world.ui.adviser:say(_A.staff_place_advice.doctors_cannot_work_in_room:format(room_name))
   elseif required then
     if required.Nurse then
@@ -765,8 +765,8 @@ function Staff:isIdle()
   local room = self:getRoom()
   if room then
     -- in special rooms, never
-    if room.room_info.id == "staff_room" or room.room_info.id == "research" or
-        room.room_info.id == "training" then
+    if room.data.id == "staff_room" or room.data.id == "research" or
+        room.data.id == "training" then
       return false
     end
 
@@ -798,7 +798,7 @@ function Staff:isIdle()
     local x, y = self.action_queue[1].x, self.action_queue[1].y
     if x then
       room = self.world:getRoom(x, y)
-      if room and (room.room_info.id == "training" or room.room_info.id == "research") then
+      if room and (room.data.id == "training" or room.data.id == "research") then
         return false
       end
     end

--- a/CorsixTH/Lua/entities/vip.lua
+++ b/CorsixTH/Lua/entities/vip.lua
@@ -203,7 +203,7 @@ function Vip:evaluateRoom()
   self.num_visited_rooms = self.num_visited_rooms + 1
   local room = self.next_room
   -- if the player is about to kill a live patient for research, lower their rating dramatically
-  if room.room_info.id == "research" then
+  if room.data.id == "research" then
     if room:getPatient() then
       self.vip_rating = self.vip_rating - 80
     end
@@ -320,7 +320,7 @@ function Vip:setVIPRating()
   -- now we check for toilet presence
   local sum_toilets = 0
   for i, room in pairs(self.world.rooms) do
-    if room.room_info.id == "toilets" then
+    if room.data.id == "toilets" then
       for object, value in pairs(room.objects) do
         if object.object_type.id == "loo" then
           sum_toilets = sum_toilets + 1

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -427,9 +427,9 @@ function Hospital:afterLoad(old, new)
     -- Go through all rooms and find if a research department has been built
     -- Also check for training rooms where the training_factor needs to be set
     for _, room in pairs(self.world.rooms) do
-      if room.room_info.id == "research" then
+      if room.data.id == "research" then
         self.research_dep_built = true
-      elseif room.room_info.id == "training" then
+      elseif room.data.id == "training" then
         -- A standard value to keep things going
         room.training_factor = 5
       end
@@ -1787,13 +1787,13 @@ function Hospital:hasStaffOfCategory(category)
 end
 
 --! Checks if the hospital has a room of a given type.
---!param type (string) A room_info.id, e.g. "ward".
+--!param type (string) A data.id, e.g. "ward".
 --! Returns false if none, else number of that type found
 function Hospital:hasRoomOfType(type)
   -- Check how many rooms there are.
   local result = false
   for _, room in pairs(self.world.rooms) do
-    if room.hospital == self and room.room_info.id == type and room.is_active then
+    if room.hospital == self and room.data.id == type and room.is_active then
       result = (result or 0) + 1
     end
   end

--- a/CorsixTH/Lua/humanoid_actions/meander.lua
+++ b/CorsixTH/Lua/humanoid_actions/meander.lua
@@ -51,7 +51,7 @@ local function meander_action_start(action, humanoid)
           room:testStaffCriteria(room:getMaximumStaffCriteria(), humanoid) then
         humanoid:queueAction(room:createEnterAction(humanoid))
         humanoid:setDynamicInfoText(_S.dynamic_info.staff.actions.heading_for
-            :format(room.room_info.name))
+            :format(room.data.name))
         humanoid:finishAction()
         return
       end

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -372,7 +372,7 @@ local function action_queue_start(action, humanoid)
   if door then
     door:updateDynamicInfo()
     if class.is(humanoid, Patient) then
-      humanoid:updateDynamicInfo(_S.dynamic_info.patient.actions.queueing_for:format(door.room.room_info.name))
+      humanoid:updateDynamicInfo(_S.dynamic_info.patient.actions.queueing_for:format(door.room.data.name))
     end
   end
   humanoid:queueAction(IdleAction():setMustHappen(true):setIsLeaving(humanoid:isLeaving()), 0)

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -106,7 +106,7 @@ local action_seek_room_goto_room = permanent"action_seek_room_goto_room"( functi
   humanoid:setNextAction(room:createEnterAction(humanoid))
   humanoid.next_room_to_visit = room
   humanoid:updateDynamicInfo(_S.dynamic_info.patient.actions.on_my_way_to
-    :format(room.room_info.name))
+    :format(room.data.name))
   room.door.queue:expect(humanoid)
   room.door:updateDynamicInfo()
   if not room:testStaffCriteria(room:getRequiredStaffCriteria()) then
@@ -256,7 +256,7 @@ local function action_seek_room_start(action, humanoid)
       action.must_happen = true
 
       local remove_callback = --[[persistable:action_seek_room_remove_callback]] function(room)
-        if room.room_info.id == "research" then
+        if room.data.id == "research" then
           humanoid:updateMessage("research")
         end
       end -- End of remove_callback function
@@ -266,14 +266,14 @@ local function action_seek_room_start(action, humanoid)
       local build_callback
       build_callback = --[[persistable:action_seek_room_build_callback]] function(room)
         -- if research room was built, message may need to be updated
-        if room.room_info.id == "research" then
+        if room.data.id == "research" then
           humanoid:updateMessage("research")
         end
 
         local found = false
-        if room.room_info.id == action.room_type then
+        if room.data.id == action.room_type then
           found = true
-        elseif room.room_info.id == action.room_type_needed then
+        elseif room.data.id == action.room_type_needed then
           -- So the room that we're going to is not actually the room we waited for to be built.
           -- Example: Will go to ward, but is waiting for the operating theatre.
           -- Clean up and start over to find the room we actually want to go to.
@@ -286,7 +286,7 @@ local function action_seek_room_start(action, humanoid)
           -- Waiting for a diagnosis room, we need to go through the list - unless it is gp
           if action.room_type ~= "gp" then
             for i = 1, #humanoid.available_diagnosis_rooms do
-              if humanoid.available_diagnosis_rooms[i].id == room.room_info.id then
+              if humanoid.available_diagnosis_rooms[i].id == room.data.id then
                 found = true
               end
             end
@@ -296,7 +296,7 @@ local function action_seek_room_start(action, humanoid)
           -- Don't add a "go to room" action to the patient's queue if the
           -- autopsy machine is about to kill them:
           local current_room = humanoid:getRoom()
-          if not current_room or not (current_room.room_info.id == "research" and current_room:getStaffMember() and current_room:getStaffMember().action_queue[1].name == "multi_use_object") then
+          if not current_room or not (current_room.data.id == "research" and current_room:getStaffMember() and current_room:getStaffMember().action_queue[1].name == "multi_use_object") then
             action_seek_room_goto_room(room, humanoid, action.diagnosis_room)
           end
           TheApp.ui.bottom_panel:removeMessage(humanoid)

--- a/CorsixTH/Lua/humanoid_actions/seek_staffroom.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_staffroom.lua
@@ -42,7 +42,7 @@ local function seek_staffroom_action_start(action, humanoid)
   if room then
     local task = room:createEnterAction(humanoid):setMustHappen(true):setIsLeaving(true)
     humanoid:queueAction(task, 0)
-    humanoid:setDynamicInfoText(_S.dynamic_info.staff.actions.heading_for:format(room.room_info.name))
+    humanoid:setDynamicInfoText(_S.dynamic_info.staff.actions.heading_for:format(room.data.name))
   else
     -- This should happen only in rare cases, e.g. if the target staff room was removed while heading there and none other exists
     print("No staff room found in seek_staffroom action")

--- a/CorsixTH/Lua/humanoid_actions/seek_toilets.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_toilets.lua
@@ -57,7 +57,7 @@ local function seek_toilets_action_start(action, humanoid)
     -- removed while heading there and none other exists. In that case, go back
     -- to the previous room or go to the reception.
     if humanoid.next_room_to_visit then
-      humanoid:setNextAction(SeekRoomAction(humanoid.next_room_to_visit.room_info.id))
+      humanoid:setNextAction(SeekRoomAction(humanoid.next_room_to_visit.data.id))
     else
       humanoid:queueAction(SeekReceptionAction())
     end

--- a/CorsixTH/Lua/humanoid_actions/use_staffroom.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_staffroom.lua
@@ -116,10 +116,10 @@ local function use_staffroom_action_start(action, humanoid)
       -- Make sure that the room is still there though.
       -- If not, just answer the call
       if room and room.is_active and
-          (room.room_info.id == "research" or room.room_info.id == "training") and
+          (room.data.id == "research" or room.data.id == "training") and
           room:testStaffCriteria(room:getMaximumStaffCriteria(), humanoid) then
         humanoid:queueAction(room:createEnterAction(humanoid))
-        humanoid:setDynamicInfoText(_S.dynamic_info.staff.actions.heading_for:format(room.room_info.name))
+        humanoid:setDynamicInfoText(_S.dynamic_info.staff.actions.heading_for:format(room.data.name))
       else
         -- Send the staff out of the room
         humanoid:queueAction(MeanderAction())

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -300,7 +300,7 @@ navigateDoor = function(humanoid, x1, y1, dir)
     local action_index = 0
     if is_entering_room and queue:size() == 0 and not room:getPatient() and
         not door.user and not door.reserved_for and humanoid.should_knock_on_doors and
-        room.room_info.required_staff and not swinging then
+        room.data.required_staff and not swinging then
       humanoid:queueAction(KnockDoorAction(door, dir), action_index)
       action_index = action_index + 1
     end
@@ -314,7 +314,7 @@ navigateDoor = function(humanoid, x1, y1, dir)
     assert(action.reserve_on_resume == door)
     action.reserve_on_resume = nil
   elseif is_entering_room and not action.done_knock and humanoid.should_knock_on_doors and
-      room.room_info.required_staff and not swinging then
+      room.data.required_staff and not swinging then
     humanoid:setTilePositionSpeed(x1, y1)
     humanoid:queueAction(KnockDoorAction(door, dir), 0)
     action.reserve_on_resume = door
@@ -325,7 +325,7 @@ navigateDoor = function(humanoid, x1, y1, dir)
   local to_x, to_y
   local anims = humanoid.door_anims
   if not anims.leaving or not anims.entering then
-    local from_rm, to_rm = room.room_info.id, "corridor"
+    local from_rm, to_rm = room.data.id, "corridor"
     if is_entering_room then
       from_rm, to_rm = to_rm, from_rm
     end

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -321,7 +321,7 @@ function Map:setPlotOwner(plot_number, new_owner)
       if dir.layer == 0 and dir.room_cell_flags.roomId ~= 0 and
           dir.room_cell_flags.parcelId ~= dir.adj_cell_flags.parcelId then
         local room = self.app.world.rooms[dir.room_cell_flags.roomId]
-        local wall_type = self.app.walls[room.room_info.wall_type][dir.tile_cat][dir.wall_dir]
+        local wall_type = self.app.walls[room.data.wall_type][dir.tile_cat][dir.wall_dir]
         self.th:setCell(x, y, dir.block_id, wall_type)
       end
     end

--- a/CorsixTH/Lua/objects/door.lua
+++ b/CorsixTH/Lua/objects/door.lua
@@ -58,11 +58,11 @@ function Door:updateDynamicInfo()
   if self.room and self.queue then
     if not self.room:hasQueueDialog() then
       self:setDynamicInfo('text', {
-        self.room.room_info.name
+        self.room.data.name
       })
     else
       self:setDynamicInfo('text', {
-        self.room.room_info.name,
+        self.room.data.name,
         _S.dynamic_info.object.queue_size:format(self.queue:reportedSize()),
         _S.dynamic_info.object.queue_expected:format(self.queue:expectedSize())
       })
@@ -145,7 +145,7 @@ end
 
 function Door:closeDoor()
   if self.queue then
-    self.queue:rerouteAllPatients(SeekRoomAction(self:getRoom().room_info.id))
+    self.queue:rerouteAllPatients(SeekRoomAction(self:getRoom().data.id))
     self.queue = nil
   end
   self:clearDynamicInfo(nil)

--- a/CorsixTH/Lua/objects/reception_desk.lua
+++ b/CorsixTH/Lua/objects/reception_desk.lua
@@ -101,7 +101,7 @@ function ReceptionDesk:tick()
       if self.queue_advance_timer >= 4 + self.world.hours_per_day * (1.0 - self.receptionist.profile.skill) then
         reset_timer = true
         if queue_front.next_room_to_visit then
-          queue_front:queueAction(SeekRoomAction(queue_front.next_room_to_visit.room_info.id))
+          queue_front:queueAction(SeekRoomAction(queue_front.next_room_to_visit.data.id))
         else
           if class.is(queue_front, Inspector) then
             local inspector = queue_front

--- a/CorsixTH/Lua/research_department.lua
+++ b/CorsixTH/Lua/research_department.lua
@@ -603,7 +603,7 @@ function ResearchDepartment:researchCost()
   -- Find out how many doctors are currently doing research
   local doctors = 0
   for _, room in pairs(self.world.rooms) do
-    if room.room_info.id == "research" then
+    if room.data.id == "research" then
       for _, _ in pairs(room.staff_member_set) do
         doctors = doctors + 1
       end

--- a/CorsixTH/Lua/rooms/gp.lua
+++ b/CorsixTH/Lua/rooms/gp.lua
@@ -123,7 +123,7 @@ function GPRoom:dealtWithPatient(patient)
   end
 
   patient:setNextAction(self:createLeaveAction())
-  patient:addToTreatmentHistory(self.room_info)
+  patient:addToTreatmentHistory(self.data)
 
   -- If the patient got sent to the wrong room and needs telling where
   -- to go next - this happens when a disease changes for an epidemic

--- a/CorsixTH/Lua/rooms/toilets.lua
+++ b/CorsixTH/Lua/rooms/toilets.lua
@@ -62,7 +62,7 @@ function ToiletRoom:dealtWithPatient(patient)
   -- Continue going to the room before going to the toilets.
   patient:setNextAction(self:createLeaveAction())
   if patient.next_room_to_visit then
-    patient:queueAction(SeekRoomAction(patient.next_room_to_visit.room_info.id))
+    patient:queueAction(SeekRoomAction(patient.next_room_to_visit.data.id))
   else
     patient:queueAction(SeekReceptionAction())
   end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -794,13 +794,13 @@ function World:unregisterRoomRemoveCallback(callback)
   self.room_remove_callbacks[callback] = nil
 end
 
-function World:newRoom(x, y, w, h, room_info, ...)
+function World:newRoom(x, y, w, h, data, ...)
   local id = #self.rooms + 1
   -- Note: Room IDs will be unique, but they may not form continuous values
   -- from 1, as IDs of deleted rooms may not be re-issued for a while
-  local class = room_info.class and _G[room_info.class] or Room
+  local class = data.class and _G[data.class] or Room
   local hospital = self:getHospital(x, y)
-  local room = class(x, y, w, h, id, room_info, self, hospital, ...)
+  local room = class(x, y, w, h, id, data, self, hospital, ...)
 
   self.rooms[id] = room
   self:clearCaches()
@@ -811,9 +811,9 @@ end
 --!param room (Room) The new room.
 function World:markRoomAsBuilt(room)
   room:roomFinished()
-  local diag_disease = self.hospitals[1].disease_casebook["diag_" .. room.room_info.id]
+  local diag_disease = self.hospitals[1].disease_casebook["diag_" .. room.data.id]
   if diag_disease and not diag_disease.discovered then
-    self.hospitals[1].disease_casebook["diag_" .. room.room_info.id].discovered = true
+    self.hospitals[1].disease_casebook["diag_" .. room.data.id].discovered = true
   end
   for _, entity in ipairs(self.entities) do
     if entity.notifyNewRoom then
@@ -1859,7 +1859,7 @@ function World:findRoomNear(humanoid, room_type_id, distance, mode)
     distance = 2^30
   end
   for _, r in pairs(self.rooms) do repeat
-    if r.built and (not room_type_id or r.room_info.id == room_type_id) and r.is_active and r.door.queue.max_size ~= 0 then
+    if r.built and (not room_type_id or r.data.id == room_type_id) and r.is_active and r.door.queue.max_size ~= 0 then
       local x, y = r:getEntranceXY(false)
       local d = self:getPathDistance(humanoid.tile_x, humanoid.tile_y, x, y)
       if not d or d > distance then
@@ -1991,12 +1991,12 @@ function World:willObjectsFootprintTileBeWithinItsAllowedRoomIfLocatedAt(x, y, o
   elseif xy_rooms_id == 0 then
     return {within_room = object.corridor_object ~= nil, roomId = xy_rooms_id}
   else
-    for _, additional_objects_name in pairs(self.rooms[xy_rooms_id].room_info.objects_additional) do
+    for _, additional_objects_name in pairs(self.rooms[xy_rooms_id].data.objects_additional) do
       if TheApp.objects[additional_objects_name].thob == object.thob then
         return {within_room = true, roomId = xy_rooms_id}
       end
     end
-    for needed_objects_name, _ in pairs(self.rooms[xy_rooms_id].room_info.objects_needed) do
+    for needed_objects_name, _ in pairs(self.rooms[xy_rooms_id].data.objects_needed) do
       if TheApp.objects[needed_objects_name].thob == object.thob then
         return {within_room = true, roomId = xy_rooms_id}
       end
@@ -2429,10 +2429,10 @@ function World:afterLoad(old, new)
 
     -- Add room values
     for _, room in pairs(self.rooms) do
-      local valueChange = room.room_info.build_cost
+      local valueChange = room.data.build_cost
 
       -- Subtract values of objects in rooms to avoid calculating those object values twice
-      for obj, num in pairs(room.room_info.objects_needed) do
+      for obj, num in pairs(room.data.objects_needed) do
         valueChange = valueChange - num * TheApp.objects[obj].build_cost
       end
       value = value + valueChange
@@ -2617,7 +2617,7 @@ function World:afterLoad(old, new)
     -- Unreserve objects which are not actually reserved for real in the staff room.
     -- This is a special case where reserved_for could be set just as a staff member was leaving
     for _, room in pairs(self.rooms) do
-      if room.room_info.id == "staff_room" then
+      if room.data.id == "staff_room" then
         -- Find all objects in the room
         local fx, fy = room:getEntranceXY(true)
         for obj, _ in pairs(self:findAllObjectsNear(fx, fy)) do


### PR DESCRIPTION
room_info holds room-based data, and since it is already attached to a
Room object, the 'room_' part of the variable is redundant.

- This refactor helps simplify code snippets from `room.room_info` to
`room.data`.

*Note*: I need to test this more on my end; an old save seems to be
throwing errors about `room.data` being `nil` in the `hasRoomOfType`
function called in the Hospital `tick` function.

Also, if this is not worth pursuing, feel free to let me know.

Thanks.