### PR TITLE
[rdy] Move more advice to player hospital

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 146
+local SAVEGAME_VERSION = 147
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
@@ -173,7 +173,7 @@ function UITownMap:draw(canvas, x, y)
   -- and radiators.
   -- NB: original TH's patient count was always 1 too big (started counting at 1)
   -- This is likely a bug and we do not copy this behavior.
-  local patientcount = hospital.patientcount
+  local patientcount = hospital:countPatients()
   local plants = hospital:countPlants()
   local fireext = hospital:countFireExtinguishers()
   local objs = hospital:countGeneralObjects()

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1635,6 +1635,7 @@ function Hospital:objectPlaced(entity, id)
         end
       end
     end
+    return
   end
 
   if id == "reception_desk" then
@@ -1648,16 +1649,8 @@ function Hospital:objectPlaced(entity, id)
   end
 
   if id == "gates_to_hell" then
-    if self:isPlayerHospital() then
-      entity:playEntitySounds("LAVA00*.WAV", {0,1350,1150,950,750,350},
-          {0,1450,1250,1050,850,450}, 40)
-      entity:setTimer(entity.world:getAnimLength(2550),
-                      --[[persistable:lava_hole_spawn_animation_end]]
-                      function(anim_entity)
-                        anim_entity:setAnimation(1602)
-                      end)
-      entity:setAnimation(2550)
-    end
+    self:showGatesToHell(entity)
+    return
   end
 end
 
@@ -1668,6 +1661,12 @@ end
 
 --! Give advice to the user about maintenance of plants.
 function Hospital:msgPlant()
+  -- Nothing to do, override in a sub-class.
+end
+
+--! Show the 'Gates to hell' animation.
+--!param _entity (Entity) Gates to hell.
+function Hospital:showGatesToHell(_entity)
   -- Nothing to do, override in a sub-class.
 end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -660,23 +660,6 @@ end
 --! Called each tick, also called 'hours'. Check hours_per_day in
 --! date.lua to see how many times per day this is.
 function Hospital:tick()
