### PR TITLE
[rdy] Improved distinction between world and hospital, and between different hospitals.

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
@@ -169,15 +169,15 @@ function UITownMap:draw(canvas, x, y)
     config = self:initRuntimeConfig()
   end
 
-  -- We need to draw number of people, plants, fire extinguisers, other objects
+  -- We need to draw number of people, plants, fire extinguishers, other objects
   -- and radiators.
   -- NB: original TH's patient count was always 1 too big (started counting at 1)
   -- This is likely a bug and we do not copy this behavior.
   local patientcount = hospital.patientcount
-  local plants = world.object_counts.plant
-  local fireext = world.object_counts.extinguisher
-  local objs = world.object_counts.general
-  local radiators = world.object_counts.radiator
+  local plants = hospital:countPlants()
+  local fireext = hospital:countFireExtinguishers()
+  local objs = hospital:countGeneralObjects()
+  local radiators = hospital:countRadiators()
 
   self.info_font:draw(canvas, patientcount, x +  95, y +  57)
   self.info_font:draw(canvas, plants,       x +  95, y + 110)

--- a/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
@@ -59,7 +59,7 @@ end
 
 function Receptionist:needsWorkStation()
   if self.hospital and not self.hospital.receptionist_msg then
-    if self.world.object_counts["reception_desk"] == 0 then
+    if self.hospital:countReceptionDesks() == 0 then
       self.world.ui.adviser:say(_A.warnings.no_desk_4)
       self.hospital.receptionist_msg = true
     end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -753,17 +753,18 @@ function Hospital:checkFacilities()
 
         -- We don't want to see praise messages about seating every month, so randomise the chances of it being shown
         local show_praise = math.random(1, 4) == 4
-        if self.world.object_counts.bench > self.patientcount and show_praise then
+        local num_benches = self:countBenches()
+        if num_benches > self.patientcount and show_praise then
           self:praiseBench()
         -- Are there enough benches for the volume of patients in your hospital?
-        elseif self.world.object_counts.bench < self.patientcount then
+        elseif num_benches < self.patientcount then
           self:warningBench()
         end
       end
     end
 
     -- Make players more aware of the need for radiators
-    if self.world.object_counts.radiator == 0 then
+    if self:countRadiators() == 0 then
       self.world.ui.adviser:say(_A.information.initial_general_advice.place_radiators)
     end
 
@@ -1030,9 +1031,10 @@ function Hospital:onEndDay()
   end
 
   -- Is the boiler working today?
+  local num_radiators = self:countRadiators()
   local breakdown = math.random(1, 240)
   if breakdown == 1 and not self.heating_broke and self.boiler_can_break and
-      self.world.object_counts.radiator > 0 then
+      num_radiators > 0 then
     if tonumber(self.world.map.level_number) then
       if self.world.map.level_number == 1 and (self.world:date() >= Date(1,6)) then
         self:boilerBreakdown()
@@ -1045,8 +1047,7 @@ function Hospital:onEndDay()
   end
 
   -- Calculate heating cost daily.  Divide the monthly cost by the number of days in that month
-  local radiators = self.world.object_counts.radiator
-  local heating_costs = (((self.radiator_heat * 10) * radiators) * 7.50) / self.world:date():lastDayOfMonth()
+  local heating_costs = (self.radiator_heat * 10 * num_radiators * 7.50) / self.world:date():lastDayOfMonth()
   self.acc_heating = self.acc_heating + heating_costs
 
   if self:isPlayerHospital() then dailyUpdateRatholes(self) end
@@ -1142,7 +1143,7 @@ function Hospital:onEndMonth()
     if self.receptionist_count ~= 0 and current_month > 2 and not self.receptionist_msg then
       self.world.ui.adviser:say(_A.warnings.no_desk_6)
       self.receptionist_msg = true
-    elseif self.receptionist_count == 0 and current_month > 2 and self.world.object_counts["reception_desk"] ~= 0  then
+    elseif self.receptionist_count == 0 and current_month > 2 and self:countReceptionDesks() ~= 0  then
       self.world.ui.adviser:say(_A.warnings.no_desk_7)
     --  self.receptionist_msg = true
     elseif current_month == 3 then
