### PR TITLE
[WIP] Add queue warnings, skip level board movie on restarts, fix edge scrolling bugs, shortern win faxes

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -608,7 +608,7 @@ end
 -- Loads the specified level. If a string is passed it looks for the file with the same name
 -- in the "Levels" folder of CorsixTH, if it is a number it tries to load that level from
 -- the original game.
-function App:loadLevel(level, difficulty, level_name, level_file, level_intro, map_editor)
+function App:loadLevel(level, difficulty, level_name, level_file, level_intro, map_editor, skip_movie)
   if self.world then
     self:worldExited()
   end
@@ -662,7 +662,7 @@ function App:loadLevel(level, difficulty, level_name, level_file, level_intro, m
   self.ui = GameUI(self, self.world:getLocalPlayerHospital(), map_editor)
   self.world:setUI(self.ui) -- Function call allows world to set up its keyHandlers
 
-  if tonumber(level) then
+  if tonumber(level) and not skip_movie then
     self.moviePlayer:playAdvanceMovie(level)
   end
 
@@ -1534,7 +1534,7 @@ function App:restart()
       self.ui:addWindow(UIInformation(self.ui, {_S.information.cannot_restart}))
       return
     end
-    local status, err = pcall(self.loadLevel, self, level, difficulty, name, file, intro)
+    local status, err = pcall(self.loadLevel, self, level, difficulty, name, file, intro, nil, true)
     if not status then
       err = "Error while loading level: " .. err
       print(err)

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -657,7 +657,10 @@ function UIMenuBar:makeGameMenu(app)
   -- Edge Scrolling
   options:appendCheckItem(_S.menu_options.edge_scrolling,
     not app.config.prevent_edge_scrolling,
-    function(item) app.config.prevent_edge_scrolling = not item.checked end,
+    function(item)
+      app.config.prevent_edge_scrolling = not item.checked
+      app:saveConfig()
+    end,
     nil,
     function() return not app.config.prevent_edge_scrolling end)
 

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -208,6 +208,21 @@ function PlayerHospital:monthlyAdviceChecks()
   end
 
   self:checkReceptionAdvice(current_month, current_year)
+
+  -- Once a month the advisor will warn about long queues.
+  -- Warnings are less likely for the diagnosis rooms to keep the quantity of warnings down
+  for _, room in pairs(self.world.rooms) do
+    if #room.door.queue > 5 then
+      local info = room.room_info
+      if math.random(1, 3) == 1 and info.required_staff["Doctor"] and info.categories["diagnosis"] then
+        self:giveAdvice({_A.warnings.queue_too_long_send_doctor:format(info.name)})
+        break
+      elseif info.categories["treatment"] or info.categories["clinics"] then
+        self:giveAdvice({_A.warnings.queues_too_long})
+        break
+      end
+    end
+  end
 end
 
 --! Make players aware of the need for a receptionist and desk.

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -299,6 +299,17 @@ function PlayerHospital:onEndDay()
     self:dailyAdviceChecks()
   end
 
+  -- Occasionally unstaffed rooms with a queue will call for staff
+  for _, room in pairs(self.world.rooms) do
+    if math.random(1, 20) == 1 and #room.door.queue > 0 and not room.staff_member and
+        not room:testStaffCriteria(room:getRequiredStaffCriteria()) then
+          self.world.dispatcher:callForStaff(room)
+          break
+    end
+  end
+
+  -- TODO: Do other regular things? Such as making plants need water.
+
   Hospital.onEndDay(self)
 end
 

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -104,8 +104,13 @@ multiplayer.everyone_failed = "Everyone failed to satisfy that last objective. S
 -- Override for a disease patient choice typo
 disease_discovered_patient_choice.need_to_employ = "Employ a %s to be able to handle this situation."
 
---Win message override typo
-letter[12][2] = "Your successful career as the best hospital administrator since Moses is nearing an end. However, such has been your impact on the cosy world of medicine, the Ministry would like to offer you a salary of $%d simply to appear on our behalf, opening fetes, launching ships, and doing chat shows. The whole world is clamouring for you, and it would be great PR for us all!//"
+-- Override for shorter messages and a typo
+letter[9][2] = "You have proved yourself to be the best hospital administrator in medicine's long and chequered history. Such a momentous achievement cannot go unrewarded, so we would like to offer you the honorary post of Supreme Chief of All Hospitals. This comes with a salary of $%d. You will be given a tickertape parade, and people will show their appreciation wherever you go.//"
+letter[10][2] = "Congratulations on successfully running every hospital we assigned you to. Such a superb performance qualifies you for the freedom of all the world's cities. You are to be given a pension of $%d, and all we ask is that you travel, for free, around the nation, promoting the work of all hospitals to your adoring public.//"
+letter[11][2] = "Your career has been exemplary, and you are an inspiration to all of us. Thank you for running so many hospitals so well. We would like to grant you a lifetime salary of $%d, and would ask simply that you travel by official open-topped car from city to city, giving lectures about how you achieved so much so fast.//"
+letter[11][3] = "You are an example to every wise person, and without exception, everybody in the world regards you as a supreme asset.//"
+letter[12][2] = "Your successful career as the best hospital administrator since Moses is nearing an end. However, such has been your impact on the nation, the PM would like to offer you a salary of $%d simply to appear on our behalf, opening fetes, launching ships, and doing chat shows. It would be great PR for us all!//"
+
 -------------------------------  NEW STRINGS  -------------------------------
 date_format = {
   daymonth = "%1% %2:months%",

--- a/CorsixTH/Lua/objects/plant.lua
+++ b/CorsixTH/Lua/objects/plant.lua
@@ -229,7 +229,8 @@ function Plant:createHandymanActions(handyman)
   handyman:queueAction(AnswerCallAction())
 end
 
---! When a handyman should go to the plant he should approach it from the closest reachable tile.
+--! When a handyman should go to the plant he should approach it from the
+-- closest reachable tile within hospital buildings.
 --!param from_x (integer) The x coordinate of tile to calculate from.
 --!param from_y (integer) The y coordinate of tile to calculate from.
 function Plant:getBestUsageTileXY(from_x, from_y)
@@ -243,8 +244,8 @@ function Plant:getBestUsageTileXY(from_x, from_y)
   for _, point in ipairs(access_points) do
     local dest_x, dest_y = self.tile_x + point.dx, self.tile_y + point.dy
     local room_there = self.world:getRoom(dest_x, dest_y)
-    if room_here == room_there then
-      local distance = self.world:getPathDistance(from_x, from_y, self.tile_x + point.dx, self.tile_y + point.dy)
+    if room_here == room_there and self.hospital:isInHospital(dest_x, dest_y) then
+      local distance = self.world:getPathDistance(from_x, from_y, dest_x, dest_y)
       if distance and (not best_point or shortest > distance) then
         best_point = point
         shortest = distance

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2642,6 +2642,9 @@ function World:afterLoad(old, new)
     self:resetSideObjects()
   end
 
+  -- Cancel any saved screen movement from edge scrolling
+  self.ui.tick_scroll_amount_mouse = nil
+
   self.savegame_version = new
 end
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1158,8 +1158,6 @@ function World:onEndDay()
       self.spawn_hours[hour] = self.spawn_hours[hour] and self.spawn_hours[hour] + 1 or 1
     end
   end
-  -- TODO: Do other regular things? Such as checking if any room needs
-  -- staff at the moment and making plants need water.
 end
 
 function World:checkIfGameWon()


### PR DESCRIPTION
*Fixes #*

**Describe what the proposed change does**
- Sometimes idle staff can be called to a room they can help in
- Use two more announcer strings about long queues
- Fix #1534 
- Fix #1311 
- Fix #525 
- Fix #474
- Fix #526 Caveat: receptionists can only be placed on the centre tile of the desk
- Fix #1663 There are many possible versions of this. We will want to guide translators to the original strings and have them do it within the same limit