### PR TITLE
[RDY] Fix leaking file descriptors

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/directory_browser.lua
+++ b/CorsixTH/Lua/dialogs/resizables/directory_browser.lua
@@ -37,7 +37,10 @@ function DirTreeNode:isValidFile(name)
   if FileTreeNode.isValidFile(self, name) and
       lfs.attributes(self:childPath(name), "mode") == "directory" then
     -- Make sure that we are allowed to read the directory.
-    local status, _ = pcall(lfs.dir, self:childPath(name))
+    local status, _, dir_obj = pcall(lfs.dir, self:childPath(name))
+    if status then
+      dir_obj:close()
+    end
     return status
   end
 end

--- a/CorsixTH/Lua/dialogs/tree_ctrl.lua
+++ b/CorsixTH/Lua/dialogs/tree_ctrl.lua
@@ -279,16 +279,17 @@ function FileTreeNode:hasChildren()
     if lfs.attributes(self.path, "mode") ~= "directory" then
       return false
     end
-    local status, _f, _s, _v = pcall(lfs.dir, self.path)
+    local status, err, dir_obj = pcall(lfs.dir, self.path)
     if not status then
-      print("Error while fetching children for " .. self.path .. ": " .. _f)
+      print("Error while fetching children for " .. self.path .. ": " .. err)
     else
-      for item in _f, _s, _v do
+      for item in dir_obj.next, dir_obj do
         if self:isValidFile(item) then
           self.has_children = true
           break
         end
       end
+      dir_obj:close()
     end
   end
   return self.has_children


### PR DESCRIPTION
lfs opens a file when lfs.dir is called. The file is only closed when
the iterator hits the end of the directory list, or close is explicitly
called. This commit calls close in the necessary places.

Should fix #1460 