### PR TITLE
[RDY] Kings complex patient in psych

### DIFF
--- a/CorsixTH/Lua/rooms/psych.lua
+++ b/CorsixTH/Lua/rooms/psych.lua
@@ -91,10 +91,10 @@ function PsychRoom:commandEnteringPatient(patient)
     if bookcase == nil then
       bookcase, bx, by = self.world:findObjectNear(staff, "bookcase")
     end
-    if patient and patient.user_of then
+    if patient and patient.user_of and patient.user_of.object_type.id == "couch" then
       duration = duration - 1
     end
-    if duration <= 0 then
+    if duration == 0 then
       if patient.diagnosed and patient.disease.id == "king_complex" then
         -- Diagnosed patients (Elvis) need to change clothes
         local after_use_screen = --[[persistable:psych_screen_after_use]] function()
@@ -114,6 +114,11 @@ function PsychRoom:commandEnteringPatient(patient)
         self:dealtWithPatient(patient)
       end
       return
+	else
+      if patient:getRoom() ~= self and self:getStaffMember() then
+        self:getStaffMember():setNextAction(MeanderAction())
+        return
+      end
     end
     if bookcase and (duration % 10) == 0 and math.random(1, 2) == 1 then
       staff:walkTo(bx, by)


### PR DESCRIPTION
Addressing #1394
A kings complex patient in psych that is diagnosed and being treated, will generally, if interrupted, queue the walkTo/UseScreen actions upon navigating the door.

The 'couch' check prevents the duration ticking down when navigating the door.
Also limited the duration check to equality to only allow running it once, the walkTo to screen can still be interrupted once started.

Staff will also get a MeanderAction if patient no longer in the room as the book case use logic can leave the count above 0 and therefore the doctor stuck. This will allow the doctor to start over as if the patient was dealt with.