### PR TITLE
[RDY] Prevent vaccination actions outside vaccination mode

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -66,17 +66,10 @@ function Patient:onClick(ui, button)
     else
       local hospital = self.hospital or self.world:getLocalPlayerHospital()
       local epidemic = hospital and hospital.epidemic
-      if not epidemic or
-          (not epidemic.coverup_in_progress or
-            (not self.infected or self.marked_for_vaccination) and
-            not epidemic.vaccination_mode_active) then
-        ui:addWindow(UIPatient(ui, self))
-      end
-      if epidemic and epidemic.coverup_in_progress and
-          self.infected and not self.marked_for_vaccination and
-          -- Prevent further vaccinations when the timer ends
-          not epidemic.timer.closed and epidemic.vaccination_mode_active then
+      if epidemic and epidemic.vaccination_mode_active then
         epidemic:markForVaccination(self)
+      else
+        ui:addWindow(UIPatient(ui, self))
       end
     end
   elseif self.user_of then

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -75,7 +75,7 @@ function Patient:onClick(ui, button)
       if epidemic and epidemic.coverup_in_progress and
           self.infected and not self.marked_for_vaccination and
           -- Prevent further vaccinations when the timer ends
-          not epidemic.timer.closed then
+          not epidemic.timer.closed and epidemic.vaccination_mode_active then
         epidemic:markForVaccination(self)
       end
     end

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -293,7 +293,7 @@ end
  the player and can only happen during a cover up. ]]
 function Epidemic:markForVaccination(patient)
   if patient.infected and not patient.vaccinated and
-      not patient.marked_for_vaccination and self.vaccination_mode_active then
+      not patient.marked_for_vaccination then
     patient.marked_for_vaccination = true
     patient:setMood("epidemy4","deactivate")
     patient:setMood("epidemy2","activate")

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -293,7 +293,7 @@ end
  the player and can only happen during a cover up. ]]
 function Epidemic:markForVaccination(patient)
   if patient.infected and not patient.vaccinated and
-      not patient.marked_for_vaccination then
+      not patient.marked_for_vaccination and self.vaccination_mode_active then
     patient.marked_for_vaccination = true
     patient:setMood("epidemy4","deactivate")
     patient:setMood("epidemy2","activate")


### PR DESCRIPTION
Fixes #1619

Actions inside function Epidemic:markForVaccination(patient) were getting triggered outside of vaccination mode. Causes a graphic update for contagious patients without making a call for the nurse to vaccinate.

Function now checks if vaccination mode is on before executing. Tested and working.