### PR TITLE
[RDY] Add English names of languages beside the native name in options

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -730,7 +730,7 @@ function App:dumpStrings()
 
   self:checkMissingStringsInLanguage(dir, self.config.language)
   -- Uncomment these lines to get diffs for all languages in the game
-  -- for _, lang in ipairs(self.strings.languages_english) do
+  -- for _, lang in pairs(self.strings.languages_english) do
   --   self:checkMissingStringsInLanguage(dir, lang)
   -- end
   print("")
@@ -746,7 +746,6 @@ end
 --!param dir The directory where the file to write to should be.
 --!param language The language to check against.
 function App:checkMissingStringsInLanguage(dir, language)
-
   -- Accessors to reach through the userdata proxies on strings
   local LUT = debug.getregistry().StringProxyValues
   local function val(o)
@@ -788,7 +787,7 @@ function App:checkMissingStringsInLanguage(dir, language)
 
     -- if possible, use the English name of the language for the file name.
     local language_english = language
-    for _, lang_eng in ipairs(self.strings.languages_english) do
+    for _, lang_eng in pairs(self.strings.languages_english) do
       if ltc[language] == ltc[lang_eng:lower()] then
         language_english = lang_eng
         break

--- a/CorsixTH/Lua/dialogs/resizables/dropdown.lua
+++ b/CorsixTH/Lua/dialogs/resizables/dropdown.lua
@@ -29,7 +29,7 @@ local UIDropdown = _G["UIDropdown"]
 --!param parent_window (Window) The window that this dropdown will be attached to
 --!param parent_button (Button) The button in the parent_window that this dropdown will be positioned under
 --!param items (table) A list of items for the list to display, where each item is a table with at least
---       the field text, and optionally fields font and/or tooltip
+--       the field text, and optionally fields font and/or tooltip, which is a table containing text, x and y positions.
 --!param callback (function) A function to be called when an item is selected. It is called with two parameters:
 --       The parent window and the index of the selected item
 --!param colour (table) A colour in the form of {red = ..., green = ..., blue = ...}. Optional if parent_window is a UIResizable
