### PR TITLE
[RDY] Win fax comes less often after it was declined

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 148
+local SAVEGAME_VERSION = 149
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -226,6 +226,8 @@ function UIFax:choice(choice_number)
   elseif choice == "return_to_main_menu" then
     self.ui.app.moviePlayer:playWinMovie()
     self.ui.app:loadMainMenu()
+  elseif choice == "stay_on_level" then
+    self.ui.hospital.win_declined = true
   end
   self.icon:removeMessage()
   self:close()

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -39,6 +39,8 @@ function PlayerHospital:PlayerHospital(world, avail_rooms, name)
     sitting_ratios = {}, -- Measurements of recent sitting/standing ratios.
     sitting_index = 1 -- Next entry in 'sitting_ratios' to update.
   }
+
+  self.win_declined = false -- Has not yet declined the level win fax
 end
 
 --! Give advice to the player at the end of a day.
@@ -348,6 +350,16 @@ function PlayerHospital:onEndMonth()
   end
   self.adviser_data.cured_died_message = nil -- Enable the message again.
 
+  -- Check if a player has won the level at months 3, 6 and 9. The annual report
+  -- window will perform this check at month 12 when it has been closed.
+  -- If the offer is declined then the next check is at month 6 and the annual report.
+  local check_months = {
+    [3] = not self.win_declined,
+    [6] = true,
+    [9] = not self.win_declined
+  }
+  if check_months[self.world.game_date:monthOfYear()] then self.world:checkIfGameWon() end
+
   Hospital.onEndMonth(self)
 end
 
@@ -369,6 +381,9 @@ function PlayerHospital:afterLoad(old, new)
   end
   if old < 148 then
     self.adviser_data.cured_died_message = nil
+  end
+  if old < 149 then
+    self.win_declined = false -- Has not yet declined the level win fax
   end
 
   Hospital.afterLoad(self, old, new)

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1174,16 +1174,6 @@ end
 -- Called immediately prior to the ingame month changing.
 -- returns true if the game was killed due to the player losing
 function World:onEndMonth()
-  -- Check if a player has won the level if the year hasn't ended, if it has the
-  -- annual report window will perform this check when it has been closed.
-
-  -- TODO.... this is a step closer to the way TH would check.
-  -- What is missing is that if offer is declined then the next check should be
-  -- either 6 months later or at the end of month 12 and then every 6 months
-  if self.game_date:monthOfYear() % 3 == 0 and self.game_date:monthOfYear() < 12 then
-    self:checkIfGameWon()
-  end
-
   local local_hospital = self:getLocalPlayerHospital()
   local_hospital.population = 0.25
   if self.game_date:monthOfGame() >= self.map.level_config.gbv.AllocDelay then
@@ -1476,7 +1466,8 @@ end
 function World:getCampaignWinningText(player_no)
   local text = {}
   local choice_text, choice
-  local repeated_offer = false -- TODO whether player was asked previously to advance and declined
+  local hosp = self:getLocalPlayerHospital()
+  local repeated_offer = hosp.win_declined
   local has_next = false
   if type(self.map.level_number) == "number" then
     local no = tonumber(self.map.level_number)


### PR DESCRIPTION
Previous feedback in #1722 

**Describe what the proposed change does**
- Change the timing of win faxes per the todo
- This then uses the second set of fax texts, which ask the player to reconsider staying at this hospital
