### PR TITLE
[RDY] Research fax options updating

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -202,6 +202,7 @@ add_ignore("CorsixTH/Lua/humanoid_actions/multi_use_object.lua", "212")
 add_ignore("CorsixTH/Lua/humanoid_actions/pickup.lua", "212")
 add_ignore("CorsixTH/Lua/humanoid_actions/seek_reception.lua", "212")
 add_ignore("CorsixTH/Lua/humanoid_actions/seek_reception.lua", "542")
+add_ignore("CorsixTH/Lua/humanoid_actions/seek_room.lua", "212")
 add_ignore("CorsixTH/Lua/humanoid_actions/staff_reception.lua", "113") -- ReceptionDesk does exist
 add_ignore("CorsixTH/Lua/humanoid_actions/use_object.lua", "542")
 add_ignore("CorsixTH/Lua/humanoid_actions/vaccinate.lua", "212")

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 133
+local SAVEGAME_VERSION = 134
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -166,6 +166,7 @@ function UIFax:choice(choice_number)
         owner:goHome("over_priced", owner.disease.id)
       end
     elseif choice == "research" then
+      owner:unregisterCallbacks()
       owner:setMood("idea", "activate")
       owner:setNextAction(SeekRoomAction("research"))
     end

--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -144,8 +144,10 @@ function UIMessage:removeMessage(choice_number)
       self.owner.message = nil
       self.owner.message_callback = nil
     end
-    self:onClose(false)
-    self.onClose = nil
+    if self.onClose then
+      self:onClose(false)
+      self.onClose = nil
+    end
     self:close()
   end
 end

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -300,6 +300,7 @@ function Humanoid:Humanoid(...)
 
   self.build_callbacks  = {--[[set]]}
   self.remove_callbacks = {--[[set]]}
+  self.staff_callbacks = {--[[set]]}
 end
 
 -- Save game compatibility
@@ -337,11 +338,15 @@ function Humanoid:afterLoad(old, new)
   if old < 83 and new >= 83 and self.humanoid_class == "Chewbacca Patient" then
     self.die_anims.extra_east = 1682
   end
+  if old < 133 then
+    self.staff_callbacks = {}
+  end
 
   for _, action in pairs(self.action_queue) do
     -- Sometimes actions not actual instances of HumanoidAction
     HumanoidAction.afterLoad(action, old, new)
   end
+
   Entity.afterLoad(self, old, new)
 end
 
@@ -819,6 +824,12 @@ function Humanoid:notifyNewRoom(room)
   end
 end
 
+function Humanoid:notifyOfStaff(staff)
+  for callback, _ in pairs(self.staff_callbacks) do
+    callback(staff)
+  end
+end
+
 -- Registers a new remove callback for this humanoid.
 --!param callback (function) The callback to call when a room has been removed.
 function Humanoid:registerRoomRemoveCallback(callback)
@@ -841,6 +852,29 @@ function Humanoid:unregisterRoomRemoveCallback(callback)
   end
 end
 
+
+-- Registers a new staff callback for this humanoid.
+--!param callback (function) The callback to call when a staff member has been hired or fired
+function Humanoid:registerStaffCallback(callback)
+  if self.staff_callbacks and not self.staff_callbacks[callback] then
+    self.staff_callbacks[callback] = true
+  else
+    self.world:gameLog("Warning: Trying to re-add staff callback (" .. tostring(callback) .. ") for humanoid (" .. tostring(self) .. ").")
+  end
+end
+
+-- Unregisters a remove callback for this humanoid.
+--!param callback (function) The callback to remove.
+function Humanoid:unregisterStaffCallback(callback)
+
+  if self.staff_callbacks and self.staff_callbacks[callback] then
+    self.staff_callbacks[callback] = nil
+  else
+    self.world:gameLog("Warning: Trying to remove nonexistant staff callback (" .. tostring(callback) .. ") from humanoid (" .. tostring(self) .. ").")
+  end
+end
+
+
 -- Function called when a humanoid is sent away from the hospital to prevent
 -- further actions taken as a result of a callback
 function Humanoid:unregisterCallbacks()
