### PR TITLE
[RFC] Fix for CorsixTH#1673

### DIFF
--- a/CorsixTH/Lua/objects/reception_desk.lua
+++ b/CorsixTH/Lua/objects/reception_desk.lua
@@ -135,6 +135,16 @@ function ReceptionDesk:tick()
         queue_front.has_passed_reception = true
       end
     end
+  -- A reception desk with patients has become unmanned, make sure we reroute patients
+  -- If there are no manned desks available, let patients meander until one is available
+  elseif not self.receptionist and self.queue:size() > 0 then
+    local hospital = self.hospital
+    for _, staff in ipairs(hospital.staff) do
+      if staff.humanoid_class == "Receptionist" and staff.associated_desk then
+        self.queue:rerouteAllPatients(SeekReceptionAction(), self)
+        break
+      end
+    end
   end
   if reset_timer then
     self.queue_advance_timer = 0
@@ -207,7 +217,7 @@ function ReceptionDesk:onDestroy()
       end
     end)
   end
-  self.queue:rerouteAllPatients(SeekReceptionAction())
+  self.queue:rerouteAllPatients(SeekReceptionAction(), self)
 
   self.being_destroyed = nil
   return Object.onDestroy(self)

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -321,14 +321,14 @@ function Queue:movePatient(index, new_index)
   self:move(first_patient_index + index - 1, new_index)
 end
 
---! Called when reception desk is destroyed, or when a room is destroyed from a crashed machine.
---!param action What should the patient do now
---!param origin Usually self, if needed
+--! Called when reception desk is destroyed (or unmanned), or when a room is destroyed from a crashed machine.
+--!param action (function) What should the patient do now
+--!param origin The room or object, if needed
 function Queue:rerouteAllPatients(action, origin)
   for _, humanoid in ipairs(self) do
     -- check by class type as staff/vips shouldn't get a SeekRoomAction
     -- Except at reception desks, a Vip could otherwise get stuck
-    if class.is(humanoid, Patient) or (class.is(humanoid, Vip) and class.is(origin, ReceptionDesk)) then
+    if class.is(humanoid, Patient) or (class.is(humanoid, Vip) and origin.class == "ReceptionDesk") then
       -- slight delay so the desk is really destroyed before rerouting
       humanoid:setNextAction(IdleAction():setCount(1))
       -- Don't queue the same action table, but clone it for each patient.

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -322,10 +322,13 @@ function Queue:movePatient(index, new_index)
 end
 
 --! Called when reception desk is destroyed, or when a room is destroyed from a crashed machine.
-function Queue:rerouteAllPatients(action)
+--!param action What should the patient do now
+--!param origin Usually self, if needed
+function Queue:rerouteAllPatients(action, origin)
   for _, humanoid in ipairs(self) do
     -- check by class type as staff/vips shouldn't get a SeekRoomAction
-    if class.is(humanoid, Patient) then
+    -- Except at reception desks, a Vip could otherwise get stuck
+    if class.is(humanoid, Patient) or (class.is(humanoid, Vip) and class.is(origin, ReceptionDesk)) then
       -- slight delay so the desk is really destroyed before rerouting
       humanoid:setNextAction(IdleAction():setCount(1))
       -- Don't queue the same action table, but clone it for each patient.

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -321,7 +321,7 @@ function Queue:movePatient(index, new_index)
   self:move(first_patient_index + index - 1, new_index)
 end
 
---! Called when reception desk is destroyed (or unmanned), or when a room is destroyed from a crashed machine.
+--! Called when reception desk is destroyed (or unstaffed), or when a room is destroyed from a crashed machine.
 --!param action (function) What should the patient do now
 --!param origin The room or object, if needed
 function Queue:rerouteAllPatients(action, origin)


### PR DESCRIPTION
Covers the highly unlikely event we have an unmanned reception desk for whatever reason.

*Fixes #1673*

**Describe what the proposed change does**
- If a reception desk with a queue becomes unmanned, all patients are now rerouted to another desk
- Vip also now gets handled correctly if this happens (otherwise he gets stuck in an infinite meander loop)
- If there are no manned desks available, patients meander until a manned desk is available.
