### PR TITLE
[RDY] Handle duplicate announcements

### DIFF
--- a/CorsixTH/Lua/announcer.lua
+++ b/CorsixTH/Lua/announcer.lua
@@ -112,7 +112,7 @@ function AnnouncementEntry:AnnouncementEntry()
   self.name = nil -- filename to play
   self.priority = default_announcement_priority
   self.created_date = nil -- when it has been created
-  self.decay_horus = nil -- how long until the announcement isn't relevant anymore
+  self.decay_hours = nil -- how long until the announcement isn't relevant anymore
   self.played_callback = nil -- call me whenever the sound was played, ...
   self.played_callback_delay = nil -- but not until delay has passed
 end

--- a/CorsixTH/Luatest/spec/announcer_spec.lua
+++ b/CorsixTH/Luatest/spec/announcer_spec.lua
@@ -2,6 +2,8 @@ require("class_test_base")
 
 require("announcer")
 
+require("date")
+
 local Announcer = _G["Announcer"]
 local AnnouncementPriority = _G["AnnouncementPriority"]
 

--- a/CorsixTH/Luatest/spec/announcer_spec.lua
+++ b/CorsixTH/Luatest/spec/announcer_spec.lua
@@ -133,6 +133,20 @@ describe("Announcer", function()
     assert.equal(0, #app_mock.audio.__played_sounds__)
   end)
 
+  it("duplicate announcements should be discarded", function()
+    local app_mock = create_app_mock(false, true)
+    local announcer = Announcer(app_mock)
+
+    announcer:playAnnouncement("sound.wav")
+    announcer:playAnnouncement("sound.wav")
+    announcer:playAnnouncement("sound.wav")
+
+    announcer:onTick()
+    announcer:onTick()
+    announcer:onTick()
+    assert.equal(1, #app_mock.audi.__played_sounds__)
+  end)
+
   it("announcements are played priority-wise", function()
     local app_mock = create_app_mock(false, true)
     local announcer = Announcer(app_mock)

--- a/CorsixTH/Luatest/spec/announcer_spec.lua
+++ b/CorsixTH/Luatest/spec/announcer_spec.lua
@@ -1,8 +1,8 @@
+require("corsixth")
+
 require("class_test_base")
 
 require("announcer")
-
-require("date")
 
 local Announcer = _G["Announcer"]
 local AnnouncementPriority = _G["AnnouncementPriority"]

--- a/CorsixTH/Luatest/spec/announcer_spec.lua
+++ b/CorsixTH/Luatest/spec/announcer_spec.lua
@@ -144,7 +144,7 @@ describe("Announcer", function()
     announcer:onTick()
     announcer:onTick()
     announcer:onTick()
-    assert.equal(1, #app_mock.audi.__played_sounds__)
+    assert.equal(1, #app_mock.audio.__played_sounds__)
   end)
 
   it("announcements are played priority-wise", function()


### PR DESCRIPTION
An update to the announcer to throw unnecessary duplicate announcements already in the queue.

**Describe what the proposed change does**
- Increases rate of decay on announcements to be more realistic
- Handles duplicate announcements by refreshing the created_date of the existing one
- Adds a luatest for duplicates
