### PR TITLE
[RDY] Don't destroy the renderer

### DIFF
--- a/CorsixTH/Src/th_gfx_font.h
+++ b/CorsixTH/Src/th_gfx_font.h
@@ -238,7 +238,7 @@ private:
         uint8_t* pData;
 
         //! Generated texture ready to be rendered
-        void* pTexture;
+        SDL_Texture* pTexture;
 
         //! The length of sMessage
         size_t iMessageLength;

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -1535,7 +1535,7 @@ void THFreeTypeFont::_freeTexture(cached_text_t* pCacheEntry) const
 {
     if(pCacheEntry->pTexture != nullptr)
     {
-        SDL_DestroyTexture(reinterpret_cast<SDL_Texture*>(pCacheEntry->pTexture));
+        SDL_DestroyTexture(pCacheEntry->pTexture);
         pCacheEntry->pTexture = nullptr;
     }
 }
@@ -1567,7 +1567,7 @@ void THFreeTypeFont::_drawTexture(THRenderTarget* pCanvas, cached_text_t* pCache
         return;
 
     SDL_Rect rcDest = { iX, iY, pCacheEntry->iWidth, pCacheEntry->iHeight };
-    pCanvas->draw(static_cast<SDL_Texture*>(pCacheEntry->pTexture), nullptr, &rcDest, 0);
+    pCanvas->draw(pCacheEntry->pTexture, nullptr, &rcDest, 0);
 }
 
 #endif // CORSIX_TH_USE_FREETYPE2


### PR DESCRIPTION
Fixes #1266 and #1263 and maybe a few others

The renderer was being destroyed every time `THRenderTarget::update` was called, due to a bug in the flag check logic. Destroying the renderer also invalidated all of the game textures, but we have no mechanism to discard them.

The only reason the renderer would be legitimately destroyed (a change to the vsync setting) isn't currently possible in game anyway, so this PR removes the capability and moves the creation of the renderer into `create` instead of `update`.

The first commit just removes some unnecessary casts that I found while investigating this problem.