### PR TITLE
Patients queue for rooms with max queue size 0

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1806,7 +1806,7 @@ function World:findRoomNear(humanoid, room_type_id, distance, mode)
     distance = 2^30
   end
   for _, r in pairs(self.rooms) do repeat
-    if r.built and (not room_type_id or r.room_info.id == room_type_id) and r.is_active and r.door.queue.max_size ~= 0 then
+    if r.built and (not room_type_id or r.room_info.id == room_type_id) and r.is_active then
       local x, y = r:getEntranceXY(false)
       local d = self:getPathDistance(humanoid.tile_x, humanoid.tile_y, x, y)
       if not d or d > distance then


### PR DESCRIPTION
Related to issue #573 

This restores the original TH behaviour of having rooms with max queue size 0 be used once all available queues are above their max queue size.

Closed rooms still receive a penalty in findRoomNear so they should never be used before open rooms.

Not 100% sure how this will interact with the usage of findRoomNear in patient.lua, which doesn't use advanced mode.