### PR TITLE
[RFC] Fixes and reorg from unit test changes

### DIFF
--- a/CorsixTH/Src/iso_fs.cpp
+++ b/CorsixTH/Src/iso_fs.cpp
@@ -21,6 +21,8 @@ SOFTWARE.
 */
 
 #include "iso_fs.h"
+
+#include <lua.h>
 #include <cstring>
 #include <cstdarg>
 #include <cstdlib>

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -142,6 +142,47 @@ public:
     }
 };
 
+//! Convert legacy 8bpp sprite data to recoloured 32bpp data, using special recolour table 0xFF.
+/*!
+@param pPixelData Legacy 8bpp pixels.
+@param iPixelDataLength Number of pixels in the \a pPixelData.
+@return Converted 32bpp pixel data, if succeeded else nullptr is returned. Caller should free the returned memory.
+*/
+uint8_t *convertLegacySprite(const uint8_t* pPixelData, size_t iPixelDataLength)
+{
+	// Recolour blocks are 63 pixels long.
+	// XXX To reduce the size of the 32bpp data, transparent pixels can be stored more compactly.
+	size_t numBlocks = iPixelDataLength / 63;
+	size_t remainingPixels = iPixelDataLength - numBlocks * 63;
+
+	const int blockLength = 63;
+	const int numExtraBlocks = 3;
+
+	size_t iNewSize = numBlocks * (blockLength + numExtraBlocks);
+
+	// If there are remaining pixels add enough space for our extra blocks and those pixels
+	// in the destination buffer
+	iNewSize += (remainingPixels > 0) ? numExtraBlocks + remainingPixels : 0;
+
+	uint8_t *pData = new (std::nothrow) uint8_t[iNewSize];
+	if (pData == nullptr)
+		return nullptr;
+
+	uint8_t *pDest = pData;
+	while (iPixelDataLength > 0)
+	{
+		size_t iLength = (iPixelDataLength >= 63) ? 63 : iPixelDataLength;
+		*pDest++ = static_cast<uint8_t>(iLength + 0xC0); // Recolour layer type of block.
+		*pDest++ = 0xFF; // Use special table 0xFF (which uses the palette as table).
+		*pDest++ = 0xFF; // Non-transparent.
+		std::memcpy(pDest, pPixelData, iLength);
+		pDest += iLength;
+		pPixelData += iLength;
+		iPixelDataLength -= iLength;
+	}
+	return pData;
+}
+
 THAnimationManager::THAnimationManager()
 {
     m_vFirstFrames.clear();

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -20,11 +20,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include "config.h"
 #include "th_gfx.h"
+
+#include "config.h"
 #include "persist_lua.h"
 #include "th_map.h"
 #include "th_sound.h"
+
 #include <new>
 #include <algorithm>
 #include <cstring>
@@ -1015,13 +1017,6 @@ THChunkRenderer::~THChunkRenderer()
     delete[] m_data;
 }
 
-uint8_t* THChunkRenderer::takeData()
-{
-    uint8_t *buffer = m_data;
-    m_data = 0;
-    return buffer;
-}
-
 void THChunkRenderer::chunkFillToEndOfLine(uint8_t value)
 {
     if(m_x != 0 || !m_skip_eol)
@@ -1056,6 +1051,12 @@ void THChunkRenderer::chunkCopy(int npixels, const uint8_t* data)
     }
 }
 
