### PR TITLE
[RDY] Remove handyman task upon sweep action start

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = dofile "run_debugger"
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 120
+local SAVEGAME_VERSION = 121
 
 class "App"
 

--- a/CorsixTH/Lua/entities/staff.lua
+++ b/CorsixTH/Lua/entities/staff.lua
@@ -900,6 +900,15 @@ function Staff:afterLoad(old, new)
     end
   end
 
+  if old < 121 then
+    if self.humanoid_class == "Handyman" and self.user_of and self.user_of.object_type.class == "Litter" then
+      local litter = self.user_of
+      local hospital = self.world:getHospital(litter.tile_x, litter.tile_y)
+      local taskIndex = hospital:getIndexOfTask(litter.tile_x, litter.tile_y, "cleaning", litter)
+      hospital:removeHandymanTask(taskIndex, "cleaning")
+    end
+  end
+
   Humanoid.afterLoad(self, old, new)
 end
 

--- a/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
+++ b/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
@@ -57,6 +57,11 @@ end)
 local function action_sweep_floor_start(action, humanoid)
   action.must_happen = true
   humanoid.user_of = action.litter
+  -- remove handyman task as soon as action starts - we should be committed to completing this task
+  local litter = action.litter
+  local hospital = litter.world:getHospital(litter.tile_x, litter.tile_y)
+  local taskIndex = hospital:getIndexOfTask(litter.tile_x, litter.tile_y, "cleaning", litter)
+  hospital:removeHandymanTask(taskIndex, "cleaning")
   local anim = animation_numbers[1]
   humanoid:setAnimation(anim)
   humanoid:setTimer(humanoid.world:getAnimLength(anim), sweep)

--- a/CorsixTH/Lua/objects/litter.lua
+++ b/CorsixTH/Lua/objects/litter.lua
@@ -56,6 +56,7 @@ local Litter = _G["Litter"]
 function Litter:Litter(world, object_type, x, y, direction, etc)
   local th = TH.animation()
   self:Entity(th)
+  self.ticks = object_type.ticks
   self.object_type = object_type
   self.world = world
   self:setTile(x, y)
@@ -148,6 +149,10 @@ function Litter:afterLoad(old, new)
       local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning", self)
       hospital:removeHandymanTask(taskIndex, "cleaning")
     end
+  end
+
+  if old < 121 then
+    self.ticks = object.ticks
   end
 end
 


### PR DESCRIPTION
Litter not 'tickable' as in to interrupt Handyman tasks when Litter:remove on build over.

I didn't update Litter:remove() to enforce the ticks = false, just left that to new litter only.

Removing the task in the action_sweep_floor_start is similar to Plant:restoreToFullHealth called from the end of action_use_object_start.
Hopefully addresses issues in #1155.