### PR TITLE
[RDY] Crashed room despawn

### DIFF
--- a/CorsixTH/Lua/entities/staff.lua
+++ b/CorsixTH/Lua/entities/staff.lua
@@ -148,7 +148,7 @@ end
 function Staff:tick()
   Entity.tick(self)
   -- don't do anything if they're fired or picked up or have no hospital
-  if self.fired or self.pickup or not self.hospital then
+  if self.fired or self.pickup or not self.hospital or self.dead then
     return
   end
 
@@ -388,7 +388,6 @@ function Staff:fire()
 end
 
 function Staff:die()
-  self:despawn()
   if self.task then
     -- If the staff member had a task outstanding, unassigning them from that task.
     -- Tasks with no handyman assigned will be eligible for reassignment by the hospital.
@@ -400,8 +399,7 @@ function Staff:die()
   if window then
     window:updateStaffList(self)
   end
-  -- It may be that the staff member was fired just before dying (then self.hospital = nil)
-  self.world.ui.hospital:humanoidDeath(self)
+  self.dead = true
 end
 
 -- Despawns the staff member and removes them from the hospital

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -787,7 +787,7 @@ function Room:crashRoom()
   for humanoid, _ in pairs(self.humanoids) do
     remove_humanoid(humanoid)
   end
-  self.humanoids = nil
+  self.humanoids = {}
   -- There might also be someone using the door, even if that person is just about to exit
   -- he/she is killed too.
   local walker = self.door.user

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -779,6 +779,7 @@ function Room:crashRoom()
       table.remove(self.world:getLocalPlayerHospital().emergency_patients, humanoid.is_emergency)
     end
     humanoid:die()
+    humanoid:despawn()
     self.world:destroyEntity(humanoid)
   end
 
@@ -786,6 +787,7 @@ function Room:crashRoom()
   for humanoid, _ in pairs(self.humanoids) do
     remove_humanoid(humanoid)
   end
+  self.humanoids = nil
   -- There might also be someone using the door, even if that person is just about to exit
   -- he/she is killed too.
   local walker = self.door.user


### PR DESCRIPTION
Addresses #1429.

One additional change here was to remove the humanoidDeath call from Staff:die() as staff deaths didn't count to death count in TH or affect reputation (room being destroyed did).

There is one outstanding issue which might contribute (or not) to some bugs, is that Room:crashRoom calls World:destroyEntity, which removes multiple entities. From my understanding that can result in skipped tick calls as calling table.remove from within an iteration from ipairs is bad.

