### PR TITLE
[RDY] Show errors when loading bitmaps

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -26,6 +26,7 @@ SOFTWARE.
 
 #include <SDL.h>
 #include "persist_lua.h"
+#include <stdexcept>
 
 class cursor;
 struct clip_rect : public SDL_Rect {
@@ -55,7 +56,7 @@ public:
         @param iSpriteFlags Flags how to render the sprite.
         @return Decoding was successful.
     */
-    bool decode_image(const uint8_t* pImg, const ::palette *pPalette, uint32_t iSpriteFlags);
+    void decode_image(const uint8_t* pImg, const ::palette *pPalette, uint32_t iSpriteFlags);
 
 private:
     //! Store a decoded pixel. Use x and y if necessary.
@@ -87,7 +88,7 @@ private:
         }
         else
         {
-            x = 1; // Will return 'failed'.
+            throw std::logic_error("Attempt to push_pixel past the end of the image");
         }
     }
 };
@@ -383,7 +384,7 @@ public:
         @param pEventualCanvas Canvas to render the image to (eventually).
         @return Loading was a success.
     */
-    bool load_from_th_file(const uint8_t* pPixelData, size_t iPixelDataLength,
+    void load_from_th_file(const uint8_t* pPixelData, size_t iPixelDataLength,
                            int iWidth, render_target *pEventualCanvas);
 
     //! Draw the image at a given position at the given canvas.

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -24,6 +24,7 @@ SOFTWARE.
 #include "th_gfx.h"
 #include <SDL.h>
 #include <cstring>
+#include <exception>
 
 static int l_palette_new(lua_State *L)
 {
@@ -80,11 +81,16 @@ static int l_rawbitmap_load(lua_State *L)
     int iWidth = static_cast<int>(luaL_checkinteger(L, 3));
     render_target* pSurface = luaT_testuserdata<render_target>(L, 4, luaT_upvalueindex(1), false);
 
-    if(pBitmap->load_from_th_file(pData, iDataLen, iWidth, pSurface))
-        lua_pushboolean(L, 1);
-    else
-        lua_pushboolean(L, 0);
+    try {
+        pBitmap->load_from_th_file(pData, iDataLen, iWidth, pSurface);
+    }
+    catch (const std::exception& ex) {
+        lua_pushstring(L, ex.what());
+        lua_error(L);
+        return 1;
+    }
 
+    lua_pushboolean(L, 1);
     return 1;
 }
 


### PR DESCRIPTION
Use exceptions and lua_error to show the cause of any error loading bitmaps
instead of simply false. This makes diagnosing errors much easier.

This patch was used to diagnose #1468 but does not fix the issue.