### PR TITLE
Use self.ui.app rather than self.world.app, apparently.

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -864,7 +864,7 @@ function UIEditRoom:enterDoorPhase()
 
   -- check if all adjacent tiles of the rooms are still connected
   if not self:checkReachability() then
-    if self.world.app.config.allow_blocking_off_areas then
+    if self.ui.app.config.allow_blocking_off_areas then
       print("Blocking off areas is allowed with room " .. self.blueprint_rect.x .. ", " .. self.blueprint_rect.y .. ".")
     else
       -- undo passable flags and go back to walls phase

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -698,7 +698,7 @@ function UIPlaceObjects:setBlueprintCell(x, y)
     if self.object_anim and object.class ~= "SideObject" then
       if allgood then
         if world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, self.object_orientation, roomId) then
-          if self.world.app.config.allow_blocking_off_areas then
+          if self.ui.app.config.allow_blocking_off_areas then
             print("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
           else
             allgood = false
@@ -727,7 +727,7 @@ function UIPlaceObjects:setBlueprintCell(x, y)
         if not world.pathfinder:findDistance(x, y, checked_x, checked_y) then
           --we need to check if the failure to get the distance is due to the presence of an object in the adjacent tile
           if map:getCellFlags(checked_x, checked_y)["passable"] then
-            if self.world.app.config.allow_blocking_off_areas then
+            if self.ui.app.config.allow_blocking_off_areas then
               print("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
             else
               allgood = false


### PR DESCRIPTION
mugmuggy said in https://github.com/CorsixTH/CorsixTH/pull/1667#pullrequestreview-464171942
that I shouldn't use `self.world.app` but use `self.ui.app` instead.

Both cases work locally, so I don't know what the preferred solution is, but here goes.
