### PR TITLE
[RDY] 'Folders' menu renders values with default font

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/folder_settings.lua
+++ b/CorsixTH/Lua/dialogs/resizables/folder_settings.lua
@@ -61,7 +61,7 @@ function UIFolder:UIFolder(ui, mode)
     .lowered = true
 
   -- Location of original game
-  local built_in = app.gfx:loadBuiltinFont()
+  local built_in = app.gfx:loadMenuFont()
 
   self:addBevelPanel(20, 50, 130, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.folders_window.data_label):setTooltip(_S.tooltip.folders_window.data_location)

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -354,6 +354,17 @@ local function font_reloader(font)
   font:clearCache()
 end
 
+--! Utility function to return preferred font for main menu ui
+function Graphics:loadMenuFont()
+  local font
+  if self.language_font then
+    font = self:loadFont("QData", "Font01V")
+  else
+    font = self:loadBuiltinFont()
+  end
+  return font
+end
+
 function Graphics:loadLanguageFont(name, sprite_table, ...)
   local font
   if name == nil then

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -513,8 +513,6 @@ function Graphics:updateTarget(target)
       reloader(resource)
     end
   end
-  -- Fix here for #1263
-  self.builtin_font = nil
 end
 
 --! Utility class for setting animation markers and querying animation length.

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -513,6 +513,8 @@ function Graphics:updateTarget(target)
       reloader(resource)
     end
   end
+  -- Fix here for #1263
+  self.builtin_font = nil
 end
 
 --! Utility class for setting animation markers and querying animation length.


### PR DESCRIPTION
Refers to a solution for #1218 
Using the language font on both the labels and fields when its an option.
Using builtin when it isn't