### PR TITLE
Fix unsigned integer comparisons

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -1104,7 +1104,7 @@ namespace {
  */
 uint32_t get32BppPixel(const uint8_t* pImg, int iWidth, int iHeight,
                        const ::palette* pPalette, size_t iPixelNumber) {
-  if (iWidth <= 0 || iHeight <= 0 || iPixelNumber < 0 ||
+  if (iWidth <= 0 || iHeight <= 0 ||
       iPixelNumber >= static_cast<size_t>(iWidth) * iHeight) {
     return palette::pack_argb(0, 0, 0, 0);
   }

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -316,8 +316,9 @@ int l_anim_get_crop(lua_State* L) {
 int l_anim_set_anim(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   animation_manager* pManager = luaT_testuserdata<animation_manager>(L, 2);
-  size_t iAnim = luaL_checkinteger(L, 3);
-  if (iAnim < 0 || iAnim >= pManager->get_animation_count())
+  lua_Integer iAnim = luaL_checkinteger(L, 3);
+  if (iAnim < 0 ||
+      iAnim >= static_cast<lua_Integer>(pManager->get_animation_count()))
     luaL_argerror(L, 3, "Animation index out of bounds");
 
   if (lua_isnoneornil(L, 4)) {
@@ -326,7 +327,7 @@ int l_anim_set_anim(lua_State* L) {
     pAnimation->set_flags(static_cast<uint32_t>(luaL_checkinteger(L, 4)));
   }
 
-  pAnimation->set_animation(pManager, iAnim);
+  pAnimation->set_animation(pManager, static_cast<size_t>(iAnim));
   lua_settop(L, 2);
   luaT_setenvfield(L, 1, "animator");
   lua_pushnil(L);

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -156,13 +156,15 @@ int l_spritesheet_count(lua_State* L) {
 
 int l_spritesheet_size(lua_State* L) {
   sprite_sheet* pSheet = luaT_testuserdata<sprite_sheet>(L);
-  size_t iSprite = luaL_checkinteger(L, 2);  // No array adjustment
-  if (iSprite < 0 || iSprite >= pSheet->get_sprite_count())
+  lua_Integer iSprite = luaL_checkinteger(L, 2);  // No array adjustment
+  if (iSprite < 0 ||
+      iSprite >= static_cast<lua_Integer>(pSheet->get_sprite_count()))
     return luaL_argerror(L, 2, "Sprite index out of bounds");
 
   int iWidth;
   int iHeight;
-  pSheet->get_sprite_size_unchecked(iSprite, &iWidth, &iHeight);
+  pSheet->get_sprite_size_unchecked(static_cast<size_t>(iSprite), &iWidth,
+                                    &iHeight);
 
   lua_pushinteger(L, iWidth);
   lua_pushinteger(L, iHeight);


### PR DESCRIPTION
Clang warns about this, are they genuine problems?

> [ 19%] Building CXX object CorsixTH/CMakeFiles/CorsixTH_lib.dir/Src/th_gfx_sdl.cpp.o
CorsixTH/CorsixTH/Src/th_gfx_sdl.cpp:1107:51: warning: 
      comparison of unsigned expression < 0 is always false [-Wtautological-compare]
  if (iWidth <= 0 || iHeight <= 0 || iPixelNumber < 0 ||
                                     ~~~~~~~~~~~~ ^ ~
1 warning generated.
[ 22%] Building CXX object CorsixTH/CMakeFiles/CorsixTH_lib.dir/Src/th_lua.cpp.o
[ 25%] Building CXX object CorsixTH/CMakeFiles/CorsixTH_lib.dir/Src/th_lua_anims.cpp.o
CorsixTH/CorsixTH/Src/th_lua_anims.cpp:320:13: warning: 
      comparison of unsigned expression < 0 is always false [-Wtautological-compare]
  if (iAnim < 0 || iAnim >= pManager->get_animation_count())
      ~~~~~ ^ ~
1 warning generated.
[ 27%] Building CXX object CorsixTH/CMakeFiles/CorsixTH_lib.dir/Src/th_lua_gfx.cpp.o
CorsixTH/CorsixTH/Src/th_lua_gfx.cpp:160:15: warning: 
      comparison of unsigned expression < 0 is always false [-Wtautological-compare]
  if (iSprite < 0 || iSprite >= pSheet->get_sprite_count())
      ~~~~~~~ ^ ~
