### PR TITLE
Update room.lua

### DIFF
--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -993,3 +993,18 @@ function Room:getStaffServiceQuality()
 
   return quality
 end
+
+--! checks if the room is fully staffed,
+--! even if the staff is not present in the room
+function Room:isFullyStaffed()
+    local missing = self:getMissingStaff(self:getRequiredStaffCriteria())
+    local anyone_missed = next(missing)
+    for _, staff in ipairs(self.hospital.staff) do
+        if staff.humanoid_class ~= "Handyman"
+        and staff.last_room == self
+        and not anyone_missed then
+            return true
+        end
+    end
+    return false
+end


### PR DESCRIPTION
Added a function Room:isFullyStaffed to test if a room is fully staffed even if the staff is not currently present in the room. The function is needed for pull #1405 to prevent wandering staff to steal rooms that do not belong to them when the staff are not allowed to leave their offices.