### PR TITLE
[RDY] Switching faxes keeps game paused

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -160,11 +160,12 @@ function UIAnnualReport:UIAnnualReport(ui, world)
     table.sort(self.value_sort, desc_order)
     table.sort(self.salary_sort, desc_order)
 
-  -- Pause the game to allow the player plenty of time to check all statistics and trophies won
-  if world and not world:isCurrentSpeed("Pause") then
-    world:setSpeed("Pause")
-  end
   TheApp.video:setBlueFilterActive(false)
+end
+
+-- Make sure this window pauses the game, we want to let the player browse their awards
+function UIAnnualReport:mustPause()
+  return true
 end
 
 --! Finds out which awards and/or trophies the player has been awarded this year.
@@ -445,17 +446,8 @@ end
 --! Overridden close function. The game should be unpaused again when closing the dialog.
 function UIAnnualReport:close()
   if TheApp.world:getLocalPlayerHospital().game_won then
-    if not TheApp.world:isCurrentSpeed("Pause") then
-      TheApp.world:setSpeed("Pause")
-      TheApp.video:setBlueFilterActive(false)
-    end
+    TheApp.video:setBlueFilterActive(false)
     TheApp.world.ui.bottom_panel:openLastMessage()
-  elseif TheApp.world:isCurrentSpeed("Pause") then
-    if TheApp.ui.speed_up_key_pressed then
-      TheApp.world:setSpeed("Speed Up")
-    else
-      TheApp.world:setSpeed(TheApp.world.prev_speed)
-    end
   end
   self:updateAwards()
   Window.close(self)

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -283,7 +283,6 @@ function UIFax:appendNumber(number)
 end
 
 function UIFax:close()
-  local world = self.ui.app.world
   self.icon.fax = nil
   self.icon:adjustToggle()
   UIFullscreen.close(self)

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -282,7 +282,7 @@ function UIFax:close()
   self.icon.fax = nil
   self.icon:adjustToggle()
   UIFullscreen.close(self)
-  if world and world:isCurrentSpeed("Pause") then
+  if world and world:isCurrentSpeed("Pause") and #self.ui:getWindows(UIStaffRise) == 0 then
     world:setSpeed(world.prev_speed)
   end
 end

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -88,6 +88,11 @@ function UIFax:UIFax(ui, icon)
   self:addPanel(0, 326, 382):makeButton(0, 0, 44, 11, 13, button("#"))
 end
 
+-- Faxes pause the game
+function UIFax:mustPause()
+  return true
+end
+
 function UIFax:updateChoices()
   local choices = self.message.choices
   for i, button in ipairs(self.choice_buttons) do
@@ -282,9 +287,6 @@ function UIFax:close()
   self.icon.fax = nil
   self.icon:adjustToggle()
   UIFullscreen.close(self)
-  if world and world:isCurrentSpeed("Pause") and #self.ui:getWindows(UIStaffRise) == 0 then
-    world:setSpeed(world.prev_speed)
-  end
 end
 
 function UIFax:afterLoad(old, new)

--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -108,11 +108,9 @@ function UIMessage:openMessage()
   if TheApp.world:isCurrentSpeed("Speed Up") then
     TheApp.world:previousSpeed()
   end
-  if not TheApp.world:isCurrentSpeed("Pause") then
-    TheApp.world:setSpeed("Pause")
-  end
   if self.type == "strike" then -- strikes are special cases, as they are not faxes
     self.ui:addWindow(UIStaffRise(self.ui, self.owner, self.message))
+    TheApp.world:setSpeed("Pause")
     self:removeMessage()
   else
     if self.fax then
@@ -121,6 +119,7 @@ function UIMessage:openMessage()
       self.fax = UIFax(self.ui, self)
       self.ui:addWindow(self.fax)
       self.ui:playSound("fax_in.wav")
+      TheApp.world:setSpeed("Pause")
     end
     -- Manual adjustion of toggle state is necessary if owner's message_callback was used
     self:adjustToggle()

