### PR TITLE
Door and Object placement corrections Issues #221, #799

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1105,7 +1105,7 @@ end
 --!param xpos (int) X position of the tile.
 --!param ypos (int) Y position of the tile.
 --!param player_id (int) Player id owning the hospital.
---!param flag_names (array) If set, array with four additional required properties.
+--!param flag_names (array) If set, array with arbitrary additional required properties.
 --!return Whether the tile is considered to be valid.
 local function validDoorTile(xpos, ypos, player_id, flag_names)
   local th = TheApp.map.th
@@ -1113,7 +1113,11 @@ local function validDoorTile(xpos, ypos, player_id, flag_names)
   local tile_flags = th:getCellFlags(xpos, ypos)
   if not (tile_flags.buildable or tile_flags.passable or tile_flags.owner == player_id) then return false end
   if not flag_names then return true end
-  return tile_flags[flag_names[1]] and tile_flags[flag_names[2]] and tile_flags[flag_names[3]] and tile_flags[flag_names[4]]
+  local accumulate_flags = true
+  for i,flagtype in ipairs(flag_names) do
+    accumulate_flags = accumulate_flags and tile_flags[flagtype]
+  end
+  return accumulate_flags
 end
 
 function UIEditRoom:setDoorBlueprint(orig_x, orig_y, orig_wall)

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1105,7 +1105,7 @@ end
 --!param xpos (int) X position of the tile.
 --!param ypos (int) Y position of the tile.
 --!param player_id (int) Player id owning the hospital.
---!param flag_names (array) If set, array with two additional required properties.
+--!param flag_names (array) If set, array with four additional required properties.
 --!return Whether the tile is considered to be valid.
 local function validDoorTile(xpos, ypos, player_id, flag_names)
   local th = TheApp.map.th
@@ -1113,7 +1113,7 @@ local function validDoorTile(xpos, ypos, player_id, flag_names)
   local tile_flags = th:getCellFlags(xpos, ypos)
   if not (tile_flags.buildable or tile_flags.passable or tile_flags.owner == player_id) then return false end
   if not flag_names then return true end
-  return tile_flags[flag_names[1]] and tile_flags[flag_names[2]]
+  return tile_flags[flag_names[1]] and tile_flags[flag_names[2]] and tile_flags[flag_names[3]] and tile_flags[flag_names[4]]
 end
 
 function UIEditRoom:setDoorBlueprint(orig_x, orig_y, orig_wall)
@@ -1208,9 +1208,9 @@ function UIEditRoom:setDoorBlueprint(orig_x, orig_y, orig_wall)
     -- Ensure that the door isn't being built on top of an object
     local flag_names
     if wall == "west" then
-      flag_names = {"buildableNorth", "buildableSouth"}
+      flag_names = {"buildableNorth", "buildableSouth", "travelEast", "travelWest"}
     else
-      flag_names = {"buildableWest", "buildableEast"}
+      flag_names = {"buildableWest", "buildableEast","travelSouth", "travelNorth"}
     end
     local player_id = self.ui.hospital:getPlayerIndex()
 
@@ -1222,12 +1222,12 @@ function UIEditRoom:setDoorBlueprint(orig_x, orig_y, orig_wall)
     if self.room_type.swing_doors then
       local dx = x_mod and 1 or 0
       local dy = y_mod and 1 or 0
-      if not validDoorTile(x + dx, y + dy, player_id, nil) or
-          not validDoorTile(x2 + dx, y2 + dy, player_id, nil) then
+      if not validDoorTile(x + dx, y + dy, player_id, flag_names) or
+          not validDoorTile(x2 + dx, y2 + dy, player_id, flag_names) then
         self.blueprint_door.valid = false
       end
