### PR TITLE
[RDY] Implement a goHome handler for evacuated patients

### DIFF
--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -556,7 +556,7 @@ function Patient:goHome(reason, disease_id)
 
   elseif reason == "evacuated" then
     self:clearDynamicInfo()
-    self:updateDynamicInfo('text', {_S.dynamic_info.patient.actions.epidemic_sent_home})
+    self:setDynamicInfo('text', {_S.dynamic_info.patient.actions.epidemic_sent_home})
     self:setMood("exit","activate")
 
   else
@@ -583,7 +583,7 @@ function Patient:goHome(reason, disease_id)
   if room then
     room:makeHumanoidLeave(self)
   end
-  self:despawn()
+  Humanoid.despawn(self)
 end
 
 -- Despawns the patient and removes them from the hospital

--- a/CorsixTH/Lua/entities/patient.lua
+++ b/CorsixTH/Lua/entities/patient.lua
@@ -554,6 +554,11 @@ function Patient:goHome(reason, disease_id)
     self:clearDynamicInfo()
     self:updateDynamicInfo(_S.dynamic_info.patient.actions.prices_too_high)
 
+  elseif reason == "evacuated" then
+    self:clearDynamicInfo()
+    self:updateDynamicInfo('text', {_S.dynamic_info.patient.actions.epidemic_sent_home})
+    self:setMood("exit","activate")
+
   else
     TheApp.world:gameLog("Error: unknown reason " .. reason .. "!")
   end

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -513,16 +513,8 @@ end
 --[[ Forces evacuation of the hospital - it makes ALL patients leave and storm out. ]]
 function Epidemic:evacuateHospital()
   for _, patient in ipairs(self.hospital.patients) do
-    local patient_room = patient:getRoom()
-    if patient_room then
-      patient_room:makeHumanoidDressIfNecessaryAndThenLeave(patient)
-    end
-    if patient.has_passed_reception then
-      patient:clearDynamicInfo()
-      patient:setDynamicInfo('text', {_S.dynamic_info.patient.actions.epidemic_sent_home})
-      patient:setMood("exit","activate")
-      local spawn_point = self.world.spawn_points[math.random(1, #self.world.spawn_points)]
-      patient:setNextAction(SpawnAction("despawn", spawn_point):setMustHappen(true))
+    if patient.has_passed_reception and not patient.going_home then
+      patient:goHome("evacuated")
     end
   end
 end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1922,8 +1922,9 @@ function Hospital:getAveragePatientAttribute(attribute, default_value)
   local sum = 0
   local count = 0
   for _, patient in ipairs(self.patients) do
+    local tx, ty = patient.tile_x, patient.tile_y
     -- Some patients (i.e. Alien) may not have the attribute in question, so check for that
-    if patient.attributes[attribute] then
+    if tx and ty and self:isInHospital(tx, ty) and patient.attributes[attribute] then
       sum = sum + patient.attributes[attribute]
       count = count + 1
     end

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -148,7 +148,7 @@ function Room:dealtWithPatient(patient)
   patient = patient or self:getPatient()
   -- If the patient was sent home while in the room, don't
   -- do anything apart from removing any leading idle action.
-  if not patient.hospital then
+  if not patient.hospital or patient.going_home then
     if patient:getCurrentAction().name == "idle" then
       patient:finishAction()
     end


### PR DESCRIPTION
Addressing #1436. I can't recall if an evacuation affected the statistics in the original for not treated, but have stopped the percentages being updated here.

The only negative is that goHome will get called twice, when a patient is 'dealtWithPatient' call is made in a callback after an action completes, the warning will be printed.