### PR TITLE
Add desktop and appdata in cmake install

### DIFF
--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -251,6 +251,9 @@ if(NOT USE_SOURCE_DATADIRS)
 
   if(UNIX AND NOT APPLE)
     install(FILES corsix-th.6 DESTINATION ${CMAKE_INSTALL_MANDIR}/man6)
+    install(FILES com.corsixth.CorsixTH.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
+    install(FILES com.corsixth.CorsixTH.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+    install(FILES Original_Logo.svg DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps RENAME corsix-th.svg)
   endif()
 
   if(APPLE)


### PR DESCRIPTION
@emorrp1 / @tim77 I think this does the right thing.

My one concern is that now cmake install adds a desktop file, but not the required icons. Do you think this is ok for 0.63?