### PR TITLE
[RDY] Fix undefined behaviour in luaT_setclosure

### DIFF
--- a/CorsixTH/Src/th_lua.cpp
+++ b/CorsixTH/Src/th_lua.cpp
@@ -244,23 +244,8 @@ static int l_get_compile_options(lua_State *L)
     return 1;
 }
 
-void luaT_setclosure(const THLuaRegisterState_t *pState, lua_CFunction fn,
-                     eTHLuaMetatable eMetatable1, ...)
-{
-    int iUpCount = 0;
-    va_list args;
-    for(va_start(args, eMetatable1);
-        eMetatable1 != MT_Count;
-        eMetatable1 = static_cast<eTHLuaMetatable>(va_arg(args, int)))
-    {
-        if(eMetatable1 == MT_DummyString)
-            lua_pushstring(pState->L, va_arg(args, char*));
-        else
-            lua_pushvalue(pState->L, pState->aiMetatables[eMetatable1]);
-        ++iUpCount;
-    }
-    va_end(args);
-    luaT_pushcclosure(pState->L, fn, iUpCount);
+void luaT_setclosure(const THLuaRegisterState_t *pState, lua_CFunction fn, size_t iUps) {
+    luaT_pushcclosure(pState->L, fn, iUps);
 }
 
 int luaopen_th(lua_State *L)

--- a/CorsixTH/Src/th_lua_strings.cpp
+++ b/CorsixTH/Src/th_lua_strings.cpp
@@ -745,11 +745,11 @@ void THLuaRegisterStrings(const THLuaRegisterState_t *pState)
     luaT_setmetamethod(l_str_ipairs, "ipairs");
     luaT_setmetamethod(l_str_next, "next");
     luaT_setmetamethod(l_str_inext, "inext");
-    luaT_setfunction(l_str_func, "format" , MT_DummyString, "format");
-    luaT_setfunction(l_str_func, "lower"  , MT_DummyString, "lower");
-    luaT_setfunction(l_str_func, "rep"    , MT_DummyString, "rep");
-    luaT_setfunction(l_str_func, "reverse", MT_DummyString, "reverse");
-    luaT_setfunction(l_str_func, "upper"  , MT_DummyString, "upper");
+    luaT_setfunction(l_str_func, "format", "format");
+    luaT_setfunction(l_str_func, "lower", "lower");
+    luaT_setfunction(l_str_func, "rep", "rep");
+    luaT_setfunction(l_str_func, "reverse", "reverse");
+    luaT_setfunction(l_str_func, "upper", "upper");
     luaT_setfunction(l_str_unwrap, "_unwrap");
     luaT_setfunction(l_str_reload, "reload");
     luaT_endclass();


### PR DESCRIPTION
Converts C style luaT_setclosure with varargs to a vararg template.

This adds (some) type safety and fixes:
```
/home/stephen/github/CorsixTH/CorsixTH/Src/th_lua.cpp:252:24: warning: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Wvarargs]
    for(va_start(args, eMetatable1);
```