### PR TITLE
Move lua includes out of sdl2_mixer section of sdl_audio.cpp

### DIFF
--- a/CorsixTH/Src/sdl_audio.cpp
+++ b/CorsixTH/Src/sdl_audio.cpp
@@ -21,6 +21,8 @@ SOFTWARE.
 */
 
 #include "config.h"
+#include "lua_sdl.h"
+#include "th_lua.h"
 #ifdef CORSIX_TH_USE_SDL_MIXER
 #include <SDL_mixer.h>
 
@@ -28,8 +30,6 @@ SOFTWARE.
 #include <cmath>
 #include <cstring>
 
-#include "lua_sdl.h"
-#include "th_lua.h"
 #include "xmi2mid.h"
 #ifdef _MSC_VER
 #pragma comment(lib, "SDL2_mixer")


### PR DESCRIPTION
When building without audio, this prevents the error

> [ 19%] Building CXX object CorsixTH/CMakeFiles/CorsixTH_lib.dir/Src/sdl_audio.cpp.o
CorsixTH/CorsixTH/Src/sdl_audio.cpp:308:23: error: unknown type
      name 'lua_State'
int luaopen_sdl_audio(lua_State* L) {
                      ^
CorsixTH/CorsixTH/Src/sdl_audio.cpp:316:33: error: unknown type
      name 'lua_State'
int l_load_music_async_callback(lua_State* L) { return 0; }