### PR TITLE
[RDY] Annual Report sort function, announcer state reset on load and persistance callback for staff reception action

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -150,10 +150,9 @@ function UIAnnualReport:UIAnnualReport(ui, world)
       self.salary_sort[i] = {value = math.floor(hospital.player_salary), hosp_index = i}
     end
 
-    local local_hosp_index = 1
     -- sort putting local player hospital first when values the same
-    local desc_order = function(a,b) return a.value > b.value or (a.value == b.value and a.hosp_index == local_hosp_index) end
-    local asc_order = function(a,b) return a.value < b.value or (a.value == b.value and a.hosp_index == local_hosp_index) end
+    local desc_order = function(a,b) return a.value > b.value or (a.value == b.value and a.hosp_index < b.hosp_index) end
+    local asc_order = function(a,b) return a.value < b.value or (a.value == b.value and a.hosp_index < b.hosp_index) end
     table.sort(self.money_sort, desc_order)
     table.sort(self.visitors_sort, desc_order)
     table.sort(self.deaths_sort, asc_order)

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -1211,6 +1211,8 @@ function GameUI:afterLoad(old, new)
     self.announcer = Announcer(self.app)
   end
 
+  self.announcer.playing = false
+
   return UI.afterLoad(self, old, new)
 end
 

--- a/CorsixTH/Lua/humanoid_actions/staff_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/staff_reception.lua
@@ -45,7 +45,8 @@ local action_staff_reception_interrupt = permanent"action_staff_reception_interr
     humanoid:setTilePositionSpeed(dx, dy)
     humanoid:finishAction()
   else
-    HumanoidRawWalk(humanoid, humanoid.tile_x, humanoid.tile_y, dx, dy, nil, function()
+    HumanoidRawWalk(humanoid, humanoid.tile_x, humanoid.tile_y, dx, dy, nil,
+        --[[persistable:action_staff_reception_walk]] function()
       humanoid:setTilePositionSpeed(dx, dy)
       humanoid:finishAction()
     end)


### PR DESCRIPTION
This will fix #1607.
Just changes so the hospitals get displayed in order of hospital index
Fix #1611 resetting announcer state
Fix #1622 persistance callback