### PR TITLE
[WIP] Use initial reputation, overdraft interest rate and competitor names from custom levels

### DIFF
--- a/CorsixTH/Levels/avatar.level
+++ b/CorsixTH/Levels/avatar.level
@@ -209,7 +209,7 @@ Divides research input to get the amount of research points. must be > 0
 
 --------------------- Competitor Information -----------------------
 
-| Index in the away "computer" | Is that opponent playing? | 1 is yes, 0 no | Comment |
-#computer[12].Playing 1 CORSIX
-#computer[13].Playing 1 ROUJIN
-#computer[14].Playing 1 EDVIN
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing.Name 1 CORSIX
+#computer[13].Playing.Name 1 ROUJIN
+#computer[14].Playing.Name 1 EDVIN

--- a/CorsixTH/Levels/confined_v5.level
+++ b/CorsixTH/Levels/confined_v5.level
@@ -206,10 +206,10 @@ Divides research input to get the amount of research points. must be > 0
 
 --------------------- Competitor Information -----------------------
 
-| Index in the away "computer" | Is that opponent playing? | 1 is yes, 0 no | Comment |
-#computer[12].Playing 1 CORSIX
-#computer[13].Playing 1 ROUJIN
-#computer[14].Playing 1 EDVIN
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing.Name 1 CORSIX
+#computer[13].Playing.Name 1 ROUJIN
+#computer[14].Playing.Name 1 EDVIN
 
 ----------------------- Emergency Control --------------------------
 

--- a/CorsixTH/Levels/demo.level
+++ b/CorsixTH/Levels/demo.level
@@ -108,6 +108,7 @@ When a drug is researched, what effectiveness does it have
 
 --------------------- Competitor Information -----------------------
 
-#computer[12].Playing 1 CORSIX
-#computer[13].Playing 1 ROUJIN
-#computer[14].Playing 1 EDVIN
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing.Name 1 CORSIX
+#computer[13].Playing.Name 1 ROUJIN
+#computer[14].Playing.Name 1 EDVIN

--- a/CorsixTH/Levels/example.level
+++ b/CorsixTH/Levels/example.level
@@ -55,7 +55,7 @@ InterestRate is defined as centiprocent to allow for two decimals precision, i.e
 -------------------- Disease Configuration -------------------------
 
 When a drug is researched, what effectiveness does it have
-#gbv.StartRating 100 
+#gbv.StartRating 100
 
 The following table contains all diagnoses and treatments that shows up in the drug casebook
 in the game. Known specifies whether it should show up from the beginning of the level and
@@ -230,10 +230,10 @@ But we don't want any such conditions on the example level!
 
 --------------------- Competitor Information -----------------------
 
-| Index in the away "computer" | Is that opponent playing? | 1 is yes, 0 no | Comment |
-#computer[12].Playing 1 CORSIX
-#computer[13].Playing 1 ROUJIN
-#computer[14].Playing 1 EDVIN
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing 1.Name CORSIX
+#computer[13].Playing 1.Name ROUJIN
+#computer[14].Playing 1.Name EDVIN
 
 ----------------------- Emergency Control --------------------------
 

--- a/CorsixTH/Levels/finisham.level
+++ b/CorsixTH/Levels/finisham.level
@@ -280,7 +280,7 @@ But we don't want any such conditions on the example level!
 
 --------------------- Competitor Information -----------------------
 
-| Index in the away "computer" | Is that opponent playing? | 1 is yes, 0 no | Comment |
-#computer[12].Playing 1 CORSIX
-#computer[13].Playing 1 ROUJIN
-#computer[14].Playing 1 EDVIN
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing.Name 1 CORSIX
+#computer[13].Playing.Name 1 ROUJIN
+#computer[14].Playing.Name 1 EDVIN

--- a/CorsixTH/Levels/st.peter's.level
+++ b/CorsixTH/Levels/st.peter's.level
@@ -372,7 +372,7 @@ But we don't want any such conditions on the example level!
 
 --------------------- Competitor Information -----------------------
 
-| Index in the away "computer" | Is that opponent playing? | 1 is yes, 0 no | Comment |
-#computer[12].Playing 1 Corsix
-#computer[13].Playing 1 Roujin
-#computer[14].Playing 1 Edvin
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing.Name 1 Corsix
+#computer[13].Playing.Name 1 Roujin
+#computer[14].Playing.Name 1 Edvin