+uint8_t* THChunkRenderer::takeData()
+{
+	uint8_t *buffer = m_data;
+	m_data = nullptr;
+	return buffer;
+}
 
 inline void THChunkRenderer::_fixNpixels(int& npixels) const
 {

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -155,16 +155,34 @@ public:
 
     ~THChunkRenderer();
 
-    //! Perform a "copy" chunk (normally called by decodeChunks)
+    //! Copies given data into the internal buffer from its internally tracked position.
+	//! Moves the internal position along by n-pixels
+	/*!
+        @param npixels The number of pixels to copy from the input buffer to the internal buffer
+        @param data The source buffer. This must be less than or equal to npixels length
+	*/
     void chunkCopy(int npixels, const uint8_t* data);
 
-    //! Perform a "fill" chunk (normally called by decodeChunks)
+    //! Fills n pixels in the internal position starting at its internally tracked position
+	//! Moves the internal position by n-pixels
+	/*!
+        @param npixels The number of pixels to fill in the internal buffer
+        @param value The value to set these pixels to in the internal buffer
+	*/
     void chunkFill(int npixels, uint8_t value);
 
-    //! Perform a "fill to end of line" chunk (normally called by decodeChunks)
+    //! Fills to the end of the current line which is determined from the width and current pos
+    //! If we are not at the start of the line or skip_eol is set to false
+    //! Then sets skip_eol to false
+    /*! 
+        @param value The value to fill the remainder of the line with
+    */
     void chunkFillToEndOfLine(uint8_t value);
 
-    //! Perform a "fill to end of file" chunk (normally called by decodeChunks)
+    //! Fills to the end of the buffer with the given value from the current internal position
+    /*! 
+        @param value The value to fill the remainder of the buffer with
+    */
     void chunkFinish(uint8_t value);
 
 	//! Convert a stream of chunks into a raw bitmap
@@ -177,7 +195,7 @@ public:
 
 	Use getData() or takeData() to obtain the resulting bitmap.
 	*/
-	void decodeChunks(const uint8_t* pData, int iDataLen, bool bComplex);
+	void decodeChunks(const uint8_t* data, int dataLen, bool bComplex);
 
 	//! Get the result buffer
 	inline const uint8_t* getData() const { return m_data; }
@@ -191,9 +209,12 @@ public:
 	uint8_t* takeData();
 
 private:
-    inline bool _isDone() {return m_ptr == m_end;}
+    inline bool _isEndOfBuffer() {return m_ptr == m_end;}
     inline void _fixNpixels(int& npixels) const;
     inline void _incrementPosition(int npixels);
+
+    void decodeChunksSimple(const uint8_t* inputData, int dataLen);
+    void decodeChunksComplex(const uint8_t* inputData, int dataLen);
 
     uint8_t *m_data, *m_ptr, *m_end;
     int m_x, m_y, m_width, m_height;

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -43,6 +43,9 @@ enum THScaledItems
 
 void IntersectTHClipRect(THClipRect& rcClip,const THClipRect& rcIntersect);
 
+// Converts 8bpp sprite data to recoloured 32bpp using recolour table 0XFF
+uint8_t *convertLegacySprite(const uint8_t* pPixelData, size_t iPixelDataLength);
+
 //! Bitflags for drawing operations
 enum THDrawFlags
 {

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -33,7 +33,7 @@ SOFTWARE.
 class LuaPersistReader;
 class LuaPersistWriter;
 
-enum THScaledItems
+enum THScaledItems : char
 {
     THSI_None = 0,
     THSI_SpriteSheets = 1 << 0,

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -23,6 +23,12 @@ SOFTWARE.
 #ifndef CORSIX_TH_TH_GFX_H_
 #define CORSIX_TH_TH_GFX_H_
 #include "th.h"
+#include "th_gfx_sdl.h"
+#include "th_gfx_font.h"
+
+#include <vector>
+#include <map>
+#include <string>
 
 class LuaPersistReader;
 class LuaPersistWriter;
@@ -34,17 +40,6 @@ enum THScaledItems
     THSI_Bitmaps = 1 << 1,
     THSI_All = 3,
 };
-
-#include "th_gfx_sdl.h"
-#include "th_gfx_font.h"
-#include <vector>
-#include <map>
-#include <string>
-
-void IntersectTHClipRect(THClipRect& rcClip,const THClipRect& rcIntersect);
-
-// Converts 8bpp sprite data to recoloured 32bpp using recolour table 0XFF
-uint8_t *convertLegacySprite(const uint8_t* pPixelData, size_t iPixelDataLength);
 
 //! Bitflags for drawing operations
 enum THDrawFlags
@@ -137,6 +132,9 @@ struct THDrawable : public THLinkList
     bool (*m_fnIsMultipleFrameAnimation)(THDrawable *pSelf);
 };
 
+// Converts 8bpp sprite data to recoloured 32bpp using recolour table 0XFF
+uint8_t *convertLegacySprite(const uint8_t* pPixelData, size_t iPixelDataLength);
+
 /*!
     Utility class for decoding Theme Hospital "chunked" graphics files.
     Generally used internally by THSpriteSheet.
@@ -157,29 +155,6 @@ public:
 
     ~THChunkRenderer();
 
-    //! Convert a stream of chunks into a raw bitmap
-    /*!
-        @param pData Stream data.
-        @param iDataLen Length of \a pData.
-        @param bComplex true if pData is a stream of "complex" chunks, false if
-          pData is a stream of "simple" chunks. Passing the wrong value will
-          usually result in a very visible wrong result.
-
-        Use getData() or takeData() to obtain the resulting bitmap.
-    */
-    void decodeChunks(const uint8_t* pData, int iDataLen, bool bComplex);
-
-    //! Get the result buffer, and take ownership of it
-    /*!
-        This transfers ownership of the buffer to the caller. After calling,
-        the class will not have any buffer, and thus cannot be used for
-        anything.
-    */
-    uint8_t* takeData();
-
-    //! Get the result buffer
-    inline const uint8_t* getData() const {return m_data;}
-
     //! Perform a "copy" chunk (normally called by decodeChunks)
     void chunkCopy(int npixels, const uint8_t* data);
 
@@ -191,6 +166,29 @@ public:
 
     //! Perform a "fill to end of file" chunk (normally called by decodeChunks)
     void chunkFinish(uint8_t value);
+
+	//! Convert a stream of chunks into a raw bitmap
+	/*!
+	@param pData Stream data.
+	@param iDataLen Length of \a pData.
+	@param bComplex true if pData is a stream of "complex" chunks, false if
+	pData is a stream of "simple" chunks. Passing the wrong value will
+	usually result in a very visible wrong result.
+
+	Use getData() or takeData() to obtain the resulting bitmap.
+	*/
+	void decodeChunks(const uint8_t* pData, int iDataLen, bool bComplex);
+
+	//! Get the result buffer
+	inline const uint8_t* getData() const { return m_data; }
+
+	//! Get the result buffer, and take ownership of it
+	/*!
+	This transfers ownership of the buffer to the caller. After calling,
+	the class will not have any buffer, and thus cannot be used for
+	anything.
+	*/
+	uint8_t* takeData();
 
 private:
     inline bool _isDone() {return m_ptr == m_end;}

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -23,7 +23,6 @@ SOFTWARE.
 #include "config.h"
 
 #include "th_gfx.h"
-#include "sprite.h"
 #ifdef CORSIX_TH_USE_FREETYPE2
 #include "th_gfx_font.h"
 #endif

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -23,6 +23,7 @@ SOFTWARE.
 #include "config.h"
 
 #include "th_gfx.h"
+#include "sprite.h"
 #ifdef CORSIX_TH_USE_FREETYPE2
 #include "th_gfx_font.h"
 #endif
@@ -591,38 +592,7 @@ void THRenderTarget::_flushZoomBuffer()
     m_pZoomTexture = nullptr;
 }
 
