### PR TITLE
Add a flag to allow builds that block off areas.

### DIFF
--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -489,6 +489,13 @@ audio_music = nil -- [[X:\ThemeHospital\Music]]
 -- ]=] .. '\n' ..
 'room_information_dialogs = ' .. tostring(config_values.room_information_dialogs)  .. '\n' .. [=[
 
+-------------------------------------------------------------------------------------------------------------------------
+-- If true, parts of the hospital can be made inaccessible by blocking the path
+-- with rooms or objects. If false, all parts of the hospital must be kept
+-- accessible, the game will disallow any attempt to blocking the path.
+-- ]=] .. '\n' ..
+'allow_blocking_off_areas = ' .. tostring(config_values.allow_blocking_off_areas) .. '\n' .. [=[
+
 
 -------------------------------------------------------------------------------------------------------------------------
 

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -864,12 +864,16 @@ function UIEditRoom:enterDoorPhase()
 
   -- check if all adjacent tiles of the rooms are still connected
   if not self:checkReachability() then
-    -- undo passable flags and go back to walls phase
-    self.phase = "walls"
-    self:returnToWallPhase(true)
-    self.ui:playSound("wrong2.wav")
-    self.ui.adviser:say(_A.room_forbidden_non_reachable_parts)
-    return
+    if self.world.app.config.allow_blocking_off_areas then
+      print("Blocking off areas is allowed with room " .. self.blueprint_rect.x .. ", " .. self.blueprint_rect.y .. ".")
+    else
+      -- undo passable flags and go back to walls phase
+      self.phase = "walls"
+      self:returnToWallPhase(true)
+      self.ui:playSound("wrong2.wav")
+      self.ui.adviser:say(_A.room_forbidden_non_reachable_parts)
+      return
+    end
   end
 
   self.desc_text = _S.place_objects_window.place_door

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -756,6 +756,9 @@ function UIMenuBar:makeGameMenu(app)
   local function disable_salary_raise(item)
     app.world:debugDisableSalaryRaise(item.checked)
   end
+  local function allowBlockingAreas(item)
+    app.config.allow_blocking_off_areas = item.checked
+  end
   local function overlay(...)
     local args = {n = select('#', ...), ...}
     return function(item, m)
@@ -783,6 +786,7 @@ function UIMenuBar:makeGameMenu(app)
       :appendItem(_S.menu_debug.connect_debugger:format(hotkey_value_label("global_connectDebugger", hotkeys)), function() self.ui:connectDebugger() end)
       :appendCheckItem(_S.menu_debug.limit_camera,         true, limit_camera, nil, function() return self.ui.limit_to_visible_diamond end)
       :appendCheckItem(_S.menu_debug.disable_salary_raise, false, disable_salary_raise, nil, function() return self.ui.app.world.debug_disable_salary_raise end)
+      :appendCheckItem(_S.menu_debug.allow_blocking_off_areas, false, allowBlockingAreas, nil, function() return self.ui.app.config.allow_blocking_off_areas end)
       :appendItem(_S.menu_debug.make_debug_fax,     function() self.ui:makeDebugFax() end)
       :appendItem(_S.menu_debug.make_debug_patient, function() self.ui:addWindow(UIMakeDebugPatient(self.ui)) end)
       :appendItem(_S.menu_debug.cheats:format(hotkey_value_label("ingame_showCheatWindow", hotkeys)),             function() self.ui:addWindow(UICheats(self.ui)) end)

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -697,7 +697,13 @@ function UIPlaceObjects:setBlueprintCell(x, y)
     end
     if self.object_anim and object.class ~= "SideObject" then
       if allgood then
-        allgood = not world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, self.object_orientation, roomId)
+        if world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, self.object_orientation, roomId) then
+          if self.world.app.config.allow_blocking_off_areas then
+            print("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
+          else
+            allgood = false
+          end
+        end
       end
       if ATTACH_BLUEPRINT_TO_TILE then
         self.object_anim:setTile(map, x, y)
@@ -721,7 +727,11 @@ function UIPlaceObjects:setBlueprintCell(x, y)
         if not world.pathfinder:findDistance(x, y, checked_x, checked_y) then
           --we need to check if the failure to get the distance is due to the presence of an object in the adjacent tile
           if map:getCellFlags(checked_x, checked_y)["passable"] then
-            allgood = false
+            if self.world.app.config.allow_blocking_off_areas then
+              print("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
+            else
+              allgood = false
+            end
           end
         end
         flags[passable_flag] = true

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -187,6 +187,7 @@ menu_debug = {
   transparent_walls           = "  (%1%) TRANSPARENT WALLS  ",
   limit_camera                = "  LIMIT CAMERA  ",
   disable_salary_raise        = "  DISABLE SALARY RAISE  ",
+  allow_blocking_off_areas    = "  ALLOW BLOCKING OFF AREAS  ",
   make_debug_fax              = "  MAKE DEBUG FAX  ",
   make_debug_patient          = "  MAKE DEBUG PATIENT  ",
   cheats                      = "  (%1%) CHEATS  ",

--- a/WindowsInstaller/config_template.txt
+++ b/WindowsInstaller/config_template.txt
@@ -179,3 +179,10 @@ movies = true
 -- additional rooms in later levels. Affects campaign only.
 room_information_dialogs = true
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- If true, parts of the hospital can be made inaccessible by blocking the path
+-- with rooms or objects. If false, all parts of the hospital must be kept
+-- accessible, the game will disallow any attempt to blocking the path.
+allow_blocking_off_areas = false
+-------------------------------------------------------------------------------


### PR DESCRIPTION
Addresses #826 (first meta issue) first step: "Implement debug flag to allow placing objects that would block off a portion of the map."

**Describe what the proposed change does**
- Add a debug config setting "Allow blocking off areas"
- Use the flag to allow building rooms and placing objects even if they block off some area in the hospital or room.

![Screenshot_20200716_144635](https://user-images.githubusercontent.com/3254232/87674188-f5f81a00-c775-11ea-89fa-004b0d921302.png)
