### PR TITLE
[WIP] Use vcpkg preinstalled in appveyor

### DIFF
--- a/CMake/VcpkgDeps.cmake
+++ b/CMake/VcpkgDeps.cmake
@@ -25,6 +25,7 @@ set(_VCPKG_SCRIPT_NAME "build_vcpkg_deps.ps1")
 set(_SCRIPT_DIR ${CMAKE_SOURCE_DIR}/scripts)
 # By default place VCPKG into root folder
 set(VCPKG_PARENT_DIR ${CMAKE_SOURCE_DIR} CACHE PATH "Destination for vcpkg dependencies")
+set(VCPKG_REMOTE "origin" CACHE STRING "Name of the remote in the git repository")
 
 # Determine the args to use
 if(VCPKG_TARGET_TRIPLET)
@@ -45,7 +46,7 @@ else()
   string(CONCAT _VCPKG_ARGS ${_VCPKG_ARGS} " -BuildAnimView $False")
 endif()
 
-string(CONCAT _VCPKG_ARGS ${_VCPKG_ARGS} " -VcpkgCommitSha " ${VCPKG_COMMIT_SHA} " ")
+string(CONCAT _VCPKG_ARGS ${_VCPKG_ARGS} " -VcpkgCommitSha " ${VCPKG_COMMIT_SHA} " -VcpkgRemote " ${VCPKG_REMOTE} " ")
 
 # Run the build script
 set(_SCRIPT_COMMAND  powershell ${_SCRIPT_DIR}/${_VCPKG_SCRIPT_NAME})

--- a/CMake/VcpkgDeps.cmake
+++ b/CMake/VcpkgDeps.cmake
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-set(VCPKG_COMMIT_SHA "1a9f008c2b532eac72ebe6e988574dc260bf7151")
+set(VCPKG_COMMIT_SHA "9f35b7da7c46efea01b8a15beb0b3df3539b4781")
 
 # Setup the various paths we are using
 set(_VCPKG_SCRIPT_NAME "build_vcpkg_deps.ps1")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - git remote add corsixth https://github.com/CorsixTH/vcpkg
 before_build:
   - cmd: cd %APPVEYOR_BUILD_FOLDER%
-  - cmd: cmake -G "%GENERATOR%" -DUSE_VCPKG_DEPS=ON -DVCPKG_PARENT_DIR=c:/tools -DVCPKG_REMOTE=corsixth .
+  - cmd: cmake -G "%GENERATOR%" -DUSE_VCPKG_DEPS=ON -DVCPKG_PARENT_DIR=c:/tools -DVCPKG_REMOTE=corsixth --trace .
 build:
   project: CorsixTH_Top_Level.sln
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,14 @@ environment:
   matrix:
   - GENERATOR: Visual Studio 15 2017 Win64
 cache:
-  - vcpkg -> CMake/VcpkgDeps.cmake, scripts/build_vcpkg_deps.ps1
+  - C:\tools\vcpkg\installed\
 configuration: Release
+install:
+  - cd C:\Tools\vcpkg
+  - git remote add corsixth https://github.com/CorsixTH/vcpkg
 before_build:
-  - cmd: cmake -G "%GENERATOR%" -DUSE_VCPKG_DEPS=ON .
+  - cmd: cd %APPVEYOR_BUILD_FOLDER%
+  - cmd: cmake -G "%GENERATOR%" -DUSE_VCPKG_DEPS=ON -DVCPKG_PARENT_DIR=c:/tools -DVCPKG_REMOTE=corsixth .
 build:
   project: CorsixTH_Top_Level.sln
   verbosity: minimal

--- a/scripts/build_vcpkg_deps.ps1
+++ b/scripts/build_vcpkg_deps.ps1
@@ -26,7 +26,8 @@
 Param(
     [Parameter(Mandatory=$true)][bool]$BuildAnimView,
     [Parameter(Mandatory=$true)][string]$VcpkgTriplet,
-    [Parameter(Mandatory=$true)][string]$VcpkgCommitSha
+    [Parameter(Mandatory=$true)][string]$VcpkgCommitSha,
+    [Parameter(Mandatory=$true)][string]$VcpkgRemote
 )
 
 ################
@@ -74,7 +75,7 @@ function run_script {
     } else {
         # Move into vcpkg folder and update to latest version
         Set-Location -Path $dest_folder_path
-        run_command "git reset --hard; git fetch origin; git checkout $VcpkgCommitSha"
+        run_command "git reset --hard; git fetch $VcpkgRemote; git checkout $VcpkgCommitSha"
     }
 
     $commit_id_filename = "commit_id.txt"


### PR DESCRIPTION
Attempt to speed up the build by using the vcpkg included with appveyor instead of checking out our own copy.