### PR TITLE
Fix french intern promotion string

### DIFF
--- a/CorsixTH/Lua/languages/french.lua
+++ b/CorsixTH/Lua/languages/french.lua
@@ -207,7 +207,8 @@ adviser.information = {
   patient_leaving_too_expensive = "Un patient part sans payer la facture pour %s. Sacrée perte !",
   vip_arrived = "Attention ! %s arrive pour visiter votre hôpital ! Faites en sorte de lui faire bonne impression.",
   first_death = "Vous venez de tuer votre premier patient. Alors, heureux ?",
-  promotion_to_specialist = "L'un de vos MÉDECIN est devenu un SPÉCIALISTE.", -- Fix the famous "Level 5 bug"
+  promotion_to_doctor = "L'un de vos INTERNES est devenu MÉDECIN.", -- Fix the famous "Level 5 bug"
+  promotion_to_specialist = "L'un de vos MÉDECINS est devenu SPÉCIALISTE.",
 }
 buy_objects_window = {
   price = "Prix : ",


### PR DESCRIPTION
The level 5 bug was actually when an intern was promoted to doctor. The current version still displays the original "Un des médecins est devenu %s" which caused a segfault in the original game.
Fixes a couple of typos, while we are there.