@@ -1176,6 +1177,7 @@ end
 --! Collect the reception desks in the hospital.
 --!return (list) The reception desks in the hospital.
 function Hospital:findReceptionDesks()
+  -- TODO Breaks in multiplayer mode.
   local reception_desks = {}
   for _, obj_list in pairs(self.world.objects) do
     for _, obj in ipairs(obj_list) do
@@ -1760,6 +1762,48 @@ function Hospital:countRoomOfType(type)
     end
   end
   return result
+end
+
+--! Get the number of reception desks in the hospital.
+--!return (int) Number of reception desks in the hospital.
+function Hospital:countReceptionDesks()
+  -- TODO Breaks in multiplayer mode.
+  return self.world.object_counts["reception_desk"]
+end
+
+--! Get the number of benches in the hospital.
+--!return (int) Number of benches in the hospital.
+function Hospital:countBenches()
+  -- TODO Breaks in multiplayer mode.
+  return self.world.object_counts["bench"]
+end
+
+--! Get the number of radiators in the hospital.
+--!return (int) Number of radiators in the hospital.
+function Hospital:countRadiators()
+  -- TODO Breaks in multiplayer mode.
+  return self.world.object_counts["radiator"]
+end
+
+--! Get the number of plants in the hospital.
+--!return (int) Number of plants in the hospital.
+function Hospital:countPlants()
+  -- TODO Breaks in multiplayer mode.
+  return self.world.object_counts["plant"]
+end
+
+--! Get the number of fire extinguishers in the hospital.
+--!return (int) Number of fire extinguishers in the hospital.
+function Hospital:countFireExtinguishers()
+  -- TODO Breaks in multiplayer mode.
+  return self.world.object_counts["extinguisher"]
+end
+
+--! Get the number of general objects in the hospital.
+--!return (int) Number of general objects in the hospital.
+function Hospital:countGeneralObjects()
+  -- TODO Breaks in multiplayer mode.
+  return self.world.object_counts["general"]
 end
 
 --! Remove the first entry with a given value from a table.

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -999,11 +999,12 @@ function Hospital:onEndDay()
     local overdraft_payment = (overdraft*overdraft_interest)/365
     self.acc_overdraft = self.acc_overdraft + overdraft_payment
   end
-  local hosp = self.world.hospitals[1]
-  hosp.receptionist_count = 0
+
+  -- Count receptionists.
+  self.receptionist_count = 0
   for _, staff in ipairs(self.staff) do
     if staff.humanoid_class == "Receptionist" then
-      hosp.receptionist_count = hosp.receptionist_count + 1
+      self.receptionist_count = self.receptionist_count + 1
     end
   end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1840,8 +1840,8 @@ function Hospital:objectPlaced(entity, id)
   end
 
   -- If it is a plant it might be advisable to hire a handyman
-  if id == "plant" and self:countStaffOfCategory("Handyman") == 0 then
-    if self:isPlayerHospital() then
+  if self:isPlayerHospital() then
+    if id == "plant" and self:countStaffOfCategory("Handyman") == 0 then
       self.world.ui.adviser:say(_A.staff_advice.need_handyman_plants)
     end
   end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -363,21 +363,21 @@ end
 
 -- Remind the player when cash is low that a loan might be available
 function Hospital:cashLow()
-  -- Don't remind in free build mode.
-  if self.world.free_build_mode then
+  -- Don't remind in free build mode or when not controlled by the user.
+  if self.world.free_build_mode or not self:isPlayerHospital() then
     return
   end
-  local hosp = self.world.hospitals[1]
+
   local cashlowmessage = {
     (_A.warnings.money_low),
     (_A.warnings.money_very_low_take_loan),
     (_A.warnings.cash_low_consider_loan),
   }
