### PR TITLE
[RDY] Enhancements for case sensitive filesystems

### DIFF
--- a/AnimView/frmSprites.cpp
+++ b/AnimView/frmSprites.cpp
@@ -194,16 +194,16 @@ void frmSprites::_onPanelPaint(wxPaintEvent& evt)
 void frmSprites::_onBrowseTable(wxCommandEvent& WXUNUSED(evt))
 {
     m_txtTable->SetValue(::wxFileSelector(L"Select location of Font00V.tab (DATA)",
-        m_txtTable->GetValue(),L"Font00V.tab",L"tab",L"Tab files (*.tab)|*.tab"
+        m_txtTable->GetValue(),L"Font00V.tab",L"tab",L"Tab files (*.tab)|*.[tT][aA][bB]"
         ,0, this));
 }
 void frmSprites::_onBrowseData(wxCommandEvent& WXUNUSED(evt))
 {
     m_txtData->SetValue(::wxFileSelector(L"Choose Theme Hospital data file",
-        m_txtData->GetValue(),L"",L"dat",L"Dat files (*.dat)|*.dat", 0, this));
+        m_txtData->GetValue(),L"",L"dat",L"Dat files (*.dat)|*.[dD][aA][tT]", 0, this));
 }
 void frmSprites::_onBrowsePalette(wxCommandEvent& WXUNUSED(evt))
 {
     m_txtPalette->SetValue(::wxFileSelector(L"Select location of MPalette.dat (QDATA)",
-        m_txtPalette->GetValue(),L"MPalette.dat",L"dat",L"Dat or Pal files (*.dat, *.pal)|*.dat;*.pal", 0, this));
+        m_txtPalette->GetValue(),L"MPalette.dat",L"dat",L"Dat or Pal files (*.dat, *.pal)|*.[dD][aA][tT];*.[pP][aA][lL]", 0, this));
 }


### PR DESCRIPTION
AnimView's Sprite Viewer did not allow selecting tab/dat/pal files if
they used uppercase naming in Linux.