### PR TITLE
[RDY] Invisible drinks machine

### DIFF
--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -494,20 +494,22 @@ function Patient:pee()
 end
 
 function Patient:checkWatch()
-  if self.check_watch_anim and not self:getCurrentAction().is_leaving then
+  local action = self:getCurrentAction()
+  if self.check_watch_anim and (action.name == "idle" or action.name == "seek_room") and not action.is_leaving then
     self:queueAction(CheckWatchAction(), 0)
   end
 end
 
 function Patient:yawn()
   local action = self:getCurrentAction()
-  if self.yawn_anim and action.name == "idle" then
+  if self.yawn_anim and (action.name == "idle" or action.name == "seek_room") and not action.is_leaving then
     self:queueAction(YawnAction(), 0)
   end
 end
 
 function Patient:tapFoot()
-  if self.tap_foot_anim and not self:getCurrentAction().is_leaving then
+  local action = self:getCurrentAction()
+  if self.tap_foot_anim and (action.name == "idle" or action.name == "seek_room") and not action.is_leaving then
     self:queueAction(TapFootAction(), 0)
   end
 end


### PR DESCRIPTION
Finally tracked down the invisible drinks machine (mentioned in #1206).

From memory checking watch, yawns and tapping foot were only done whilst waiting in queue or whilst waiting for a room to be built, I can't recall it very well.

As the patient had to be waiting for a room to be built in this instance, waiting for 30 or 50 days and also happen to be using the drinks machine at the same time, it happens rarely. I'm not sure if there is any value in the is_leaving, I assume that was put in some time back for some purpose but I've replicated it across to the yawn as well. Likewise even though the checkWatch/tapFoot calls were only ever done within the Patient:tickDay checks at the start, and therefore patient.waiting had to be ticking down, they would never be called for an idle state from my quick perusal.

Put this as RFC for the fact I'm not sure on the correct state.