### PR TITLE
[RDY] Enroute to queue

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 136
+local SAVEGAME_VERSION = 137
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/queue_dialog.lua
+++ b/CorsixTH/Lua/dialogs/queue_dialog.lua
@@ -197,15 +197,20 @@ function UIQueue:onMouseUp(button, x, y)
       room = self.ui.app.world:getRoom(wx, wy)
     end
 
-    -- The new room must be of the same class as the current one
+    -- The new room must be of the same class as the current one and active
     local this_room = self.dragged.patient.next_room_to_visit
-    if this_room and room and room ~= this_room and room.room_info.id == this_room.room_info.id then
+    if this_room and room and room ~= this_room and
+        room.room_info.id == this_room.room_info.id and room.is_active then
       -- Move to another room
       local patient = self.dragged.patient
       patient:setNextAction(room:createEnterAction(patient))
       patient.next_room_to_visit = room
       patient:updateDynamicInfo(_S.dynamic_info.patient.actions.on_my_way_to:format(room.room_info.name))
       room.door:updateDynamicInfo()
+      -- call staff to room if required
+      if not room:testStaffCriteria(room:getRequiredStaffCriteria()) then
+        patient.world.dispatcher:callForStaff(room)
+      end
     end
   end
   self.dragged = nil

--- a/CorsixTH/Lua/dialogs/queue_dialog.lua
+++ b/CorsixTH/Lua/dialogs/queue_dialog.lua
@@ -205,7 +205,6 @@ function UIQueue:onMouseUp(button, x, y)
       patient:setNextAction(room:createEnterAction(patient))
       patient.next_room_to_visit = room
       patient:updateDynamicInfo(_S.dynamic_info.patient.actions.on_my_way_to:format(room.room_info.name))
-      room.door.queue:expect(patient)
       room.door:updateDynamicInfo()
     end
   end

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -580,6 +580,19 @@ function Humanoid:setNextAction(action, high_priority)
       if removed.object and removed.object:isReservedFor(self) then
         removed.object:removeReservedUser(self)
       end
+      if removed.is_entering then
+        local dest_room = self.world:getRoom(removed.x, removed.y)
+        if self.next_room_to_visit and self.next_room_to_visit == dest_room or
+            dest_room and dest_room ~= self.next_room_to_visit and (not self:getRoom() or class.is(self, Staff)) and
+            dest_room.door.queue then
+          dest_room.door.queue:unexpect(self)
+          dest_room.door:updateDynamicInfo()
+        end
+        if removed.reserve_on_resume and removed.reserve_on_resume:isReservedFor(self) then
+          removed.reserve_on_resume:removeReservedUser(self)
+          dest_room:tryAdvanceQueue()
+        end
+      end
     end
   end
 

--- a/CorsixTH/Lua/entities/humanoids/vip.lua
+++ b/CorsixTH/Lua/entities/humanoids/vip.lua
@@ -206,6 +206,12 @@ function Vip:evaluateRoom()
   -- Another room visited.
   self.num_visited_rooms = self.num_visited_rooms + 1
   local room = self.next_room
+
+  -- Consider doing this when reserving the door instead
+  if room.door.queue then
+    room.door.queue:unexpect(self)
+  end
+
   -- if the player is about to kill a live patient for research, lower their rating dramatically
   if room.room_info.id == "research" then
     if room:getPatient() then

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -203,8 +203,8 @@ local action_queue_on_change_position = permanent"action_queue_on_change_positio
   end
 
   -- Find out if we have to be standing up - considering humanoid_class covers both health inspector and VIP
-  local must_stand = class.is(humanoid, Staff) or humanoid.humanoid_class == "Inspector" or
-    humanoid.humanoid_class == "VIP" or (humanoid.disease and humanoid.disease.must_stand)
+  local must_stand = not class.is(humanoid, Patient) or humanoid.is_leaving or
+      (humanoid.disease and humanoid.disease.must_stand)
   local queue = action.queue
   if not must_stand then
     for i = 1, queue.bench_threshold do

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -204,7 +204,7 @@ local action_queue_on_change_position = permanent"action_queue_on_change_positio
 
   -- Find out if we have to be standing up - considering humanoid_class covers both health inspector and VIP
   local must_stand = not class.is(humanoid, Patient) or humanoid.is_leaving or
-      (humanoid.disease and humanoid.disease.must_stand)
+    (humanoid.disease and humanoid.disease.must_stand)
   local queue = action.queue
   if not must_stand then
     for i = 1, queue.bench_threshold do

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -203,7 +203,7 @@ local action_queue_on_change_position = permanent"action_queue_on_change_positio
   end
 
   -- Find out if we have to be standing up - considering humanoid_class covers both health inspector and VIP
