### PR TITLE
Add 'UTF-8 BOM' to LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-CorsixTH is free software, distributed under the following terms:
+﻿CorsixTH is free software, distributed under the following terms:
 
 Copyright (C) 2009-2016 Peter "Corsix" Cawley
 Copyright (C) 2009-2016 Edvin "Lego3" Linge,


### PR DESCRIPTION
Fixes #1640 (Windows Installer does not display non-ascii characters properly)

The things we do for Microsoft 🤦 