-      if not validDoorTile(x - dx, y - dy, player_id, nil) or
-          not validDoorTile(x2 - dx, y2 - dy, player_id, nil) then
+      if not validDoorTile(x - dx, y - dy, player_id, flag_names) or
+          not validDoorTile(x2 - dx, y2 - dy, player_id, flag_names) then
         self.blueprint_door.valid = false
       end
     end

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1113,11 +1113,10 @@ local function validDoorTile(xpos, ypos, player_id, flag_names)
   local tile_flags = th:getCellFlags(xpos, ypos)
   if not (tile_flags.buildable or tile_flags.passable or tile_flags.owner == player_id) then return false end
   if not flag_names then return true end
-  local accumulate_flags = true
-  for i,flagtype in ipairs(flag_names) do
-    accumulate_flags = accumulate_flags and tile_flags[flagtype]
+  for _,flagtype in ipairs(flag_names) do
+    if not tile_flags[flagtype] then return false end
   end
-  return accumulate_flags
+  return true
 end
 
 function UIEditRoom:setDoorBlueprint(orig_x, orig_y, orig_wall)

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -627,6 +627,9 @@ function UIPlaceObjects:setBlueprintCell(x, y)
       end
     end
 
+    local is_object_allowed = true
+    local good_tile = 24 + flag_alpha75
+    local bad_tile = 67 + flag_alpha75
     for i, tile in ipairs(object_footprint) do
       local xpos = x + tile[1]
       local ypos = y + tile[2]
@@ -637,8 +640,6 @@ function UIPlaceObjects:setBlueprintCell(x, y)
         ypos = 0
       else
         local flag = "buildable"
-        local good_tile = 24 + flag_alpha75
-        local bad_tile = 67 + flag_alpha75
         if tile.only_passable then
           flag = "passable"
         end
@@ -652,30 +653,43 @@ function UIPlaceObjects:setBlueprintCell(x, y)
 
         -- Check 2: Is the tile in the object's allowed room?:
         local result = world:willObjectsFootprintTileBeWithinItsAllowedRoomIfLocatedAt(xpos, ypos, object, roomId)
-        local is_object_allowed = result.within_room
+        is_object_allowed = is_object_allowed and result.within_room
         roomId = result.roomId
 
         -- Check 3: The footprint tile should either be buildable or passable, is it?:
+        flags = map:getCellFlags(xpos, ypos)
         if not tile.only_side and is_object_allowed then
-           is_object_allowed = world:isFootprintTileBuildableOrPassable(xpos, ypos, tile, object_footprint, flag, player_id)
+            is_object_allowed = is_object_allowed and (world:isFootprintTileBuildableOrPassable(xpos, ypos, tile, object_footprint, flag, player_id) or tile.invisible)
         elseif is_object_allowed then
-          is_object_allowed = map:getCellFlags(xpos, ypos, flags)[flag] and (player_id == 0 or flags.owner == player_id)
+          is_object_allowed = is_object_allowed and flags[flag] and (player_id == 0 or flags.owner == player_id)
         end
+        -- Check if tile is in the hospital building footprint
+        is_object_allowed = is_object_allowed and flags["hospital"]
 
-        -- Having checked if the tile is good set its blueprint appearance flag:
-        if is_object_allowed then
-          if not tile.invisible then
-            map:setCell(xpos, ypos, 4, good_tile)
-          end
-        else
-          if not tile.invisible then
-            map:setCell(xpos, ypos, 4, bad_tile)
-          end
-          setAllGood(tile)
+        -- Check 4: Are you placing next to a door?:
+        if not(tile.invisible) then
+		  is_object_allowed = is_object_allowed and not(flags["doorNorth"] or flags["doorWest"])
         end
+        -- Check 5: Object in the way still?:
+        is_object_allowed = is_object_allowed and ((flags["thob"] == 0 and flags["buildable"]) or tile.invisible)
       end
       self.object_footprint[i][1] = xpos
       self.object_footprint[i][2] = ypos
