### PR TITLE
[RDY] Make CMake src files explicit

### DIFF
--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -28,21 +28,8 @@ else()
   set(CORSIX_TH_INTERPRETER_PATH ${CMAKE_INSTALL_FULL_DATADIR}/corsix-th/CorsixTH.lua)
 endif()
 
-# Modify the config.h based upon our selection of options
-configure_file(${CMAKE_SOURCE_DIR}/CorsixTH/Src/config.h.in ${CMAKE_BINARY_DIR}/CorsixTH/Src/config.h)
-include_directories(${CMAKE_BINARY_DIR}/CorsixTH/Src/)
 
-# Generate source files list
-# Note: Done after generating config.h
-add_subdirectory(${PROJECT_SOURCE_DIR}/Src)
-
-add_library(Corsixth_lib STATIC ${corsixth_lib_src_files} ${corsixth_lib_hdr_files})
-
-set(corsixth_main_files
-  ${CMAKE_SOURCE_DIR}/CorsixTH/Src/main.cpp
-  ${CMAKE_SOURCE_DIR}/CorsixTH/SrcUnshared/main.cpp
-  ${CMAKE_SOURCE_DIR}/CorsixTH/Src/main.h
-)
+add_library(CorsixTH_lib STATIC "")
 
 # Declaration of the executable
 if(APPLE)
@@ -54,7 +41,7 @@ if(APPLE)
   )
   set(MACOSX_BUNDLE_ICON_FILE Icon.icns)
 
