### PR TITLE
[RDY] Make cheat.wav announceable

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/cheats.lua
+++ b/CorsixTH/Lua/dialogs/resizables/cheats.lua
@@ -134,7 +134,7 @@ function UICheats:buttonClicked(num)
     if self.cheats[num].name ~= "lose_level" then
       local announcements = self.ui.app.world.cheat_announcements
       if announcements then
-        self.ui:playSound(announcements[math.random(1, #announcements)])
+       self.ui:playAnnouncement(announcements[math.random(1, #announcements)], AnnouncementPriority.Critical)
       end
       self.ui.hospital.cheated = true
       self:updateCheatedStatus()

--- a/CorsixTH/Lua/dialogs/resizables/cheats.lua
+++ b/CorsixTH/Lua/dialogs/resizables/cheats.lua
@@ -134,7 +134,7 @@ function UICheats:buttonClicked(num)
     if self.cheats[num].name ~= "lose_level" then
       local announcements = self.ui.app.world.cheat_announcements
       if announcements then
-       self.ui:playAnnouncement(announcements[math.random(1, #announcements)], AnnouncementPriority.Critical)
+        self.ui:playAnnouncement(announcements[math.random(1, #announcements)], AnnouncementPriority.Critical)
       end
       self.ui.hospital.cheated = true
       self:updateCheatedStatus()

--- a/CorsixTH/Lua/dialogs/resizables/cheats.lua
+++ b/CorsixTH/Lua/dialogs/resizables/cheats.lua
@@ -18,6 +18,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+corsixth.require("announcer")
+
+local AnnouncementPriority = _G["AnnouncementPriority"]
+
 --! A dialog for activating cheats
 class "UICheats" (UIResizable)
 


### PR DESCRIPTION
**Describe what the proposed change does**
- Moves the sound for when a cheat is used into the announcement queue as PriorityCritical. This means it will still play while the game is paused.