### PR TITLE
[rdy] Keep labels of the graph within their space, addresses #1008

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = dofile "run_debugger"
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 116
+local SAVEGAME_VERSION = 117
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/fullscreen/graphs.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/graphs.lua
@@ -434,7 +434,7 @@ function UIGraphs:close()
 end
 
 function UIGraphs:afterLoad(old, new)
-  if old < 60 then
+  if old < 117 then
     self:close()
   end
 end


### PR DESCRIPTION
Don't print graph labels below the bottom of the graph, 2 pictures to show below.

The order of the entries in a clustered sequence looks unstable, but it's not a problem imho, as such labels all belong to the same position at the screen, so order has little meaning anyway

![screenshot from 2016-12-03 13-41-36](https://cloud.githubusercontent.com/assets/3254232/20859410/c3facc7e-b95e-11e6-82ee-0c679a537bde.png)
