### PR TITLE
[RDY] Pathfinding broken by side objects

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = dofile "run_debugger"
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 117
+local SAVEGAME_VERSION = 120
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -666,7 +666,9 @@ function UIPlaceObjects:setBlueprintCell(x, y)
         if not tile.shareable and is_object_allowed then
           -- Check 4: only one object per tile allowed original TH
           -- can build on litter and unoccupied tiles and only placeable if not on another objects passable footprint unless that too is a shareable tile
-          is_object_allowed = world:isTileExclusivelyPassable(xpos, ypos, 10)
+          local objchk = map:getCellFlags(xpos, ypos, flags)["thob"]
+          is_object_allowed = objchk == 0 or objchk == 62 or objchk == 64 -- no object, litter/puke, ratholes
+          is_object_allowed = is_object_allowed and world:isTileExclusivelyPassable(xpos, ypos, 10)
         end
 
         -- Having checked if the tile is good set its blueprint appearance flag:

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -709,6 +709,11 @@ function Object:onDestroy()
 
   Entity.onDestroy(self)
 
+  -- Issue 1105 - rebuild wall travel<dir> and pathfinding on side object removal
+  if self.object_type.class == "SideObject" then
+    self.world.map.th:updatePathfinding()
+    self.world:resetSideObjects()
+  end
 end
 
 function Object:afterLoad(old, new)

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -774,4 +774,8 @@ function Map:afterLoad(old, new)
       end
     end
   end
+  if old < 118 then
+    -- Issue #1105 update pathfinding (rebuild walls) potentially broken by side object placement
+    self.th:updatePathfinding()
+  end
 end

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -774,7 +774,7 @@ function Map:afterLoad(old, new)
       end
     end
   end
-  if old < 118 then
+  if old < 120 then
     -- Issue #1105 update pathfinding (rebuild walls) potentially broken by side object placement
     self.th:updatePathfinding()
   end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2674,6 +2674,10 @@ function World:afterLoad(old, new)
       self.next_earthquake.warning_timer = earthquake_warning_period
     end
   end
+  if old < 118 then
+    -- Issue #1105 updates to fix any broken saves with travel<dir> flags for side objects
+    self:resetSideObjects()
+  end
 
   self.savegame_version = new
 end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2674,7 +2674,7 @@ function World:afterLoad(old, new)
       self.next_earthquake.warning_timer = earthquake_warning_period
     end
   end
-  if old < 118 then
+  if old < 120 then
     -- Issue #1105 updates to fix any broken saves with travel<dir> flags for side objects
     self:resetSideObjects()
   end


### PR DESCRIPTION
A proposed resolution to #1105 and related issues where pathfinding breaks from placement of side objects.

afterLoad in map and world to call their required methods to fix pathfinding on old saves.

To prevent the issue occuring, added a check and calls to those same functions in Object:onDestroy after the super class method is called when any side objects are moved.
