### PR TITLE
[RDY] Use CMake standard method of setting C++ std

### DIFF
--- a/AnimView/CMakeLists.txt
+++ b/AnimView/CMakeLists.txt
@@ -45,6 +45,11 @@ else()
   )
 endif()
 
+# Set language standard
+set_property(TARGET AnimView PROPERTY CXX_STANDARD 11)
+set_property(TARGET AnimView PROPERTY CXX_EXTENSIONS OFF)
+set_property(TARGET AnimView PROPERTY CXX_STANDARD_REQUIRED ON)
+
 ## Finding libraries
 
 # Find WxWidgets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,15 +26,6 @@ endif()
 
 project(CorsixTH_Top_Level)
 
-include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
-check_cxx_compiler_flag("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-endif()
-
 if(MINGW)
   set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
 endif()

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -78,6 +78,11 @@ if(UNIX AND NOT APPLE)
   set_target_properties(CorsixTH PROPERTIES OUTPUT_NAME corsix-th)
 endif()
 
+# Set language standard
+set_property(TARGET CorsixTH PROPERTY CXX_STANDARD 11)
+set_property(TARGET CorsixTH PROPERTY CXX_EXTENSIONS OFF)
+set_property(TARGET CorsixTH PROPERTY CXX_STANDARD_REQUIRED ON)
+
 # Add an extra step to copy built DLLs on MSVC
 if(USE_VCPKG_DEPS)
   include(CopyVcpkgLua)


### PR DESCRIPTION
Minor change to more conventional CMake for setting c++ standard version.