### PR TITLE
Use CMake to handle pre-built dependencies automatically 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ CorsixTH/config.txt
 /Makefile
 /SDL
 /SDL_mixer-1.2.8
+/PrecompiledDeps
 /doc
 
 # For CorsixTH directory and Windows

--- a/CMake/PrecompiledDeps.cmake
+++ b/CMake/PrecompiledDeps.cmake
@@ -80,7 +80,7 @@ unset( _DEPS_TMP_PATH )
 unset( _DEPS_MODULES_TEMPLATE_NAME )
 
 # Determine the appropriate libs to use for this compiler
-if (UNIX AND CMAKE_COMPILER_IS_GNUCC)
+if (UNIX AND CMAKE_COMPILER_IS_GNU)
     # We need user to choose which arch they are intending to compile for
     set(DEPS_ARCH "x86" CACHE STRING "Architecture of precompiled dependencies to use.")
     set_property(CACHE DEPS_ARCH

--- a/CMake/PrecompiledDeps.cmake
+++ b/CMake/PrecompiledDeps.cmake
@@ -90,9 +90,9 @@ if (UNIX AND CMAKE_COMPILER_IS_GNUCC)
 elseif(MSVC)
     # First determine arch user has selected then version
     if( CMAKE_CL_64 )
-        set(DEPS_ARCH "x86")
-    else()
         set(DEPS_ARCH "x64")
+    else()
+        set(DEPS_ARCH "x86")
     endif()
 
     if (MSVC12)

--- a/CMake/PrecompiledDeps.cmake
+++ b/CMake/PrecompiledDeps.cmake
@@ -1,3 +1,23 @@
+# Copyright (c) 2017 David Fairbrother
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 # Clones and sets any dependencies up
 include(ExternalProject)
     

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@ INCLUDE(CheckIncludeFiles)
 SET(CORSIX_TH_DONE_TOP_LEVEL_CMAKE ON)
 
 # Define our options
+OPTION(USE_PRECOMPILED_DEPS "Use Precompiled Dependencies" ON) # On for MSVC
+if ( NOT MSVC )
+  set(USE_PRECOMPILED_DEPS cache BOOL OFF) # Make *nix systems opt in
+endif()
 OPTION(WITH_SDL "Activate SDL Renderer" ON) # our default option
 OPTION(WITH_AUDIO "Activate Sound" ON) # enabled by default
 OPTION(WITH_MOVIES "Activate in game movies" ON)
@@ -90,8 +94,13 @@ ELSE()
   SET(CORSIX_TH_USE_VLD OFF)
 ENDIF(MSVC)
 
-# Environment handling
+# Get precompiled dependencies before running the various find modules
+if ( USE_PRECOMPILED_DEPS )
+message("Note: Using Precompiled Dependencies.")
+include(PrecompiledDeps)
+endif()
 
+# Environment handling
 CHECK_INCLUDE_FILES(inttypes.h CORSIX_TH_HAS_INTTYPES_H)
 
 # Include individual projects

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,12 @@ INCLUDE(CheckIncludeFiles)
 SET(CORSIX_TH_DONE_TOP_LEVEL_CMAKE ON)
 
 # Define our options
-OPTION(USE_PRECOMPILED_DEPS "Use Precompiled Dependencies" ON) # On for MSVC
-if ( NOT MSVC )
-  set(USE_PRECOMPILED_DEPS cache BOOL OFF) # Make *nix systems opt in
+if ( MSVC )
+  OPTION(USE_PRECOMPILED_DEPS "Use Precompiled Dependencies" ON) # On for MSVC
+elseif ( UNIX AND CMAKE_COMPILER_IS_GNU)
+  OPTION(USE_PRECOMPILED_DEPS "Use Precompiled Dependencies" OFF) # Make *nix systems opt in
 endif()
+
 OPTION(WITH_SDL "Activate SDL Renderer" ON) # our default option
 OPTION(WITH_AUDIO "Activate Sound" ON) # enabled by default
 OPTION(WITH_MOVIES "Activate in game movies" ON)


### PR DESCRIPTION
This PR adds an option to CMake to automatically pull in and use the pre-compiled dependencies. This is something I've been planning on doing since writing the instruction on how to compile for Windows.

- On MSVC this is on by default, 
- On GCC + Linux the option requires users to opt in and select the arch they intend to compile against.
- We use CMake to checkout a specific commit from the deps repo, determine the appropriate folder to use and finally update the path for find modules to use.

I've tested this against MSVC and it successfully builds as expected. Could somebody on Linux with GCC test this:
- Is it off by default, does the option correctly appear "USE_PRECOMPILED_DEPS"?
- Can you select the correct architecture with "DEPS_ARCH" when "USE_PRECOMPILED_DEPS" is selected?
- Does it work as expected (links against the pre-built libraries rather than system libs)?

Also - I wasn't sure about the projects licensing so went for MIT. Would it be worth mentioning this in the contribution guidelines?

Edit: I've noticed AppyVeyor also has its own logic for handling dependencies which this was inspired by. Ideally if everything works a future issue would be to have AppVeyor use this new option too.