### PR TITLE
[RDY] Fix cppcheck errors

### DIFF
--- a/AnimView/th.cpp
+++ b/AnimView/th.cpp
@@ -25,6 +25,7 @@ SOFTWARE.
 #include <wx/toplevel.h>
 #include <wx/filename.h>
 #include <map>
+#include <vector>
 
 static const unsigned char palette_upscale_map[0x40] = {
     0x00, 0x04, 0x08, 0x0C, 0x10, 0x14, 0x18, 0x1C,
@@ -368,7 +369,7 @@ bool THAnimations::loadXMLFile(TiXmlDocument* xmlDocument)
     m_pFrames = new th_frame_t[m_iFrameCount];
     m_pElementList = new uint16_t[m_iElementListCount];
     m_pElements = new th_element_t[m_iElementCount];
-    uint16_t* tmp_pElementMap = new uint16_t[m_iElementListCount];
+    std::vector<uint16_t> tmp_elementMap(m_iElementListCount, 0);
     m_pSprites = new th_sprite_t[m_iSpriteCount];
     m_pSpriteImages = new wxImage[m_iSpriteCount];
     m_pSpriteScaleFactors = new uint8_t[m_iSpriteCount];
@@ -419,11 +420,11 @@ bool THAnimations::loadXMLFile(TiXmlDocument* xmlDocument)
                     if(iOldElement < iOldElementCount) {
                         //this is a re-used element id from the old numbering system, so look up the new element id
                         //in the new numbering system.
-                        iNewElement = tmp_pElementMap[iOldElement];
+                        iNewElement = tmp_elementMap.at(iOldElement);
                     } else {
                         if( iNewElementCount < m_iElementCount )
                         {
-                            tmp_pElementMap[iOldElement]=iNewElementCount;
+                            tmp_elementMap[iOldElement] = iNewElementCount;
                             iOldElementCount = iOldElement + 1;
                             iNewElement = iNewElementCount;
                             iNewElementCount++;

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -632,10 +632,13 @@ bool THAnimationManager::loadCustomAnimations(const uint8_t* pData, size_t iData
 
             // Load data.
             uint8_t *pData = new (std::nothrow) uint8_t[iSize];
-            if (pData == nullptr)
+            if (pData == nullptr) {
                 return false;
-            if (!input.Available(iSize))
+            }
+            if (!input.Available(iSize)) {
+                delete[] pData;
                 return false;
+            }
             for (uint32_t i = 0; i < iSize; i++)
                 pData[i] = input.Uint8();
 

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -506,8 +506,8 @@ void THMap::save(std::string filename)
     }
     aReverseBlockLUT[0] = 0;
 
-    for(THMapNode *pNode = m_pCells, *pLastNode = pNode + m_iWidth * m_iHeight;
-        pNode != pLastNode; ++pNode)
+    for(THMapNode *pNode = m_pCells, *pLimitNode = pNode + m_iWidth * m_iHeight;
+        pNode != pLimitNode; ++pNode)
     {
         // TODO: Nicer system for saving object data
         aBuffer[iBufferNext++] = pNode->flags.tall_west ? 1 : 0;
@@ -547,8 +547,8 @@ void THMap::save(std::string filename)
             iBufferNext = 0;
         }
     }
-    for(THMapNode *pNode = m_pCells, *pLastNode = pNode + m_iWidth * m_iHeight;
-        pNode != pLastNode; ++pNode)
+    for(THMapNode *pNode = m_pCells, *pLimitNode = pNode + m_iWidth * m_iHeight;
+        pNode != pLimitNode; ++pNode)
     {
         aBuffer[iBufferNext++] = static_cast<uint8_t>(pNode->iParcelId & 0xFF);
         aBuffer[iBufferNext++] = static_cast<uint8_t>(pNode->iParcelId >> 8);
@@ -1233,8 +1233,8 @@ uint32_t THMap::thermalNeighbour(uint32_t &iNeighbourSum, bool canTravel, uint32
     THMapNode* pNeighbour = pNode + relative_idx;
 
     // Ensure the neighbour is within the map bounds
-    THMapNode* pLastNode = m_pCells + m_iWidth * m_iHeight;
-    if (pNeighbour < m_pCells || pNeighbour >= pLastNode) {
+    THMapNode* pLimitNode = m_pCells + m_iWidth * m_iHeight;
+    if (pNeighbour < m_pCells || pNeighbour >= pLimitNode) {
         return 0;
     }
 
@@ -1272,8 +1272,8 @@ void THMap::updateTemperatures(uint16_t iAirTemperature,
     m_iCurrentTemperatureIndex ^= 1;
     const int iNewTemp = m_iCurrentTemperatureIndex;
 
-    THMapNode* pLastNode = m_pCells + m_iWidth * m_iHeight;
-    for(THMapNode *pNode = m_pCells; pNode != pLastNode; ++pNode)
+    THMapNode* pLimitNode = m_pCells + m_iWidth * m_iHeight;
+    for(THMapNode *pNode = m_pCells; pNode != pLimitNode; ++pNode)
     {
         // Get average temperature of neighbour cells
         uint32_t iNeighbourSum = 0;
@@ -1437,8 +1437,8 @@ void THMap::persist(LuaPersistWriter *pWriter) const
     pWriter->writeVUInt(m_iHeight);
     pWriter->writeVUInt(m_iCurrentTemperatureIndex);
     oEncoder.initialise(6);
-    for(THMapNode *pNode = m_pCells, *pLastNode = m_pCells + m_iWidth * m_iHeight;
-        pNode != pLastNode; ++pNode)
+    for(THMapNode *pNode = m_pCells, *pLimitNode = m_pCells + m_iWidth * m_iHeight;
+        pNode != pLimitNode; ++pNode)
     {
         oEncoder.write(pNode->iBlock[0]);
         oEncoder.write(pNode->iBlock[1]);
@@ -1466,8 +1466,8 @@ void THMap::persist(LuaPersistWriter *pWriter) const
     oEncoder.pumpOutput(pWriter);
 
     oEncoder.initialise(5);
-    for(THMapNode *pNode = m_pOriginalCells, *pLastNode = m_pOriginalCells + m_iWidth * m_iHeight;
-        pNode != pLastNode; ++pNode)
+    for(THMapNode *pNode = m_pOriginalCells, *pLimitNode = m_pOriginalCells + m_iWidth * m_iHeight;
+        pNode != pLimitNode; ++pNode)
     {
         oEncoder.write(pNode->iBlock[0]);
         oEncoder.write(pNode->iBlock[1]);
@@ -1540,8 +1540,8 @@ void THMap::depersist(LuaPersistReader *pReader)
         if(!pReader->readVUInt(m_iCurrentTemperatureIndex))
             return;
     }
-    for(THMapNode *pNode = m_pCells, *pLastNode = m_pCells + m_iWidth * m_iHeight;
-        pNode != pLastNode; ++pNode)
+    for(THMapNode *pNode = m_pCells, *pLimitNode = m_pCells + m_iWidth * m_iHeight;
+        pNode != pLimitNode; ++pNode)
     {
         uint32_t f;
         if(!pReader->readVUInt(f)) return;
@@ -1573,8 +1573,8 @@ void THMap::depersist(LuaPersistReader *pReader)
         lua_pop(L, 1);
     }
     oDecoder.initialise(6, pReader);
-    for(THMapNode *pNode = m_pCells, *pLastNode = m_pCells + m_iWidth * m_iHeight;
-        pNode != pLastNode; ++pNode)
+    for(THMapNode *pNode = m_pCells, *pLimitNode = m_pCells + m_iWidth * m_iHeight;
+        pNode != pLimitNode; ++pNode)
     {
         pNode->iBlock[0] = static_cast<uint16_t>(oDecoder.read());
         pNode->iBlock[1] = static_cast<uint16_t>(oDecoder.read());
@@ -1584,8 +1584,8 @@ void THMap::depersist(LuaPersistReader *pReader)
         pNode->iRoomId   = static_cast<uint16_t>(oDecoder.read());
     }
     oDecoder.initialise(5, pReader);
-    for(THMapNode *pNode = m_pOriginalCells, *pLastNode = m_pOriginalCells + m_iWidth * m_iHeight;
-        pNode != pLastNode; ++pNode)
+    for(THMapNode *pNode = m_pOriginalCells, *pLimitNode = m_pOriginalCells + m_iWidth * m_iHeight;
+        pNode != pLimitNode; ++pNode)
     {
         pNode->iBlock[0] = static_cast<uint16_t>(oDecoder.read());
         pNode->iBlock[1] = static_cast<uint16_t>(oDecoder.read());

--- a/CorsixTH/Src/th_map.h
+++ b/CorsixTH/Src/th_map.h
@@ -393,6 +393,15 @@ private:
     void _writeTileIndex(uint8_t* pData, int iX, int iY) const;
     int _getParcelTileCount(int iParcelId) const;
 
+    //! Calculate a weighted impact of a neighbour node on the temperature of the current node.
+    //! \param iNeighbourSum Incremented by the temperature of the node multiplied by the weight of the connection.
+    //! \param canTravel A node flag indicating whether travel between this node and it's neighbour is allowed.
+    //! \param relative_idx The index of the neighbour node, relative to this node into m_pCells.
+    //! \param pNode A pointer to the current node being tested.
+    //! \param prevTemp The array index into THMapNode::aiTemperature that currently stores the temperature of the node (prior to this calculation).
+    //! \return The weight of the connection, 0 if there is no neighbour, 1 through walls, and 4 through air.
+    uint32_t thermalNeighbour(uint32_t &iNeighbourSum, bool canTravel, uint32_t relative_idx, THMapNode* pNode, int prevTemp) const;
+
     //! Create the adjacency matrix if it doesn't already exist
     void _makeAdjacencyMatrix();
 

--- a/CorsixTH/Src/th_pathfind.h
+++ b/CorsixTH/Src/th_pathfind.h
@@ -203,7 +203,7 @@ public:
     path.
 
     Internally, the A* search algorithm is used. The open set is implemented as
-    a heap in m_ppOpenHeap, and there is no explicit closed set. For each cell
+    a heap in m_openHeap, and there is no explicit closed set. For each cell
     of the map, a node_t structure is created (and cached between searches if
     the map size is constant), which holds information about said map cell in
     the current search. The algorithm is implemented in such a way that most
@@ -278,18 +278,13 @@ public:
           value(i) <= value(i * 2 + 1)
           value(i) <= value(i * 2 + 2)
         This causes the array to be a minimum binary heap.
-
-        Note that unlike the dirty list, there is only space for #m_iOpenSize
-        items (with #m_iOpenCount being the current number of items).
     */
-    node_t **m_ppOpenHeap;
+    std::vector<node_t*> m_openHeap;
 
     node_t *m_pDestination;
     int m_iNodeCacheWidth;
     int m_iNodeCacheHeight;
     int m_iDirtyCount;
-    int m_iOpenCount;
-    int m_iOpenSize;
 
 private:
     PathFinder m_oPathFinder;


### PR DESCRIPTION
Fixes all errors reported by cppcheck 1.80 using the default arguments. A few warnings remain in scanner.cpp.

Mostly this involved fixing edge case memory leaks, either by adding deletes or by moving away from using raw memory buffers entirely.