### PR TITLE
Always query the game date from world:date()

### DIFF
--- a/CorsixTH/Lua/announcer.lua
+++ b/CorsixTH/Lua/announcer.lua
@@ -157,7 +157,7 @@ function Announcer:playAnnouncement(name, priority, decay_hours, played_callback
   -- already has had several other jobs and has died already [joke].
 
   -- Check for duplicate announcements, if there is we refresh the existing one
-  local created_date = self.app.world.game_date:clone()
+  local created_date = self.app.world:date()
   local duplicate_announcement = self.entries:checkForDuplicates(name, created_date)
   if duplicate_announcement then
     return
@@ -199,7 +199,7 @@ function Announcer:onTick()
     if staffedDesk or criticalAnnounces > 0 then
       while not self.playing and not self.entries:isEmpty() do
         local entry = self.entries:pop()
-        local game_date = self.app.world.game_date
+        local game_date = self.app.world:date()
 
         if entry.decay_hours == -1 or game_date <= entry.created_date:plusHours(entry.decay_hours) then
           if self.app.config.play_announcements then

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -105,7 +105,7 @@ function World:World(app)
   self.hours_per_tick = 1
   self.tick_rate = 3
   self.tick_timer = 0
-  self.game_date = Date()
+  self.game_date = Date() -- Current date in the game.
 
   self.room_information_dialogs = app.config.room_information_dialogs
   -- This is false when the game is paused.
@@ -2691,6 +2691,8 @@ function World:isTileExclusivelyPassable(x, y, distance)
   return true
 end
 
+--! Get todays date.
+--!return (Date) Current game date.
 function World:date()
   return self.game_date:clone()
 end

--- a/CorsixTH/Luatest/spec/announcer_spec.lua
+++ b/CorsixTH/Luatest/spec/announcer_spec.lua
@@ -39,15 +39,15 @@ end
 local create_date_mock = create_date_mock_type()
 
 local function create_app_mock(speed_set, desk_set)
-  local world_mock = {
-    game_date = create_date_mock(),
-    isCurrentSpeed = function() return speed_set end,
-    getLocalPlayerHospital = function()
-      return {
-        hasStaffedDesk = function() return desk_set end
-      }
-    end
-  }
+  local world_mock = {}
+  world_mock.mock_game_date = create_date_mock()
+  world_mock.date = function() return world_mock.mock_game_date end
+  world_mock.isCurrentSpeed = function() return speed_set end
+  world_mock.getLocalPlayerHospital = function()
+    return {
+      hasStaffedDesk = function() return desk_set end
+    }
+  end
 
   local config_mock = {
     play_announcements = true
@@ -184,7 +184,7 @@ describe("Announcer", function()
     local announcer = Announcer(app_mock)
 
     announcer:playAnnouncement("normal.wav")
-    app_mock.world.game_date = app_mock.world.game_date:plusHours(1000) -- time must be after announcement
+    app_mock.world.mock_game_date = app_mock.world.mock_game_date:plusHours(1000) -- time must be after announcement
 
     announcer:onTick()
     assert.equal(0, #app_mock.audio.__played_sounds__)


### PR DESCRIPTION
*Fixes external use of `world.game_date`

**Describe what the proposed change does**
- Replace the last few uses of `world.game_date` by `world:date()`.
- Document the meaning of `world.game_date`.
