### PR TITLE
[RDY] Handymen announcements more often

### DIFF
--- a/CorsixTH/Lua/calls_dispatcher.lua
+++ b/CorsixTH/Lua/calls_dispatcher.lua
@@ -121,11 +121,19 @@ function CallsDispatcher:callForRepair(object, urgent, manual, lock_room)
   end
 
   if not manual and urgent then
+    local earthquake = object.world.next_earthquake
     local room = object:getRoom()
     local sound = room.room_info.handyman_call_sound
     if sound then
-      ui:playAnnouncement(sound, AnnouncementPriority.High)
-      ui:playSound("machwarn.wav")
+      if earthquake.active and earthquake.warning_timer == 0 then
+        if not earthquake.machwarn_trigger then
+          ui:playAnnouncement("machwarn.wav", AnnouncementPriority.Critical)
+          earthquake.machwarn_trigger = true
+        end
+      else
+        ui:playAnnouncement("machwarn.wav", AnnouncementPriority.Critical)
+        ui:playAnnouncement(sound, AnnouncementPriority.Critical)
+      end
     end
     message = _A.warnings.machines_falling_apart
   end

--- a/CorsixTH/Lua/calls_dispatcher.lua
+++ b/CorsixTH/Lua/calls_dispatcher.lua
@@ -121,20 +121,6 @@ function CallsDispatcher:callForRepair(object, urgent, manual, lock_room)
   end
 
   if not manual and urgent then
-    local earthquake = object.world.next_earthquake
-    local room = object:getRoom()
-    local sound = room.room_info.handyman_call_sound
-    if sound then
-      if earthquake.active and earthquake.warning_timer == 0 then
-        if not earthquake.machwarn_trigger then
-          ui:playAnnouncement("machwarn.wav", AnnouncementPriority.Critical)
-          earthquake.machwarn_trigger = true
-        end
-      else
-        ui:playAnnouncement("machwarn.wav", AnnouncementPriority.Critical)
-        ui:playAnnouncement(sound, AnnouncementPriority.Critical)
-      end
-    end
     message = _A.warnings.machines_falling_apart
   end
   if message then

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -75,18 +75,11 @@ end
 function Machine:announceRepair(room)
   local sound = room.room_info.handyman_call_sound
   local earthquake = self.world.next_earthquake
-  -- If an earthquake is happening limit the amount of machine warnings
-  if earthquake.active and earthquake.warning_timer == 0 then
-    if not earthquake.machwarn_trigger then
-      self.world.ui:playAnnouncement("machwarn.wav", AnnouncementPriority.Critical)
-      earthquake.machwarn_trigger = true -- resets with each damage phase
-    end
-  else
-    -- TODO: Don't announce handyman call sound if there are no handymen
-    -- Must be same priority
-    self.world.ui:playAnnouncement("machwarn.wav", AnnouncementPriority.Critical)
-    if sound then self.world.ui:playAnnouncement(sound, AnnouncementPriority.Critical) end
-  end
+  self.world.ui:playAnnouncement("machwarn.wav", AnnouncementPriority.Critical)
+  -- If an earthquake is happening don't play the call sound to prevent spamming
+  if earthquake.active and earthquake.warning_timer == 0 then return end
+  -- TODO: Don't announce handyman call sound if there are no handymen
+  if sound then self.world.ui:playAnnouncement(sound, AnnouncementPriority.Critical) end
 end
 
 --! Set whether the smoke animation should be showing

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -87,7 +87,7 @@ function Machine:announceRepair(room)
     if sound then self.world.ui:playAnnouncement(sound, AnnouncementPriority.Critical) end
   end
 end
-  
+
 --! Set whether the smoke animation should be showing
 local function setSmoke(self, isSmoking)
   -- If turning smoke on for this machine
@@ -179,8 +179,8 @@ function Machine:machineUsed(room)
       self.hospital:addHandymanTask(self, "repairing", 2, self.tile_x, self.tile_y, call)
       self:announceRepair(room)
     else -- Otherwise the task is already queued. Increase the priority to above that of machines with at least 4 uses left
-      local subTable = self.hospital:findHandymanTaskSubtable("repairing")
-      if subTable[taskIndex].priority == 1 then
+       -- Upgrades task from low (1) priority to high (2) priority
+      if self.hospital:getHandymanTaskPriority(taskIndex, "repairing") == 1 then
         self.hospital:modifyHandymanTaskPriority(taskIndex, 2, "repairing")
         self:announceRepair(room)
       end

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -82,6 +82,7 @@ function Machine:announceRepair(room)
       earthquake.machwarn_trigger = true -- resets with each damage phase
     end
   else
+    -- TODO: Don't announce handyman call sound if there are no handymen
     -- Must be same priority
     self.world.ui:playAnnouncement("machwarn.wav", AnnouncementPriority.Critical)
     if sound then self.world.ui:playAnnouncement(sound, AnnouncementPriority.Critical) end

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -20,6 +20,10 @@ SOFTWARE. --]]
 
 local TH = require("TH")
 
+corsixth.require("announcer")
+
+local AnnouncementPriority = _G["AnnouncementPriority"]
+
 --! An `Object` which needs occasional repair (to prevent explosion).
 class "Machine" (Object)
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2297,10 +2297,22 @@ function Hospital:removeRatholeXY(x, y)
   end
 end
 
