### PR TITLE
[RDY] Hotkey assign, recall window title update

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/hotkey_assign.lua
+++ b/CorsixTH/Lua/dialogs/resizables/hotkey_assign.lua
@@ -952,7 +952,7 @@ function UIHotkeyAssign_storeRecallPos:UIHotkeyAssign_storeRecallPos(ui, mode)
   end
 
   -- Title
-  self:addBevelPanel(10, 10, 430, panel_height, col_caption):setLabel(_S.hotkey_window.caption_panels)
+  self:addBevelPanel(10, 10, 420, panel_height, col_caption):setLabel(_S.hotkey_window.panel_recallPosKeys)
 
   -- "Back" button
   self:addBevelPanel(10, 270, 420, 40, col_bg):setLabel(_S.hotkey_window.button_back)


### PR DESCRIPTION
Minor cosmetic stuff.

Changes this
![image](https://user-images.githubusercontent.com/8009292/57207926-efb7cb00-7013-11e9-8f3d-27a293ee6efa.png)

to
![image](https://user-images.githubusercontent.com/8009292/57208107-4eca0f80-7015-11e9-926f-4e2de5115ca2.png)

Just iffy on the 'Recall Position Keys' being there twice.