@@ -57,10 +57,16 @@ function UIDropdown:UIDropdown(ui, parent_window, parent_button, items, callback
 
   local y = 0
   for i, item in ipairs(items) do
+  if item.tooltip and item.tooltip[1] then
+    self:addBevelPanel(1, y + 1, width - 2, height - 2, parent_window.colour):setLabel(item.text, item.font)
+      :makeButton(-1, -1, width, height, nil, --[[persistable:dropdown_tooltip_callback]] function() self:selectItem(i) end)
+      :setTooltip(item.tooltip[1], item.tooltip[2] or math.floor(self.ui.app.config.width / 2 - 25),
+        math.floor(self.ui.app.config.height / 4 - 130 + item.tooltip[3]) or 0)
+        -- Magic numbers used to find a static position across different screen resolutions.
+  else
     self:addBevelPanel(1, y + 1, width - 2, height - 2, parent_window.colour):setLabel(item.text, item.font)
       :makeButton(-1, -1, width, height, nil, --[[persistable:dropdown_callback]] function() self:selectItem(i) end)
-      -- TODO: tooltips for dropdown items currently deactivated because alignment and conditions for displaying are off for tooltips on sub-windows
-      --:setTooltip(item.tooltip)
+  end
     y = y + height
   end
 

--- a/CorsixTH/Lua/dialogs/resizables/new_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/new_game.lua
@@ -79,14 +79,17 @@ function UINewGame:UINewGame(ui)
 
 
   local avail_diff = {
-    {text = _S.new_game_window.medium, tooltip = _S.tooltip.new_game_window.medium, param = "full"},
+    {text = _S.new_game_window.medium, tooltip = { _S.tooltip.new_game_window.medium,
+     nil, 130 }, param = "full"}
   }
   if TheApp.fs:fileExists("Levels", "Easy01.SAM") then
-    table.insert(avail_diff, 1, {text = _S.new_game_window.easy, tooltip = _S.tooltip.new_game_window.easy, param = "easy"})
+    table.insert(avail_diff, 1, {text = _S.new_game_window.easy, tooltip = { _S.tooltip.new_game_window.easy,
+     nil, 100 }, param = "easy"})
     self.difficulty = 2
   end
   if TheApp.fs:fileExists("Levels", "Hard01.SAM") then
-    avail_diff[#avail_diff + 1] = {text = _S.new_game_window.hard, tooltip = _S.tooltip.new_game_window.hard, param = "hard"}
+    avail_diff[#avail_diff + 1] = {text = _S.new_game_window.hard, tooltip = { _S.tooltip.new_game_window.hard,
+     nil, 175 }, param = "hard"}
   end
   self.available_difficulties = avail_diff
 

--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -24,6 +24,10 @@ class "UIOptions" (UIResizable)
 ---@type UIOptions
 local UIOptions = _G["UIOptions"]
 
+-- Constants for most button's width and height
+local BTN_WIDTH = 135
+local BTN_HEIGHT = 20
+
 local col_bg = {
   red = 154,
   green = 146,
@@ -88,10 +92,6 @@ function UIOptions:UIOptions(ui, mode)
 
   -- Tracks the current position of the object
   self._current_option_index = 1
-
-  -- Constants for most button's width and height
-  local BTN_WIDTH = 135
-  local BTN_HEIGHT = 20
 
   self:checkForAvailableLanguages()
 
@@ -221,12 +221,15 @@ local --[[persistable:options_height_textbox_reset]] function height_textbox_res
 function UIOptions:checkForAvailableLanguages()
   local app = self.app
   -- Set up list of available languages
-  local langs = {}
-  for _, lang in ipairs(app.strings.languages) do
+  local langs, c = {}, 1
+  for _, lang in pairs(app.strings.languages) do
     local font = app.strings:getFont(lang)
-    if app.gfx:hasLanguageFont(font) then
+    if app.gfx:hasLanguageFont(font) and app.strings.languages_english[lang] then
+      local eng_name = app.strings.languages_english[lang]
+      c = c + 1
       font = font and app.gfx:loadLanguageFont(font, app.gfx:loadSpriteTable("QData", "Font01V"))
-      langs[#langs + 1] = {text = lang, font = font, tooltip = _S.tooltip.options_window.language_dropdown_item:format(lang)}
+      langs[#langs + 1] = { text = lang, font = font,
+      tooltip = { _S.tooltip.options_window.language_dropdown_item:format(eng_name), nil, BTN_HEIGHT * c } }
     end
   end
   self.available_languages = langs
@@ -247,8 +250,9 @@ function UIOptions:dropdownLanguage(activate)
 end
 
 function UIOptions:selectLanguage(number)
+  local lang = self.app.strings.languages_english[self.available_languages[number]["text"]]
   local app = self.ui.app
-  app.config.language = (self.available_languages[number].text)
+  app.config.language = (lang)
   app:initLanguage()
   app:saveConfig()
 end

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -18,7 +18,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
-Language("English", "en", "eng")
+Language("English", "English", "en", "eng")
 Inherit("original_strings", 0)
 
 -------------------------------  OVERRIDE  ----------------------------------

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -89,8 +89,8 @@ function Strings:init()
         -- Use the first name for display purposes (case-dependent!).
         if names[1] ~= "original_strings" then
           self.languages[#self.languages + 1] = names[1]
-          -- Also save the second name for internal purposes.
-          self.languages_english[#self.languages_english + 1] = names[2]
+          -- Also save the second name for tooltips and internal purposes.
+          self.languages_english[names[1]] = names[2]
         end
         -- Associate every passed name with this file, case-independently
         for _, name in pairs(names) do


### PR DESCRIPTION
The change in strings.lua affects https://github.com/CorsixTH/CorsixTH/blob/master/CorsixTH/Lua/app.lua#L721 and https://github.com/CorsixTH/CorsixTH/blob/master/CorsixTH/Lua/app.lua#L779 but I'm not sure what to do.

The longer text spills well outside the box, but it looked bad simply widening the background element. How do you want it to look?