-  if hosp.balance < 2000 and hosp.balance >= -500 then
-    hosp.world.ui.adviser:say(cashlowmessage[math.random(1, #cashlowmessage)])
-  elseif hosp.balance < -2000 and hosp.world:date():monthOfYear() > 8 then
+  if self.balance < 2000 and self.balance >= -500 then
+    self.world.ui.adviser:say(cashlowmessage[math.random(1, #cashlowmessage)])
+  elseif self.balance < -2000 and self.world:date():monthOfYear() > 8 then
     -- ideally this should be linked to the lose criteria for balance
-    hosp.world.ui.adviser:say(_A.warnings.bankruptcy_imminent)
+    self.world.ui.adviser:say(_A.warnings.bankruptcy_imminent)
   end
 end
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2062,7 +2062,7 @@ end
 --! Notifies the world that an object has been placed, notifying
 --  interested entities in the vicinity of the new arrival.
 --!param entity (Entity) The entity that was just placed.
---!param id (string) That entity's id.
+--!param id (optional string) That entity's id.
 function World:objectPlaced(entity, id)
   -- If id is not supplied, we can use the entities internal id if it exists
   -- This is so the bench check below works
@@ -2072,45 +2072,11 @@ function World:objectPlaced(entity, id)
   end
 
   self.entities[#self.entities + 1] = entity
-  -- If it is a bench we're placing, notify queueing patients in the vicinity
-  if id == "bench" and entity.tile_x and entity.tile_y then
-    local notify_distance = 6
-    local w, h = self.map.th:size()
-    for tx = math.max(1, entity.tile_x - notify_distance), math.min(w, entity.tile_x + notify_distance) do
-      for ty = math.max(1, entity.tile_y - notify_distance), math.min(h, entity.tile_y + notify_distance) do
-        for _, patient in ipairs(self.entity_map:getHumanoidsAtCoordinate(tx, ty)) do
-          if class.is(patient, Patient) then
-            patient:notifyNewObject(id)
-          end
-        end
-      end
-    end
-  end
-  if id == "reception_desk" then
-    local numReceptionists = self.hospitals[1]:countStaffOfCategory("Receptionist")
-    if not self.ui.start_tutorial and numReceptionists == 0 then
-      -- TODO: Will not work correctly for multiplayer
-      self.ui.adviser:say(_A.room_requirements.reception_need_receptionist)
-    elseif numReceptionists > 0 and self.object_counts["reception_desk"] == 1 and
-        not self.hospitals[1].receptionist_msg and self.game_date:monthOfGame() > 3 then
-      self.ui.adviser:say(_A.warnings.no_desk_5)
-      self.hospitals[1].receptionist_msg = true
-    end
-  end
-  -- If it is a plant it might be advisable to hire a handyman
-  if id == "plant" and self.hospitals[1]:countStaffOfCategory("Handyman") == 0 then
-    self.ui.adviser:say(_A.staff_advice.need_handyman_plants)
-  end
-  if id == "gates_to_hell" then
-    entity:playEntitySounds("LAVA00*.WAV", {0,1350,1150,950,750,350},
-        {0,1450,1250,1050,850,450}, 40)
-    entity:setTimer(entity.world:getAnimLength(2550),
-                    --[[persistable:lava_hole_spawn_animation_end]]
-                    function(anim_entity)
-                      anim_entity:setAnimation(1602)
-                    end)
-    entity:setAnimation(2550)
-  end
+
+  -- Warn a hospital if that is possible.
+  if not entity.tile_x or not entity.tile_y then return end
+  local hosp = self:getHospital(entity.tile_x, entity.tile_y)
+  if hosp then hosp:objectPlaced(entity, id) end
 end
 
 --! Notify the world of an object being removed from a tile


### PR DESCRIPTION
Added a few hospital methods to make a cleaner distinction between hospital and world responsibilities, although the underlying administration is still not correct for multiplayer.

Also, towards having several hospitals at the same time, reduce confusion between `self` hospital and player hospital, and move a bit further away from having `world.hospitals[1]`. Code isn't even close to done yet though.
