### PR TITLE
Stopgap solution for #1193

### DIFF
--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -393,8 +393,8 @@ end
 function Graphics:loadFont(sprite_table, x_sep, y_sep, ...)
   -- Allow (multiple) arguments for loading a sprite table in place of the
   -- sprite_table argument.
-  -- TODO: Native number support for e.g. Korean languages. Current use of cach_x_sep is a stopgap solution for #1193 and should be eventually removed
-  local cache_x_sep = x_sep
+  -- TODO: Native number support for e.g. Korean languages. Current use of load_font is a stopgap solution for #1193 and should be eventually removed
+  local load_font = x_sep
   if type(sprite_table) == "string" then
     local arg = {sprite_table, x_sep, y_sep, ...}
     local n_pass_on_args = #arg
@@ -414,7 +414,7 @@ function Graphics:loadFont(sprite_table, x_sep, y_sep, ...)
 
   local use_bitmap_font = true
   -- Force bitmap font for the moneybar (Font05V)
-  if not sprite_table:isVisible(46) or cache_x_sep == "Font05V" then -- uppercase M
+  if not sprite_table:isVisible(46) or load_font == "Font05V" then -- uppercase M
     -- The font doesn't contain an uppercase M, so (in all likelihood) is used
     -- for drawing special symbols rather than text, so the original bitmap
     -- font should be used.

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -393,6 +393,8 @@ end
 function Graphics:loadFont(sprite_table, x_sep, y_sep, ...)
   -- Allow (multiple) arguments for loading a sprite table in place of the
   -- sprite_table argument.
+  -- TODO: Native number support for e.g. Korean languages. Current use of cach_x_sep is a stopgap solution for #1193 and should be eventually removed
+  local cache_x_sep = x_sep
   if type(sprite_table) == "string" then
     local arg = {sprite_table, x_sep, y_sep, ...}
     local n_pass_on_args = #arg
@@ -411,7 +413,8 @@ function Graphics:loadFont(sprite_table, x_sep, y_sep, ...)
   end
 
   local use_bitmap_font = true
-  if not sprite_table:isVisible(46) then -- uppercase M
+  -- Force bitmap font for the moneybar (Font05V)
+  if not sprite_table:isVisible(46) or cache_x_sep == "Font05V" then -- uppercase M
     -- The font doesn't contain an uppercase M, so (in all likelihood) is used
     -- for drawing special symbols rather than text, so the original bitmap
     -- font should be used.


### PR DESCRIPTION
Forces the money bar to use the bitmap font for legibility reasons; until native language numbers are introduced (see #1193 discussion).

**Describe what the proposed change does**
- Makes all languages use the bitmap font for moneybar for legibility's sake
- At some point we want to replace this with support for native language numbers (e.g. Korean) but for now this is better than the current improperly drawn moneybar numbers (added a TODO to reflect this)
