### PR TITLE
[RDY] AnimView compliance fixes

### DIFF
--- a/AnimView/CMakeLists.txt
+++ b/AnimView/CMakeLists.txt
@@ -1,22 +1,31 @@
 # Project Declaration
 project(AnimView)
 
+configure_file(config.h.in config.h)
+
 # Generate source files list
 # Note: do not use generic includes (*.cpp and such) this will break things with cmake
 set(animview_source_files
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+
+  ${CMAKE_SOURCE_DIR}/common/rnc.h
+  ${CMAKE_SOURCE_DIR}/common/rnc.cpp
+
   app.cpp
   frmMain.cpp
   frmSprites.cpp
-  ${CMAKE_SOURCE_DIR}/common/rnc.h
-  ${CMAKE_SOURCE_DIR}/common/rnc.cpp
   th.cpp
+
   app.h
   backdrop.h
   frmMain.h
   frmSprites.h
   th.h
+
   AnimView.rc
 )
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Declaration of the executable
 if(APPLE)

--- a/AnimView/app.cpp
+++ b/AnimView/app.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include "config.h"
 #include "app.h"
 #include "frmMain.h"
 #include "frmSprites.h"

--- a/AnimView/config.h.in
+++ b/AnimView/config.h.in
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2009 Peter "Corsix" Cawley
+Copyright (c) 2019 Stephen "TheCycoONE" Baker
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,26 +20,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#pragma once
+#ifndef CORSIX_AV_CONFIG_H_
+#define CORSIX_AV_CONFIG_H_
 
-#include "config.h"
-// For compilers that support precompilation, includes "wx/wx.h".
-#include "wx/wxprec.h"
+/** Standard includes **/
+#include <cstddef>
+#include <cstdint>
 
-#ifdef __BORLANDC__
-    #pragma hdrstop
-#endif
+// We bring in the most common stddef and stdint types to avoid typing
+using std::size_t;
+using std::uint8_t;
+using std::uint16_t;
+using std::uint32_t;
+using std::uint64_t;
+using std::int8_t;
+using std::int16_t;
+using std::int32_t;
+using std::int64_t;
 
-// for all others, include the necessary headers (this file is usually all you
-// need because it includes almost all "standard" wxWidgets headers)
-#ifndef WX_PRECOMP
-    #include "wx/wx.h"
-#endif
-// ----------------------------
-
-class ThemeHospitalAnimViewApp : public wxApp
-{
-    virtual bool OnInit();
-};
-
-DECLARE_APP(ThemeHospitalAnimViewApp)
+#endif // CORSIX_AV_CONFIG_H_

--- a/AnimView/frmMain.cpp
+++ b/AnimView/frmMain.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include "config.h"
 #include "frmMain.h"
 #include <wx/radiobut.h>
 #include <wx/sizer.h>

--- a/AnimView/frmMain.h
+++ b/AnimView/frmMain.h
@@ -21,6 +21,7 @@ SOFTWARE.
 */
 
 #pragma once
+#include "config.h"
 #include <wx/frame.h>
 #include <wx/button.h>
 #include <wx/spinctrl.h>

--- a/AnimView/frmMain.h
+++ b/AnimView/frmMain.h
@@ -129,5 +129,5 @@ protected:
     wxCheckBox* m_chkFrameFlags[16];
     wxListBox* m_lstSearchResults;
     wxPanel* m_panFrame;
-    DECLARE_EVENT_TABLE();
+    DECLARE_EVENT_TABLE()
 };

--- a/AnimView/frmSprites.cpp
+++ b/AnimView/frmSprites.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include "config.h"
 #include "frmSprites.h"
 #include <wx/sizer.h>
 #include <wx/stattext.h>

--- a/AnimView/frmSprites.h
+++ b/AnimView/frmSprites.h
@@ -21,6 +21,8 @@ SOFTWARE.
 */
 
 #pragma once
+
+#include "config.h"
 #include <wx/bitmap.h>
 #include <wx/frame.h>
 #include <wx/button.h>

--- a/AnimView/frmSprites.h
+++ b/AnimView/frmSprites.h
@@ -88,5 +88,5 @@ protected:
     wxTextCtrl* m_txtData;
     wxTextCtrl* m_txtPalette;
     MyVScrolled* m_panFrame;
-    DECLARE_EVENT_TABLE();
+    DECLARE_EVENT_TABLE()
 };

--- a/AnimView/th.cpp
+++ b/AnimView/th.cpp
@@ -501,11 +501,12 @@ th_element_t* THAnimations::_getElement(uint32_t iListIndex)
 
 unsigned char* THAnimations::Decompress(unsigned char* pData, size_t& iLength)
 {
-    unsigned long outlen = rnc_output_size(pData);
-    unsigned char* outbuf = new unsigned char[outlen];
     if (rnc_input_size(pData) != iLength) {
         throw std::length_error("rnc data does not match the expected length");
     }
+
+    unsigned long outlen = rnc_output_size(pData);
+    unsigned char* outbuf = new unsigned char[outlen];
 
     if(rnc_unpack(pData, outbuf) == rnc_status::ok)
     {

--- a/AnimView/th.cpp
+++ b/AnimView/th.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include "config.h"
 #include "th.h"
 #include "../common/rnc.h"
 #include <wx/app.h>

--- a/AnimView/th.h
+++ b/AnimView/th.h
@@ -35,6 +35,7 @@ SOFTWARE.
 */
 
 #pragma once
+#include "config.h"
 #include <wx/string.h>
 #include <wx/file.h>
 #include <wx/image.h>

--- a/AnimView/th.h
+++ b/AnimView/th.h
@@ -117,7 +117,7 @@ public:
         if(0 <= iLayer && iLayer < 13)
             for(int iId = 0; iId < 32; ++iId)
             {
-                if((m_iMask[iLayer] & (1 << iId)) != 0)
+                if((m_iMask[iLayer] & (static_cast<std::uint32_t>(1) << iId)) != 0)
                     return true;
             }
         return false;


### PR DESCRIPTION
Fixes a couple cases of undefined behaviour; the use of unprefixed stdint types (via a new config.h); and semicolons after macros that triggered `-Wpedantic` warnings.