-//! Convert legacy 8bpp sprite data to recoloured 32bpp data, using special recolour table 0xFF.
-/*!
-    @param pPixelData Legacy 8bpp pixels.
-    @param iPixelDataLength Number of pixels in the \a pPixelData.
-    @return Converted 32bpp pixel data, if succeeded else nullptr is returned. Caller should free the returned memory.
- */
-static uint8_t *convertLegacySprite(const uint8_t* pPixelData, size_t iPixelDataLength)
-{
-    // Recolour blocks are 63 pixels long.
-    // XXX To reduce the size of the 32bpp data, transparent pixels can be stored more compactly.
-    size_t iNumFilled = iPixelDataLength / 63;
-    size_t iRemaining = iPixelDataLength - iNumFilled * 63;
-    size_t iNewSize = iNumFilled * (3 + 63) + ((iRemaining > 0) ? 3 + iRemaining : 0);
 
-    uint8_t *pData = new (std::nothrow) uint8_t[iNewSize];
-    if (pData == nullptr)
-        return nullptr;
-
-    uint8_t *pDest = pData;
-    while (iPixelDataLength > 0)
-    {
-        size_t iLength = (iPixelDataLength >= 63) ? 63 : iPixelDataLength;
-        *pDest++ = static_cast<uint8_t>(iLength + 0xC0); // Recolour layer type of block.
-        *pDest++ = 0xFF; // Use special table 0xFF (which uses the palette as table).
-        *pDest++ = 0xFF; // Non-transparent.
-        std::memcpy(pDest, pPixelData, iLength);
-        pDest += iLength;
-        pPixelData += iLength;
-        iPixelDataLength -= iLength;
-    }
-    return pData;
-}
 
 SDL_Texture* THRenderTarget::createPalettizedTexture(
             int iWidth, int iHeight, const uint8_t* pPixels,

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -30,7 +30,7 @@ SOFTWARE.
 
 // Forward declerations
 class THCursor;
-enum THScaledItems;
+enum THScaledItems : char;
 
 struct THClipRect : public SDL_Rect
 {

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -23,11 +23,15 @@ SOFTWARE.
 #ifndef CORSIX_TH_TH_GFX_SDL_H_
 #define CORSIX_TH_TH_GFX_SDL_H_
 #include "config.h"
+#include "th_gfx.h"
 
 #include <SDL.h>
 #include "persist_lua.h"
 
+// Forward declerations
 class THCursor;
+enum THScaledItems;
+
 struct THClipRect : public SDL_Rect
 {
     typedef Sint16 xy_t;

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -22,6 +22,8 @@ SOFTWARE.
 
 #include "th_lua_internal.h"
 #include "th_gfx.h"
+#include "th_map.h"
+
 #include <SDL.h>
 #include <cstring>
 

--- a/CorsixTH/Src/th_map.h
+++ b/CorsixTH/Src/th_map.h
@@ -175,6 +175,8 @@ enum THMapTemperatureDisplay
     THMT_Count, //!< Number of temperature display values.
 };
 
+void IntersectTHClipRect(THClipRect& rcClip, const THClipRect& rcIntersect);
+
 struct THMapNode : public THLinkList
 {
     THMapNode();


### PR DESCRIPTION
Moves the changes from #1330 as per PR feedback:

Changes are:
-----

- Moves `convertLegacySprite()` into `th_gfx.cpp` as it is not SDL specific (no changes to source code) following feedback in previous PR.
- Moves the deceleration of `IntersectTHClipRect(..)` into `th_map.h` as the definition is in the respective cpp file (and I didn't think it warranted a separate PR)
  - Fixes up header includes following that move
- `THChunkRenderer` fix ups:

  - Store a `nullptr` instead of 0 when we call `takeData()`
  - Add doxgen in the header for all methods explaining in detail what the method does
  - Account for the size of the data when calling `memset` or `memcpy` 
  - Split decode chunks into two seperate methods: `decodeChunksSimple` and `decodeChunksComplex`
  - Document the code of those new methods, which can be a bit terse to understand at points. Note: There was no code changes for these methods
  - Rename the private method `_isDone()` to `_isEndOfBuffer()`