### PR TITLE
[RDY] Enhancement - Extinguishers reduce chance of machines exploding

### DIFF
--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -181,7 +181,7 @@ function Machine:calculateSmoke(room)
     -- Display smoke, up to three animations per machine
     -- i.e. < 4 one plume, < 3 two plumes or < 2 three plumes of smoke
     setSmoke(self, true)
-    -- turn on additional ldayers of the animation for extra smoke plumes, depending on how damaged the machine is
+    -- turn on additional layers of the animation for extra smoke plumes, depending on how damaged the machine is
     if threshold < 3 then
       self.smokeInfo:setLayer(11, 2)
     end

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -106,7 +106,7 @@ function Machine:machineUsed(room)
   if threshold < 1 then
     -- If a fire extinguisher in the room, room has chance not to explode
     for object, _ in pairs(room.objects) do
-      if object.object_type.id == "extinguisher" then
+      if object.object_type.id == "extinguisher" and num_extinguishers < 4 then
         num_extinguishers = num_extinguishers + 1
       end
     end

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -20,8 +20,6 @@ SOFTWARE. --]]
 
 local TH = require("TH")
 
-corsixth.require("announcer")
-local AnnouncementPriority = _G["AnnouncementPriority"]
 --! An `Object` which needs occasional repair (to prevent explosion).
 class "Machine" (Object)
 
@@ -102,7 +100,7 @@ function Machine:machineUsed(room)
   -- Find a queued task for a handyman coming to repair this machine
   local taskIndex = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "repairing")
   local num_extinguishers = 0
-  local explosion_chance = 1
+  local explosion_chance
   local explode = false
   -- Room is set to explode
   if threshold < 1 then

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -112,7 +112,6 @@ function Machine:machineUsed(room)
     end
     -- Extinguisher failed to save the room
     if self.saved_by_extinguisher == 0 then
-      print("machine lost!")
       -- Clean up any task of handyman coming to repair the machine
       self.hospital:removeHandymanTask(taskIndex, "repairing")
       -- Blow up the room
@@ -133,8 +132,7 @@ function Machine:machineUsed(room)
       self:setRepairing(nil)
       return true
     else
-      -- Extinguisher saved room, machine sure a handyman has been called
-      print("machine saved!")
+      -- Extinguisher saved room, make sure a handyman has been called
       if taskIndex == -1 then
         local call = self.world.dispatcher:callForRepair(self, true, false, true)
         self.hospital:addHandymanTask(self, "repairing", 2, self.tile_x, self.tile_y, call)

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -100,46 +100,40 @@ function Machine:machineUsed(room)
   -- Find a queued task for a handyman coming to repair this machine
   local taskIndex = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "repairing")
   -- extinguisher check must be reset after each use
-  self.saved_by_extinguisher = 0
+  local saved_by_extinguisher = 0
+  local explode = false
   -- Room is set to explode
   if threshold < 1 then
     -- If a fire extinguisher in the room, make explosion chance 50%
     for object, _ in pairs(room.objects) do
       if object.object_type.id == "extinguisher" then
-        self.saved_by_extinguisher = math.random(0,1)
+        saved_by_extinguisher = math.random(0,1)
         break
       end
     end
-    -- Extinguisher failed to save the room
-    if self.saved_by_extinguisher == 0 then
-      -- Clean up any task of handyman coming to repair the machine
-      self.hospital:removeHandymanTask(taskIndex, "repairing")
-      -- Blow up the room
-      room:crashRoom()
-      self:setCrashedAnimation()
-      -- No special cursor required when hovering over the crashed room
-      self.hover_cursor = nil
-      -- Clear dynamic info (tracks machine usage which is no longer required)
-      self:clearDynamicInfo()
-      -- Prevent the machine from smoking, it's now just a pile of rubble
-      setSmoke(self, false)
-      -- If we have the window for this machine open, close it
-      local window = self.world.ui:getWindow(UIMachine)
-      if window and window.machine == self then
-        window:close()
-      end
-      -- Clear the icon showing a handyman is coming to repair the machine
-      self:setRepairing(nil)
-      return true
-    else
-      -- Extinguisher saved room, make sure a handyman has been called
-      if taskIndex == -1 then
-        local call = self.world.dispatcher:callForRepair(self, true, false, true)
-        self.hospital:addHandymanTask(self, "repairing", 2, self.tile_x, self.tile_y, call)
-      else -- Otherwise the task is already queued. Increase the priority to above that of machines with at least 4 uses left
-        self.hospital:modifyHandymanTaskPriority(taskIndex, 2, "repairing")
-      end
+    explode = saved_by_extinguisher == 0
+  end
+  -- Fire extinguisher failed to save the room or none were present
+  if explode then
+    -- Clean up any task of handyman coming to repair the machine
+    self.hospital:removeHandymanTask(taskIndex, "repairing")
+    -- Blow up the room
+    room:crashRoom()
+    self:setCrashedAnimation()
+    -- No special cursor required when hovering over the crashed room
+    self.hover_cursor = nil
+    -- Clear dynamic info (tracks machine usage which is no longer required)
+    self:clearDynamicInfo()
+    -- Prevent the machine from smoking, it's now just a pile of rubble
+    setSmoke(self, false)
+    -- If we have the window for this machine open, close it
+    local window = self.world.ui:getWindow(UIMachine)
+    if window and window.machine == self then
+      window:close()
     end