--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -110,7 +110,6 @@ function UIMessage:openMessage()
   end
   if self.type == "strike" then -- strikes are special cases, as they are not faxes
     self.ui:addWindow(UIStaffRise(self.ui, self.owner, self.message))
-    TheApp.world:setSpeed("Pause")
     self:removeMessage()
   else
     if self.fax then
@@ -119,7 +118,6 @@ function UIMessage:openMessage()
       self.fax = UIFax(self.ui, self)
       self.ui:addWindow(self.fax)
       self.ui:playSound("fax_in.wav")
-      TheApp.world:setSpeed("Pause")
     end
     -- Manual adjustion of toggle state is necessary if owner's message_callback was used
     self:adjustToggle()

--- a/CorsixTH/Lua/dialogs/staff_rise.lua
+++ b/CorsixTH/Lua/dialogs/staff_rise.lua
@@ -102,6 +102,11 @@ function UIStaffRise:UIStaffRise(ui, staff, rise_amount)
   end
 end
 
+-- Staff raise requests pause game
+function UIStaffRise:mustPause()
+  return true
+end
+
 function UIStaffRise:getStaffPosition(dx, dy)
   local staff = self.staff
   local x, y = self.ui.app.map:WorldToScreen(staff.tile_x, staff.tile_y)
@@ -172,10 +177,6 @@ function UIStaffRise:fireStaff()
   self.staff.message_callback = nil
   self.staff:fire()
   self:close()
-  local world = self.ui.app.world
-  if world and world:isCurrentSpeed("Pause") and #self.ui:getWindows(UIFax) == 0 then
-    world:setSpeed(world.prev_speed)
-  end
 end
 
 function UIStaffRise:increaseSalary()
@@ -183,10 +184,6 @@ function UIStaffRise:increaseSalary()
   self.staff:increaseWage(self.rise_amount)
   self.staff.quitting_in = nil
   self:close()
-  local world = self.ui.app.world
-  if world and world:isCurrentSpeed("Pause") and #self.ui:getWindows(UIFax) == 0 then
-    world:setSpeed(world.prev_speed)
-  end
 end
 
 function UIStaffRise:afterLoad(old, new)

--- a/CorsixTH/Lua/dialogs/staff_rise.lua
+++ b/CorsixTH/Lua/dialogs/staff_rise.lua
@@ -173,7 +173,7 @@ function UIStaffRise:fireStaff()
   self.staff:fire()
   self:close()
   local world = self.ui.app.world
-  if world and world:isCurrentSpeed("Pause") then
+  if world and world:isCurrentSpeed("Pause") and #self.ui:getWindows(UIFax) == 0 then
     world:setSpeed(world.prev_speed)
   end
 end
@@ -184,7 +184,7 @@ function UIStaffRise:increaseSalary()
   self.staff.quitting_in = nil
   self:close()
   local world = self.ui.app.world
-  if world and world:isCurrentSpeed("Pause") then
+  if world and world:isCurrentSpeed("Pause") and #self.ui:getWindows(UIFax) == 0 then
     world:setSpeed(world.prev_speed)
   end
 end

--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -59,6 +59,11 @@ function Window:Window()
   self.draggable = true
 end
 
+-- Most windows don't pause the game. Specific windows: fax, annual report, staff rise do pause and are set in the specific files
+function Window:mustPause()
+  return false
+end
+
 -- Sets the window's onscreen position. Each of x and y can be:
 -- Integers >= 0 - Absolute pixel positions of top/left edge of window relative
 --                 to top/left edge of screen


### PR DESCRIPTION
*Fixes #1625*

**Describe what the proposed change does**
- Game will now stay paused when you switch between faxes
- Game also recognises if a staff_rise window is open (and vice versa) and stays paused then too

The function call `` TheApp.world:setSpeed("Pause") `` had to be moved in message.lua to after the new window was made, which was the reason why the game would unpause.