### PR TITLE
Doors should be passable

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1105,7 +1105,7 @@ end
 --!param xpos (int) X position of the tile.
 --!param ypos (int) Y position of the tile.
 --!param player_id (int) Player id owning the hospital.
---!param flag_names (array) If set, array with four additional required properties.
+--!param flag_names (array) If set, array with arbitrary additional required properties.
 --!return Whether the tile is considered to be valid.
 local function validDoorTile(xpos, ypos, player_id, flag_names)
   local th = TheApp.map.th
@@ -1113,7 +1113,11 @@ local function validDoorTile(xpos, ypos, player_id, flag_names)
   local tile_flags = th:getCellFlags(xpos, ypos)
   if not (tile_flags.buildable or tile_flags.passable or tile_flags.owner == player_id) then return false end
   if not flag_names then return true end
-  return tile_flags[flag_names[1]] and tile_flags[flag_names[2]] and tile_flags[flag_names[3]] and tile_flags[flag_names[4]]
+  local accumulate_flags = true
+  for i,flagtype in ipairs(flag_names) do
+    accumulate_flags = accumulate_flags and tile_flags[flagtype]
+  end
+  return accumulate_flags
 end
 
 function UIEditRoom:setDoorBlueprint(orig_x, orig_y, orig_wall)

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1124,7 +1124,7 @@ end
 --!param xpos (int) X position of the tile.
 --!param ypos (int) Y position of the tile.
 --!param player_id (int) Player id owning the hospital.
---!param flag_names (array) If set, array with four additional required properties.
+--!param flag_names (array) If set, array with arbitrary additional required properties.
 --!return Whether the tile is considered to be valid.
 local function validDoorTile(xpos, ypos, player_id, flag_names)
   local th = TheApp.map.th

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1105,7 +1105,7 @@ end
 --!param xpos (int) X position of the tile.
 --!param ypos (int) Y position of the tile.
 --!param player_id (int) Player id owning the hospital.
---!param flag_names (array) If set, array with two additional required properties.
+--!param flag_names (array) If set, array with four additional required properties.
 --!return Whether the tile is considered to be valid.
 local function validDoorTile(xpos, ypos, player_id, flag_names)
   local th = TheApp.map.th
@@ -1113,7 +1113,7 @@ local function validDoorTile(xpos, ypos, player_id, flag_names)
   local tile_flags = th:getCellFlags(xpos, ypos)
   if not (tile_flags.buildable or tile_flags.passable or tile_flags.owner == player_id) then return false end
   if not flag_names then return true end
-  return tile_flags[flag_names[1]] and tile_flags[flag_names[2]]
+  return tile_flags[flag_names[1]] and tile_flags[flag_names[2]] and tile_flags[flag_names[3]] and tile_flags[flag_names[4]]
 end
 
 function UIEditRoom:setDoorBlueprint(orig_x, orig_y, orig_wall)
@@ -1208,9 +1208,9 @@ function UIEditRoom:setDoorBlueprint(orig_x, orig_y, orig_wall)
     -- Ensure that the door isn't being built on top of an object
     local flag_names
     if wall == "west" then
-      flag_names = {"buildableNorth", "buildableSouth"}
+      flag_names = {"buildableNorth", "buildableSouth", "travelEast", "travelWest"}
     else
-      flag_names = {"buildableWest", "buildableEast"}
+      flag_names = {"buildableWest", "buildableEast","travelSouth", "travelNorth"}
     end
     local player_id = self.ui.hospital:getPlayerIndex()
 
@@ -1222,12 +1222,12 @@ function UIEditRoom:setDoorBlueprint(orig_x, orig_y, orig_wall)
     if self.room_type.swing_doors then
       local dx = x_mod and 1 or 0
       local dy = y_mod and 1 or 0
-      if not validDoorTile(x + dx, y + dy, player_id, nil) or
-          not validDoorTile(x2 + dx, y2 + dy, player_id, nil) then
+      if not validDoorTile(x + dx, y + dy, player_id, flag_names) or
+          not validDoorTile(x2 + dx, y2 + dy, player_id, flag_names) then
         self.blueprint_door.valid = false
       end
-      if not validDoorTile(x - dx, y - dy, player_id, nil) or
-          not validDoorTile(x2 - dx, y2 - dy, player_id, nil) then
+      if not validDoorTile(x - dx, y - dy, player_id, flag_names) or
+          not validDoorTile(x2 - dx, y2 - dy, player_id, flag_names) then
         self.blueprint_door.valid = false
       end
     end

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1113,11 +1113,10 @@ local function validDoorTile(xpos, ypos, player_id, flag_names)
   local tile_flags = th:getCellFlags(xpos, ypos)
   if not (tile_flags.buildable or tile_flags.passable or tile_flags.owner == player_id) then return false end
   if not flag_names then return true end
-  local accumulate_flags = true
-  for i,flagtype in ipairs(flag_names) do
-    accumulate_flags = accumulate_flags and tile_flags[flagtype]
+  for _,flagtype in ipairs(flag_names) do
+    if not tile_flags[flagtype] then return false end
   end
-  return accumulate_flags
+  return true
 end
 
 function UIEditRoom:setDoorBlueprint(orig_x, orig_y, orig_wall)


### PR DESCRIPTION
Door logic updated to better reflect issues raised in and preparing to fix #221, #799. This commit doesn't prevent objects being placed in the path of a door, just that a door cannot be placed with an object in the way.

There are some changes to displaying the individual tile on a swing door that is blocked, either 1, 2 or all 3 on swing doors will show as red if blocked.

Swing doors were not correctly being placed into corners, I've replicated TH - which might have been a bug originally, that it has to be two tiles down on the north wall to the east, not 1 like the others.
East (right corner) and South walls (left corner) were not enforcing swing doors out of the corners