+    -- Clear the icon showing a handyman is coming to repair the machine
+    self:setRepairing(nil)
+    return true
   -- Else if urgent repair needed or extinguisher saved the room
   elseif threshold < 4 then
     -- If the job of repairing the machine isn't queued, queue it now (higher priority)
@@ -172,12 +166,8 @@ function Machine:calculateSmoke(room)
   -- How many uses this machine has left until it explodes
   local threshold = self:getRemainingUses()
 
-  -- If now exploding, clear any smoke
-  if threshold < 1 and self.saved_by_extinguisher == 0 then
-    setSmoke(self, false)
-    return
-  -- Else if urgent repair needed
-  elseif threshold < 4 then
+  -- Machines needing urgent repair show smoke
+  if threshold < 4 then
     -- Display smoke, up to three animations per machine
     -- i.e. < 4 one plume, < 3 two plumes or < 2 three plumes of smoke
     setSmoke(self, true)

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -115,7 +115,10 @@ function Machine:machineUsed(room)
       explode = true
     else
       -- Explosion chance increases 20% with every use over strength, and reduced by 5% for every additional extinguisher in the room bar the first one
-      explosion_chance = 0.25 + (threshold * -0.2) - (num_extinguishers * 0.05)
+      explosion_chance = (2 / self.strength) + (threshold * -0.2) - (num_extinguishers * 0.05) + 0.05
+      -- Cap it until guaranteed explosion
+      explosion_chance = explosion_chance > 0.95 and 0.95 or explosion_chance
+      explosion_chance = explosion_chance < 0.05 and 0.05 or explosion_chance
       explode = math.random() < explosion_chance
     end
   end

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -116,7 +116,7 @@ function Machine:machineUsed(room)
       -- If no extinguisher in room, or machine used 5 times over its strength always explode
       explode = true
     else
-      -- Explosion chance increaes 20% with every use over strength, and reduced by 5% for every additional extinguisher in the room bar the first one
+      -- Explosion chance increases 20% with every use over strength, and reduced by 5% for every additional extinguisher in the room bar the first one
       explosion_chance = 0.25 + (threshold * -0.2) - (num_extinguishers * 0.05)
       explode = math.random() < explosion_chance
     end

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -114,7 +114,7 @@ function Machine:machineUsed(room)
       -- If no extinguisher in room, or machine used 5 times over its strength always explode
       explode = true
     else
-      -- Explosion chance increases 20% with every use over strength, and reduced by 5% for every additional extinguisher in the room bar the first one
+      -- Explosion chance increases 20% with every use over strength, and reduced by 5% for every additional extinguisher (up to 3 extra) in the room bar the first one
       explosion_chance = (2 / self.strength) + (threshold * -0.2) - (num_extinguishers * 0.05) + 0.05
       -- Cap it until guaranteed explosion
       explosion_chance = explosion_chance > 0.95 and 0.95 or explosion_chance
@@ -122,7 +122,7 @@ function Machine:machineUsed(room)
       explode = math.random() < explosion_chance
     end
   end
-  -- Fire extinguisher failed to save the room or none were present
+  -- Room failed to be saved, or no extinguishers were present
   if explode then
     -- Clean up any task of handyman coming to repair the machine
     self.hospital:removeHandymanTask(taskIndex, "repairing")
@@ -143,7 +143,7 @@ function Machine:machineUsed(room)
     -- Clear the icon showing a handyman is coming to repair the machine
     self:setRepairing(nil)
     return true
-  -- Else if urgent repair needed or extinguisher saved the room
+  -- Else if urgent repair needed or room didn't explode
   elseif threshold < 4 then
     -- If the job of repairing the machine isn't queued, queue it now (higher priority)
     if taskIndex == -1 then

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -55,6 +55,7 @@ function Object:Object(world, object_type, x, y, direction, etc)
   self.hospital = world:getLocalPlayerHospital()
   self.user = false
   self.times_used = -1 -- Incremented in the call on the next line
+  self.saved_by_extinguisher = 0
   self:updateDynamicInfo()
   self:initOrientation(direction)
   self:setTile(x, y)

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -55,7 +55,6 @@ function Object:Object(world, object_type, x, y, direction, etc)
   self.hospital = world:getLocalPlayerHospital()
   self.user = false
   self.times_used = -1 -- Incremented in the call on the next line
-  self.saved_by_extinguisher = 0
   self:updateDynamicInfo()
   self:initOrientation(direction)
   self:setTile(x, y)


### PR DESCRIPTION
Would resolve #994 

PR will implement a variable saved_by_extinguisher to each machine/object defaulted at 0.
When machine threshold falls <1, the variable is recalculated by math.random(0,1) to see if an extinguisher in the room will save the room (saved_by_extinguisher == 1 is a success). Variable is saved until the machine is next used (inc. earthquake tick), in which case it sets back to 0.

The addition of self.saved_by_extinguisher may not be needed in object.lua... it was added more as a safeguard.

As for machine_dialog.lua nothing needs to be changed. The health marker in the dialogue is not affected if the number of times a machine is used is higher than its strength.