### PR TITLE
[rdy] Fix Cheats for new games

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 143
+local SAVEGAME_VERSION = 144
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -283,7 +283,7 @@ end
 
 function UIFax:cheatByFax()
   local cheatWindow = self.ui:getWindow(UICheats)
-  local cheat = self.ui.hospital.hosp_cheats
+  local cheat = self.ui.hosp_cheats
   cheat:announceCheat()
   -- If a cheats window is open, make sure the UI is updated
   if cheatWindow then

--- a/CorsixTH/Lua/dialogs/resizables/cheats_dialog.lua
+++ b/CorsixTH/Lua/dialogs/resizables/cheats_dialog.lua
@@ -59,8 +59,8 @@ local col_cheated_yes = {
 !param ui (UI) The active ui.
 ]]
 function UICheats:UICheats(ui)
-  self.cheats = ui.hospital.hosp_cheats
-  self.cheat_list = ui.hospital.hosp_cheats.cheat_list
+  self.cheats = ui.hosp_cheats
+  self.cheat_list = ui.hosp_cheats.cheat_list
 
   self:UIResizable(ui, 300, 200, col_bg)
 
@@ -132,7 +132,7 @@ function UICheats:buttonBack()
 end
 
 function UICheats:afterLoad(old, new)
-  if old < 141 then
+  if old < 144 then
     -- Window must be closed if open for compatibility
     local cheatWindow = self.ui:getWindow(UICheats)
     if cheatWindow then

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -29,8 +29,6 @@ local Hospital = _G["Hospital"]
 
 function Hospital:Hospital(world, avail_rooms, name)
   self.world = world
-  -- Initialise Cheats inside the player hospital
-  self.hosp_cheats = Cheats(self.world.ui)
   local level_config = world.map.level_config
   local level = world.map.level_number
   local balance = 40000
@@ -689,10 +687,6 @@ function Hospital:afterLoad(old, new)
     self.has_impressive_reputation = self.reputation_above_threshold and true or false
     self.reputation_above_threshold = nil
     self:unconditionalChangeReputation(0) -- Setup 'has_impressive_reputation'
-  end
-
-  if old < 141 then
-    self.hosp_cheats = Cheats(self.world.ui)
   end
 
   if old < 142 then

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -139,6 +139,7 @@ function UI:UI(app, minimal)
   self:Window()
   self:initKeyAndButtonCodes()
   self.app = app
+  self.hosp_cheats = Cheats(self)
   self.screen_offset_x = 0
   self.screen_offset_y = 0
   self.cursor = nil
@@ -1172,3 +1173,10 @@ end
 
 -- Stub for compatibility with savegames r1896-1921
 function UI:stopVideo() end
+
+function UI:afterLoad(old, new)
+  if old < 144 then
+    self.hosp_cheats = Cheats(self)
+  end
+  Window.afterLoad(self, old, new)
+end


### PR DESCRIPTION
*Fixes new games crashing on the Cheats window.*

**Describe what the proposed change does**
- Temporarily moves Cheats out of hospital and into UI
- Has an open issue to recode Cheats #1718 back into playerhospital (or world)
- PR hotfix just so trunk isn't broken.
