### PR TITLE
[rdy]French typo fix (resubmission)

### DIFF
--- a/WindowsInstaller/LanguageStrings.nsh
+++ b/WindowsInstaller/LanguageStrings.nsh
@@ -86,7 +86,7 @@ LangString confirm_removal    ${LANG_FRENCH} "Êtes-vous sûr de vouloir complè
 LangString files_left         ${LANG_FRENCH} "Certains fichiers n'ont pas pu être supprimés."
 LangString options_title      ${LANG_FRENCH} "Options additionnelles"
 LangString options_subtitle   ${LANG_FRENCH} "Préciser où se trouve le jeu original."
-LangString save_in_appdata    ${LANG_FRENCH} "Enregistrer les données de jeu et les paramètres dabs %APPDATA% (recommandé)"
+LangString save_in_appdata    ${LANG_FRENCH} "Enregistrer les données de jeu et les paramètres dans %APPDATA% (recommandé)"
 LangString remove_saves       ${LANG_FRENCH} "Voulez-vous conserver vos parties sauvegardées ?"
 LangString overwrite_install  ${LANG_FRENCH} "Il semble que vous installez par dessus une installation existante de CorsixTH. Tous les changements faits aux fichiers pourraient être perdus. Voulez-vous continuer ?"
 


### PR DESCRIPTION
*Fixes #1710* 's travis failure.

**Describe what the proposed change does**
- Sends the language adjustment to the french installer string hopefully to travis this time.
Thanks @mioux for spotting
