### PR TITLE
[RDY] Litter placed before a door was placed was only found on thob checks

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -206,12 +206,12 @@ local action_walk_tick; action_walk_tick = permanent"action_walk_tick"( function
     -- if going to the corridor we don't care as we are at the door
     -- as this will be false we won't bother checking for rerouting
     recalc_route = flags_there.room
-    local door = TheApp.objects.door.thob
-    local door2 = TheApp.objects.swing_door_right.thob
+    local door = TheApp.objects.door.id
+    local door2 = TheApp.objects.swing_door_right.id
+    local doorcheck = {[door] = true, [door2] = true}
     -- but we should see if this is the same room id we want to go to and cancel the reroute
     -- ensure we still have a door on this route
-    if recalc_route and (flags_here.thob == door or flags_here.thob == door2 or --is there any door
-        flags_there.thob == door or flags_there.thob == door2) and -- is there any door
+    if recalc_route and (humanoid.world:getObject(x1, y1, doorcheck) or humanoid.world:getObject(x2, y2, doorcheck)) and -- is there any door
         map:getCellFlags(path_x[#path_x], path_y[#path_y]).roomId == flags_there.roomId then
       recalc_route = false
     end


### PR DESCRIPTION
Using getObject with a table input to find either door type instead. Refers to #1425 still