-  local must_stand = not class.is(humanoid, Patient) or humanoid.is_leaving or
+  local must_stand = not class.is(humanoid, Patient) or action.is_leaving or
     (humanoid.disease and humanoid.disease.must_stand)
   local queue = action.queue
   if not must_stand then

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -107,7 +107,6 @@ local action_seek_room_goto_room = permanent"action_seek_room_goto_room"( functi
   humanoid.next_room_to_visit = room
   humanoid:updateDynamicInfo(_S.dynamic_info.patient.actions.on_my_way_to
     :format(room.room_info.name))
-  room.door.queue:expect(humanoid)
   room.door:updateDynamicInfo()
   if not room:testStaffCriteria(room:getRequiredStaffCriteria()) then
     humanoid.world.dispatcher:callForStaff(room)

--- a/CorsixTH/Lua/humanoid_actions/seek_toilets.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_toilets.lua
@@ -51,6 +51,8 @@ local function seek_toilets_action_start(action, humanoid)
       end
       humanoid:updateDynamicInfo("")
     end
+    -- toilet door should reflect the expected count
+    room.door:updateDynamicInfo()
     humanoid:finishAction()
   else
     -- This should happen only in rare cases, e.g. if the target toilet room was

--- a/CorsixTH/Lua/humanoid_actions/vip_go_to_next_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/vip_go_to_next_room.lua
@@ -42,7 +42,7 @@ local function action_vip_go_to_next_room_start(action, humanoid)
     end
     humanoid:queueAction(WalkAction(x, y))
     -- What happens if the room disappears:
-    humanoid.next_room.humanoids_enroute[humanoid] = {callback = callback}
+    humanoid.next_room.door.queue:expect(humanoid, {callback = callback})
 
     -- Evaluation function
     local --[[persistable:vip_next_room_eval]] function evaluate()

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -296,8 +296,6 @@ navigateDoor = function(humanoid, x1, y1, dir)
   end
   if door.user or (door.reserved_for and door.reserved_for ~= humanoid) or
       (is_entering_room and not room:canHumanoidEnter(humanoid)) then
-    --queueing patients are no longer enroute
-    room.humanoids_enroute[humanoid] = nil
     local queue = door.queue
     if door.reserved_for == humanoid then
       door.reserved_for = nil

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -83,18 +83,25 @@ action_walk_interrupt = permanent"action_walk_interrupt"( function(action, human
         door:updateDynamicInfo()
       end
     end
+
+    -- guarding with the action.keep_reserved check as we don't want to unexpect
+    -- if we are just interrupting but resume the walk action afterwards
+    local dest_room = humanoid.world:getRoom(action.x, action.y)
+    -- Unexpect the patient from a possible destination room.
+    -- 1st condition checks normal room routing
+	-- 2nd checks patients going to toilets, doctors and nurses
+    -- and redundantly checks patients routed between rooms
+    if (humanoid.next_room_to_visit and humanoid.next_room_to_visit == dest_room or
+        dest_room and dest_room ~= humanoid.next_room_to_visit and not humanoid:getRoom()) and
+        dest_room.door.queue then
+      dest_room.door.queue:unexpect(humanoid)
+      dest_room.door:updateDynamicInfo()
+    end
   else
     -- This flag can be used only once at a time.
     action.keep_reserved = nil
   end
-  -- Unexpect the patient from a possible destination room.
-  if humanoid.next_room_to_visit then
-    local door = humanoid.next_room_to_visit.door
-    if door.queue then
-      door.queue:unexpect(humanoid)
-      door:updateDynamicInfo()
-    end
-  end
+
   -- Terminate immediately if high-priority
   if high_priority then
     local timer_function = humanoid.timer_function

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -335,10 +335,10 @@ function Queue:rerouteAllPatients(action)
     elseif class.is(humanoid, Staff) then
       -- likewise believe we need action here to stop
       humanoid:setNextAction(IdleAction():setCount(1))
-	  humanoid:queueAction(MeanderAction())
+      humanoid:queueAction(MeanderAction())
     else
       -- other humanoids don't enter rooms
-	  humanoid:setNextAction(MeanderAction())
+      humanoid:setNextAction(MeanderAction())
     end
   end
   for humanoid, callback in pairs(self.expected) do

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -324,12 +324,22 @@ end
 --! Called when reception desk is destroyed, or when a room is destroyed from a crashed machine.
 function Queue:rerouteAllPatients(action)
   for _, humanoid in ipairs(self) do
-    -- slight delay so the desk is really destroyed before rerouting
-    humanoid:setNextAction(IdleAction():setCount(1))
-    -- Don't queue the same action table, but clone it for each patient.
-    local clone = {}
-    for k, v in pairs(action) do clone[k] = v end
-    humanoid:queueAction(clone)
+    -- check by class type as staff/vips shouldn't get a SeekRoomAction
+    if class.is(humanoid, Patient) then
+      -- slight delay so the desk is really destroyed before rerouting
+      humanoid:setNextAction(IdleAction():setCount(1))
+      -- Don't queue the same action table, but clone it for each patient.
+      local clone = {}
+      for k, v in pairs(action) do clone[k] = v end
+      humanoid:queueAction(clone)
+    elseif class.is(humanoid, Staff) then
+      -- likewise believe we need action here to stop
+      humanoid:setNextAction(IdleAction():setCount(1))
+	  humanoid:queueAction(MeanderAction())
+    else
+      -- other humanoids don't enter rooms
+	  humanoid:setNextAction(MeanderAction())
+    end
   end
   for humanoid, callback in pairs(self.expected) do
     -- call the callback if registered as door is closing

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -36,7 +36,7 @@ local Queue = _G["Queue"]
 --! Constructor of a queue.
 function Queue:Queue()
   self.reported_size = 0   -- Number of real patients
-  self.expected = {}       -- Expected patients
+  self.expected = {}       -- Expected humanoids
   self.callbacks = {}
   self.expected_count = 0  -- Number of expected patients
   self.visitor_count = 0
@@ -45,20 +45,27 @@ function Queue:Queue()
 end
 
 --! A humanoid is expected in a queue.
---!param humanoid New patient that is expected.
-function Queue:expect(humanoid)
-  if not self.expected[humanoid] and not class.is(humanoid, Vip) then
-    self.expected[humanoid] = true
-    self.expected_count = self.expected_count + 1
+--!param humanoid - any humanoid expected for the room
+--!param callback - register a callback for when queue is 'destroyed'
+function Queue:expect(humanoid, callback)
+  if not self.expected[humanoid] then
+    self.expected[humanoid] = callback
+    -- only count patients in the expected count
+    if class.is(humanoid, Patient) then
+      self.expected_count = self.expected_count + 1
+    end
   end
 end
 
 --! A humanoid is canceled as expected in a queue.
---!param humanoid Patient that is not coming to this queue.
+--!param humanoid - Humanoid that is not coming to this queue.
 function Queue:unexpect(humanoid)
   if self.expected[humanoid] then
     self.expected[humanoid] = nil
-    self.expected_count = self.expected_count - 1
+    -- only count patients in the expected count
+    if class.is(humanoid, Patient) then
+      self.expected_count = self.expected_count - 1
+    end
   end
 end
 
@@ -324,9 +331,11 @@ function Queue:rerouteAllPatients(action)
     for k, v in pairs(action) do clone[k] = v end
     humanoid:queueAction(clone)
   end
-  for humanoid in pairs(self.expected) do
-    humanoid:setNextAction(IdleAction():setCount(1))
-    humanoid:queueAction(action)
+  for humanoid, callback in pairs(self.expected) do
+    -- call the callback if registered as door is closing
+    if callback then
+      callback.callback()
+    end
     self:unexpect(humanoid)
   end
 end

--- a/CorsixTH/Lua/rooms/training.lua
+++ b/CorsixTH/Lua/rooms/training.lua
@@ -161,11 +161,6 @@ function TrainingRoom:onHumanoidEnter(humanoid)
   humanoid.in_room = self
   humanoid.last_room = self -- Remember where the staff was for them to come back after staffroom rest
 
-  --entering humanoids are no longer enroute
-  if self.humanoids_enroute[humanoid] then
-    self.humanoids_enroute[humanoid] = nil -- humanoid is no longer walking to this room
-  end
-
   humanoid:setCallCompleted()
   self:commandEnteringStaff(humanoid)
   self.humanoids[humanoid] = true


### PR DESCRIPTION
This is a change that resolves #1104, and the instance in #441, and #1487

I've used the queue.expected to replace the humanoids_enroute structure which was broken in a few places and included other related changes and fixes to address short falls which existed.

Some are small changes;
queue_dialog - don't direct them to a crash room, and call for staff if room unoccupied
queue (action) - tweaked the must_stand logic - don't need to search for a bench when leaving a room
seek_toilets - not updating the expected count when a patient is expected.
room - the condition around tryFindNearbyPatients

#441 is addressed by assuring the expected count is correctly reflected when redirecting patients from one room to another. Which is also the cause in #1104 of staff meandering in rooms, they are still recorded as expected in other rooms.

The two more interesting changes in Queue:rerouteAllPatients (the first for loop is managing #1487 and the 2nd one is the callback processing for the expected patients.

The other is 'callback = --[[persistable:room_humanoid_enroute_cancel]] function()' and this is related to the change around detecting staff answering a call in #1567. When they are answering a call and the destination room door is closed, instead of the MeanderAction, we want to have the staff restart in the current room if required.

I can see a few issues I need to go back around formatting, and I just have to review that I have got everything, hence WIP for now whilst I finish that and some more testing and if there is any early review issues, I can address them.