### PR TITLE
Reset Build Rooms dialog when new rooms are researched

### DIFF
--- a/CorsixTH/Lua/dialogs/build_room.lua
+++ b/CorsixTH/Lua/dialogs/build_room.lua
@@ -96,22 +96,27 @@ function UIBuildRoom:UIBuildRoom(ui)
     _S.room_classes.clinics,
     _S.room_classes.facilities
   }
-  self.category_rooms = {
-  }
+
+  self:updateBuildableRooms()
+
+  self:makeTooltip(_S.tooltip.build_room_window.cost, 160, 228, 282, 242)
+end
+
+function UIBuildRoom:updateBuildableRooms()
+  local app = self.ui.app
+  self.category_rooms = {}
   for i, category in ipairs({"diagnosis", "treatment", "clinics", "facilities"}) do
     local rooms = {}
     self.category_rooms[i] = rooms
     for _, room in ipairs(app.world.available_rooms) do
       -- NB: Unimplemented rooms are hidden unless in debug mode
       if (app.config.debug or room.class) and room.categories[category] and
-          ui.hospital.discovered_rooms[room] then
+          self.ui.hospital.discovered_rooms[room] then
         rooms[#rooms + 1] = room
       end
     end
     table.sort(rooms, function(r1, r2) return r1.categories[category] < r2.categories[category] end)
   end
-
-  self:makeTooltip(_S.tooltip.build_room_window.cost, 160, 228, 282, 242)
 end
 
 local cat_label_y = {21, 53, 84, 116}
@@ -145,6 +150,7 @@ function UIBuildRoom:setCategory(index)
     self.ui:tutorialStep(3, 3, 2)
   end
   self.category_index = index
+  self:updateBuildableRooms()
   self.list_title = _S.build_room_window.pick_room_type
   self.list = self.category_rooms[index]
 


### PR DESCRIPTION
*Fixes #513 #148*

**Describe what the proposed change does**
- When a room is researched, if the build rooms dialog is open then reopen it
