### PR TITLE
[RFC] Stored camera positions

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 127
+local SAVEGAME_VERSION = 128
 
 class "App"
 

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -357,7 +357,8 @@ function GameUI:onCursorWorldPositionChange()
   local x = math.floor(self.screen_offset_x + self.cursor_x / zoom)
   local y = math.floor(self.screen_offset_y + self.cursor_y / zoom)
   local entity = nil
-  if self.do_world_hit_test and not self:hitTest(self.cursor_x, self.cursor_y) then
+  local overwindow = self:hitTest(self.cursor_x, self.cursor_y)
+  if self.do_world_hit_test and not overwindow then
     entity = self.app.map.th:hitTestObjects(x, y)
     if self.do_world_hit_test ~= true then
       -- limit to non-door objects in room
@@ -410,7 +411,7 @@ function GameUI:onCursorWorldPositionChange()
   wx = math.floor(wx)
   wy = math.floor(wy)
   local room
-  if wx > 0 and wy > 0 and wx < self.app.map.width and wy < self.app.map.height then
+  if not overwindow and wx > 0 and wy > 0 and wx < self.app.map.width and wy < self.app.map.height then
     room = self.app.world:getRoom(wx, wy)
   end
   if room ~= self.cursor_room then


### PR DESCRIPTION
When referring to the table here in [programming ideas](https://github.com/CorsixTH/CorsixTH/wiki/Programming-Ideas#key-bindings) I noted the only unimplemented original feature was having stored camera positions that you can recall with a key combo. Alt 0-9 to save a position and Ctrl 0-9 to restore them. Currently I don't have this changing the zoom level, so when zoomed out, the movement is limited but if zoomed in a bit, you can navigate to different part of the maps quickly.

I included the fix to address room queue dialog mood icons showing queue icons when dialog is interacted with - #789 - changes limited to onCursorWorldPositionChange.