### PR TITLE
[WIP] Null out format_context

### DIFF
--- a/CorsixTH/Src/th_movie.cpp
+++ b/CorsixTH/Src/th_movie.cpp
@@ -589,6 +589,7 @@ void movie_player::unload()
     if(format_context)
     {
         avformat_close_input(&format_context);
+        format_context = nullptr;
     }
 }
 


### PR DESCRIPTION
Set format_context to null pointer after closing to prevent possible double free.

The error in #1409 appears to be in avformat_close_input.