+    end
+    for i, tile in ipairs(object_footprint) do
+      local xpos = x + tile[1]
+      local ypos = y + tile[2]
+      -- Having checked if the tile is good set its blueprint appearance flag:
+      if is_object_allowed then
+        if not tile.invisible then
+          map:setCell(xpos, ypos, 4, good_tile)
+        end
+      else
+        if not tile.invisible then
+          map:setCell(xpos, ypos, 4, bad_tile)
+        end
+        setAllGood(tile)
+      end
     end
     if self.object_anim and object.class ~= "SideObject" then
       if allgood then

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -659,7 +659,7 @@ function UIPlaceObjects:setBlueprintCell(x, y)
         -- Check 3: The footprint tile should either be buildable or passable, is it?:
         flags = map:getCellFlags(xpos, ypos)
         if not tile.only_side and is_object_allowed then
-            is_object_allowed = is_object_allowed and (world:isFootprintTileBuildableOrPassable(xpos, ypos, tile, object_footprint, flag, player_id) or tile.invisible)
+          is_object_allowed = is_object_allowed and (world:isFootprintTileBuildableOrPassable(xpos, ypos, tile, object_footprint, flag, player_id) or tile.invisible)
         elseif is_object_allowed then
           is_object_allowed = is_object_allowed and flags[flag] and (player_id == 0 or flags.owner == player_id)
         end

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -663,12 +663,10 @@ function UIPlaceObjects:setBlueprintCell(x, y)
         elseif is_object_allowed then
           is_object_allowed = flags[flag] and (player_id == 0 or flags.owner == player_id)
         end
-        -- Check if tile is in the hospital building footprint
-        is_object_allowed = is_object_allowed and flags["hospital"]
 
         -- Check 4: Are you placing next to a door?:
         if not(tile.invisible) then
-         is_object_allowed = is_object_allowed and not(flags["doorNorth"] or flags["doorWest"])
+          is_object_allowed = is_object_allowed and not(flags["doorNorth"] or flags["doorWest"])
         end
         -- Check 5: Object in the way still?:
         is_object_allowed = is_object_allowed and ((flags["thob"] == 0 and flags["buildable"]) or tile.invisible)

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -659,16 +659,16 @@ function UIPlaceObjects:setBlueprintCell(x, y)
         -- Check 3: The footprint tile should either be buildable or passable, is it?:
         flags = map:getCellFlags(xpos, ypos)
         if not tile.only_side and is_object_allowed then
-          is_object_allowed = is_object_allowed and (world:isFootprintTileBuildableOrPassable(xpos, ypos, tile, object_footprint, flag, player_id) or tile.invisible)
+          is_object_allowed = world:isFootprintTileBuildableOrPassable(xpos, ypos, tile, object_footprint, flag, player_id) or tile.invisible
         elseif is_object_allowed then
-          is_object_allowed = is_object_allowed and flags[flag] and (player_id == 0 or flags.owner == player_id)
+          is_object_allowed = flags[flag] and (player_id == 0 or flags.owner == player_id)
         end
         -- Check if tile is in the hospital building footprint
         is_object_allowed = is_object_allowed and flags["hospital"]
 
         -- Check 4: Are you placing next to a door?:
         if not(tile.invisible) then
-		  is_object_allowed = is_object_allowed and not(flags["doorNorth"] or flags["doorWest"])
+         is_object_allowed = is_object_allowed and not(flags["doorNorth"] or flags["doorWest"])
         end
         -- Check 5: Object in the way still?:
         is_object_allowed = is_object_allowed and ((flags["thob"] == 0 and flags["buildable"]) or tile.invisible)


### PR DESCRIPTION
Fixes here hopefully resolves the  #221 & #799 issues. I also corrected a number of inconsistencies with the original TH. Like restricting objects to the room when building a room. Persisting the footprint checks across all tiles, rather than each individual tile. Restricting other objects to the wall boundaries of the hospital (I can't recall if litter can be dropped outside, and if this will have an issue).
Thats just a couple lines in place_object.lua
+        -- Check if tile is in the hospital building footprint
+        is_object_allowed = is_object_allowed and flags["hospital"]

