### PR TITLE
[RDY] Mark mouse click handled in file tree ctrl

### DIFF
--- a/CorsixTH/Lua/dialogs/tree_ctrl.lua
+++ b/CorsixTH/Lua/dialogs/tree_ctrl.lua
@@ -619,6 +619,7 @@ function TreeControl:onMouseUp(button, x, y)
       end
     elseif self.selected_node == node and self.select_callback then
       self.select_callback(node)
+      redraw = true
     else
       self.selected_node = node
       node:select()


### PR DESCRIPTION
When selecting a file in the tree control the mouse up event was not
marked as handled, causing it to propogate to underlying windows. In the
map editor this resulted in an error if an overlay was enabled because
the map would be replaced before the event would be handled.

FIxes #1387 