### PR TITLE
Added version tag

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1284,8 +1284,10 @@ end
 -- a specific savegame verion is from.
 function App:getVersion(version)
   local ver = version or self.savegame_version
-  if ver > 111 then
+  if ver > 117 then
     return "Trunk"
+  elseif ver > 111 then
+    return "v0.61"
   elseif ver > 105 then
     return "v0.60"
   elseif ver > 91 then


### PR DESCRIPTION
Added a proper version tag for the latest source build of CorsixTH (Version number 117.)

It was just showing as "Trunk" and now it will show as "v0.61" (Whoever updated the version number to 117 forgot to add a version tag for it.)