### PR TITLE
[RDY] Support current FFMPEG / libAV APIs

### DIFF
--- a/CorsixTH/Src/th_movie.h
+++ b/CorsixTH/Src/th_movie.h
@@ -288,6 +288,9 @@ private:
     static const size_t ms_movieErrorBufferSize = 128; ///< Buffer to hold last error description
     static const size_t ms_audioBufferSize = 1024; ///< Buffer for audio playback
 
+    //! Get the AVCodecContext associated with a given stream
+    AVCodecContext* getCodecContextForStream(AVCodec* codec, AVStream* stream) const;
+
     //! Decode audio from the movie into a format suitable for playback
     int decodeAudioFrame(bool fFirst);
 


### PR DESCRIPTION
Conditionally replaces deprecated ffmpeg / libav functions and procedures with current equivalents. The most significant being the change to the avcodec_send_packet / avcodec_receive_frame decoding API that replaces the old avcodec_video_decode and avcodec_audio_decode functions.