### PR TITLE
[rdy] Move checkFacilities to PlayerHospital

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 145
+local SAVEGAME_VERSION = 146
 
 class "App"
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -630,6 +630,7 @@ function Hospital:afterLoad(old, new)
     self.warmth_msg = nil
     self.thirst_msg = nil
     self.seating_warning = nil
+    self.cash_msg = nil
   end
 
   -- Update other objects in the hospital (added in version 106).
@@ -669,20 +670,6 @@ function Hospital:countSittingStanding()
     end
   end
   return numberSitting, numberStanding
-end
-
-
--- A range of checks to help a new player. These are set days apart and will show no more than once a month
-function Hospital:checkFacilities()
-  local current_date = self.world:date()
-  local day = current_date:dayOfMonth()
-  -- All messages are shown after first 4 months if respective conditions are met
-  if self:isPlayerHospital() and current_date >= Date(1,5) then
-    -- reset all the messages on 28th of each month
-    if day == 28 then
-      self.cash_msg = false
-    end
-  end
 end
 
 --! Called each tick, also called 'hours'. Check hours_per_day in
@@ -895,9 +882,7 @@ function Hospital:onEndDay()
   local pay_this = self.loan*self.interest_rate/365 -- No leap years
   self.acc_loan_interest = self.acc_loan_interest + pay_this
   self.research:researchCost()
-  if self:hasStaffedDesk() then
-    self:checkFacilities()
-  end
+
   self.show_progress_screen_warnings = math.random(1, 3) -- used in progress report to limit warnings
   self.msg_counter = self.msg_counter + 1
   if self.balance < 0 then
@@ -971,15 +956,6 @@ function Hospital:onEndMonth()
   if math.round(self.acc_heating) > 0 then
     self:spendMoney(math.round(self.acc_heating), _S.transactions.heating)
     self.acc_heating = 0
-  end
-  -- how is the bank balance
-  if self:isPlayerHospital() then
-    if self.balance < 1000 and not self.cash_msg then
-      self:cashLow()
-    elseif self.balance > 6000 and self.loan > 0 and not self.cash_ms then
-      self.world.ui.adviser:say(_A.warnings.pay_back_loan)
-    end
-    self.cash_msg = true
   end
   -- Pay interest on loans
   if math.round(self.acc_loan_interest) > 0 then

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -258,20 +258,6 @@ function Hospital:Hospital(world, avail_rooms, name)
   end
 end
 
