### PR TITLE
[RDY] Fix write to empty vector

### DIFF
--- a/CorsixTH/Src/th_pathfind.cpp
+++ b/CorsixTH/Src/th_pathfind.cpp
@@ -551,6 +551,11 @@ node_t* THPathfinder::_openHeapPop()
     node_t *pResult = m_openHeap[0];
     node_t *pNode = m_openHeap.back();
     m_openHeap.pop_back();
+
+    if (m_openHeap.empty()) {
+        return pResult;
+    }
+
     m_openHeap[0] = pNode;
     int i = 0;
     int min = 0;


### PR DESCRIPTION
We were writing to an empty vector when poping the last element.