### PR TITLE
[RDY] Epidemic patient loop reversal

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -582,11 +582,12 @@ function Humanoid:setNextAction(action, high_priority)
       end
       if removed.is_entering then
         local dest_room = self.world:getRoom(removed.x, removed.y)
-        if self.next_room_to_visit and self.next_room_to_visit == dest_room or
-            dest_room and dest_room ~= self.next_room_to_visit and (not self:getRoom() or class.is(self, Staff)) and
-            dest_room.door.queue then
-          dest_room.door.queue:unexpect(self)
-          dest_room.door:updateDynamicInfo()
+        if dest_room and dest_room.door.queue then
+          if self.next_room_to_visit and self.next_room_to_visit == dest_room or
+              dest_room ~= self.next_room_to_visit and (not self:getRoom() or class.is(self, Staff)) then
+            dest_room.door.queue:unexpect(self)
+            dest_room.door:updateDynamicInfo()
+          end
         end
         if removed.reserve_on_resume and removed.reserve_on_resume:isReservedFor(self) then
           removed.reserve_on_resume:removeReservedUser(self)

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -334,6 +334,10 @@ function Patient:die()
   hospital:msgKilled()
   self:setMood("dead", "activate")
   self.world.ui:playSound("boo.wav") -- this sound is always heard
+
+  -- Remove any messages and/or callbacks related to the patient.
+  self:unregisterCallbacks()
+
   self.going_home = true
   if self:getRoom() then
     self:queueAction(MeanderAction():setCount(1))

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -268,7 +268,7 @@ end
 epidemic was started to be fair on the players so they don't instantly fail.
 Additionally if any patients die during an epidemic we also remove them,
 otherwise a player may never win the epidemic in such a case.]]
-function Epidemic:checkPatientsForRemoval(lastchance)
+function Epidemic:checkPatientsForRemoval()
   for i = #self.infected_patients, 1, -1 do
     local infected_patient = self.infected_patients[i]
     if (not self.coverup_in_progress and infected_patient.going_home) or

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -268,8 +268,9 @@ end
 epidemic was started to be fair on the players so they don't instantly fail.
 Additionally if any patients die during an epidemic we also remove them,
 otherwise a player may never win the epidemic in such a case.]]
-function Epidemic:checkPatientsForRemoval()
-  for i, infected_patient in ipairs(self.infected_patients) do
+function Epidemic:checkPatientsForRemoval(lastchance)
+  for i = #self.infected_patients, 1, -1 do
+    local infected_patient = self.infected_patients[i]
     if (not self.coverup_in_progress and infected_patient.going_home) or
         infected_patient.dead then
       table.remove(self.infected_patients,i)
@@ -389,6 +390,8 @@ function Epidemic:startCoverUp()
   self.timer = UIWatch(self.world.ui, "epidemic")
   self.countdown_intervals = self.timer.open_timer
   self.world.ui:addWindow(self.timer)
+  -- last chance clean up as entities might have ticked and changed state
+  self:checkPatientsForRemoval()
   self.coverup_in_progress = true
   --Set the mood icon for all infected patients
   for _, infected_patient in ipairs(self.infected_patients) do

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -83,18 +83,7 @@ action_walk_interrupt = permanent"action_walk_interrupt"( function(action, human
 
     -- guarding with the action.keep_reserved check as we don't want to unexpect
     -- if we are just interrupting but resume the walk action afterwards
-    local dest_room = humanoid.world:getRoom(action.x, action.y)
-    -- Unexpect the patient from a possible destination room.
-    if dest_room and dest_room.door.queue then
-      -- 1st condition checks normal room routing
-      -- 2nd checks patients going to toilets, doctors and nurses
-      -- and redundantly checks patients routed between rooms
-      if humanoid.next_room_to_visit and humanoid.next_room_to_visit == dest_room or
-          dest_room ~= humanoid.next_room_to_visit and (not humanoid:getRoom() or class.is(humanoid, Staff)) then
-        dest_room.door.queue:unexpect(humanoid)
-        dest_room.door:updateDynamicInfo()
-      end
-    end
+    humanoid:unexpectFromRoom(humanoid.world:getRoom(action.x, action.y))
   else
     -- This flag can be used only once at a time.
     action.keep_reserved = nil

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -85,14 +85,15 @@ action_walk_interrupt = permanent"action_walk_interrupt"( function(action, human
     -- if we are just interrupting but resume the walk action afterwards
     local dest_room = humanoid.world:getRoom(action.x, action.y)
     -- Unexpect the patient from a possible destination room.
-    -- 1st condition checks normal room routing
-	-- 2nd checks patients going to toilets, doctors and nurses
-    -- and redundantly checks patients routed between rooms
-    if humanoid.next_room_to_visit and humanoid.next_room_to_visit == dest_room or
-        dest_room and dest_room ~= humanoid.next_room_to_visit and (not humanoid:getRoom() or class.is(humanoid, Staff)) and
-        dest_room.door.queue then
-      dest_room.door.queue:unexpect(humanoid)
-      dest_room.door:updateDynamicInfo()
+    if dest_room and dest_room.door.queue then
+      -- 1st condition checks normal room routing
+      -- 2nd checks patients going to toilets, doctors and nurses
+      -- and redundantly checks patients routed between rooms
+      if humanoid.next_room_to_visit and humanoid.next_room_to_visit == dest_room or
+          dest_room ~= humanoid.next_room_to_visit and (not humanoid:getRoom() or class.is(humanoid, Staff)) then
+        dest_room.door.queue:unexpect(humanoid)
+        dest_room.door:updateDynamicInfo()
+      end
     end
   else
     -- This flag can be used only once at a time.

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -682,8 +682,8 @@ local function tryMovePatient(old_room, new_room, patient)
   local world = new_room.world
 
   local px, py = patient.tile_x, patient.tile_y
-  -- Don't reroute the patient if he just decided to go to the toilet
-  if patient.going_to_toilet ~= "no" then
+  -- Don't reroute the patient if he just decided to go to the toilet or is going home
+  if patient.going_to_toilet ~= "no" or patient.going_home then
     return false
   end
 


### PR DESCRIPTION
Fixes the loop as mentioned in #1334
Also addresses what I believe is the two states that could result in the patients entering a room when they should be going home, by unregistering callbacks and not routing the patient between rooms if they are going_home.

Latest commit fixes logic error that occurs during earthquake room crashes, when door.queue is or room itself is not indexable