### PR TITLE
[RDY] Adjustments to announcer

### DIFF
--- a/CorsixTH/Lua/announcer.lua
+++ b/CorsixTH/Lua/announcer.lua
@@ -169,7 +169,7 @@ function Announcer:onTick()
       self.ticks_since_last_announcement = ticks_since_last_announcement + 1
     end
 
-  -- Wait for an occupied desk or announcement is critical
+    -- Wait for an occupied desk or announcement is critical
     if staffedDesk or criticalAnnounces > 0 then
       while not self.playing and not self.entries:isEmpty() do
         local entry = self.entries:pop()

--- a/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
@@ -40,10 +40,8 @@ function Receptionist:tickDay()
 end
 
 function Receptionist:leaveAnnounce()
-  local announcement_priority = AnnouncementPriority.Critical
-
   local receptionist_leave_sounds = {"sack007.wav", "sack008.wav",}
-  self.world.ui:playAnnouncement(receptionist_leave_sounds[math.random(1, #receptionist_leave_sounds)], announcement_priority) -- must always be played even without receptionist
+  self.world.ui:playAnnouncement(receptionist_leave_sounds[math.random(1, #receptionist_leave_sounds)], AnnouncementPriority.Critical) -- must always be played even without receptionist
 end
 
 function Receptionist:isTiring()

--- a/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
@@ -40,10 +40,10 @@ function Receptionist:tickDay()
 end
 
 function Receptionist:leaveAnnounce()
-  local announcement_priority = AnnouncementPriority.High
+  local announcement_priority = AnnouncementPriority.Critical
 
   local receptionist_leave_sounds = {"sack007.wav", "sack008.wav",}
-  self.world.ui:playAnnouncement(receptionist_leave_sounds[math.random(1, #receptionist_leave_sounds)], announcement_priority)
+  self.world.ui:playAnnouncement(receptionist_leave_sounds[math.random(1, #receptionist_leave_sounds)], announcement_priority) -- must always be played even without receptionist
 end
 
 function Receptionist:isTiring()

--- a/CorsixTH/Luatest/spec/announcer_spec.lua
+++ b/CorsixTH/Luatest/spec/announcer_spec.lua
@@ -173,7 +173,7 @@ describe("Announcer", function()
     announcer:onTick()
     assert.equal(0, #app_mock.audio.__played_sounds__)
   end)
-  
+
   it("only critical announcements play when paused", function()
     local app_mock = create_app_mock(true, true)
     local announcer = Announcer(app_mock)

--- a/CorsixTH/Luatest/spec/announcer_spec.lua
+++ b/CorsixTH/Luatest/spec/announcer_spec.lua
@@ -36,13 +36,13 @@ end
 
 local create_date_mock = create_date_mock_type()
 
-local function create_app_mock()
+local function create_app_mock(speed_set, desk_set)
   local world_mock = {
     game_date = create_date_mock(),
-    isCurrentSpeed = function() return true end,
+    isCurrentSpeed = function() return speed_set end,
     getLocalPlayerHospital = function()
       return {
-        hasStaffedDesk = function() return true end
+        hasStaffedDesk = function() return desk_set end
       }
     end
   }
@@ -81,9 +81,29 @@ local function create_app_mock()
   return app
 end
 
+--[[
+Test formats for the announcer should be as follows (empty lines should be used as indicated):
+it("description of what is expected/tested", function()
+  local app_mock = create_app_mock(speed_set, desk_set)
+  local announcer = Announcer(app_mock)
+
+  Insert config settings here
+  Followed by announcements to queue
+
+  announcer:onTick --group ticks with each test
+  Some test
+
+  announcer:onTick
+  Some test etc...
+end)
+
+speed_set is whether to obey the requested speed check in announcer.lua
+desk_set is whether we have a staffed desk
+]]--
+
 describe("Announcer", function()
   it("nothing is played with an empty queue", function()
-    local app_mock = create_app_mock()
+    local app_mock = create_app_mock(false, true)
     local announcer = Announcer(app_mock)
 
     announcer:onTick()
@@ -92,30 +112,29 @@ describe("Announcer", function()
   end)
 
   it("an announcement is played", function()
-    local app_mock = create_app_mock()
+    local app_mock = create_app_mock(false, true)
     local announcer = Announcer(app_mock)
 
     announcer:playAnnouncement("sound.wav")
-    announcer:onTick()
 
+    announcer:onTick()
     assert.equal(1, #app_mock.audio.__played_sounds__)
     assert.equal("sound.wav", app_mock.audio.__played_sounds__[1].name)
   end)
 
   it("announcements shouldn't play when disabled", function()
-    local app_mock = create_app_mock()
+    local app_mock = create_app_mock(false, true)
     local announcer = Announcer(app_mock)
 
     app_mock.config.play_announcements = false
     announcer:playAnnouncement("normal.wav")
 
     announcer:onTick()
-
     assert.equal(0, #app_mock.audio.__played_sounds__)
   end)
 
   it("announcements are played priority-wise", function()
-    local app_mock = create_app_mock()
+    local app_mock = create_app_mock(false, true)
     local announcer = Announcer(app_mock)
 
     announcer:playAnnouncement("low.wav", AnnouncementPriority.Low)
@@ -145,14 +164,43 @@ describe("Announcer", function()
   end)
 
   it("announcements shouldn't play when not relevant anymore", function()
-    local app_mock = create_app_mock()
+    local app_mock = create_app_mock(false, true)
     local announcer = Announcer(app_mock)
 
     announcer:playAnnouncement("normal.wav")
-    app_mock.world.game_date = app_mock.world.game_date:plusHours(1000)
+    app_mock.world.game_date = app_mock.world.game_date:plusHours(1000) -- time must be after announcement
 
     announcer:onTick()
-
     assert.equal(0, #app_mock.audio.__played_sounds__)
+  end)
+  
+  it("only critical announcements play when paused", function()
+    local app_mock = create_app_mock(true, true)
+    local announcer = Announcer(app_mock)
+
+    announcer:playAnnouncement("low.wav", AnnouncementPriority.Low)
+    announcer:playAnnouncement("critical.wav", AnnouncementPriority.Critical)
+    announcer:playAnnouncement("normal.wav", AnnouncementPriority.Normal)
+    announcer:playAnnouncement("high.wav", AnnouncementPriority.High)
+
+    announcer:onTick()
+    assert.equal(1, #app_mock.audio.__played_sounds__)
+    assert.equal("critical.wav", app_mock.audio.__played_sounds__[1].name)
+    app_mock.audio.__mark_sounds_played__()
+
+    announcer:onTick()
+    assert.equal(0, #app_mock.audio.__played_sounds__)
+  end)
+
+  it("critical announcements play without a staffed desk", function()
+    local app_mock = create_app_mock(false, false)
+    local announcer = Announcer(app_mock)
+
+    announcer:playAnnouncement("critical.wav", AnnouncementPriority.Critical)
+
+    announcer:onTick()
+    assert.equal(1, #app_mock.audio.__played_sounds__)
+    assert.equal("critical.wav", app_mock.audio.__played_sounds__[1].name)
+    app_mock.audio.__mark_sounds_played__()
   end)
 end)


### PR DESCRIPTION
Closes CorsixTH#1671

Also fixes CorsixTH#1533

**Describe what the proposed change does**
- Announcements where a receptionist is not at a desk no longer build up; except for critical announcements that will play regardless (such as cheating, epidemics, earthquakes, and emergencies)
- The announcement for a receptionist leaving will always play
- Announcements can no longer play when the game is paused. Exception again is critical announcements (for cheating; or if a critical announcement was due to play after the current announcement just as you paused).
