### PR TITLE
[RDY] Queue dialog patient reordering fixes

### DIFF
--- a/CorsixTH/Lua/dialogs/queue_dialog.lua
+++ b/CorsixTH/Lua/dialogs/queue_dialog.lua
@@ -175,17 +175,16 @@ function UIQueue:onMouseUp(button, x, y)
       self.dragged = nil
       return
     end
-
     if x > 170 and x < 210 and y > 25 and y < 105 then -- Inside door bounding box
-      queue:move(index, 1) -- move to front
+      queue:movePatient(index, 'front') -- move to front
     elseif x > 542 and x < 585 and y > 50 and y < 105 then -- Inside exit sign bounding box
-      queue:move(index, num_patients) -- move to back
+      queue:movePatient(index, 'back') -- move to back
     elseif isInsideQueueBoundingBox(x, y) then
       local dx = 1
       if num_patients ~= 1 then
         dx = math.floor(width / (num_patients - 1))
       end
-      queue:move(index, math.floor((x - 220) / dx) + 1) -- move to dropped position
+      queue:movePatient(index, math.floor((x - 220) / dx)) -- move to dropped position
       self:onMouseMove(x, y, 0, 0)
     end
 

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -294,6 +294,26 @@ function Queue:move(index, new_index)
   end
 end
 
+--! Move an entering patient in the queue at position 'index' to position 'new_index'.
+--! Persons between 'index' and 'new_index' move one place to 'index'.
+--! Values are relative to the reported humanoids in the queue
+--!param index (int) Index number of the person to move.
+--!param new_index (int) Destination of the person being moved.
+--!param new_index (string) 'front' or 'back' as relative markers
+function Queue:movePatient(index, new_index)
+  local first_patient_index = self:size() - self:reportedSize() + 1
+  if type(new_index) == "string" then
+    if new_index == 'front' then
+      new_index = first_patient_index
+    else
+      new_index = self:size()
+    end
+  else
+    new_index = first_patient_index + new_index
+  end
+  self:move(first_patient_index + index - 1, new_index)
+end
+
 --! Called when reception desk is destroyed, or when a room is destroyed from a crashed machine.
 function Queue:rerouteAllPatients(action)
   for _, humanoid in ipairs(self) do


### PR DESCRIPTION
#368 indicates some problems with queue reordering. I wasn't able to get an instance of the handyman at the front preventing a move of an epidemic patient, but I did manage to get a queue that happened to have 2 epidemic patients in it, and the order would not change.

I also got the other more easily observed issue of the handyman in room popping into and out of the queue when re-ordering. The changes here, insert re-ordered patients relative to the start of the 'reportedHumanoids' of the queue rather than the entire queue addresses both issues. And this appears to fix both issues.