### PR TITLE
[RDY] Suggestion - Give nurse dynamic info when vaccinating

### DIFF
--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -584,6 +584,7 @@ function Epidemic:createVaccinationActions(patient,nurse)
     patient:giveVaccinationCandidateStatus()
     local level_config = self.world.map.level_config
     local fee = level_config.gbv.VacCost or 50
+    nurse:setDynamicInfoText(_S.dynamic_info.staff.actions.vaccine)
     nurse:setNextAction(WalkAction(x, y):setMustHappen(true):enableWalkingToVaccinate())
     nurse:queueAction(VaccinateAction(patient, fee))
   end

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -260,6 +260,7 @@ dynamic_info.patient.actions.no_gp_available = "Waiting for you to build a GP's 
 dynamic_info.staff.actions.heading_for = "Heading for %s"
 dynamic_info.staff.actions.fired = "Fired"
 dynamic_info.patient.actions.epidemic_vaccinated = "I am no longer contagious"
+dynamic_info.patient.actions.vaccine = "Vaccinating a patient"
 
 progress_report.free_build = "FREE BUILD"
 

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -259,8 +259,8 @@ adviser = {
 dynamic_info.patient.actions.no_gp_available = "Waiting for you to build a GP's office"
 dynamic_info.staff.actions.heading_for = "Heading for %s"
 dynamic_info.staff.actions.fired = "Fired"
+dynamic_info.staff.actions.vaccine = "Vaccinating a patient"
 dynamic_info.patient.actions.epidemic_vaccinated = "I am no longer contagious"
-dynamic_info.patient.actions.vaccine = "Vaccinating a patient"
 
 progress_report.free_build = "FREE BUILD"
 


### PR DESCRIPTION
Addition to #1620 that adds an improvement for when the nurse is assigned a patient to vaccinate.

Currently, the nurse has the dynamic info "Just wandering around" when going to vaccinate a patient.
This PR would change her dynamic info to "Vaccinating a patient" in that time frame.

Dyanmic info resets back to normal once vaccination is done.