### PR TITLE
[RDY] Add empty multigesture handler to ui.lua

### DIFF
--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -763,6 +763,13 @@ function UI:onMouseMove(x, y, dx, dy)
   return repaint
 end
 
+--! Process SDL_MULTIGESTURE events.
+--!
+--!return (boolean) event processed indicator
+function UI:onMultiGesture()
+  return false
+end
+
 function UI:onTick()
   Window.onTick(self)
   local repaint = false


### PR DESCRIPTION
Silences error about the missing handler. May be extended in the future.

Fixes #1464 