-  add_executable(CorsixTH MACOSX_BUNDLE ${corsixth_main_files} ${corsixth_icon_file})
+  add_executable(CorsixTH MACOSX_BUNDLE ${corsixth_icon_file})
 
   set_target_properties(CorsixTH PROPERTIES LINK_FLAGS_MINSIZEREL "-dead_strip")
   set_target_properties(CorsixTH PROPERTIES XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/../Frameworks")
@@ -62,7 +49,7 @@ if(APPLE)
   target_link_libraries(CorsixTH SDL2main)
   include_directories(${CMAKE_BINARY_DIR}/CorsixTH/SDLMain/)
 else()
-  add_executable(CorsixTH ${corsixth_main_files})
+  add_executable(CorsixTH "")
 endif()
 
 target_link_libraries(CorsixTH CorsixTH_lib)
@@ -70,6 +57,23 @@ target_link_libraries(CorsixTH CorsixTH_lib)
 if(UNIX AND NOT APPLE)
   set_target_properties(CorsixTH PROPERTIES OUTPUT_NAME corsix-th)
 endif()
+
+# Generate source files list
+# Note: Done after generating targets
+add_subdirectory(${PROJECT_SOURCE_DIR}/Src)
+add_subdirectory(${PROJECT_SOURCE_DIR}/SrcUnshared)
+
+# Manually add common files - as different targets could include the file 
+# so we can't just do it in in the folder like above
+target_sources(CorsixTH_lib
+  PRIVATE
+  ${CMAKE_SOURCE_DIR}/common/rnc.cpp
+  ${CMAKE_SOURCE_DIR}/common/rnc.h
+)
+
+# Ensure config.h is picked up by cmake - moving this into subdir cmake files will
+# prevent it applying to the CorsixTH project
+include_directories(${CMAKE_BINARY_DIR}/CorsixTH/Src/)
 
 # Set language standard
 set_property(TARGET CorsixTH_lib PROPERTY CXX_STANDARD 14)
@@ -79,10 +83,6 @@ set_property(TARGET CorsixTH_lib PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET CorsixTH PROPERTY CXX_STANDARD 14)
 set_property(TARGET CorsixTH PROPERTY CXX_EXTENSIONS OFF)
 set_property(TARGET CorsixTH PROPERTY CXX_STANDARD_REQUIRED ON)
-
-set_property(TARGET Corsixth_lib PROPERTY CXX_STANDARD 14)
-set_property(TARGET Corsixth_lib PROPERTY CXX_EXTENSIONS OFF)
-set_property(TARGET Corsixth_lib PROPERTY CXX_STANDARD_REQUIRED ON)
 
 # Add an extra step to copy built DLLs on MSVC
 if(USE_VCPKG_DEPS)

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -34,43 +34,15 @@ include_directories(${CMAKE_BINARY_DIR}/CorsixTH/Src/)
 
 # Generate source files list
 # Note: Done after generating config.h
+add_subdirectory(${PROJECT_SOURCE_DIR}/Src)
 
-# XXX: We should manually specify the files to include in each directory rather
-# than glob them all
-file(GLOB_RECURSE corsixth_source_files
-  ${CMAKE_SOURCE_DIR}/CorsixTH/SrcUnshared/*.cpp
-  ${CMAKE_SOURCE_DIR}/CorsixTH/SrcUnshared/*.c
-  ${CMAKE_SOURCE_DIR}/CorsixTH/SrcUnshared/*.h
-  ${CMAKE_SOURCE_DIR}/CorsixTH/SrcUnshared/*.hpp
-  ${CMAKE_SOURCE_DIR}/CorsixTH/Src/*.cpp
-  ${CMAKE_SOURCE_DIR}/CorsixTH/Src/*.c
-  ${CMAKE_SOURCE_DIR}/CorsixTH/Src/*.hpp
-  ${CMAKE_SOURCE_DIR}/CorsixTH/Src/*.h
-  ${CMAKE_SOURCE_DIR}/common/rnc.cpp
-  ${CMAKE_SOURCE_DIR}/common/rnc.h
-  ${CMAKE_SOURCE_DIR}/CorsixTH/Src/shaders/*.psh
-  ${CMAKE_SOURCE_DIR}/CorsixTH/Lua/api_version.lua
-  ${CMAKE_SOURCE_DIR}/CorsixTH/CorsixTH.rc
-  ${CMAKE_SOURCE_DIR}/LFS/*.c
-  ${CMAKE_SOURCE_DIR}/LPEG/*.c
-
-  ${CMAKE_BINARY_DIR}/CorsixTH/Src/config.h
-)
+add_library(Corsixth_lib STATIC ${corsixth_lib_src_files} ${corsixth_lib_hdr_files})
 
 set(corsixth_main_files
   ${CMAKE_SOURCE_DIR}/CorsixTH/Src/main.cpp
   ${CMAKE_SOURCE_DIR}/CorsixTH/SrcUnshared/main.cpp
   ${CMAKE_SOURCE_DIR}/CorsixTH/Src/main.h
 )
-
-message(${corsixth_main_files})
-
-# Remove main.cpp and main.h from the files we compile in to lib
-list(REMOVE_ITEM corsixth_source_files "${CMAKE_SOURCE_DIR}/CorsixTH/Src/main.cpp" 
-                                   "${CMAKE_SOURCE_DIR}/CorsixTH/SrcUnshared/main.cpp")
-list(REMOVE_ITEM corsixth_source_files "${CMAKE_SOURCE_DIR}/CorsixTH/Src/main.h")
-
-add_library(CorsixTH_lib STATIC ${corsixth_source_files})
 
 # Declaration of the executable
 if(APPLE)
@@ -107,6 +79,10 @@ set_property(TARGET CorsixTH_lib PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET CorsixTH PROPERTY CXX_STANDARD 14)
 set_property(TARGET CorsixTH PROPERTY CXX_EXTENSIONS OFF)
 set_property(TARGET CorsixTH PROPERTY CXX_STANDARD_REQUIRED ON)
+
+set_property(TARGET Corsixth_lib PROPERTY CXX_STANDARD 14)
+set_property(TARGET Corsixth_lib PROPERTY CXX_EXTENSIONS OFF)
+set_property(TARGET Corsixth_lib PROPERTY CXX_STANDARD_REQUIRED ON)
 
 # Add an extra step to copy built DLLs on MSVC
 if(USE_VCPKG_DEPS)

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -73,7 +73,7 @@ target_sources(CorsixTH_lib
 
 # Ensure config.h is picked up by cmake - moving this into subdir cmake files will
 # prevent it applying to the CorsixTH project
-include_directories(${CMAKE_BINARY_DIR}/CorsixTH/Src/)
+target_include_directories(CorsixTH_lib PUBLIC ${CMAKE_BINARY_DIR}/CorsixTH/Src/)
 
 # Set language standard
 set_property(TARGET CorsixTH_lib PROPERTY CXX_STANDARD 14)

--- a/CorsixTH/CppTest/CMakeLists.txt
+++ b/CorsixTH/CppTest/CMakeLists.txt
@@ -20,11 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-set (TESTING_FILES
-    test_main.cpp
-    example.cpp
-)
-
 find_package(Catch2 CONFIG REQUIRED)
 
 add_custom_target(AllTests)
@@ -32,7 +27,7 @@ add_custom_target(AllTests)
 # Expose the header files from CorsixTH
 include_directories(${CMAKE_SOURCE_DIR}/CorsixTH/Src/)
 
-add_executable(UnitTests ${TESTING_FILES} ${TEST_SOURCE_FILES})
+add_executable(UnitTests "")
 target_link_libraries(UnitTests Catch2::Catch2)
 target_link_libraries(UnitTests CorsixTH_lib)
 
@@ -46,3 +41,10 @@ set_target_properties(UnitTests PROPERTIES FOLDER UnitTests)
 
 # Make sure we add it as a dependency to all tests (some day we can add LuaTest here)
 add_dependencies(AllTests UnitTests)
+
+# List of all test files
+target_sources(UnitTests
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/example.cpp
+)

--- a/CorsixTH/Src/CMakeLists.txt
+++ b/CorsixTH/Src/CMakeLists.txt
@@ -1,4 +1,8 @@
-set(corsixth_lib_src_files 
+# Modify the config.h based upon our selection of options
+configure_file(${CMAKE_SOURCE_DIR}/CorsixTH/Src/config.h.in ${CMAKE_BINARY_DIR}/CorsixTH/Src/config.h)
+
+target_sources(CorsixTH_lib
+    PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/random.c
     ${CMAKE_CURRENT_SOURCE_DIR}/bootstrap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/iso_fs.cpp
@@ -27,12 +31,12 @@ set(corsixth_lib_src_files
     ${CMAKE_CURRENT_SOURCE_DIR}/th_pathfind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/th_sound.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/xmi2mid.cpp
-
-    ${CMAKE_SOURCE_DIR}/common/rnc.cpp
-    PARENT_SCOPE
 )
 
-set(corsixth_lib_hdr_files
+# These are for IDEs such as XCode and MSVC to track headers within their
+# project files. They are not used by the build system.
+target_sources(CorsixTH_lib
+    PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/bootstrap.h
     ${CMAKE_CURRENT_SOURCE_DIR}/cp437_table.h
     ${CMAKE_CURRENT_SOURCE_DIR}/cp936_table.h
@@ -54,8 +58,11 @@ set(corsixth_lib_hdr_files
     ${CMAKE_CURRENT_SOURCE_DIR}/th_sound.h
     ${CMAKE_CURRENT_SOURCE_DIR}/xmi2mid.h
 
-    ${CMAKE_SOURCE_DIR}/common/rnc.h
-
     ${CMAKE_BINARY_DIR}/CorsixTH/Src/config.h
-    PARENT_SCOPE
+)
+
+target_sources(CorsixTH
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/main.h
 )

--- a/CorsixTH/Src/CMakeLists.txt
+++ b/CorsixTH/Src/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(CorsixTH_lib
     ${CMAKE_CURRENT_SOURCE_DIR}/th_lua.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_anims.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_gfx.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_iso.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_lfs_ext.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_map.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_movie.cpp

--- a/CorsixTH/Src/CMakeLists.txt
+++ b/CorsixTH/Src/CMakeLists.txt
@@ -1,0 +1,61 @@
+set(corsixth_lib_src_files 
+    ${CMAKE_CURRENT_SOURCE_DIR}/random.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/bootstrap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/iso_fs.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/lua_rnc.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/persist_lua.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/run_length_encoder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sdl_audio.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sdl_core.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sdl_wm.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_gfx.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_gfx_font.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_gfx_sdl.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_anims.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_gfx.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_lfs_ext.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_map.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_movie.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_sound.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_strings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_ui.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_map.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_map_overlays.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_movie.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_pathfind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_sound.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xmi2mid.cpp
+
+    ${CMAKE_SOURCE_DIR}/common/rnc.cpp
+    PARENT_SCOPE
+)
+
+set(corsixth_lib_hdr_files
+    ${CMAKE_CURRENT_SOURCE_DIR}/bootstrap.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/cp437_table.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/cp936_table.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/iso_fs.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/lua_rnc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/lua_sdl.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/persist_lua.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/run_length_encoder.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/th.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_gfx.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_gfx_font.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_gfx_sdl.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_lua_internal.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_map.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_map_overlays.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_movie.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_pathfind.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/th_sound.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/xmi2mid.h
+
+    ${CMAKE_SOURCE_DIR}/common/rnc.h
+
+    ${CMAKE_BINARY_DIR}/CorsixTH/Src/config.h
+    PARENT_SCOPE
+)

--- a/CorsixTH/SrcUnshared/CMakeLists.txt
+++ b/CorsixTH/SrcUnshared/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(CorsixTH
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+)


### PR DESCRIPTION
*Requires #1550 to be merged first*

Normally I avoid feature branches based on feature branches, but the previous one added a static library we will have merge conflicts with later.

Names all .cpp and .hpp files we use explicitly. This uses a separate file to keep the bloat out of the main CMake list, however I'm open for suggestions if anyone has a better way?
