### PR TITLE
[RDY] Fix campaign not preserving salary between levels

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/new_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/new_game.lua
@@ -195,8 +195,8 @@ end
 function UINewGame:startGame(difficulty)
   self.ui.app:loadLevel(1, difficulty)
   -- Initiate campaign progression. The UI above may now have changed.
-  if TheApp.world and not TheApp.using_demo_files then
-    TheApp.world.campaign = "TH.campaign"
+  if not TheApp.using_demo_files then
+    TheApp.world.campaign_info = "TH.campaign"
   end
   if self.start_tutorial then
     TheApp.ui.start_tutorial = true


### PR DESCRIPTION
Fixes the salary not increasing between levels. 
In `app.lua : 592` we only carry across the player state if the `world.campaign_info` variable is set. This isn't set correctly in `dialogs/resizables/newgame.lua : 199`  so the salary was not preserved.

Also I've removed a check that `TheApp.world` has been created, `loadLevel` should handle this and bail if something goes wrong on our behalf instead of us checking and ignoring.


Fixes #1275 

----
Ideally the UI dialogue should not be setting states on the app behalf. Instead it should be tweaked so `app.lua` has a method to start the original campaign (we already have a function for custom campaigns) which keeps this logic in a single location. However I wanted to get this change into the RC so left the re-factoring for a future date.

-----
To test:
- Load a new campaign
- Either play through the level properly or cheat through a couple of months
- Check the end of year salary and make a note
- Win the level and proceed to next level (cheats also work but forfeit the bonus)
- Using cheats skip to end of year: 
- The salary should be greater than the end of year from the previous level (ie. not around 10,000-11,000)

