### PR TITLE
[RDY] Add earthquake cheat function

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1342,15 +1342,18 @@ end
 
 -- Earthquake override from cheat menu
 function World:createEarthquake()
-  self.next_earthquake.start_day = self.game_date:dayOfMonth()
-  self.next_earthquake.start_month = self.game_date:monthOfGame()
-  if self.next_earthquake.size == nil then
-    --forcefully make an earthquake if none left in level file
-    self.next_earthquake.size = math.random(1,6) -- above 6 seems disastrous
-    self.next_earthquake.remaining_damage = self.next_earthquake.size
-    self.next_earthquake.damage_timer = earthquake_damage_time
-    self.next_earthquake.warning_timer = earthquake_warning_period
-    self.current_map_earthquake = self.current_map_earthquake + 1
+  --make sure an earthquake isn't already happening
+  if not self.next_earthquake.active then
+    self.next_earthquake.start_day = self.game_date:dayOfMonth()
+    self.next_earthquake.start_month = self.game_date:monthOfGame()
+    if self.next_earthquake.size == nil then
+      --forcefully make an earthquake if none left in level file
+      self.next_earthquake.size = math.random(1,6) -- above 6 seems disastrous
+      self.next_earthquake.remaining_damage = self.next_earthquake.size
+      self.next_earthquake.damage_timer = earthquake_damage_time
+      self.next_earthquake.warning_timer = earthquake_warning_period
+      self.current_map_earthquake = self.current_map_earthquake + 1
+    end
   end
 end
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1344,7 +1344,7 @@ end
 function World:createEarthquake()
   self.next_earthquake.start_day = self.game_date:dayOfMonth()
   self.next_earthquake.start_month = self.game_date:monthOfGame()
-  if self.next_earthquake.remaining_damage == nil then
+  if self.next_earthquake.size == nil then
     --forcefully make an earthquake if none left in level file
     self.next_earthquake.size = math.random(1,6) -- above 6 seems disastrous
     self.next_earthquake.remaining_damage = self.next_earthquake.size

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1333,7 +1333,6 @@ function World:nextEarthquake()
     self.next_earthquake.start_day = math.random(1, eqml)
 
     self.next_earthquake.size = control.Severity
-    print("next size is " .. self.next_earthquake.size)
     self.next_earthquake.remaining_damage = self.next_earthquake.size
     self.next_earthquake.damage_timer = earthquake_damage_time
     self.next_earthquake.warning_timer = earthquake_warning_period

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1333,6 +1333,7 @@ function World:nextEarthquake()
     self.next_earthquake.start_day = math.random(1, eqml)
 
     self.next_earthquake.size = control.Severity
+    print("next size is " .. self.next_earthquake.size)
     self.next_earthquake.remaining_damage = self.next_earthquake.size
     self.next_earthquake.damage_timer = earthquake_damage_time
     self.next_earthquake.warning_timer = earthquake_warning_period
@@ -1340,6 +1341,19 @@ function World:nextEarthquake()
   end
 end
 
+-- Earthquake override from cheat menu
+function World:createEarthquake()
+  self.next_earthquake.start_day = self.game_date:dayOfMonth()
+  self.next_earthquake.start_month = self.game_date:monthOfGame()
+  if self.next_earthquake.remaining_damage == nil then
+    --forcefully make an earthquake if none left in level file
+    self.next_earthquake.size = math.random(1,6) -- above 6 seems disastrous
+    self.next_earthquake.remaining_damage = self.next_earthquake.size
+    self.next_earthquake.damage_timer = earthquake_damage_time
+    self.next_earthquake.warning_timer = earthquake_warning_period
+    self.current_map_earthquake = self.current_map_earthquake + 1
+  end
+end
 
 --! Checks if all goals have been achieved or if the player has lost.
 --! Returns a table that always contains a state string ("win", "lose" or "nothing").

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1352,7 +1352,6 @@ function World:createEarthquake()
       self.next_earthquake.remaining_damage = self.next_earthquake.size
       self.next_earthquake.damage_timer = earthquake_damage_time
       self.next_earthquake.warning_timer = earthquake_warning_period
-      self.current_map_earthquake = self.current_map_earthquake + 1
     end
   end
 end


### PR DESCRIPTION
Fixes #1634 

Function will call the next earthquake in the level file if available, otherwise it will forcefully make one at random.

Previously this cheat would cause the game to partially break because the function didn't exist.
If it's too late to merge this, I can make another PR to remove the menu option for earthquakes instead.