### PR TITLE
[RDY] Prevent double remove on same litter object

### DIFF
--- a/CorsixTH/Lua/objects/litter.lua
+++ b/CorsixTH/Lua/objects/litter.lua
@@ -96,12 +96,15 @@ end
 function Litter:remove()
   assert(self:isCleanable())
 
-  self.world:removeObjectFromTile(self, self.tile_x, self.tile_y)
+  if self.tile_x then
+    self.world:removeObjectFromTile(self, self.tile_x, self.tile_y)
 
-  local hospital = self.world:getHospital(self.tile_x, self.tile_y)
-  local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning", self)
-  hospital:removeHandymanTask(taskIndex, "cleaning")
-
+    local hospital = self.world:getHospital(self.tile_x, self.tile_y)
+    local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning", self)
+    hospital:removeHandymanTask(taskIndex, "cleaning")
+  else
+    print("Warning: Removing litter that has already been removed.")
+  end
   self.world:destroyEntity(self)
 end
 


### PR DESCRIPTION
Provides a quick fix for handyman issue in #1329. I actually recall having this change in there previously, but can't recall testing this exact scenario, alas at somepoint I had removed it and forgot to put it back in.

Appears to be a more extensive issue of placing objects where a humanoid is already standing which was prevented in original.