### PR TITLE
[RDY] Fix bug from #1674 PR

### DIFF
--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1052,7 +1052,7 @@ function UI:removeWindow(closing_window)
           break
         end
       end
-      if not pauseGame then
+      if not pauseGame and closing_window.mustPause() then
         self.app.world:setSpeed(self.app.world.prev_speed)
       end
     end


### PR DESCRIPTION
New code was accidentally causing other dialogs to unpause the game. Didn't notice it when testing #1674 so my fault.

**Describe what the proposed change does**
- Now makes sure our closing window is a mustPause() window before we unpause the game.

