### PR TITLE
[RFC] Indicate to SDL2 when we are expecting textbox input

### DIFF
--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -26,6 +26,8 @@ class "Window"
 ---@type Window
 local Window = _G["Window"]
 
+local sdl = require("sdl")
+
 -- NB: pressed mouse buttons are denoted with a "mouse_" prefix in buttons_down,
 -- i.e. mouse_left, mouse_middle, mouse_right
 Window.buttons_down = permanent"Window.buttons_down" {}
@@ -973,9 +975,11 @@ function Textbox:setActive(active)
     self.cursor_state = true
     self.cursor_pos[1] = type(self.text) == "table" and #self.text or 1
     self.cursor_pos[2] = type(self.text) == "table" and string.len(self.text[#self.text]) or string.len(self.text)
+    sdl.startTextInput()
     -- Update text
     self.panel:setLabel(self.text)
   else
+    sdl.stopTextInput()
     self.cursor_state = false
   end
 

--- a/CorsixTH/Src/sdl_core.cpp
+++ b/CorsixTH/Src/sdl_core.cpp
@@ -357,10 +357,24 @@ static int l_get_ticks(lua_State *L)
     return 1;
 }
 
+static int l_start_text_input(lua_State *L)
+{
+    SDL_StartTextInput();
+    return 0;
+}
+
+static int l_stop_text_input(lua_State *L)
+{
+    SDL_StopTextInput();
+    return 0;
+}
+
 static const std::vector<luaL_Reg> sdllib = {
     {"init", l_init},
     {"getTicks", l_get_ticks},
     {"getKeyModifiers", l_get_key_modifiers},
+    {"startTextInput", l_start_text_input},
+    {"stopTextInput", l_stop_text_input},
     {nullptr, nullptr}
 };
 static const std::vector<luaL_Reg> sdllib_with_upvalue = {


### PR DESCRIPTION
This will open a virtual keyboard on appropriate environments and tell SDL2 to
fire SDL_TEXTINPUT events which handles unicode (IME) input. This commit does
not add processing of SDL_TEXTINPUT events.

I don't actually have any devices to test this on, so if anyone has a touch screen with an on demand virtual keyboard please run this and see if it works!