@@ -851,6 +885,10 @@ function Humanoid:unregisterCallbacks()
   -- Remove callbacks for removed rooms
   for cb, _ in pairs(self.remove_callbacks) do
     self:unregisterRoomRemoveCallback(cb)
+  end
+  -- Remove callbacks for removed rooms
+  for cb, _ in pairs(self.staff_callbacks) do
+    self:unregisterStaffCallback(cb)
   end
   -- Remove any message related to the humanoid.
   if self.message_callback then

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -300,7 +300,7 @@ function Humanoid:Humanoid(...)
 
   self.build_callbacks  = {--[[set]]}
   self.remove_callbacks = {--[[set]]}
-  self.staff_callbacks = {--[[set]]}
+  self.staff_change_callbacks = {--[[set]]}
 end
 
 -- Save game compatibility
@@ -338,8 +338,8 @@ function Humanoid:afterLoad(old, new)
   if old < 83 and new >= 83 and self.humanoid_class == "Chewbacca Patient" then
     self.die_anims.extra_east = 1682
   end
-  if old < 133 then
-    self.staff_callbacks = {}
+  if old < 134 and new >= 134 then
+    self.staff_change_callbacks = {}
   end
 
   for _, action in pairs(self.action_queue) do
@@ -824,8 +824,8 @@ function Humanoid:notifyNewRoom(room)
   end
 end
 
-function Humanoid:notifyOfStaff(staff)
-  for callback, _ in pairs(self.staff_callbacks) do
+function Humanoid:notifyOfStaffChange(staff)
+  for callback, _ in pairs(self.staff_change_callbacks) do
     callback(staff)
   end
 end
@@ -853,22 +853,22 @@ function Humanoid:unregisterRoomRemoveCallback(callback)
 end
 
 
--- Registers a new staff callback for this humanoid.
+-- Registers a new staff change callback for this humanoid.
 --!param callback (function) The callback to call when a staff member has been hired or fired
-function Humanoid:registerStaffCallback(callback)
-  if self.staff_callbacks and not self.staff_callbacks[callback] then
-    self.staff_callbacks[callback] = true
+function Humanoid:registerStaffChangeCallback(callback)
+  if self.staff_change_callbacks and not self.staff_change_callbacks[callback] then
+    self.staff_change_callbacks[callback] = true
   else
     self.world:gameLog("Warning: Trying to re-add staff callback (" .. tostring(callback) .. ") for humanoid (" .. tostring(self) .. ").")
   end
 end
 
--- Unregisters a remove callback for this humanoid.
+-- Unregisters a staff change callback for this humanoid.
 --!param callback (function) The callback to remove.
-function Humanoid:unregisterStaffCallback(callback)
+function Humanoid:unregisterStaffChangeCallback(callback)
 
-  if self.staff_callbacks and self.staff_callbacks[callback] then
-    self.staff_callbacks[callback] = nil
+  if self.staff_change_callbacks and self.staff_change_callbacks[callback] then
+    self.staff_change_callbacks[callback] = nil
   else
     self.world:gameLog("Warning: Trying to remove nonexistant staff callback (" .. tostring(callback) .. ") from humanoid (" .. tostring(self) .. ").")
   end
@@ -887,8 +887,8 @@ function Humanoid:unregisterCallbacks()
     self:unregisterRoomRemoveCallback(cb)
   end
   -- Remove callbacks for removed rooms
-  for cb, _ in pairs(self.staff_callbacks) do
-    self:unregisterStaffCallback(cb)
+  for cb, _ in pairs(self.staff_change_callbacks) do
+    self:unregisterStaffChangeCallback(cb)
   end
   -- Remove any message related to the humanoid.
   if self.message_callback then

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -1081,17 +1081,33 @@ function Patient:updateMessage(choice)
     local enabled = false
     if choice == "research" then
       -- enable only if research department is built and a room in the treatment chain is undiscovered