--- add some random background sounds, ringing phones, coughing, belching etc
-  local sounds = {
-  "ispot001.wav", "ispot002.wav", "ispot003.wav", "ispot004.wav", "ispot005.wav", "ispot006.wav", "ispot007.wav", "ispot008.wav",
-  "ispot009.wav", "ispot010.wav", "ispot011.wav", "ispot012.wav", "ispot013.wav", "ispot014.wav", "ispot015.wav", "ispot016.wav",
-  "ispot017.wav", "ispot018.wav", "ispot019.wav", "ispot020.wav", "ispot021.wav", "ispot022.wav", "ispot023.wav", "ispot024.wav",
-  "ispot025.wav"
-  } -- ispot026 and ispot027 are both toilet related sounds
--- wait until there are some patients in the hospital and a room, otherwise you will wonder who is coughing or who is the
--- receptionist telephoning! opted for gp as you can't run the hospital without one.
-  if self:countRoomOfType("gp") > 0 and self:countPatients(3) > 2 then
-    if math.random(1, 100) == 3 then
-      local sound_to_play = sounds[math.random(1, #sounds)]
-      if TheApp.audio:soundExists(sound_to_play) then
-        self.world.ui:playSound(sound_to_play)
-      end
-    end
-  end
   self:manageEpidemics()
 end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -284,26 +284,6 @@ function Hospital:msgKilled()
   end
 end
 
--- Remind the player when cash is low that a loan might be available
-function Hospital:cashLow()
-  -- Don't remind in free build mode or when not controlled by the user.
-  if self.world.free_build_mode or not self:isPlayerHospital() then
-    return
-  end
-
-  local cashlowmessage = {
-    (_A.warnings.money_low),
-    (_A.warnings.money_very_low_take_loan),
-    (_A.warnings.cash_low_consider_loan),
-  }
-  if self.balance < 2000 and self.balance >= -500 then
-    self.world.ui.adviser:say(cashlowmessage[math.random(1, #cashlowmessage)])
-  elseif self.balance < -2000 and self.world:date():monthOfYear() > 8 then
-    -- ideally this should be linked to the lose criteria for balance
-    self.world.ui.adviser:say(_A.warnings.bankruptcy_imminent)
-  end
-end
-
 --! Update the loaded game with version 'old' to the version 'new'.
 --!param old Version of the loaded game.
 --!param new Version of the code being executed.

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1642,11 +1642,9 @@ function Hospital:objectPlaced(entity, id)
     return
   end
 
-  -- If it is a plant it might be advisable to hire a handyman
-  if self:isPlayerHospital() then
-    if id == "plant" and self:countStaffOfCategory("Handyman") == 0 then
-      self.world.ui.adviser:say(_A.staff_advice.need_handyman_plants)
-    end
+  if id == "plant" then
+    self:msgPlant()
+    return
   end
 
   if id == "gates_to_hell" then
@@ -1665,6 +1663,11 @@ end
 
 --! Give advice to the user about having bought a reception desk.
 function Hospital:msgReceptionDesk()
+  -- Nothing to do, override in a sub-class.
+end
+
+--! Give advice to the user about maintenance of plants.
+function Hospital:msgPlant()
   -- Nothing to do, override in a sub-class.
 end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -661,6 +661,32 @@ end
 --! Called each tick, also called 'hours'. Check hours_per_day in
 --! date.lua to see how many times per day this is.
 function Hospital:tick()
+  -- Add some random background sounds, ringing phones, coughing, belching etc.
+  --
+  -- TODO: Background noises of other hospitals are heard in multi-player,
+  -- TODO: decide where this should go.
+  if math.random(1, 100) == 3 then
+    -- Wait until there are some patients in the hospital and a room, otherwise you
+    -- will wonder who is coughing or who is the receptionist telephoning!
+    -- Opted for gp as you can't run the hospital without one.
+    if self:countRoomOfType("gp") > 0 and self:countPatients(3) > 2 then
+      local sounds = {
+        "ispot001.wav", "ispot002.wav", "ispot003.wav", "ispot004.wav",
+        "ispot005.wav", "ispot006.wav", "ispot007.wav", "ispot008.wav",
+        "ispot009.wav", "ispot010.wav", "ispot011.wav", "ispot012.wav",
+        "ispot013.wav", "ispot014.wav", "ispot015.wav", "ispot016.wav",
+        "ispot017.wav", "ispot018.wav", "ispot019.wav", "ispot020.wav",
+        "ispot021.wav", "ispot022.wav", "ispot023.wav", "ispot024.wav",
+        "ispot025.wav"
+      } -- ispot026 and ispot027 are both toilet related sounds.
+
+      local sound_to_play = sounds[math.random(1, #sounds)]
+      if TheApp.audio:soundExists(sound_to_play) then
+        self.world.ui:playSound(sound_to_play)
+      end
+    end
+  end
+
   self:manageEpidemics()
 end
 

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -253,6 +253,15 @@ function PlayerHospital:msgReceptionDesk()
   end
 end
 
+--! Give advice to the user about maintenance of plants.
+function PlayerHospital:msgPlant()
+  local num_handyman = self:countStaffOfCategory("Handyman")
+
+  if num_handyman == 0 then
+    self:giveAdvice({_A.staff_advice.need_handyman_plants})
+  end
+end
+
 --! Advises the player.
 --!param msgs (array of string) Messages to select from.
 --!param rnd_frac (optional float in range (0, 1]) Fraction of times that the

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -292,34 +292,6 @@ function PlayerHospital:giveAdvice(msgs, rnd_frac, stay_up)
   if index <= #msgs then self.world.ui.adviser:say(msgs[index], stay_up) end
 end
 
--- Update the hospital each tick.
-function PlayerHospital:tick()
-  -- Add some random background sounds, ringing phones, coughing, belching etc.
-  if math.random(1, 100) == 3 then
-    -- Wait until there are some patients in the hospital and a room, otherwise you
-    -- will wonder who is coughing or who is the receptionist telephoning!
-    -- Opted for gp as you can't run the hospital without one.
-    if self:countRoomOfType("gp") > 0 and self:countPatients(3) > 2 then
-      local sounds = {
-        "ispot001.wav", "ispot002.wav", "ispot003.wav", "ispot004.wav",
-        "ispot005.wav", "ispot006.wav", "ispot007.wav", "ispot008.wav",
-        "ispot009.wav", "ispot010.wav", "ispot011.wav", "ispot012.wav",
-        "ispot013.wav", "ispot014.wav", "ispot015.wav", "ispot016.wav",
-        "ispot017.wav", "ispot018.wav", "ispot019.wav", "ispot020.wav",
-        "ispot021.wav", "ispot022.wav", "ispot023.wav", "ispot024.wav",
-        "ispot025.wav"
-      } -- ispot026 and ispot027 are both toilet related sounds.
-
-      local sound_to_play = sounds[math.random(1, #sounds)]
-      if TheApp.audio:soundExists(sound_to_play) then
-        self.world.ui:playSound(sound_to_play)
-      end
-    end
-  end
-
-  Hospital.tick(self)
-end
-
 --! Called at the end of each day.
 function PlayerHospital:onEndDay()
   -- Advise the player.

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -33,6 +33,7 @@ function PlayerHospital:PlayerHospital(world, avail_rooms, name)
 
   self.adviser_data = { -- Variables handling player advice.
     temperature_advice = nil, -- Whether the player received advice about room temp.
+    reception_advice = nil, -- Whether advice was given about building the reception.
 
     sitting_ratios = {}, -- Measurements of recent sitting/standing ratios.
     sitting_index = 1 -- Next entry in 'sitting_ratios' to update.
@@ -184,6 +185,11 @@ end
 
 --! Give advice to the player at the end of a month.
 function PlayerHospital:monthlyAdviceChecks()
+  local today = self.world:date()
+  local current_month = today:monthOfYear()
+  local current_year = today:year()
+
+  -- Check for advice on money.
   if not self.world.free_build_mode then
     if self.balance < 2000 and self.balance >= -500 then
       local cashlow_advice = {
@@ -192,7 +198,7 @@ function PlayerHospital:monthlyAdviceChecks()
       }
       self:giveAdvice(cashlow_advice)
 
-    elseif self.balance < -2000 and self.world:date():monthOfYear() > 8 then
+    elseif self.balance < -2000 and current_month > 8 then
       -- TODO: Ideally this should be linked to the lose criteria for balance.
       self:giveAdvice({_A.warnings.bankruptcy_imminent})
 
@@ -200,13 +206,59 @@ function PlayerHospital:monthlyAdviceChecks()
       self:giveAdvice({_A.warnings.pay_back_loan})
     end
   end
+
+  self:checkReceptionAdvice(current_month, current_year)
+end
+
+--! Make players aware of the need for a receptionist and desk.
+--!param current_month (int) Month of the year.
+--!param current_year (int) Current game year.
+function PlayerHospital:checkReceptionAdvice(current_month, current_year)
+  if current_year > 1 then return end -- Playing too long.
+  if self:hasStaffedDesk() then return end -- Staffed desk available, all done.
+
+  local num_receptionists = self:countStaffOfCategory("Receptionist")
+  if num_receptionists ~= 0 and current_month > 2 and not self.adviser_data.reception_advice then
+    self:giveAdvice({_A.warnings.no_desk_6})
+    self.adviser_data.reception_advice = true
+
+  elseif num_receptionists == 0 and current_month > 2 and self:countReceptionDesks() ~= 0  then
+    self:giveAdvice({_A.warnings.no_desk_7})
+
+  elseif current_month == 3 then
+    self:giveAdvice({_A.warnings.no_desk}, 1, true)
+
+  elseif current_month == 8 then
+    self:giveAdvice({_A.warnings.no_desk_1}, 1, true)
+
+  elseif current_month == 11 then
+    if self.visitors == 0 then
+      self:giveAdvice({_A.warnings.no_desk_2}, 1, true)
+    else
+      self:giveAdvice({_A.warnings.no_desk_3}, 1, true)
+    end
+  end
+end
+
+--! Give advice to the user about having bought a reception desk.
+function PlayerHospital:msgReceptionDesk()
+  local num_receptionists = self:countStaffOfCategory("Receptionist")
+
+  if not self.world.ui.start_tutorial and num_receptionists == 0 then
+    self:giveAdvice({_A.room_requirements.reception_need_receptionist})
+  elseif num_receptionists > 0 and self:countReceptionDesks() == 1 and
+      not self.adviser_data.reception_advice and self.world:date():monthOfGame() > 3 then
+    self:giveAdvice({_A.warnings.no_desk_5})
+    self.adviser_data.reception_advice = true
+  end
 end
 
 --! Advises the player.
 --!param msgs (array of string) Messages to select from.
 --!param rnd_frac (optional float in range (0, 1]) Fraction of times that the
 --    call actually says something.
-function PlayerHospital:giveAdvice(msgs, rnd_frac)
+--!param stay_up (bool) If true, let the adviser remain visible afterwards.
+function PlayerHospital:giveAdvice(msgs, rnd_frac, stay_up)
   local max_rnd = #msgs
   if rnd_frac and rnd_frac > 0 and rnd_frac < 1 then
     -- Scale by the fraction.
@@ -214,7 +266,7 @@ function PlayerHospital:giveAdvice(msgs, rnd_frac)
   end
 
   local index = (max_rnd == 1) and 1 or math.random(1, max_rnd)
-  if index <= #msgs then self.world.ui.adviser:say(msgs[index]) end
+  if index <= #msgs then self.world.ui.adviser:say(msgs[index], stay_up) end
 end
 
 -- Update the hospital each tick.
@@ -275,6 +327,11 @@ function PlayerHospital:afterLoad(old, new)
       sitting_ratios = {},
       sitting_index = 1
     }
+  end
+
+  if old < 147 then
+    -- Copy value of the previous name of the variable.
+    self.adviser_data.reception_advice = self.receptionist_msg
   end
 
   Hospital.afterLoad(self, old, new)

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -262,6 +262,20 @@ function PlayerHospital:msgPlant()
   end
 end
 
+--! Show the 'Gates to hell' animation.
+--!param entity (Entity) Gates to hell.
+function PlayerHospital:showGatesToHell(entity)
+  local anim_func = --[[persistable:lava_hole_spawn_animation_end]]
+    function(anim_entity)
+      anim_entity:setAnimation(1602)
+    end
+
+  entity:playEntitySounds("LAVA00*.WAV", {0,1350,1150,950,750,350},
+      {0,1450,1250,1050,850,450}, 40)
+  entity:setTimer(entity.world:getAnimLength(2550), anim_func)
+  entity:setAnimation(2550)
+end
+
 --! Advises the player.
 --!param msgs (array of string) Messages to select from.
 --!param rnd_frac (optional float in range (0, 1]) Fraction of times that the

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -217,6 +217,34 @@ function PlayerHospital:giveAdvice(msgs, rnd_frac)
   if index <= #msgs then self.world.ui.adviser:say(msgs[index]) end
 end
 
+-- Update the hospital each tick.
+function PlayerHospital:tick()
+  -- Add some random background sounds, ringing phones, coughing, belching etc.
+  if math.random(1, 100) == 3 then
+    -- Wait until there are some patients in the hospital and a room, otherwise you
+    -- will wonder who is coughing or who is the receptionist telephoning!
+    -- Opted for gp as you can't run the hospital without one.
+    if self:countRoomOfType("gp") > 0 and self:countPatients(3) > 2 then
+      local sounds = {
+        "ispot001.wav", "ispot002.wav", "ispot003.wav", "ispot004.wav",
+        "ispot005.wav", "ispot006.wav", "ispot007.wav", "ispot008.wav",
+        "ispot009.wav", "ispot010.wav", "ispot011.wav", "ispot012.wav",
+        "ispot013.wav", "ispot014.wav", "ispot015.wav", "ispot016.wav",
+        "ispot017.wav", "ispot018.wav", "ispot019.wav", "ispot020.wav",
+        "ispot021.wav", "ispot022.wav", "ispot023.wav", "ispot024.wav",
+        "ispot025.wav"
+      } -- ispot026 and ispot027 are both toilet related sounds.
+
+      local sound_to_play = sounds[math.random(1, #sounds)]
+      if TheApp.audio:soundExists(sound_to_play) then
+        self.world.ui:playSound(sound_to_play)
+      end
+    end
+  end
+
+  Hospital.tick(self)
+end
+
 --! Called at the end of each day.
 function PlayerHospital:onEndDay()
   -- Advise the player.


### PR DESCRIPTION
*Fixes Move more advice and feedback to the player hospital.

**Describe what the proposed change does**
- `cashLow` was previously merged into another function, but not deleted in the original code.
- `countPatients` ran every tick, and was only used just below for generating background noise, and in the townmap.
  Now, it's run around 1% of the time for background noise, and has better performance for busy hospitals. Independently, it may also run from the townmap.
- Background noise code is now in player hospital
- Advice code about receptionsists or desks is now in player hospital
- Advice code about plants wrt handman is now in player hospital
- Gates to hell animation code is now in player hospital

Best reviewed one commit at a time.
