### PR TITLE
update copyright from git history

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -34,11 +34,12 @@ Copyright (C) 2011 Rene "Kleeze" Bergfort
 Copyright (C) 2011-2012 Sérgio "Get_It" Ribeiro
 Copyright (C) 2011 Sergei Larionov
 Copyright (C) 2011 Alexey Pinyagin
+Copyright (C) 2011-2019 Giordano "Viandante" Celeghin
 Copyright (C) 2012-2020 Stephen "TheCycoONE" Baker
 Copyright (C) 2012 Alex Ghiran
 Copyright (C) 2012-2013 Luis "Driver" Duarte
 Copyright (C) 2012-2013 Ryan Hugh Dean
-Copyright (C) 2012 Henrique Poyatos
+Copyright (C) 2012-2020 Henrique Poyatos
 Copyright (C) 2012 lwglwsss
 Copyright (C) 2013 Koanxd aka Snowblind
 Copyright (C) 2013 Chris "ChrizmanTV" Wilkinson
@@ -47,26 +48,33 @@ Copyright (C) 2013 YoungSeok Yoon
 Copyright (C) 2013-2015 Maarten Peters
 Copyright (C) 2013 nullstein
 Copyright (C) 2013 BuTcHeR (extragry.pl)
-Copyright (C) 2013-2018 Albert "Alberth" Hofkamp
+Copyright (C) 2013-2020 Albert "Alberth" Hofkamp
 Copyright (C) 2014-2015 Joseph "J-Shep" Sheppard
 Copyright (C) 2014 Phillipp Röll
 Copyright (C) 2014 Leonardo "LeonardoGamer" Malaman
 Copyright (C) 2015 Víctor "mccunyao" González
 Copyright (C) 2015 Josh Keegan
 Copyright (C) 2016-2020 Toby Lane
-Copyright (C) 2016 Phil Morrell
+Copyright (C) 2016-2018 Phil Morrell
 Copyright (C) 2017 Arne Zelasko
 Copyright (C) 2017 Víctor "IlDucci"
 Copyright (C) 2017 "wolfy1339"
 Copyright (C) 2017 Fang Xianfu
 Copyright (C) 2017 Steven Price
 Copyright (C) 2017 Radomir Wojtera
-Copyright (C) 2017 David Fairbrother
-Copyright (C) 2017-2018 Altieres Lima
+Copyright (C) 2017-2019 David Fairbrother
+Copyright (C) 2017-2020 Altieres Lima
 Copyright (C) 2017-2020 Justin "mugmuggy" Mugford
 Copyright (C) 2018 Pavel Schoffer
 Copyright (C) 2018 Rick "Feanathiel" Megens
+Copyright (C) 2018 Anton Shestakov
+Copyright (C) 2018 Thilo Ettelt
+Copyright (C) 2018 "red031000"
 Copyright (C) 2018-2019 James "leiget" Russell
+Copyright (C) 2019 Artem Polishchuk
+Copyright (C) 2020 "lewri"
+Copyright (C) 2020 "yangfl"
+Copyright (C) 2020 Jeremy Tellaa
 
 et al.
 


### PR DESCRIPTION
* noticed Giordano translation attribution was missing from 2011
* new authors since v0.62:
    comm -3 \
    <(git shortlog -s v0.62 | awk '{$1="";print}' | sort -u) \
    <(git shortlog -s v0.64 | awk '{$1="";print}' | sort -u)
* authors by year:
    git shortlog -sne --since=2018-01-01 --before=2019-01-01 v0.62..v0.64