--- a/CorsixTH/Lua/base_config.lua
+++ b/CorsixTH/Lua/base_config.lua
@@ -373,21 +373,21 @@ local configuration = {
     [0] = {StartMonth = 0, EndMonth = 0, Min = 0, Max = 0, Illness = 0, PercWin = 0, Bonus = 0},
   },
   computer = {
-    [0] = {Playing = 0}, -- ORAC
-    {Playing = 0}, -- COLOSSUS
-    {Playing = 0}, -- HAL
-    {Playing = 0}, -- MULTIVAC
-    {Playing = 0}, -- HOLLY
-    {Playing = 0}, -- DEEP THOUGHT
-    {Playing = 0}, -- ZEN
-    {Playing = 0}, -- SKYNET
-    {Playing = 0}, -- MARVIN
-    {Playing = 0}, -- CEREBRO
-    {Playing = 0}, -- MOTHER
-    {Playing = 0}, -- JAYNE
-    {Playing = 0}, -- CORSIX
-    {Playing = 0}, -- ROUJIN
-    {Playing = 0}, -- EDVIN
+    [0] = {Playing = 0, Name = "ORAC"},
+    {Playing = 0, Name = "COLOSSUS"},
+    {Playing = 0, Name = "HAL"},
+    {Playing = 0, Name = "MULTIVAC"},
+    {Playing = 0, Name = "HOLLY"},
+    {Playing = 0, Name = "DEEP THOUGHT"},
+    {Playing = 0, Name = "ZEN"},
+    {Playing = 0, Name = "SKYNET"},
+    {Playing = 0, Name = "MARVIN"},
+    {Playing = 0, Name = "CEREBRO"},
+    {Playing = 0, Name = "MOTHER"},
+    {Playing = 0, Name = "JAYNE"},
+    {Playing = 0, Name = "CORSIX"},
+    {Playing = 0, Name = "ROUJIN"},
+    {Playing = 0, Name = "EDVIN"},
   },
   awards_trophies = {
 

--- a/CorsixTH/Lua/base_config.lua
+++ b/CorsixTH/Lua/base_config.lua
@@ -28,7 +28,8 @@ local configuration = {
   town = {
     InterestRate = 0.01,
     StartCash = 40000,
-    StartRep = 500
+    StartRep = 500,
+    OverdraftDiff = 200,
   },
 
   -- New value, but should only be defined if starting staff is included.

--- a/CorsixTH/Lua/base_config.lua
+++ b/CorsixTH/Lua/base_config.lua
@@ -28,6 +28,7 @@ local configuration = {
   town = {
     InterestRate = 0.01,
     StartCash = 40000,
+    StartRep = 500
   },
 
   -- New value, but should only be defined if starting staff is included.

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -36,15 +36,19 @@ function Hospital:Hospital(world, avail_rooms, name)
   local reputation_min = 0
   local reputation_max = 1000
   local reputation = math.round((reputation_min + reputation_max) / 2)
+  -- The difference between the normal and overdraft interest rates, multiplied by 10000
+  local overdraft_differential = 200
   if level_config then
     if level_config.towns and level_config.towns[level] then
       balance = level_config.towns[level].StartCash
       interest_rate = level_config.towns[level].InterestRate / 10000
       reputation = level_config.towns[level].StartRep or reputation
+      overdraft_differential = level_config.towns[level].OverdraftDiff or overdraft_differential
     elseif level_config.town then
       balance = level_config.town.StartCash
       interest_rate = level_config.town.InterestRate / 10000
       reputation = level_config.town.StartRep or reputation
+      overdraft_differential = level_config.town.OverdraftDiff or overdraft_differential
     end
   end
   self.name = name or "PLAYER"
@@ -84,6 +88,7 @@ function Hospital:Hospital(world, avail_rooms, name)
   -- Initial values
   self.interest_rate = interest_rate
   self.inflation_rate = 0.045
+  self.overdraft_interest_rate = interest_rate + overdraft_differential / 10000
   self.salary_incr = level_config.gbv.ScoreMaxInc or 300
   self.sal_min = level_config.gbv.ScoreMaxInc / 6 or 50
   self.reputation = reputation
@@ -890,8 +895,7 @@ function Hospital:onEndDay()
   self.show_progress_screen_warnings = math.random(1, 3) -- used in progress report to limit warnings
   self.msg_counter = self.msg_counter + 1
   if self.balance < 0 then
-    -- TODO: Add the extra interest rate to level configuration.
-    local overdraft_interest = self.interest_rate + 0.02
+    local overdraft_interest = self.overdraft_interest_rate
     local overdraft = math.abs(self.balance)
     local overdraft_payment = (overdraft*overdraft_interest)/365
     self.acc_overdraft = self.acc_overdraft + overdraft_payment

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -188,18 +188,24 @@ function Hospital:Hospital(world, avail_rooms, name)
   self.policies["stop_procedure"] = 1 -- Note that this is between 1 and 2 ( = 100% - 200%)
   self.policies["goto_staffroom"] = 0.6
   self.policies["grant_wage_increase"] = TheApp.config.grant_wage_increase
+
   -- Randomly select three insurance companies to use, only different by name right now.
-  -- The first ones are more likely to come
+  -- The companies in the first quarter of the list are more likely to be selected
   self.insurance = {}
+  -- Make a local writeable copy table of the translated company names.
+  local companies = {}
   for no, local_name in ipairs(_S.insurance_companies) do
-    -- NOTE: Will not work if more companies are added
-    if math.random(1, 11) < 4 or 11 - no < #self.insurance + 3 then
-      self.insurance[#self.insurance + 1] = local_name
-    end
-    if #self.insurance > 2 then
-      break
-    end
+    companies[no] = local_name
   end
+  repeat
+    local num = math.random(1, 2) == 1 and math.random(1, math.ceil(#companies / 4)) or
+        math.random(1, #companies)
+    if companies[num] then
+      self.insurance[#self.insurance + 1] = companies[num]
+      table.remove(companies, num)
+    end
+  until #self.insurance > 2 or #companies < 1
+
   -- A list of how much each insurance company owes you. The first entry for
   -- each company is the current month's dept, the second the previous
   -- month and the third the month before that.

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -33,17 +33,21 @@ function Hospital:Hospital(world, avail_rooms, name)
   local level = world.map.level_number
   local balance = 40000
   local interest_rate = 0.01
+  local reputation_min = 0
+  local reputation_max = 1000
+  local reputation = math.round((reputation_min + reputation_max) / 2)
   if level_config then
     if level_config.towns and level_config.towns[level] then
       balance = level_config.towns[level].StartCash
       interest_rate = level_config.towns[level].InterestRate / 10000
+      reputation = level_config.towns[level].StartRep or reputation
     elseif level_config.town then
       balance = level_config.town.StartCash
       interest_rate = level_config.town.InterestRate / 10000
+      reputation = level_config.town.StartRep or reputation
     end
   end
   self.name = name or "PLAYER"
-  -- TODO: Variate initial reputation etc based on level
   -- When playing in free build mode you don't care about money.
   self.balance = not world.free_build_mode and balance or 0
   self.loan = 0
@@ -82,9 +86,9 @@ function Hospital:Hospital(world, avail_rooms, name)
   self.inflation_rate = 0.045
   self.salary_incr = level_config.gbv.ScoreMaxInc or 300
   self.sal_min = level_config.gbv.ScoreMaxInc / 6 or 50
-  self.reputation = 500
-  self.reputation_min = 0
-  self.reputation_max = 1000
+  self.reputation = reputation
+  self.reputation_min = reputation_min
+  self.reputation_max = reputation_max
 
   local difficulty = self.world.map:getDifficulty()
   -- Price distortion level under which the patients might consider the
@@ -139,7 +143,7 @@ function Hospital:Hospital(world, avail_rooms, name)
       visitors = 0,
       cures = 0,
       deaths = 0,
-      reputation = 500, -- TODO: Always 500 from the beginning?
+      reputation = reputation
     }
   }
   self.money_in = 0

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -153,6 +153,9 @@ function World:World(app)
   for key, value in pairs(level_config.computer) do
     if value.Playing == 1 then
       self.hospitals[#self.hospitals + 1] = AIHospital(tonumber(key) + 1, self, avail_rooms)
+      if value.Name then
+        self.hospitals[#self.hospitals].name = value.Name
+      end
     end
   end
 


### PR DESCRIPTION
A small portion of #1722 

**Describe what the proposed change does**
- Level config can set starting reputation
- Competitor names are already in the custom levels, this uses them
- Overdraft interest rate is set by a per mille called OverdraftDiff, ie 200 means it's 0.02 on top of the standard rate
- Picking insurance company names can take an unknown number of names in the language file