--- Seasoned players will know these things, but it does not harm to be reminded if there is no staff room or toilet!
-function Hospital:noStaffroom_msg()
-  local staffroom_msg = {
-    (_A.warnings.build_staffroom),
-    (_A.warnings.need_staffroom),
-    (_A.warnings.staff_overworked),
-    (_A.warnings.staff_tired),
-  }
-  if staffroom_msg then
-    self.world.ui.adviser:say(staffroom_msg[math.random(1, #staffroom_msg)])
-    self.staff_room_msg = true
-  end
-end
-
 function Hospital:noToilet_msg()
   local toilet_msg = {
     (_A.warnings.need_toilets),
@@ -716,6 +702,10 @@ function Hospital:afterLoad(old, new)
     return
   end
 
+  if old < 145 then
+    self.staff_room_msg = nil
+  end
+
   -- Update other objects in the hospital (added in version 106).
   if self.epidemic then self.epidemic.afterLoad(old, new) end
   for _, future_epidemic in ipairs(self.future_epidemics_pool) do
@@ -762,10 +752,6 @@ function Hospital:checkFacilities()
   local day = current_date:dayOfMonth()
   -- All messages are shown after first 4 months if respective conditions are met
   if self:isPlayerHospital() and current_date >= Date(1,5) then
-    -- If there is no staff room, remind player of the need to build one
-    if not self.staff_room_msg and day == 3 and self:countRoomOfType("staff_room") == 0 then
-      self:noStaffroom_msg()
-    end
     -- If there is no toilet, remind player of the need to build one
     if not self.toilet_msg and day == 8 and self:countRoomOfType("toilets") == 0 then
       self:noToilet_msg()
@@ -846,7 +832,6 @@ function Hospital:checkFacilities()
 
     -- reset all the messages on 28th of each month
     if day == 28 then
-      self.staff_room_msg = false
       self.toilet_msg = false
       self.bench_msg = false
       self.cash_msg = false

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -310,32 +310,6 @@ function Hospital:warningBench()
   end
 end
 
--- Warn when it is too hot
-function Hospital:warningTooHot()
-  local hot_msg = {
-    (_A.information.initial_general_advice.decrease_heating),
-    (_A.warnings.patients_too_hot),
-    (_A.warnings.patients_getting_hot),
-  }
-  if hot_msg then
-    self.world.ui.adviser:say(hot_msg[math.random(1, #hot_msg)])
-    self.warmth_msg = true
-  end
-end
-
--- Warn when it is too cold
-function Hospital:warningTooCold()
-  local cold_msg = {
-    (_A.information.initial_general_advice.increase_heating),
-    (_A.warnings.patients_very_cold),
-    (_A.warnings.people_freezing),
-  }
-  if cold_msg then
-    self.world.ui.adviser:say(cold_msg[math.random(1, #cold_msg)])
-    self.warmth_msg = true
-  end
-end
-
 function Hospital:warningThirst()
   local thirst_msg = {
     (_A.warnings.patients_thirsty),
@@ -782,9 +756,9 @@ function Hospital:checkFacilities()
       if day == 15 then
         local warmth = self:getAveragePatientAttribute("warmth", 0.3) -- Default value does not result in a message.
         if warmth < 0.22 then
-          self:warningTooCold()
+          self.warmth_msg = true -- Preserve link between patients and staff warmth warnings.
         elseif warmth >= 0.36 then
-          self:warningTooHot()
+          self.warmth_msg = true -- Preserve link between patients and staff warmth warnings.
         end
       end
       -- Are the staff warm enough?

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -310,17 +310,6 @@ function Hospital:warningBench()
   end
 end
 
-function Hospital:warningThirst()
-  local thirst_msg = {
-    (_A.warnings.patients_thirsty),
-    (_A.warnings.patients_thirsty2),
-  }
-  if thirst_msg then
-    self.world.ui.adviser:say(thirst_msg[math.random(1, #thirst_msg)])
-    self.thirst_msg = true
-  end
-end
-
 -- Remind the player when cash is low that a loan might be available
 function Hospital:cashLow()
   -- Don't remind in free build mode or when not controlled by the user.
@@ -668,6 +657,7 @@ function Hospital:afterLoad(old, new)
     self.staff_room_msg = nil
     self.toilet_msg = nil
     self.warmth_msg = nil
+    self.thirst_msg = nil
   end
 
   -- Update other objects in the hospital (added in version 106).
@@ -747,17 +737,6 @@ function Hospital:checkFacilities()
         elseif num_benches < self.patientcount then
           self:warningBench()
         end
-      end
-    end
-
-    -- Are the patients in need of a drink
-    if not self.thirst_msg and day == 24 then
-      local thirst = self:getAveragePatientAttribute("thirst", 0) -- Default value does not result in a message.
-      local thirst_threshold = current_date:year() == 1 and 0.8 or 0.9
-      if thirst > thirst_threshold then
-        self.world.ui.adviser:say(_A.warnings.patients_very_thirsty)
-      elseif thirst > 0.6 then
-        self:warningThirst()
       end
     end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -667,6 +667,7 @@ function Hospital:afterLoad(old, new)
   if old < 145 then
     self.staff_room_msg = nil
     self.toilet_msg = nil
+    self.warmth_msg = nil
   end
 
   -- Update other objects in the hospital (added in version 106).
@@ -749,29 +750,6 @@ function Hospital:checkFacilities()
       end
     end
 
-    -- Now to check how warm or cold patients and staff are. So that we are not bombarded with warmth
-    -- messages if we are told about patients then we won't be told about staff as well in the same month
-    -- And unlike TH we don't want to be told that anyone is too hot or cold when the boiler is broken do we!
-    if not self.warmth_msg and not self.heating.heating_broke then
-      if day == 15 then
-        local warmth = self:getAveragePatientAttribute("warmth", 0.3) -- Default value does not result in a message.
-        if warmth < 0.22 then
-          self.warmth_msg = true -- Preserve link between patients and staff warmth warnings.
-        elseif warmth >= 0.36 then
-          self.warmth_msg = true -- Preserve link between patients and staff warmth warnings.
-        end
-      end
-      -- Are the staff warm enough?
-      if day == 20 then
-        local avgWarmth = self:getAverageStaffAttribute("warmth", 0.25) -- Default value does not result in a message.
-        if avgWarmth < 0.22 then
-          self.world.ui.adviser:say(_A.warnings.staff_very_cold)
-        elseif avgWarmth >= 0.36 then
-          self.world.ui.adviser:say(_A.warnings.staff_too_hot)
-        end
-      end
-    end
-
     -- Are the patients in need of a drink
     if not self.thirst_msg and day == 24 then
       local thirst = self:getAveragePatientAttribute("thirst", 0) -- Default value does not result in a message.
@@ -787,7 +765,6 @@ function Hospital:checkFacilities()
     if day == 28 then
       self.bench_msg = false
       self.cash_msg = false
-      self.warmth_msg = false
       self.thirst_msg = false
       self.seating_warning = 0
     end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -775,11 +775,6 @@ function Hospital:checkFacilities()
       end
     end
 
-    -- Make players more aware of the need for radiators
-    if self:countRadiators() == 0 then
-      self.world.ui.adviser:say(_A.information.initial_general_advice.place_radiators)
-    end
-
     -- Now to check how warm or cold patients and staff are. So that we are not bombarded with warmth
     -- messages if we are told about patients then we won't be told about staff as well in the same month
     -- And unlike TH we don't want to be told that anyone is too hot or cold when the boiler is broken do we!

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -258,18 +258,6 @@ function Hospital:Hospital(world, avail_rooms, name)
   end
 end
 
-function Hospital:noToilet_msg()
-  local toilet_msg = {
-    (_A.warnings.need_toilets),
-    (_A.warnings.build_toilets),
-    (_A.warnings.build_toilet_now),
-  }
-  if toilet_msg then
-    self.world.ui.adviser:say(toilet_msg[math.random(1, #toilet_msg)])
-    self.toilet_msg = true
-  end
-end
-
 -- Give praise where it is due
 function Hospital:praiseBench()
   local bench_msg = {
@@ -704,6 +692,7 @@ function Hospital:afterLoad(old, new)
 
   if old < 145 then
     self.staff_room_msg = nil
+    self.toilet_msg = nil
   end
 
   -- Update other objects in the hospital (added in version 106).
@@ -752,11 +741,6 @@ function Hospital:checkFacilities()
   local day = current_date:dayOfMonth()
   -- All messages are shown after first 4 months if respective conditions are met
   if self:isPlayerHospital() and current_date >= Date(1,5) then
-    -- If there is no toilet, remind player of the need to build one
-    if not self.toilet_msg and day == 8 and self:countRoomOfType("toilets") == 0 then
-      self:noToilet_msg()
-    end
-
     if not self.bench_msg then
       -- How are we for seating, if there are plenty then praise is due, if not the player is warned
       -- check the seating : standing ratio of waiting patients
@@ -832,7 +816,6 @@ function Hospital:checkFacilities()
 
     -- reset all the messages on 28th of each month
     if day == 28 then
-      self.toilet_msg = false
       self.bench_msg = false
       self.cash_msg = false
       self.warmth_msg = false

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -64,6 +64,11 @@ function PlayerHospital:dailyAdvisePlayer()
     }
     self:sayAdvise(toilet_advises)
   end
+
+  -- Make players more aware of the need for radiators
+  if self:countRadiators() == 0 then
+    self:sayAdvise({_A.information.initial_general_advice.place_radiators})
+  end
 end
 
 --! Give an advise to the player.

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -104,6 +104,23 @@ function PlayerHospital:dailyAdvisePlayer()
     end
   end
 
+  -- Are there sufficient drinks available?
+  if day == 24 then
+    -- Check patients thirst, default value does not result in a message.
+    local thirst = self:getAveragePatientAttribute("thirst", 0)
+
+    -- Increase need after the first year.
+    local threshold = current_date:year() == 1 and 0.9 or 0.8
+    if thirst > threshold then
+      self:sayAdvise({_A.warnings.patients_very_thirsty})
+    elseif thirst > 0.6 then
+      local thirst_advises = {
+        _A.warnings.patients_thirsty, _A.warnings.patients_thirsty2,
+      }
+      self:sayAdvise(thirst_advises)
+    end
+  end
+
   -- Reset advise flags at the end of the month.
   if day == 28 then
     self.advise_data.temperature_advise = false

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -23,90 +23,90 @@ class "PlayerHospital" (Hospital)
 ---@type PlayerHospital
 local PlayerHospital = _G["PlayerHospital"]
 
-local NUM_SITTING_RATIOS = 15 -- Number of stored recent sitting ratio measurements.
-local RATIO_INTERVAL = 2 -- Measurement interval in days.
+local num_sitting_ratios = 15 -- Number of stored recent sitting ratio measurements.
+local ratio_interval = 2 -- Measurement interval in days.
 
 function PlayerHospital:PlayerHospital(world, avail_rooms, name)
   self:Hospital(world, avail_rooms, name)
   -- The player hospital in single player can access the Cheat System should they wish to.
   self.hosp_cheats = Cheats(self)
 
-  self.advise_data = { -- Variables handling player advises.
-    temperature_advise = nil, -- Whether the player received advise about room temp.
+  self.adviser_data = { -- Variables handling player advice.
+    temperature_advice = nil, -- Whether the player received advice about room temp.
 
     sitting_ratios = {}, -- Measurements of recent sitting/standing ratios.
     sitting_index = 1 -- Next entry in 'sitting_ratios' to update.
   }
 end
 
---! Give advise to the player at the end of a day.
-function PlayerHospital:dailyAdvisePlayer()
+--! Give advice to the player at the end of a day.
+function PlayerHospital:dailyAdviceChecks()
   local current_date = self.world:date()
   local day = current_date:dayOfMonth()
 
-  -- Wait with all advises until the game has somewhat started.
+  -- Hold any advice back until the game has somewhat started.
   if current_date < Date(1, 5) then
     return
   end
 
   -- Warn about lack of a staff room.
   if day == 3 and self:countRoomOfType("staff_room") == 0 then
-    local staffroom_advises = {
+    local staffroom_advice = {
       _A.warnings.build_staffroom, _A.warnings.need_staffroom,
       _A.warnings.staff_overworked, _A.warnings.staff_tired,
     }
-    self:sayAdvise(staffroom_advises)
+    self:giveAdvice(staffroom_advice)
   end
 
   -- Warn about lack of toilets.
   if day == 8 and self:countRoomOfType("toilets") == 0 then
-    local toilet_advises = {
+    local toilet_advice = {
       _A.warnings.need_toilets, _A.warnings.build_toilets,
       _A.warnings.build_toilet_now,
     }
-    self:sayAdvise(toilet_advises)
+    self:giveAdvice(toilet_advice)
   end
 
   -- Make players more aware of the need for radiators
   if self:countRadiators() == 0 then
-    self:sayAdvise({_A.information.initial_general_advice.place_radiators})
+    self:giveAdvice({_A.information.initial_general_advice.place_radiators})
   end
 
   -- Verify patients well-being with respect to room temperature.
-  if day == 15 and not self.advise_data.temperature_advise
+  if day == 15 and not self.adviser_data.temperature_advice
       and not self.heating.heating_broke then
     -- Check patients warmth, default value does not result in a message.
     local warmth = self:getAveragePatientAttribute("warmth", 0.3)
     if warmth < 0.22 then
-      local cold_advises = {
+      local cold_advice = {
         _A.information.initial_general_advice.increase_heating,
         _A.warnings.patients_very_cold, _A.warnings.people_freezing,
       }
-      self:sayAdvise(cold_advises)
-      self.advise_data.temperature_advise = true
+      self:giveAdvice(cold_advice)
+      self.adviser_data.temperature_advice = true
 
     elseif warmth >= 0.36 then
-      local hot_advises = {
+      local hot_advice = {
         _A.information.initial_general_advice.decrease_heating,
         _A.warnings.patients_too_hot, _A.warnings.patients_getting_hot,
       }
-      self:sayAdvise(hot_advises)
-      self.advise_data.temperature_advise = true
+      self:giveAdvice(hot_advice)
+      self.adviser_data.temperature_advice = true
     end
   end
 
   -- Verify staff well-being with respect to room temperature.
-  if day == 20 and not self.advise_data.temperature_advise
+  if day == 20 and not self.adviser_data.temperature_advice
       and not self.heating.heating_broke then
     -- Check staff warmth, default value does not result in a message.
     local warmth = self:getAverageStaffAttribute("warmth", 0.25)
     if warmth < 0.22 then
-      self:sayAdvise({_A.warnings.staff_very_cold})
-      self.advise_data.temperature_advise = true
+      self:giveAdvice({_A.warnings.staff_very_cold})
+      self.adviser_data.temperature_advice = true
 
     elseif warmth >= 0.36 then
-      self:sayAdvise({_A.warnings.staff_too_hot})
-      self.advise_data.temperature_advise = true
+      self:giveAdvice({_A.warnings.staff_too_hot})
+      self.adviser_data.temperature_advice = true
     end
   end
 
@@ -118,26 +118,26 @@ function PlayerHospital:dailyAdvisePlayer()
     -- Increase need after the first year.
     local threshold = current_date:year() == 1 and 0.9 or 0.8
     if thirst > threshold then
-      self:sayAdvise({_A.warnings.patients_very_thirsty})
+      self:giveAdvice({_A.warnings.patients_very_thirsty})
     elseif thirst > 0.6 then
-      local thirst_advises = {
+      local thirst_advice = {
         _A.warnings.patients_thirsty, _A.warnings.patients_thirsty2,
       }
-      self:sayAdvise(thirst_advises)
+      self:giveAdvice(thirst_advice)
     end
   end
 
   -- Track sitting / standing ratio of patients.
-  if day % RATIO_INTERVAL == 0 then
+  if day % ratio_interval == 0 then
     -- Compute the ratio of today.
     local num_sitting, num_standing = self:countSittingStanding()
     local ratio = (num_sitting + num_standing > 10)
         and num_sitting / (num_sitting + num_standing) or nil
 
     -- Store the measured ratio.
-    self.advise_data.sitting_ratios[self.advise_data.sitting_index] = ratio
-    self.advise_data.sitting_index = (self.advise_data.sitting_index >= NUM_SITTING_RATIOS)
-        and 1 or self.advise_data.sitting_index + 1
+    self.adviser_data.sitting_ratios[self.adviser_data.sitting_index] = ratio
+    self.adviser_data.sitting_index = (self.adviser_data.sitting_index >= num_sitting_ratios)
+        and 1 or self.adviser_data.sitting_index + 1
   end
 
   -- Check for enough (well-placed) benches.
@@ -145,8 +145,8 @@ function PlayerHospital:dailyAdvisePlayer()
     -- Compute average sitting ratio.
     local sum_ratios = 0
     local index = 1
-    while index <= NUM_SITTING_RATIOS do
-      local ratio = self.advise_data.sitting_ratios[index]
+    while index <= num_sitting_ratios do
+      local ratio = self.adviser_data.sitting_ratios[index]
       if ratio == nil then
         sum_ratios = nil
         break
@@ -158,54 +158,55 @@ function PlayerHospital:dailyAdvisePlayer()
     end
 
     if sum_ratios ~= nil then -- Sufficient data available.
-      local ratio = sum_ratios / NUM_SITTING_RATIOS
+      local ratio = sum_ratios / num_sitting_ratios
       if ratio < 0.7 then -- At least 30% standing.
-        local bench_advises = {
+        local bench_advice = {
           _A.warnings.more_benches, _A.warnings.people_have_to_stand,
         }
-        self:sayAdvise(bench_advises)
+        self:giveAdvice(bench_advice)
 
       elseif ratio > 0.9 then
         -- Praise having enough well placed seats about once a year.
-        local bench_advises = {
+        local bench_advice = {
           _A.praise.many_benches, _A.praise.plenty_of_benches,
           _A.praise.few_have_to_stand,
         }
-        self:sayAdvise(bench_advises, 1/12)
+        self:giveAdvice(bench_advice, 1/12)
       end
     end
   end
 
   -- Reset advise flags at the end of the month.
   if day == 28 then
-    self.advise_data.temperature_advise = false
+    self.adviser_data.temperature_advice = false
   end
 end
 
---! Give advise to the player at the end of a month.
-function PlayerHospital:monthlyAdvisePlayer()
+--! Give advice to the player at the end of a month.
+function PlayerHospital:monthlyAdviceChecks()
   if not self.world.free_build_mode then
     if self.balance < 2000 and self.balance >= -500 then
-      local cashlow_advises = {
+      local cashlow_advice = {
         _A.warnings.money_low, _A.warnings.money_very_low_take_loan,
         _A.warnings.cash_low_consider_loan,
       }
-      self:sayAdvise(cashlow_advises)
+      self:giveAdvice(cashlow_advice)
 
     elseif self.balance < -2000 and self.world:date():monthOfYear() > 8 then
       -- TODO: Ideally this should be linked to the lose criteria for balance.
-      self:sayAdvise({_A.warnings.bankruptcy_imminent})
+      self:giveAdvice({_A.warnings.bankruptcy_imminent})
 
     elseif self.balance > 6000 and self.loan > 0 then
-      self:sayAdvise({_A.warnings.pay_back_loan})
+      self:giveAdvice({_A.warnings.pay_back_loan})
     end
   end
 end
 
---! Give an advise to the player.
+--! Advises the player.
 --!param msgs (array of string) Messages to select from.
---!param rnd_frac (optional float in range (0, 1]) Fraction of times that the call actually says something.
-function PlayerHospital:sayAdvise(msgs, rnd_frac)
+--!param rnd_frac (optional float in range (0, 1]) Fraction of times that the
+--    call actually says something.
+function PlayerHospital:giveAdvice(msgs, rnd_frac)
   local max_rnd = #msgs
   if rnd_frac and rnd_frac > 0 and rnd_frac < 1 then
     -- Scale by the fraction.
@@ -220,7 +221,7 @@ end
 function PlayerHospital:onEndDay()
   -- Advise the player.
   if self:hasStaffedDesk() then
-    self:dailyAdvisePlayer()
+    self:dailyAdviceChecks()
   end
 
   Hospital.onEndDay(self)
@@ -230,7 +231,7 @@ end
 function PlayerHospital:onEndMonth()
   -- Advise the player on cash flow.
   if self:hasStaffedDesk() then
-    self:monthlyAdvisePlayer()
+    self:monthlyAdviceChecks()
   end
 
   Hospital.onEndMonth(self)
@@ -241,7 +242,7 @@ function PlayerHospital:afterLoad(old, new)
     self.hosp_cheats = Cheats(self)
   end
   if old < 146 then
-    self.advise_data = {
+    self.adviser_data = {
       temperature_advise = nil,
       sitting_ratios = {},
       sitting_index = 1

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -182,6 +182,26 @@ function PlayerHospital:dailyAdvisePlayer()
   end
 end
 
+--! Give advise to the player at the end of a month.
+function PlayerHospital:monthlyAdvisePlayer()
+  if not self.world.free_build_mode then
+    if self.balance < 2000 and self.balance >= -500 then
+      local cashlow_advises = {
+        _A.warnings.money_low, _A.warnings.money_very_low_take_loan,
+        _A.warnings.cash_low_consider_loan,
+      }
+      self:sayAdvise(cashlow_advises)
+
+    elseif self.balance < -2000 and self.world:date():monthOfYear() > 8 then
+      -- TODO: Ideally this should be linked to the lose criteria for balance.
+      self:sayAdvise({_A.warnings.bankruptcy_imminent})
+
+    elseif self.balance > 6000 and self.loan > 0 then
+      self:sayAdvise({_A.warnings.pay_back_loan})
+    end
+  end
+end
+
 --! Give an advise to the player.
 --!param msgs (array of string) Messages to select from.
 --!param rnd_frac (optional float in range (0, 1]) Fraction of times that the call actually says something.
@@ -204,6 +224,16 @@ function PlayerHospital:onEndDay()
   end
 
   Hospital.onEndDay(self)
+end
+
+-- Called at the end of each day.
+function PlayerHospital:onEndMonth()
+  -- Advise the player on cash flow.
+  if self:hasStaffedDesk() then
+    self:monthlyAdvisePlayer()
+  end
+
+  Hospital.onEndMonth(self)
 end
 
 function PlayerHospital:afterLoad(old, new)

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -89,6 +89,21 @@ function PlayerHospital:dailyAdvisePlayer()
     end
   end
 
+  -- Verify staff well-being with respect to room temperature.
+  if day == 20 and not self.advise_data.temperature_advise
+      and not self.heating.heating_broke then
+    -- Check staff warmth, default value does not result in a message.
+    local warmth = self:getAverageStaffAttribute("warmth", 0.25)
+    if warmth < 0.22 then
+      self:sayAdvise({_A.warnings.staff_very_cold})
+      self.advise_data.temperature_advise = true
+
+    elseif warmth >= 0.36 then
+      self:sayAdvise({_A.warnings.staff_too_hot})
+      self.advise_data.temperature_advise = true
+    end
+  end
+
   -- Reset advise flags at the end of the month.
   if day == 28 then
     self.advise_data.temperature_advise = false

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -55,6 +55,15 @@ function PlayerHospital:dailyAdvisePlayer()
     }
     self:sayAdvise(staffroom_advises)
   end
+
+  -- Warn about lack of toilets.
+  if day == 8 and self:countRoomOfType("toilets") == 0 then
+    local toilet_advises = {
+      _A.warnings.need_toilets, _A.warnings.build_toilets,
+      _A.warnings.build_toilet_now,
+    }
+    self:sayAdvise(toilet_advises)
+  end
 end
 
 --! Give an advise to the player.


### PR DESCRIPTION
*Fixes emptiness of player hospital

**Describe what the proposed change does**
- Moved an advise function from `Hospital` to `PlayerHospital`, and cleaned it up.

In more detail:
- All the functions that merely selected and said an advice removed (called from 1 location and not long)
- A lot of flags were useless, as the advise is given at most once a month (selected by day), and the end of the month cleared the flag again.
- Renamed `checkFacilities` to `daily/monthlyAdvisePlayer`

- Bench checking didn't make much sense.
  - It compared with the entire patient population, rather than directly comparing sitting and standing patients.
  - It just checked at a some point without tracking the general status (found by Lewri).
  - Number of benches is quite irrelevant, the deciding factor is whether patients can sit down.
  - Praising 'sufficient benches' is not when you have a bench for each patient.

- Drinks had a tougher requirement in the first year.

- Bank balance advise had a (useless) flag in `checkFacilities` so got moved as well. The `cashLow` function had some logic as well, which was merged.

- Added a `sayAdvise` function that deals with message selection.