### PR TITLE
[RFC] Some assorted issues

### DIFF
--- a/CorsixTH/Lua/dialogs/adviser.lua
+++ b/CorsixTH/Lua/dialogs/adviser.lua
@@ -152,8 +152,9 @@ function UIAdviser:say(speech, talk_until_next_announce, override_current)
       self.up_again = true
     elseif override_current then
       -- He was saying/was about to say something else. Discard those messages.
+      self.queued_messages[1] = self.queued_messages[#self.queued_messages]
       while #self.queued_messages > 1 do
-        table.remove(self.queued_messages, 2)
+        table.remove(self.queued_messages)
       end
       -- Now say the new thing instead.
       self:talk()

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -947,7 +947,7 @@ function Humanoid:tostring()
         distance = "nil"
       end
       local standing = "false"
-      if action:isStanding() then
+      if action.isStanding and action:isStanding() then
         standing = "true"
       end
       action_string = action_string .. " - Bench distance: " .. distance .. " Standing: " .. standing

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -511,7 +511,7 @@ function Staff:isIdle()
         return true
       else
         -- It might still be the case that the patient is leaving
-        if room:getPatient().isLeaving() then
+        if room:getPatient():isLeaving() then
           return true
         end
       end

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -395,9 +395,6 @@ function Staff:checkIfNeedRest()
       -- If occupied by patient, staff will go to the staffroom after the patient left.
       self.staffroom_needed = true
     else
-      if room then
-        room.staff_leaving = true
-      end
       self:goToStaffRoom()
     end
   end

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -511,10 +511,8 @@ function Staff:isIdle()
         return true
       else
         -- It might still be the case that the patient is leaving
-        for _, action in ipairs(room:getPatient().action_queue) do
-          if action.is_leaving then
-            return true
-          end
+        if room:getPatient().isLeaving() then
+          return true
         end
       end
     end

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -544,7 +544,7 @@ end
   @param patient (Patient) the patient we wish to determine if they are static.]]
 local function is_static(patient)
   local action = patient:getCurrentAction()
-  return action.name == "queue" or action.name == "idle" or
+  return action.name == "queue" or action.name == "idle" or action.name == "seek_room" or
       (action.name == "use_object" and action.object.object_type.id == "bench")
 end
 

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -319,7 +319,7 @@ function(action, humanoid, machine, mx, my, fun_after_use)
     -- If the patient is still in the queue, insert an idle action so that
     -- change_position can do its work.
     -- Note that it is inserted after the currently executing use_object action.
-    if action.is_in_queue then
+    if action.is_in_queue and not humanoid.going_home then
       humanoid:queueAction(IdleAction():setMustHappen(true), 1)
       action_queue_on_change_position(action, humanoid)
     end

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -358,7 +358,7 @@ local function action_seek_room_start(action, humanoid)
         -- don't need this as we unregistered all previous callbacks if we went to research
         local room_req = humanoid.hospital:checkDiseaseRequirements(humanoid.disease.id)
         -- get required staff
-        if not room_req then
+        if not humanoid.diagnosed or not room_req then
           action_seek_room_goto_room(rm, humanoid, action.diagnosis_room)
           TheApp.ui.bottom_panel:removeMessage(humanoid)
           humanoid:unregisterRoomBuildCallback(build_callback)

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -762,7 +762,7 @@ function Room:crashRoom()
     if not person:isLeaving() then
       if class.is(person, Patient) then
         --Delay so that room is destroyed before the SeekRoom search.
-        person:queueAction(IdleAction():setCount(1))
+        person:setNextAction(IdleAction():setCount(1))
         person:queueAction(SeekRoomAction(self.room_info.id))
       end
     end

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -220,7 +220,13 @@ function Room:getMissingStaff(criteria)
   local result = {}
   for attribute, count in pairs(criteria) do
     for humanoid in pairs(self.humanoids) do
-      if class.is(humanoid, Staff) and humanoid:fulfillsCriterion(attribute) and not humanoid:isLeaving() and not humanoid.fired then
+      -- check state of humanoid is appropriate for room
+      -- check they are staff and meet requirements for the room
+      -- ensure not leaving (going to staff room) or fired
+      -- check if answering a call to another room
+      if class.is(humanoid, Staff) and humanoid:fulfillsCriterion(attribute) and
+          not humanoid:isLeaving() and not humanoid.fired and
+          not (humanoid.on_call and humanoid.on_call.object ~= self) then
         count = count - 1
       end
     end


### PR DESCRIPTION
Contagious patients can't be treated if they are seeking room.

Adviser says with override was basically truncating the entire list down to the existing first message rather than leaving only the override one.

Broken seek is from #1556 I had identified this. Ward in that instance being the diagnostic room.

The setNextAction when the queue is destroyed would leave patients going from drinks machine to bench, as action_queue_on_change_position gets called from the callback process of action_queue_get_soda. Queue:rerouteAllPatients, wasn't a candidate to flag them as not is_in_queue as this had other artefacts.

Patients appearing to leave is to correct #1233 and related #500, #362, #858 and #650

Staff answering calls to another room, will appear as within the room they are in, and allow patients to enter. If that call was then given to another staff member, they would meander in room (bad for GP) and the patient would normally enter causing a stuck room situation. (#1268)
