### PR TITLE
[RDY] CMake deps handling - continuation of pr #1261

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ Release/
 MinSizeRel/
 RelWithDebInfo/
 
+# Ignore the folder where libraries are pre-compiled
+vcpkg/
+
 # Build folders
 /build*/
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ CorsixTH/config.txt
 /Makefile
 /SDL
 /SDL_mixer-1.2.8
+/PrecompiledDeps
 /doc
 
 # For CorsixTH directory and Windows

--- a/CMake/CopyVcpkgLua.cmake
+++ b/CMake/CopyVcpkgLua.cmake
@@ -1,0 +1,29 @@
+# Add an extra step to copy LUA files from vcpkg
+add_custom_command(TARGET CorsixTH POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+  "${VCPKG_INSTALLED_PATH}/share/lua"
+  $<TARGET_FILE_DIR:CorsixTH>)
+
+add_custom_command(TARGET CorsixTH POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E remove
+  $<TARGET_FILE_DIR:CorsixTH>/COPYRIGHT)
+
+add_custom_command(TARGET CorsixTH POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+  "${VCPKG_INSTALLED_PATH}/$<$<CONFIG:Debug>:debug/>bin/lfs.dll"
+  $<TARGET_FILE_DIR:CorsixTH>/lfs.dll)
+
+add_custom_command(TARGET CorsixTH POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+  "${VCPKG_INSTALLED_PATH}/$<$<CONFIG:Debug>:debug/>bin/lpeg.dll"
+  $<TARGET_FILE_DIR:CorsixTH>/lpeg.dll)
+
+add_custom_command(TARGET CorsixTH POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+  "${VCPKG_INSTALLED_PATH}/$<$<CONFIG:Debug>:debug/>bin/mime/core.dll"
+  $<TARGET_FILE_DIR:CorsixTH>/mime/core.dll)
+
+add_custom_command(TARGET CorsixTH POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+  "${VCPKG_INSTALLED_PATH}/$<$<CONFIG:Debug>:debug/>bin/socket/core.dll"
+  $<TARGET_FILE_DIR:CorsixTH>/socket/core.dll)

--- a/CMake/PrecompiledDeps.cmake
+++ b/CMake/PrecompiledDeps.cmake
@@ -1,0 +1,100 @@
+# Copyright (c) 2017 David Fairbrother
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Clones and sets any dependencies up
+include(ExternalProject)
+
+# Inform CMake about the external project
+set(_DEPS_PROJECT_NAME PrecompiledDependencies)
+
+# Place files into ./precompiled_deps folder
+set(PRECOMPILED_DEPS_BASE_DIR ${PROJECT_SOURCE_DIR}/PrecompiledDeps CACHE PATH "Destination for pre-built dependencies")
+set(_DEPS_GIT_URL "https://github.com/CorsixTH/deps.git")
+# Select the optimal dependencies commit regardless where master is.
+set(_DEPS_GIT_SHA "a23eb28bb8998b93215eccf805ee5462d75a57f2")
+
+ExternalProject_Add(${_DEPS_PROJECT_NAME}
+  PREFIX ${PRECOMPILED_DEPS_BASE_DIR}
+  GIT_REPOSITORY ${_DEPS_GIT_URL}
+  GIT_TAG ${_DEPS_GIT_SHA}
+  # As the deps are already build we can skip these
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  TEST_COMMAND "")
+
+unset(_DEPS_GIT_URL)
+unset(_DEPS_GIT_SHA)
+
+# Make sure the final make file / solution does not attempt to build
+# the dependencies target
+set_target_properties(${_DEPS_PROJECT_NAME} PROPERTIES
+  EXCLUDE_FROM_ALL 1
+  EXCLUDE_FROM_DEFAULT_BUILD 1)
+
+set(_DEPS_TMP_PATH ${PRECOMPILED_DEPS_BASE_DIR}/tmp)
+set(_DEPS_MODULES_TEMPLATE_NAME ${_DEPS_TMP_PATH}/${_DEPS_PROJECT_NAME})
+
+# Clone if we don't have the deps
+if(NOT EXISTS ${PRECOMPILED_DEPS_BASE_DIR}/src/${_DEPS_PROJECT_NAME}/.git)
+  message(STATUS "Getting Precompiled Dependencies...")
+  execute_process(COMMAND ${CMAKE_COMMAND} ARGS -P
+    ${_DEPS_MODULES_TEMPLATE_NAME}-gitclone.cmake
+    RESULT_VARIABLE return_value)
+  if(return_value)
+    message(FATAL_ERROR "Failed to clone precompiled dependencies.")
+  endif()
+
+# Deps exist, check for updates and checkout the correct tag
+else()
+  message(STATUS "Checking for Precompiled Dependency Updates...")
+  execute_process(COMMAND ${CMAKE_COMMAND} ARGS -P
+    ${_DEPS_MODULES_TEMPLATE_NAME}-gitupdate.cmake
+    RESULT_VARIABLE return_value)
+  if(return_value)
+    message(FATAL_ERROR "Failed to update precompiled dependencies.")
+  endif()
+endif()
+
+# We can dispose of tmp and modules template name afterwards
+unset(_DEPS_TMP_PATH)
+unset(_DEPS_MODULES_TEMPLATE_NAME)
+
+# Determine the appropriate libs to use for this compiler
+if(UNIX AND CMAKE_COMPILER_IS_GNU)
+  # We need user to choose which arch they are intending to compile for
+  set(DEPS_ARCH "x86" CACHE STRING "Architecture of precompiled dependencies to use.")
+  set_property(CACHE DEPS_ARCH
+    PROPERTY STRINGS "x86" "x64")
+  # Generate the folder to use
+  set(_DEPS_FOLDER_NAME "gnu-linux-" + ${DEPS_ARCH})
+else()
+  message(FATAL_ERROR "Precompiled dependencies do not exist for this platform / compiler combination yet.")
+endif()
+
+set(_DEPS_PATH ${PRECOMPILED_DEPS_BASE_DIR}/src/${_DEPS_PROJECT_NAME}/${_DEPS_FOLDER_NAME})
+
+# Update the prefix path - this refers to the base directory that find_xx
+# commands use. For example using find_include would automatically append
+# the 'include' subdirectory in.
+set(CMAKE_PREFIX_PATH ${_DEPS_PATH})
+
+unset(_DEPS_FOLDER_NAME)
+unset(_DEPS_PATH)

