### PR TITLE
Make SDL audio optional

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -121,10 +121,13 @@ function App:init()
   self:initScreenshotsDir()
 
   -- Create the window
-  if not SDL.init("audio", "video", "timer") then
+  if not SDL.init("video", "timer") then
     return false, "Cannot initialise SDL"
   end
   local compile_opts = TH.GetCompileOptions()
+  if compile_opts.audio then
+    SDL.init("audio")
+  end
   local api_version = corsixth.require("api_version")
   if api_version ~= compile_opts.api_version then
     api_version = api_version or 0


### PR DESCRIPTION
Fixes #143
This adds the first line to this output when SDL2 is compiled without audio.

> SDL_Init failed: SDL not built with audio support
Notice: Audio system not loaded as CorsixTH compiled without it
