### PR TITLE
Issue 1321: Adds default build path to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ CorsixTH/CorsixTH.sln
 .cproject/
 .vscode/
 .cproject
+
+# Default build path
+CorsixTH/CorsixTH


### PR DESCRIPTION
Even though the recommended path to build the game is outside the source, when running make without specifying path the game still gets build to `CorsixTH/CorsixTH`. That's why I created this PR anyway:) Please see the issue for more info.