--- a/CMake/VcpkgDeps.cmake
+++ b/CMake/VcpkgDeps.cmake
@@ -1,0 +1,61 @@
+# Copyright (c) 2017 David Fairbrother
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(VCPKG_COMMIT_SHA "1993a5eae610b877c7ed865040eaa3fb92e731c4")
+
+# Setup the various paths we are using
+set(_VCPKG_SCRIPT_NAME "build_vcpkg_deps.ps1")
+set(_SCRIPT_DIR ${CMAKE_SOURCE_DIR}/scripts)
+# By default place VCPKG into root folder
+set(VCPKG_PARENT_DIR ${CMAKE_SOURCE_DIR} CACHE PATH "Destination for vcpkg dependencies")
+
+# Determine the args to use
+if(VCPKG_TARGET_TRIPLET)
+  set(_VCPKG_TARGET_TRIPLET ${VCPKG_TARGET_TRIPLET})
+elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Xx]64$" OR CMAKE_GENERATOR MATCHES "Win64$")
+  set(_VCPKG_TARGET_TRIPLET "x64-windows")
+elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]$" OR CMAKE_GENERATOR MATCHES "ARM$")
+  set(_VCPKG_TARGET_TRIPLET "arm-windows")
+else()
+  set(_VCPKG_TARGET_TRIPLET "x86-windows")
+endif()
+
+set(_VCPKG_ARGS "-VcpkgTriplet " ${_VCPKG_TARGET_TRIPLET})
+
+if(BUILD_ANIMVIEWER)
+  string(CONCAT _VCPKG_ARGS ${_VCPKG_ARGS} " -BuildAnimView $True")
+else()
+  string(CONCAT _VCPKG_ARGS ${_VCPKG_ARGS} " -BuildAnimView $False")
+endif()
+
+string(CONCAT _VCPKG_ARGS ${_VCPKG_ARGS} " -VcpkgCommitSha " ${VCPKG_COMMIT_SHA} " ")
+
+# Run the build script
+set(_SCRIPT_COMMAND  powershell ${_SCRIPT_DIR}/${_VCPKG_SCRIPT_NAME})
+execute_process(WORKING_DIRECTORY ${VCPKG_PARENT_DIR}
+  COMMAND ${_SCRIPT_COMMAND} ${_VCPKG_ARGS}
+  RESULT_VARIABLE err_val)
+if(err_val)
+  message(FATAL_ERROR "Failed to build vcpkg dependencies. "
+    "\nIf this error persists try deleting the 'vcpkg' folder.\n")
+endif()
+
+set(VCPKG_INSTALLED_PATH ${VCPKG_PARENT_DIR}/vcpkg/installed/${_VCPKG_TARGET_TRIPLET})
+set(CMAKE_TOOLCHAIN_FILE ${VCPKG_PARENT_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,20 @@
 #   - WITH_VLD     : Build with Visual Leak Detector (requires Visual Studio)
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.2)
-PROJECT(CorsixTH_Top_Level)
+
 SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
+
+IF(CMAKE_GENERATOR MATCHES "^Visual Studio 14 2015" OR CMAKE_GENERATOR MATCHES "^Visual Studio 15 2017")
+  OPTION(USE_VCPKG_DEPS "Build vcpkg dependencies locally" OFF)
+ENDIF()
+
+if(USE_VCPKG_DEPS)
+  message("Note: Using locally built vcpkg dependencies.")
+  include(VcpkgDeps)
+endif()
+
+PROJECT(CorsixTH_Top_Level)
+
 INCLUDE(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
 CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
@@ -28,13 +40,13 @@ ENDIF(MINGW)
 INCLUDE(CheckIncludeFiles)
 SET(CORSIX_TH_DONE_TOP_LEVEL_CMAKE ON)
 
-# Define our options
-if ( MSVC )
-  OPTION(USE_PRECOMPILED_DEPS "Use Precompiled Dependencies" ON) # On for MSVC
-elseif ( UNIX AND CMAKE_COMPILER_IS_GNU)
+
+# Dependency management
+if ( UNIX AND CMAKE_COMPILER_IS_GNU)
   OPTION(USE_PRECOMPILED_DEPS "Use Precompiled Dependencies" OFF) # Make *nix systems opt in
 endif()
 
+# Define our options
 OPTION(WITH_SDL "Activate SDL Renderer" ON) # our default option
 OPTION(WITH_AUDIO "Activate Sound" ON) # enabled by default
 OPTION(WITH_MOVIES "Activate in game movies" ON)
@@ -98,8 +110,8 @@ ENDIF(MSVC)
 
 # Get precompiled dependencies before running the various find modules
 if ( USE_PRECOMPILED_DEPS )
-message("Note: Using Precompiled Dependencies.")
-include(PrecompiledDeps)
+  message("Note: Using precompiled dependencies.")
+  include( PrecompiledDeps )
 endif()
 
 # Environment handling

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@
 #   - WITH_LIBAV   : Whether to use LibAV (as opposed to FFMEPG) when building movies
 #   - WITH_VLD     : Build with Visual Leak Detector (requires Visual Studio)
 
+CMAKE_MINIMUM_REQUIRED(VERSION 3.2)
 PROJECT(CorsixTH_Top_Level)
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
 INCLUDE(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ INCLUDE(CheckIncludeFiles)
 SET(CORSIX_TH_DONE_TOP_LEVEL_CMAKE ON)
 
 # Define our options
+if ( MSVC )
+  OPTION(USE_PRECOMPILED_DEPS "Use Precompiled Dependencies" ON) # On for MSVC
+elseif ( UNIX AND CMAKE_COMPILER_IS_GNU)
+  OPTION(USE_PRECOMPILED_DEPS "Use Precompiled Dependencies" OFF) # Make *nix systems opt in
+endif()
+
 OPTION(WITH_SDL "Activate SDL Renderer" ON) # our default option
 OPTION(WITH_AUDIO "Activate Sound" ON) # enabled by default
 OPTION(WITH_MOVIES "Activate in game movies" ON)
@@ -90,8 +96,13 @@ ELSE()
   SET(CORSIX_TH_USE_VLD OFF)
 ENDIF(MSVC)
 
-# Environment handling
+# Get precompiled dependencies before running the various find modules
+if ( USE_PRECOMPILED_DEPS )
+message("Note: Using Precompiled Dependencies.")
+include(PrecompiledDeps)
+endif()
 
+# Environment handling
 CHECK_INCLUDE_FILES(inttypes.h CORSIX_TH_HAS_INTTYPES_H)
 
 # Include individual projects

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -85,23 +85,33 @@ ELSE()
   add_executable(CorsixTH ${corsixth_source_files})
 ENDIF()
 
+# Add an extra step to copy built DLLs on MSVC
+IF(USE_VCPKG_DEPS)
+  INCLUDE(CopyVcpkgLua)
+ENDIF()
+
 # Finding libraries
 
 # Find SDL
-FIND_PACKAGE(SDL2 REQUIRED)
-IF(SDL_FOUND)
-  INCLUDE_DIRECTORIES(${SDL_INCLUDE_DIR})
-  IF(SDLMAIN_LIBRARY STREQUAL "")
-    message(FATAL_ERROR "Error: SDL was found but SDLmain was not")
-    message("Make sure the path is correctly defined or set the environment variable SDLDIR to the correct location")
-  ENDIF(SDLMAIN_LIBRARY STREQUAL "")
-  # No need to specify sdlmain separately, the FindSDL.cmake file will take care of that. If not we get an error about it
-  TARGET_LINK_LIBRARIES(CorsixTH ${SDL_LIBRARY})
-  message("  SDL found")
-ELSE(SDL_FOUND)
-  message(FATAL_ERROR "Error: SDL library not found, it is required to build. Make sure the path is correctly defined or set the environment variable SDLDIR to the correct location")
-ENDIF(SDL_FOUND)
-
+IF (MSVC AND USE_VCPKG_DEPS)
+  FIND_PACKAGE(SDL2 CONFIG REQUIRED)
+  TARGET_LINK_LIBRARIES(CorsixTH SDL2::SDL2)
+  TARGET_LINK_LIBRARIES(CorsixTH SDL2::SDL2main)
+ELSE()
+  FIND_PACKAGE(SDL2 REQUIRED)
+  IF(SDL_FOUND)
+    INCLUDE_DIRECTORIES(${SDL_INCLUDE_DIR})
+    IF(SDLMAIN_LIBRARY STREQUAL "")
+      message(FATAL_ERROR "Error: SDL was found but SDLmain was not")
+      message("Make sure the path is correctly defined or set the environment variable SDLDIR to the correct location")
+    ENDIF(SDLMAIN_LIBRARY STREQUAL "")
+    # No need to specify sdlmain separately, the FindSDL.cmake file will take care of that. If not we get an error about it
+    TARGET_LINK_LIBRARIES(CorsixTH ${SDL_LIBRARY})
+    message("  SDL found")
+  ELSE(SDL_FOUND)
+    message(FATAL_ERROR "Error: SDL library not found, it is required to build. Make sure the path is correctly defined or set the environment variable SDLDIR to the correct location")
+  ENDIF(SDL_FOUND)
+ENDIF()
 # Find Lua
 FIND_PACKAGE(Lua REQUIRED)
 IF(Lua_FOUND)

--- a/CorsixTH/CorsixTH.rc
+++ b/CorsixTH/CorsixTH.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "WinResrc.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -34,7 +34,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""WinResrc.h""\r\n"
     "\0"
 END
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,20 @@
 version: '{build}'
+image: Visual Studio 2017
 pull_requests:
   do_not_increment_build_number: true
 init:
-- git clone --depth=1 https://github.com/CorsixTH/deps.git c:/deps
 environment:
   matrix:
-  - GENERATOR: Visual Studio 14 2015 Win64
-    CMAKE_LIBRARY_PATH: c:/deps/win_x64_msvc14/lib
-    CMAKE_INCLUDE_PATH: c:/deps/win_x64_msvc14
+  - GENERATOR: Visual Studio 15 2017 Win64
+cache:
+  - vcpkg -> CMake/VcpkgDeps.cmake, scripts/build_vcpkg_deps.ps1
 configuration: Release
 before_build:
-- cmake -G "%GENERATOR%" -DCMAKE_LIBRARY_PATH="%CMAKE_LIBRARY_PATH%" -DCMAKE_INCLUDE_PATH="%CMAKE_INCLUDE_PATH%"
+  - cmd: cmake -G "%GENERATOR%" -DUSE_VCPKG_DEPS=ON
 build:
   project: CorsixTH_Top_Level.sln
   verbosity: minimal
 after_build:
-- cp %CMAKE_LIBRARY_PATH%/*.dll %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/
-- cp -R %CMAKE_LIBRARY_PATH%/mime %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/mime
-- cp -R %CMAKE_LIBRARY_PATH%/socket %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/socket
 - cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Lua %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/Lua
 - cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Bitmap %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/Bitmap
 - cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Levels %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/Levels

--- a/scripts/build_vcpkg_deps.ps1
+++ b/scripts/build_vcpkg_deps.ps1
@@ -1,0 +1,144 @@
+# Copyright (c) 2017 David Fairbrother
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Requirements:
+
+# git - Installed and added to path
+
+# Parameters
+Param(
+    [Parameter(Mandatory=$true)][bool]$BuildAnimView,
+    [Parameter(Mandatory=$true)][string]$VcpkgTriplet,
+    [Parameter(Mandatory=$true)][string]$VcpkgCommitSha
+)
+
+################
+# Variables
+################
+
+$anim_view_libs = "wxwidgets"
+$corsixth_libs = "ffmpeg", "freetype", "lua", "luafilesystem", "lpeg", "sdl2", "sdl2-mixer", "luasocket"
+
+$vcpkg_git_url = "https://github.com/CorsixTH/vcpkg"
+
+$dest_folder_name = "vcpkg"
+$dest_folder_path = ".\vcpkg"
+
+###################
+# Functions
+###################
+
+function run_command($command) {
+    Invoke-Expression $command
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to run command :`n $command `nExiting."
+    }
+}
+
+##################
+# Main script
+##################
+
+# Wrap in function so we can try-catch
+function run_script {
+
+    # Test the required files are in the path
+    if ((Get-Command "git.exe") -eq $null) {
+        throw "Error git was not found. Is it installed, added to your path
+               and have you restarted since?"
+    }
+
+    # Check we have the latest copy of vcpkg
+    if (-Not (Test-Path $dest_folder_path)) {
+        # If vcpkg does not exist clone it
+        run_command -command "git clone $vcpkg_git_url $dest_folder_name"
+        Set-Location -Path $dest_folder_path
+        run_command "git checkout $VcpkgCommitSha"
+    } else {
+        # Move into vcpkg folder and update to latest version
+        Set-Location -Path $dest_folder_path
+        run_command "git reset --hard; git fetch origin; git checkout $VcpkgCommitSha"
+    }
+
+    $commit_id_filename = "commit_id.txt"
+    if (-Not (Test-Path $commit_id_filename) -or
+        (Get-Content $commit_id_filename | Where-Object {$_ -ne $VcpkgCommitSha })) {
+        # Sha does not match or does not exist.
+        Write-Output "Dependencies have changed. Bootstrapping and updating vcpkg."
+        run_command ".\bootstrap-vcpkg.bat"
+
+        # Remove any outdated libraries before installing
+        run_command ".\vcpkg remove --outdated --recurse"
+
+        # Update the SHA we last saw
+        Set-Content -Path $commit_id_filename -Value $VcpkgCommitSha
+    }
+
+    # Build the triplet flag e.g. --triplet "x64-windows"
+    $triplet = "--triplet `""
+    $triplet += $VcpkgTriplet
+    $triplet += '"'
+
+    $libs_list = ""
+
+    # Build our libs list
+    foreach ($library in $corsixth_libs) {
+        $libs_list += $library + ' '
+    }
+
+    # If we are building the animation viewer be sure to include those libs
+    if ($BuildAnimView) {
+        foreach ($library in $anim_view_libs) {
+            $libs_list += $library + ' '
+        }
+    }
+
+    # Compile them locally
+    $install_command = ".\vcpkg install " + $triplet + $libs_list
+    run_command -command $install_command
+
+    # Copy various files from bin to tools
+    $vcpkg_installed_path = ".\installed\"
+    $vcpkg_installed_path += $VcpkgTriplet
+
+    Set-Location $vcpkg_installed_path
+
+    Write-Output "Copying files from bin to tools"
+
+    $files_to_copy_from_bin = "lfs.dll", "lpeg.dll"
+    foreach ($file in $files_to_copy_from_bin) {
+        Copy-Item -Path ".\bin\$file" -Destination ".\tools\lua"
+    }
+
+    Write-Output "Finished building libraries"
+}
+
+# Run the script
+$starting_dir = Convert-Path .
+try {
+    run_script
+    # Move back up a dir to return user to original location
+    Set-Location -Path $starting_dir
+} catch [Exception]{
+    Set-Location -Path $starting_dir
+    # Echo the exception back out
+    $_
+    Exit -1
+}


### PR DESCRIPTION
Compared to #1261 this PR:

* Handles SDL2 on multiple configuration targets when using built in vcpkg, by using the provided sdl2 cmake config.
* Doesn't modify FindSDL2.cmake (those modifications didn't work)
* Copies lua files from the `vcpkg/installed/**/share/lua/*` directory
* Checks out the correct commit when cloning vcpkg the first time
* Checks out a newer vcpkg commit, containing luasockets and newer sdl packages
* Fixes whitespace
* Modifies appveyor to take advantage of these changes