+--! Adds a handyman task
+--!param object The object needing attention
+--!param taskType The handyman task type: repairing, watering, cleaning
+--!param priority Task priority: 1 is low, 2 is high
+--!param x co-ordinate
+--!param y co-ordinate
+--!param call The call added to the disptacher
 function Hospital:addHandymanTask(object, taskType, priority, x, y, call)
   local parcelId = self.world.map.th:getCellFlags(x, y).parcelId
   local subTable = self:findHandymanTaskSubtable(taskType)
   table.insert(subTable, {["object"] = object, ["priority"] = priority, ["tile_x"] = x, ["tile_y"] = y, ["parcelId"] = parcelId, ["call"] = call})
+end
+
+function Hospital:getHandymanTaskPriority(taskIndex, taskType)
+  local subTable = self:findHandymanTaskSubtable(taskType)
+  return subTable[taskIndex].priority
 end
 
 function Hospital:modifyHandymanTaskPriority(taskIndex, newPriority, taskType)

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2303,13 +2303,17 @@ end
 --!param priority Task priority: 1 is low, 2 is high
 --!param x co-ordinate
 --!param y co-ordinate
---!param call The call added to the disptacher
+--!param call The call added to the dispatcher
 function Hospital:addHandymanTask(object, taskType, priority, x, y, call)
   local parcelId = self.world.map.th:getCellFlags(x, y).parcelId
   local subTable = self:findHandymanTaskSubtable(taskType)
   table.insert(subTable, {["object"] = object, ["priority"] = priority, ["tile_x"] = x, ["tile_y"] = y, ["parcelId"] = parcelId, ["call"] = call})
 end
 
+--! Queries the priority of an existing handyman task
+--!param taskIndex (integer) Number of task
+--!param taskType The handyman task type: repairing, watering, cleaning
+--!return Priority of task
 function Hospital:getHandymanTaskPriority(taskIndex, taskType)
   local subTable = self:findHandymanTaskSubtable(taskType)
   return subTable[taskIndex].priority

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -99,7 +99,6 @@ function World:World(app)
   -- remaining_damage (integer) The amount of damage this earthquake has yet to inflict.
   -- damage_timer (integer) The number of hours until the earthquake next inflicts damage if active.
   -- warning_timer (integer) The number of hours left until the real damaging earthquake begins.
-  -- machwarn_trigger (boolean) True if any machine has already announced it is breaking during a damage phase (resets each phase)
   self.next_earthquake = { active = false }
 
   -- Time
@@ -648,7 +647,6 @@ function World:tickEarthquake()
 
       self.next_earthquake.remaining_damage = self.next_earthquake.remaining_damage - 1
       self.next_earthquake.damage_timer = self.next_earthquake.damage_timer + earthquake_damage_time
-      self.next_earthquake.machwarn_trigger = false
     end
 
     local hospital = self:getLocalPlayerHospital()
@@ -1350,7 +1348,6 @@ function World:nextEarthquake()
     self.next_earthquake.damage_timer = earthquake_damage_time
     self.next_earthquake.warning_timer = earthquake_warning_period
     self.current_map_earthquake = self.current_map_earthquake + 1
-    self.next_earthquake.machwarn_trigger = false
   end
 end
 
@@ -1366,7 +1363,6 @@ function World:createEarthquake()
       self.next_earthquake.remaining_damage = self.next_earthquake.size
       self.next_earthquake.damage_timer = earthquake_damage_time
       self.next_earthquake.warning_timer = earthquake_warning_period
-      self.next_earthquake.machwarn_trigger = false
     end
   end
 end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -99,6 +99,7 @@ function World:World(app)
   -- remaining_damage (integer) The amount of damage this earthquake has yet to inflict.
   -- damage_timer (integer) The number of hours until the earthquake next inflicts damage if active.
   -- warning_timer (integer) The number of hours left until the real damaging earthquake begins.
+  -- machwarn_trigger (boolean) True if a machine has already announced it is breaking during a damage phase (resets each phase)
   self.next_earthquake = { active = false }
 
   -- Time

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -647,6 +647,7 @@ function World:tickEarthquake()
 
       self.next_earthquake.remaining_damage = self.next_earthquake.remaining_damage - 1
       self.next_earthquake.damage_timer = self.next_earthquake.damage_timer + earthquake_damage_time
+      self.next_earthquake.machwarn_trigger = false
     end
 
     local hospital = self:getLocalPlayerHospital()
@@ -1348,6 +1349,7 @@ function World:nextEarthquake()
     self.next_earthquake.damage_timer = earthquake_damage_time
     self.next_earthquake.warning_timer = earthquake_warning_period
     self.current_map_earthquake = self.current_map_earthquake + 1
+    self.next_earthquake.machwarn_trigger = false
   end
 end
 
@@ -1363,6 +1365,7 @@ function World:createEarthquake()
       self.next_earthquake.remaining_damage = self.next_earthquake.size
       self.next_earthquake.damage_timer = earthquake_damage_time
       self.next_earthquake.warning_timer = earthquake_warning_period
+      self.next_earthquake.machwarn_trigger = false
     end
   end
 end

--- a/CorsixTH/Luatest/spec/entities/machine_spec.lua
+++ b/CorsixTH/Luatest/spec/entities/machine_spec.lua
@@ -17,9 +17,11 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
+require("corsixth")
 
 require("class_test_base")
 
+require("announcer")
 require("entity")
 require("entities/object")
 require("entities/machine")


### PR DESCRIPTION
*Fixes #1649*

**Describe what the proposed change does**
- Handyman repair announcements now trigger if base strength was >6. Originally they only triggered if base strength was <4
- Also ensures earthquakes don't make the announcer get spammed.

I expect some tidying up needed on this. At the moment this was to get it out of my old test environment.
