### PR TITLE
[RDY] Three one liner fixes

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -611,7 +611,7 @@ function UIEditRoom:returnToDoorPhase()
           break
         end
         if obj.object_type.id == "litter" then -- Silently remove litter from the world.
-          obj.remove()
+          obj:remove()
           break
         end
         local obj_state = obj:getState()

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -692,7 +692,7 @@ function Hospital:countSittingStanding()
   local numberStanding = 0
   for _, patient in ipairs(self.patients) do
     local pat_action = patient:getCurrentAction()
-    if pat_action.name == "idle" then
+    if pat_action.name == "idle" and not patient:getRoom() then
       numberStanding = numberStanding + 1
     elseif pat_action.name == "use_object" and pat_action.object.object_type.id == "bench" then
       numberSitting = numberSitting + 1

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -275,7 +275,7 @@ local action_queue_on_change_position = permanent"action_queue_on_change_positio
       end
     end
     humanoid.action_queue[idle_index].direction = idle_direction
-    humanoid:queueAction(WalkAction(ix, iy):setMustHappen(true), idle_index - 1)
+    humanoid:queueAction(WalkAction(ix, iy):setMustHappen(true):setIsLeaving(humanoid:isLeaving()), idle_index - 1)
   else
     action.current_bench_distance = nil
     local num_actions_prior = action_queue_leave_bench(action, humanoid)


### PR DESCRIPTION
Removing litter in a room found in #1401 though this shouldn't really be an issue in more recent builds and shouldn't be an issue once the reservation bug is fixed, which shouldn't lead to this invalid state.

#1012 I thought it would break something without more investigation, but the initial queue action start has the same changes (just there its on the IdleAction), and I haven't as yet found any side effects when running in other PRs that I've been testing.

The 3rd change is the countSittingStanding, where patients idle in a room counted negatively to the standing stats. I came across this one after an epidemic evac, when only about 6 patients were seated in a large hospital and about 24 were in rooms, but only about 4 were standing in the corridor and 12+ standing idle in rooms awaiting next action.