-      if self.hospital:hasRoomOfType("research") then
-        local req = self.hospital:checkDiseaseRequirements(self.disease.id)
-        if req then
-          for _, room_id in ipairs(req.rooms) do
-            local room = self.world.available_rooms[room_id]
-            if room and self.hospital.undiscovered_rooms[room] then
-              enabled = true
-              break
-            end
+      local req = self.hospital:checkDiseaseRequirements(self.disease.id)
+      if req then
+        local strings = _S.fax.disease_discovered_patient_choice
+        enabled = self.hospital:hasRoomOfType("research") and self.hospital:hasStaffOfCategory("Researcher")
+        local output_text = strings.can_not_cure
+        if #req.rooms > 0 then
+          local room_name, _, staff_name = self.world:getRoomNameAndRequiredStaffName(req.rooms[#req.rooms])
+          if next(req.staff) then
+            output_text = strings.need_to_build_and_employ:format(room_name, staff_name)
+          else
+            output_text = strings.need_to_build:format(room_name)
           end
+        elseif next(req.staff) then
+          local staffclass_to_string = {
+              Nurse        = _S.staff_title.nurse,
+              Doctor       = _S.staff_title.doctor,
+              Surgeon      = _S.staff_title.surgeon,
+              Psychiatrist = _S.staff_title.psychiatrist,
+          }
+          output_text = strings.need_to_employ:format(staffclass_to_string[next(req.staff)])
+        else
+          enabled = false
         end
+        self.message[3].text = output_text
+      else
+        --no requirements
+        enabled = false
       end
     else -- if choice == "guess_cure" then
       -- TODO: implement
@@ -1128,7 +1144,6 @@ function Patient:removeVaccinationCandidateStatus()
     self.vaccination_candidate = false
   end
 end
-
 
 function Patient:afterLoad(old, new)
   if old < 68 then

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -1095,7 +1095,7 @@ function Patient:updateMessage(choice)
         enabled = self.hospital:hasRoomOfType("research") and self.hospital:hasStaffOfCategory("Researcher")
         local output_text = strings.can_not_cure
         if #req.rooms == 1 then
-          local room_name, required_staff, staff_name = self.world:getRoomNameAndRequiredStaffName(req.rooms[#req.rooms])
+          local room_name, required_staff, staff_name = self.world:getRoomNameAndRequiredStaffName(req.rooms[1])
           if req.staff[required_staff] or 0 > 0 then
             output_text = strings.need_to_build_and_employ:format(room_name, staff_name)
           else

--- a/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
@@ -159,6 +159,8 @@ function Doctor:updateSkill(consultant, trait, amount) -- luacheck: no unused ar
     local is = trait:match"^is_(.*)"
     if is == "surgeon" or is == "psychiatrist" or is == "researcher" then
       self.world.ui.adviser:say(_A.information.promotion_to_specialist:format(_S.staff_title[is]))
+      -- patients might we waiting for a doctor with this skill, notify them
+      self.hospital:notifyOfStaffChange(self)
     end
     self:updateStaffTitle()
   end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1696,7 +1696,7 @@ function Hospital:addStaff(staff)
   -- Cost of hiring staff:
   self:spendMoney(staff.profile.wage, _S.transactions.hire_staff .. ": " .. staff.profile.name)
   for _, patient in pairs(self.patients) do
-    patient:notifyOfStaff(staff)
+    patient:notifyOfStaffChange(staff)
   end
 end
 
@@ -1775,7 +1775,7 @@ function Hospital:removeStaff(staff)
   RemoveByValue(self.staff, staff)
   -- update all messages for waiting patients
   for _, patient in pairs(self.patients) do
-    patient:notifyOfStaff(nil)
+    patient:notifyOfStaffChange(staff)
   end
 end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1695,9 +1695,7 @@ function Hospital:addStaff(staff)
   self.staff[#self.staff + 1] = staff
   -- Cost of hiring staff:
   self:spendMoney(staff.profile.wage, _S.transactions.hire_staff .. ": " .. staff.profile.name)
-  for _, patient in pairs(self.patients) do
-    patient:notifyOfStaffChange(staff)
-  end
+  self:notifyOfStaffChange(staff)
 end
 
 function Hospital:addPatient(patient)
@@ -1774,9 +1772,7 @@ end
 function Hospital:removeStaff(staff)
   RemoveByValue(self.staff, staff)
   -- update all messages for waiting patients
-  for _, patient in pairs(self.patients) do
-    patient:notifyOfStaffChange(staff)
-  end
+  self:notifyOfStaffChange(staff)
 end
 
 --! Remove a patient from the hospital.
@@ -2371,5 +2367,13 @@ function Hospital:computePriceLevelImpact(patient, casebook)
   elseif math.abs(price_distortion) <= 0.15 and math.random(1, 200) == 1 then
     -- When prices are well adjusted (i.e. abs(price distortion) <= 0.15)
     self.world.ui.adviser:say(_A.warnings.fair_prices:format(casebook.disease.name))
+  end
+end
+
+--! Notify patients of a change to hospital staff members
+--!param staff (Staff) Changed staff member subject of notification
+function Hospital:notifyOfStaffChange(staff)
+  for _, patient in pairs(self.patients) do
+    patient:notifyOfStaffChange(staff)
   end
 end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1695,6 +1695,9 @@ function Hospital:addStaff(staff)
   self.staff[#self.staff + 1] = staff
   -- Cost of hiring staff:
   self:spendMoney(staff.profile.wage, _S.transactions.hire_staff .. ": " .. staff.profile.name)
+  for _, patient in pairs(self.patients) do
+    patient:notifyOfStaff(staff)
+  end
 end
 
 function Hospital:addPatient(patient)
@@ -1770,6 +1773,10 @@ end
 --!param staff (Staff) Staff member to remove.
 function Hospital:removeStaff(staff)
   RemoveByValue(self.staff, staff)
+  -- update all messages for waiting patients
+  for _, patient in pairs(self.patients) do
+    patient:notifyOfStaff(nil)
+  end
 end
 
 --! Remove a patient from the hospital.

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -134,20 +134,27 @@ local function action_seek_room_no_treatment_room_found(room_type, humanoid)
   --local room = assert(humanoid.world.available_rooms[room_type], "room " .. room_type .. " not available")
 
   local req = humanoid.hospital:checkDiseaseRequirements(humanoid.disease.id)
-
+  local research_enabled = false
   if req then
-    local room_name, _, staff_name = humanoid.world:getRoomNameAndRequiredStaffName(room_type)
-    if #req.rooms > 0 then
-      if next(req.staff) then
+    research_enabled = humanoid.hospital:hasRoomOfType("research") and humanoid.hospital:hasStaffOfCategory("Researcher")
+    if #req.rooms == 1 then
+      local room_name, required_staff, staff_name = humanoid.world:getRoomNameAndRequiredStaffName(req.rooms[1])
+      if req.staff[required_staff] or 0 > 0 then
         output_text = strings.need_to_build_and_employ:format(room_name, staff_name)
       else
         output_text = strings.need_to_build:format(room_name)
       end
-    else
-      output_text = strings.need_to_employ:format(staff_name)
+    elseif #req.rooms == 0 and next(req.staff) then
+      local staffclass_to_string = {
+          Nurse        = _S.staff_title.nurse,
+          Doctor       = _S.staff_title.doctor,
+          Surgeon      = _S.staff_title.surgeon,
+          Psychiatrist = _S.staff_title.psychiatrist,
+      }
+      output_text = strings.need_to_employ:format(staffclass_to_string[next(req.staff)])
     end
   end
-  local research_enabled = humanoid.hospital:hasStaffOfCategory("Researcher") and humanoid.hospital:hasRoomOfType("research")
+
   local message = {
     {text = strings.disease_name:format(humanoid.disease.name)},
     {text = " "},

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -48,7 +48,7 @@ function SeekRoomAction:setDiagnosisRoom(room)
   return self
 end
 
-local function action_seek_room_find_room(action, humanoid)
+local action_seek_room_find_room = permanent"action_seek_room_find_room"( function(action, humanoid)
   local room_type = action.room_type
   if action.diagnosis_room then
     local tried_rooms = 0
@@ -97,7 +97,7 @@ local function action_seek_room_find_room(action, humanoid)
     end
   end
   return humanoid.world:findRoomNear(humanoid, room_type, nil, "advanced")
-end
+end)
 
 local action_seek_room_goto_room = permanent"action_seek_room_goto_room"( function(room, humanoid, diagnosis_room)
   humanoid:setMood("patient_wait", "deactivate")
@@ -128,22 +128,26 @@ local function action_seek_room_no_treatment_room_found(room_type, humanoid)
   humanoid.waiting = 60
   local strings = _S.fax.disease_discovered_patient_choice
   -- Can this room be built right now? What is then missing?
-  -- TODO: Change to make use of Hospital:checkDiseaseRequirements
+
   local output_text = strings.can_not_cure
   -- TODO: can we really assert this? Or should we just make the patient go home?
-  local room = assert(humanoid.world.available_rooms[room_type], "room " .. room_type .. " not available")
+  --local room = assert(humanoid.world.available_rooms[room_type], "room " .. room_type .. " not available")
 
-  local room_discovered = false
-  if humanoid.hospital.discovered_rooms[room] then
-    room_discovered = true
-    local room_name, required_staff, staff_name = humanoid.world:getRoomNameAndRequiredStaffName(room_type)
-    if humanoid.hospital:hasStaffOfCategory(required_staff) then
-      output_text = strings.need_to_build:format(room_name)
+  local req = humanoid.hospital:checkDiseaseRequirements(humanoid.disease.id)
+
+  if req then
+    local room_name, _, staff_name = humanoid.world:getRoomNameAndRequiredStaffName(room_type)
+    if #req.rooms > 0 then
+      if next(req.staff) then
+        output_text = strings.need_to_build_and_employ:format(room_name, staff_name)
+      else
+        output_text = strings.need_to_build:format(room_name)
+      end
     else
-      output_text = strings.need_to_build_and_employ:format(room_name, staff_name)
+      output_text = strings.need_to_employ:format(staff_name)
     end
   end
-  local research_enabled = not room_discovered and humanoid.hospital:hasRoomOfType("research")
+  local research_enabled = humanoid.hospital:hasStaffOfCategory("Researcher") and humanoid.hospital:hasRoomOfType("research")
   local message = {
     {text = strings.disease_name:format(humanoid.disease.name)},
     {text = " "},
@@ -207,6 +211,7 @@ local function action_seek_room_no_diagnosis_room_found(action, humanoid)
     humanoid:setDiagnosed()
     humanoid:unregisterRoomBuildCallback(action.build_callback)
     humanoid:unregisterRoomRemoveCallback(action.remove_callback)
+    humanoid:unregisterStaffCallback(action.staff_callback)
     if humanoid:agreesToPay(humanoid.disease.id) then
       humanoid:queueAction({
         name = "seek_room",
@@ -228,8 +233,10 @@ local action_seek_room_interrupt = permanent"action_seek_room_interrupt"( functi
   --        the callback does not happen, meaning that the message does not disappear.
   humanoid:unregisterRoomBuildCallback(action.build_callback)
   humanoid:unregisterRoomRemoveCallback(action.remove_callback)
+  humanoid:unregisterStaffCallback(action.staff_callback)
   action.build_callback = nil
   action.remove_callback = nil
+  action.staff_callback = nil
   action.done_init = false
   humanoid:finishAction()
 end)
@@ -246,115 +253,162 @@ local function action_seek_room_start(action, humanoid)
     return
   end
   -- Tries to find the room, if it is a diagnosis room, try to find any room in the diagnosis list.
-  local room = action_seek_room_find_room(action, humanoid)
+  if not humanoid.diagnosed or action.room_type == "research" then
+    local room = action_seek_room_find_room(action, humanoid)
+    -- if we have the room but not the staff we shouldn't seek out the room either
+    if room then
+      if humanoid.message then
+        TheApp.ui.bottom_panel:removeMessage(humanoid)
+      end
+      action_seek_room_goto_room(room, humanoid, action.diagnosis_room)
+      return
+    end
+  end
 
-  if room then
-    action_seek_room_goto_room(room, humanoid, action.diagnosis_room)
-  else
-    if not action.done_init then
-      action.done_init = true
-      action.must_happen = true
+  -- check we can treat the patient - and just shortcut the processing
+  local req = humanoid.hospital:checkDiseaseRequirements(humanoid.disease.id)
+  if humanoid.diagnosed and not req then
+    local room = action_seek_room_find_room(action, humanoid)
+    -- if we have the room but not the staff we shouldn't seek out the room either
+    if room then
+      if humanoid.message then
+        TheApp.ui.bottom_panel:removeMessage(humanoid)
+      end
+      action_seek_room_goto_room(room, humanoid, action.diagnosis_room)
+      return
+    end
+  end
+  -- we can't yet treat the patient, register callbacks
+  -- create message etc
+  if not action.done_init then
+    action.done_init = true
+    action.must_happen = true
 
-      local remove_callback = --[[persistable:action_seek_room_remove_callback]] function(rm)
-        if rm.room_info.id == "research" then
-          humanoid:updateMessage("research")
+    local remove_callback = --[[persistable:action_seek_room_remove_callback]] function(rm)
+      humanoid:updateMessage("research")
+    end -- End of remove_callback function
+    action.remove_callback = remove_callback
+    humanoid:registerRoomRemoveCallback(remove_callback)
+
+    local build_callback
+
+    local staff_callback
+    staff_callback = --[[persistable:action_seek_room_staff_callback]] function(staff)
+      -- we might have hired or fired a staff member
+      -- technically we don't care about Receptionist or Handyman
+      if staff then
+        if staff.humanoid_class == "Receptionist" or staff.humanoid_class == "Handyman" then
+          return
         end
-      end -- End of remove_callback function
-      action.remove_callback = remove_callback
-      humanoid:registerRoomRemoveCallback(remove_callback)
+      end
+      -- update the message either way
+      humanoid:updateMessage("research")
 
-      local build_callback
-      build_callback = --[[persistable:action_seek_room_build_callback]] function(rm)
-        -- if research room was built, message may need to be updated
-        if rm.room_info.id == "research" then
-          humanoid:updateMessage("research")
-        end
-
-        local found = false
-        if rm.room_info.id == action.room_type then
-          found = true
-        elseif rm.room_info.id == action.room_type_needed then
-          -- So the room that we're going to is not actually the room we waited for to be built.
-          -- Example: Will go to ward, but is waiting for the operating theatre.
-          -- Clean up and start over to find the room we actually want to go to.
+      local room_req = humanoid.hospital:checkDiseaseRequirements(humanoid.disease.id)
+      if not room_req then
+        local room = action_seek_room_find_room(action, humanoid)
+        if room then
           TheApp.ui.bottom_panel:removeMessage(humanoid)
           humanoid:unregisterRoomBuildCallback(build_callback)
           humanoid:unregisterRoomRemoveCallback(remove_callback)
-          action.room_type_needed = nil
-          action_seek_room_start(action, humanoid)
-        elseif not humanoid.diagnosed then
-          -- Waiting for a diagnosis room, we need to go through the list - unless it is gp
-          if action.room_type ~= "gp" then
-            for i = 1, #humanoid.available_diagnosis_rooms do
-              if humanoid.available_diagnosis_rooms[i].id == rm.room_info.id then
-                found = true
-              end
+          humanoid:unregisterStaffCallback(staff_callback)
+          action_seek_room_goto_room(room, humanoid, action.diagnosis_room)
+        end
+      end
+    end -- End of staff_callback function
+    action.staff_callback = staff_callback
+    humanoid:registerStaffCallback(staff_callback)
+
+    build_callback = --[[persistable:action_seek_room_build_callback]] function(rm)
+      -- if research room was built, message may need to be updated
+      humanoid:updateMessage("research")
+
+      local found = false
+      if rm.room_info.id == action.room_type then
+        found = true
+      elseif rm.room_info.id == action.room_type_needed then
+        -- So the room that we're going to is not actually the room we waited for to be built.
+        -- Example: Will go to ward, but is waiting for the operating theatre.
+        -- Clean up and start over to find the room we actually want to go to.
+        TheApp.ui.bottom_panel:removeMessage(humanoid)
+        humanoid:unregisterRoomBuildCallback(build_callback)
+        humanoid:unregisterRoomRemoveCallback(remove_callback)
+        humanoid:unregisterStaffCallback(staff_callback)
+        action.room_type_needed = nil
+        action_seek_room_start(action, humanoid)
+      elseif not humanoid.diagnosed then
+        -- Waiting for a diagnosis room, we need to go through the list - unless it is gp
+        if action.room_type ~= "gp" then
+          for i = 1, #humanoid.available_diagnosis_rooms do
+            if humanoid.available_diagnosis_rooms[i].id == rm.room_info.id then
+              found = true
             end
           end
         end
-        if found then
-          -- Don't add a "go to room" action to the patient's queue if the
-          -- autopsy machine is about to kill them:
-          local current_room = humanoid:getRoom()
-          if not current_room or not (current_room.room_info.id == "research" and
-              current_room:getStaffMember() and
-              current_room:getStaffMember():getCurrentAction().name == "multi_use_object") then
-            action_seek_room_goto_room(rm, humanoid, action.diagnosis_room)
-          end
+      end
+      if found then
+        -- Don't add a "go to room" action to the patient's queue if the
+        -- autopsy machine is about to kill them:
+        -- don't need this as we unregistered all previous callbacks if we went to research
+        local room_req = humanoid.hospital:checkDiseaseRequirements(humanoid.disease.id)
+        -- get required staff
+        if not room_req then
+          action_seek_room_goto_room(rm, humanoid, action.diagnosis_room)
           TheApp.ui.bottom_panel:removeMessage(humanoid)
           humanoid:unregisterRoomBuildCallback(build_callback)
           humanoid:unregisterRoomRemoveCallback(remove_callback)
+          humanoid:unregisterStaffCallback(staff_callback)
         end
-      end -- End of build_callback function
-      action.build_callback = build_callback
-      humanoid:registerRoomBuildCallback(build_callback)
+      end
+    end -- End of build_callback function
+    action.build_callback = build_callback
+    humanoid:registerRoomBuildCallback(build_callback)
 
-      action.on_interrupt = action_seek_room_interrupt
-    end
+    action.on_interrupt = action_seek_room_interrupt
+  end
 
-    -- Things needed to get the patient to the correct room in due time are done. Now it's
-    -- time to let the player know about it too.
-    -- If done_walk is set the meander action that takes place after not finding any room has been
-    -- done = nothing more to do right now.
-    if not action.done_walk then
-      local action_still_valid = true
-      if not action.message_sent then
-        -- Make a message about that something needs to be done about this patient
-        if humanoid.diagnosed then
-          -- The patient is diagnosed, a treatment room is missing.
-          -- It may happen that it is another room in a series which is missing.
-          local room_to_find = action.room_type_needed and action.room_type_needed or action.room_type
-          action_seek_room_no_treatment_room_found(room_to_find, humanoid)
+  -- Things needed to get the patient to the correct room in due time are done. Now it's
+  -- time to let the player know about it too.
+  -- If done_walk is set the meander action that takes place after not finding any room has been
+  -- done = nothing more to do right now.
+  if not action.done_walk then
+    local action_still_valid = true
+    if not action.message_sent then
+      -- Make a message about that something needs to be done about this patient
+      if humanoid.diagnosed then
+        -- The patient is diagnosed, a treatment room is missing.
+        -- It may happen that it is another room in a series which is missing.
+        local room_to_find = action.room_type_needed and action.room_type_needed or action.room_type
+        action_seek_room_no_treatment_room_found(room_to_find, humanoid)
+      else
+        -- No more diagnosis rooms can be found
+        -- The GP's office is a special case. TODO: Make a custom message anyway?
+        if action.room_type == "gp" then
+          humanoid:setMood("patient_wait", "activate")
+          humanoid:updateDynamicInfo(_S.dynamic_info.patient.actions.no_gp_available)
         else
-          -- No more diagnosis rooms can be found
-          -- The GP's office is a special case. TODO: Make a custom message anyway?
-          if action.room_type == "gp" then
-            humanoid:setMood("patient_wait", "activate")
-            humanoid:updateDynamicInfo(_S.dynamic_info.patient.actions.no_gp_available)
-          else
-            action_still_valid = action_seek_room_no_diagnosis_room_found(action, humanoid)
-          end
+          action_still_valid = action_seek_room_no_diagnosis_room_found(action, humanoid)
         end
       end
-      if action_still_valid then
-        action.done_walk = true
-        humanoid:queueAction(MeanderAction():setCount(1):setMustHappen(true), 0)
-      end
-    else
-      -- Make sure the patient stands in a correct way as he/she is waiting.
-      local direction = humanoid.last_move_direction
-      local anims = humanoid.walk_anims
-      if direction == "north" then
-        humanoid:setAnimation(anims.idle_north, 0)
-      elseif direction == "east" then
-        humanoid:setAnimation(anims.idle_east, 0)
-      elseif direction == "south" then
-        humanoid:setAnimation(anims.idle_east, 1)
-      elseif direction == "west" then
-        humanoid:setAnimation(anims.idle_north, 1)
-      end
-      humanoid:setTilePositionSpeed(humanoid.tile_x, humanoid.tile_y)
     end
+    if action_still_valid then
+      action.done_walk = true
+      humanoid:queueAction(MeanderAction():setCount(1):setMustHappen(true), 0)
+    end
+  else
+    -- Make sure the patient stands in a correct way as he/she is waiting.
+    local direction = humanoid.last_move_direction
+    local anims = humanoid.walk_anims
+    if direction == "north" then
+      humanoid:setAnimation(anims.idle_north, 0)
+    elseif direction == "east" then
+      humanoid:setAnimation(anims.idle_east, 0)
+    elseif direction == "south" then
+      humanoid:setAnimation(anims.idle_east, 1)
+    elseif direction == "west" then
+      humanoid:setAnimation(anims.idle_north, 1)
+    end
+    humanoid:setTilePositionSpeed(humanoid.tile_x, humanoid.tile_y)
   end
 end
 


### PR DESCRIPTION
When looking at the autospy discovery issue I raised, I also noted inconsistencies with seek treatment room fax as mentioned in #453. Some of these are documented, some are differences from the original (not necessarily desired though), and there are probably more better ways to perform the same functions.

Patients seeking a treatment room fax doesn't 'exist' for the 'need_to_employ' message when room exists but not the required staff - #469 
Patients seeking a treatment - seek the room when unstaffed - related to above (this change compromises on the diagnostic rooms) and patients will not attempt to queue until a staff member exists in the hospital
Research button disabled when the treatment room is discovered when it should remain enabled (research and researcher exist)
Interrupted seeks - don't remove message
Fax updates dynamically depending on the state

Just created for some more discussion
