### PR TITLE
[RDY] Emergency balance changes

### DIFF
--- a/CorsixTH/Lua/dialogs/watch.lua
+++ b/CorsixTH/Lua/dialogs/watch.lua
@@ -25,6 +25,10 @@ class "UIWatch" (Window)
 ---@type UIWatch
 local UIWatch = _G["UIWatch"]
 
+local TICK_DAYS = 100
+local TICK_DAYS_EMERGENCY = 52
+local TIMER_SEGMENTS = 13
+
 --!param count_type (string) One of: "open_countdown" or "emergency" or "epidemic"
 function UIWatch:UIWatch(ui, count_type)
   self:Window()
@@ -33,8 +37,13 @@ function UIWatch:UIWatch(ui, count_type)
 
   self.esc_closes = false
   self.modal_class = "open_countdown"
-  self.tick_rate = math.floor((100 * Date.hoursPerDay()) / 13)
-  self.tick_timer = self.tick_rate  -- Initialize tick timer
+  if count_type == "emergency" then
+    self.tick_rate = math.floor((TICK_DAYS_EMERGENCY * Date.hoursPerDay()) / TIMER_SEGMENTS)
+    self.tick_timer = self.tick_rate
+  else
+    self.tick_rate = math.floor((TICK_DAYS * Date.hoursPerDay()) / TIMER_SEGMENTS)
+    self.tick_timer = self.tick_rate  -- Initialize tick timer
+  end
   self.open_timer = 12
   self.ui = ui
   self.hospital = ui.hospital

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -251,7 +251,7 @@ moods("cold",           3994,       0,       true) -- These have no priority sin
 moods("hot",            3988,       0,       true) -- they will be shown when hovering
 moods("queue",          4568,      70)             -- no matter what other priorities.
 moods("poo",            3996,       5)
-moods("sad_money",      4018,      50)
+moods("sad_money",      4018,      55)
 moods("patient_wait",   5006,      40)
 moods("epidemy1",       4566,      55)
 moods("epidemy2",       4570,      55)

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1116,7 +1116,8 @@ function Hospital:resolveEmergency()
   local emer = self.emergency
   local rescued_patients = emer.cured_emergency_patients
   for _, patient in ipairs(self.emergency_patients) do
-    if patient and not patient.cured and not patient.dead and not patient:getRoom() then
+    if patient and not patient.cured and not patient.dead
+        and not patient.going_home and not patient:getRoom() then
       patient:die()
     end
   end
@@ -1851,6 +1852,11 @@ function Hospital:updateNotCuredCounts(patient, reason)
   if reason == "kicked" then
     local casebook = self.disease_casebook[patient.disease.id]
     casebook.turned_away = casebook.turned_away + 1
+  end
+
+  -- though not killed allows timer to close early
+  if patient.is_emergency then
+    self.emergency.killed_emergency_patients = self.emergency.killed_emergency_patients + 1
   end
 end
 


### PR DESCRIPTION
*Fixes # nothing in particular*

**Describe what the proposed change does**
- Emergency timers are around 50 days, I just made it 52 for the even segmentation for the timer
- Helicopter arrives later, more consistent with the original and the patients spawn slightly further apart, half a day
- The ability for emergency patients to leave due to cost. - Corsix allows you to accept an emergency and increase the cost and patients just pay it. ~~Likewise this change locks the last accepted price in, thus all emergency patients pay the same. These are features of the original.~~ 
![image](https://user-images.githubusercontent.com/8009292/95635915-1dd6ef80-0ad1-11eb-9431-fd8f4b8033ee.png)
- sad_money priority bumped up so shows on refusing to pay emergency patients, but shouldn't on epidemy# ones when they leave (same priority)
- different to the original - if you kick or they refuse to pay - the timer is cut short at the earliest opportunity
- dynamic info displays 'Emergency: %s' instead of 'Diagnosed: %s' and was the reason I just jumbled Helicopter:spawnPatient so it was set initially to Emergency instead of having to update it due to the issue below it wasn't technically required
- Addressed the comment https://github.com/CorsixTH/CorsixTH/issues/1173#issuecomment-630137026
- Patient:goHome updates to use existing local variable and reflect the original with dynamic info in the evacuated/over priced of using the middle text line

The patient:agreesToPay I just manipulated for testing, I didn't run it through a natural run to see how discerning it is.
