### PR TITLE
Add advisor messages about handymen and receptionists, staff happiness from windows and big rooms, all cured award

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -319,6 +319,18 @@ function App:init()
           "Please make sure you have specified a font file in the config file."}))
     end
 
+    -- If the player wants to continue then load the youngest file in the Autosaves folder
+    -- If they give a month number then load that month's autosave
+    if self.command_line.continue then
+      local num = self.command_line.continue
+      local file = "Autosaves" .. pathsep .. "Autosave" .. num .. ".sav"
+      if num >= "1" and num <= "12" and lfs.attributes(self.savegame_dir .. file, "size") then
+        self.command_line.load = file
+      else
+        self.command_line.load = "Autosaves" .. pathsep ..
+          FileTreeNode(self.savegame_dir .. "Autosaves"):getMostRecentlyModifiedChildFile(".sav").label
+      end
+    end
     -- If a savegame was specified, load it
     if self.command_line.load then
       local status, err = pcall(self.load, self, self.savegame_dir .. self.command_line.load)

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -619,6 +619,7 @@ function App:loadLevel(level, difficulty, level_name, level_file, level_intro, m
       hospital = {
         player_salary = self.ui.hospital.player_salary,
         message_popup = self.ui.hospital.message_popup,
+        handyman_popup = self.ui.hospital.handyman_popup,
         hospital_littered = self.ui.hospital.hospital_littered,
         has_seen_pay_rise = self.ui.hospital.has_seen_pay_rise,
       },

--- a/CorsixTH/Lua/base_config.lua
+++ b/CorsixTH/Lua/base_config.lua
@@ -427,9 +427,11 @@ local configuration = {
     PlantBonus = 5,
     -- Bonus - MIN 0 MAX 255 (REP BONUS)
     TrophyStaffHappinessBonus = 5,
+    -- Bonus to money for curing every patient, no deaths or send-homes (MONEY BONUS)
+    TrophyAllCuredBonus = 20000,
     -- Bonus to money for NO DEATHS in the year (MONEY BONUS)
     TrophyDeathBonus = 10000,
-    -- Bonus to money for approximately 100% Cure Rate in the year (MONEY BONUS)
+    -- Bonus to money for over 90% Cure Rate in the year (MONEY BONUS)
     TrophyCuresBonus = 6000,
     -- Bonus to reputation for pleasing VIPs in the year (REPUTATION BONUS)
     TrophyMayorBonus = 5,
@@ -494,6 +496,8 @@ local configuration = {
     CuresBonus = 2000,
     -- MIN -32000 MAX +32000 - MONEY
     CuresPenalty = -3000,
+    -- MIN -32000 MAX +32000 - MONEY
+    AllCuresBonus = 5000,
     -- MIN -32000 MAX +32000 - MONEY
     DeathsBonus = 3000,
     -- MIN -32000 MAX +32000 - MONEY

--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -205,8 +205,11 @@ function UIAnnualReport:checkTrophiesAndAwards(world)
       self:addTrophy(_S.trophy_room.consistant_rep.trophies[math.random(1, 2)], "money", prices.TrophyReputationBonus)
       self.won_amount = self.won_amount + prices.TrophyReputationBonus
     end
-    -- No deaths or around a 100% Cure rate in the year
-    if hosp.num_deaths_this_year == 0 then
+    -- Everyone treated successfully, no deaths, or around a 100% Cure rate in the year
+    if hosp.num_cured_ty > 1 and hosp.num_deaths_this_year == 0 and hosp.not_cured_ty == 0 then
+      self:addTrophy(_S.trophy_room.all_cured.trophies[math.random(1, 2)], "money", prices.TrophyAllCuredBonus)
+      self.won_amount = self.won_amount + prices.TrophyAllCuredBonus
+    elseif hosp.num_deaths_this_year == 0 then
       self:addTrophy(_S.trophy_room.no_deaths.trophies[math.random(1, 3)], "money", prices.TrophyDeathBonus)
       self.won_amount = self.won_amount + prices.TrophyDeathBonus
     elseif hosp.num_cured_ty > (hosp.not_cured_ty * 0.9)  then
@@ -252,7 +255,10 @@ function UIAnnualReport:checkTrophiesAndAwards(world)
     end
 
     -- Deaths
-    if hosp.num_deaths_this_year < prices.DeathsAward then
+    if hosp.num_cured_ty > 1 and hosp.num_deaths_this_year == 0 and hosp.not_cured_ty == 0 then
+      self:addAward(_S.trophy_room.no_deaths.awards[1], "money", prices.AllCuresBonus)
+      self.award_won_amount = self.award_won_amount + prices.AllCuresBonus
+    elseif hosp.num_deaths_this_year < prices.DeathsAward then
       self:addAward(_S.trophy_room.no_deaths.awards[math.random(1, 2)], "money", prices.DeathsBonus)
       self.award_won_amount = self.award_won_amount + prices.DeathsBonus
     elseif hosp.num_deaths_this_year > prices.DeathsPoor then

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -327,6 +327,12 @@ function UIStaff:changeHandymanAttributes(increased)
     return
   end
 
+  -- Show a helpful message if this dialog hasn't been opened yet
+  if not self.ui.hospital.handyman_popup then
+    self.ui.adviser:say(_A.information.handyman_adjust)
+    self.ui.hospital.handyman_popup = true
+  end
+
   local incr_value = 0.1  -- Increase of 'increased'
   local smallest_decr = 0.05 -- Smallest decrement that can be performed.
   local decr_attrs = {}

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -97,8 +97,23 @@ function Staff:tickDay()
    self:changeAttribute("happiness", 0.05)
   end
 
-  --TODO windows in your work space and a large space to work in add to happiness
-  -- working in a small space makes you unhappy
+  local room = self:getRoom()
+  if room then
+    -- It always makes you happy to see the outdoors (or windows to anywhere)
+    local count = room:countWindows()
+    if room.room_info.id == "staff_room" then -- Pleased another bit
+      count = count * 2
+    end
+    if count > 0 then
+      -- More windows help but in smaller increments
+      self:changeAttribute("happiness", math.round(math.log(count)) / 1000)
+    end
+
+    -- Extra space in the room you are in adds to your happiness
+    local extraspace = (room.width * room.height) / (room.room_info.minimum_size * room.room_info.minimum_size)
+    -- Greater space helps but in smaller increments
+    self:changeAttribute("happiness", math.round(math.log(extraspace)) / 1000)
+  end
 end
 
 function Staff:tick()

--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -38,6 +38,7 @@ local function action_seek_reception_start(action, humanoid)
   local world = humanoid.world
   local best_desk
   local score
+  local queuetotal = 0
 
   assert(humanoid.hospital, "humanoid must be associated with a hospital to seek reception")
 
@@ -62,6 +63,7 @@ local function action_seek_reception_start(action, humanoid)
         score = this_score
         best_desk = desk
       end
+      queuetotal = queuetotal + #desk.queue
     end
   end
   if best_desk then
@@ -93,6 +95,19 @@ local function action_seek_reception_start(action, humanoid)
         end
       end
     end
+  local desks = #humanoid.hospital:findReceptionDesks()
+  local receptionists = humanoid.hospital:countStaffOfCategory("Receptionist")
+  if (receptionists > 1 and desks > 0) or (receptionists > 0 and desks > 1) then
+    local queueavg = math.floor(queuetotal / desks)
+    if receptionists < desks and queueavg > 5 then
+      world.ui.adviser:say(_A.warnings.reception_bottleneck)
+    elseif queueavg > 4 then
+      world.ui.adviser:say(_A.warnings.queue_too_long_at_reception)
+    elseif receptionists > desks then
+      world.ui.adviser:say(_A.warnings.another_desk)
+    end
+  end
+
   else
     -- No reception desk found. One will probably be built soon, somewhere in
     -- the hospital, so either walk to the hospital, or walk around the hospital.

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -230,6 +230,7 @@ adviser = {
     no_desk_5 = "Well it's about time, you should start to see some patients arriving soon!",
     no_desk_6 = "You have a receptionist, so how about building a reception desk for her to work from?",
     no_desk_7 = "You've built the reception desk, so how about hiring a receptionist? You won't see any patients until you get this sorted out you know!",
+    another_desk = "You'll need to build another desk for that new receptionist.",
     cannot_afford = "You don't have enough money in the bank to hire that person!", -- I can't see anything like this in the original strings
     cannot_afford_2 = "You don't have enough money in the bank to make that purchase!",
     falling_1 = "Hey! That is not funny, watch where you click that mouse; someone could get hurt!",

--- a/CorsixTH/Lua/languages/original_strings.lua
+++ b/CorsixTH/Lua/languages/original_strings.lua
@@ -1142,9 +1142,9 @@ trophy_room = {
       S[55][ 7],
     },
   },
-  all_cured = {         -- not implemented
+  all_cured = {
     awards = {
-      S[27][29],          -- for 100% treat rate (does that mean none sent home or killed?)
+      S[27][29],          -- for 100% treat rate (none sent home or killed)
     },
     trophies = {
       S[27][30],          -- for 100% cure rate

--- a/CorsixTH/Lua/languages/original_strings.lua
+++ b/CorsixTH/Lua/languages/original_strings.lua
@@ -648,8 +648,8 @@ adviser = {
     patient_abducted              = S[11][111], -- what the heck is this? I never got that far in the original...
     patient_leaving_too_expensive = S[11][118],
 
-    pay_rise                      = S[11][ 29], -- TODO only in tutorial / first time?
-    handyman_adjust               = S[11][ 71], -- TODO only in tutorial / first time?
+    pay_rise                      = S[11][ 29], -- Once only
+    handyman_adjust               = S[11][ 71], -- Once only
     fax_received                  = S[11][136], -- Once only
 
     vip_arrived                   = S[21][  9], -- %s (name of VIP)

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -1030,3 +1030,19 @@ function Room:getStaffServiceQuality()
 
   return quality
 end
+
+--! Count the number of windows in the room
+--!return (int) Number of windows
+function Room:countWindows()
+  local window_tile = {[116]=true, [117]=true, [118]=true, [119]=true,
+   [124]=true, [125]=true, [126]=true, [127]=true}
+  local map, count = self.world.ui.app.map.th, 0
+  for x = self.x, self.x + self.width do
+    for y = self.y, self.y + self.height do
+      if window_tile[map:getCell(x, y, 2)] or window_tile[map:getCell(x, y, 3)] then
+        count = count + 1
+      end
+    end
+  end
+  return count
+end

--- a/CorsixTH/corsix-th.6
+++ b/CorsixTH/corsix-th.6
@@ -20,7 +20,7 @@
 .\"
 .\" This manpage is written in mdoc(7).
 .\" Language reference: https://man.openbsd.org/mdoc.7
-.Dd August 22, 2018
+.Dd August 26, 2020
 .Dt CORSIX-TH 6
 .Os
 .Sh NAME
@@ -31,6 +31,7 @@
 .Op Fl -bitmap-dir Ns = Ns Ar path
 .Op Fl -config-file Ns = Ns Ar path
 .Op Fl -connect-lua-dbgp
+.Op Fl -continue Ns = Ns Ar number
 .Op Fl -dump=strings
 .Op Fl -interpreter Ns = Ns Ar path
 .Op Fl -load Ns = Ns Ar savegame
@@ -55,6 +56,9 @@ for loading in game bitmaps.
 Use the specified config file instead of the default one.
 .It Fl -connect-lua-dbgp
 Connect to a Lua DBGp server.
+.It Fl -continue Ns = Ns Ar number
+If a number is given load that month's autosave.
+Otherwise load the youngest autosave
 .It Fl -dump=strings
 Dumps all of the game strings to the config directory.
 .It Fl -interpreter Ns = Ns Ar path
@@ -91,4 +95,4 @@ Copyright CorsixTH contributors.
 CorsixTH is available under the MIT license.
 .Pp
 For the full license text see:
-.Lk https://raw.githubusercontent.com/CorsixTH/CorsixTH/v0.62/LICENSE.txt
+.Lk https://raw.githubusercontent.com/CorsixTH/CorsixTH/v0.64/LICENSE.txt


### PR DESCRIPTION
**Describe what the proposed change does**
- Use the two remaining receptionist warnings, add a new string for the other similar event
- Award a trophy, award and bonus for successfully diagnosing and treating everyone
- Use the handyman hint for adjusting attributes, and have it come up once
- Count the windows and add staff happiness based on this. 0.001 is a starting number, it probably needs refining.
- Add staff happiness for larger rooms. This could be expanded, say use the ratio between the room requirements and the actual space as a basis for the factor, if that's realistic.
- --continue=1 will load Autosave1.sav, --continue=true (or any word) will load the youngest Autosav*.sav.
