### PR TITLE
[RDY] Staff blocking doors

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -78,10 +78,7 @@ action_walk_interrupt = permanent"action_walk_interrupt"( function(action, human
     if door and (door.reserved_for == humanoid or class.is(humanoid, Vip)) then --  "or class.is(humanoid, Vip)" is added as a temporary fix
   -- TODO: find the cause of the "VIP bug", why does the door not get unreserved sometimes when the VIP has looked into a room? See issue 1025
       door.reserved_for = nil
-      if door.queue:size() > 0 then
-        door.queue:pop()
-        door:updateDynamicInfo()
-      end
+      door:getRoom():tryAdvanceQueue()
     end
   else
     -- This flag can be used only once at a time.

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -298,10 +298,7 @@ navigateDoor = function(humanoid, x1, y1, dir)
     local queue = door.queue
     if door.reserved_for == humanoid then
       door.reserved_for = nil
-      if queue:size() > 0 and room.is_active then
-        queue:pop()
-        door:updateDynamicInfo()
-      end
+      room:tryAdvanceQueue()
     end
     humanoid:setTilePositionSpeed(x1, y1)
     local action_index = 0

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -284,6 +284,10 @@ navigateDoor = function(humanoid, x1, y1, dir)
       humanoid:setTilePositionSpeed(x1, y1)
       humanoid:setNextAction(IdleAction():setCount(10), 0)
       humanoid:queueAction(MeanderAction())
+      if door.reserved_for == humanoid then
+        door.reserved_for = nil
+        room:tryAdvanceQueue()
+      end
       return
     end
   end

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -315,6 +315,7 @@ function Room:onHumanoidEnter(humanoid)
       -- If the handyman was not assigned for the job (e.g. drop by manual pickup), do answer a call
       humanoid:setNextAction(AnswerCallAction())
     end
+    self:tryAdvanceQueue()
     return
   end
   local msg = {
@@ -488,7 +489,7 @@ function Room:commandEnteringPatient(humanoid)
 end
 
 function Room:tryAdvanceQueue()
-  if self.door.queue:size() > 0 and not self.door.user and not self.door.reserved_for then
+  if self.door.queue and self.door.queue:size() > 0 and not self.door.user and not self.door.reserved_for then
     local front = self.door.queue:front()
     -- These two conditions differ by the waiting symbol
 


### PR DESCRIPTION
3 sort of related fixes here, covering #1087 for staff not unreserving doors as basically given by BrainSample but altered for the protection of tryAdvanceQueue
#791 /#1206 the 'insane patients', get up, go to door, pop loop can occur - tryAdvanceQueue guards against this occuring as canHumanoidEnter does additional checks.

Seems like a good idea to do the same for walk interrupt as well.

Room tryAdvanceQueue protects against when the queue is destroyed and the function still being called. #1462 and other instances where this occurs is because the swing doors are swinging and there is a callback after the stop.

The onHumanoidLeave captures when handyman enter a room, and the queue doesn't pop as the function returns after that whereas later scenarios in that function do call tryAdvanceQueue.
