### PR TITLE
[RDY] Prevent emergencies of undiscovered diseases

### DIFF
--- a/CorsixTH/Lua/cheats.lua
+++ b/CorsixTH/Lua/cheats.lua
@@ -83,12 +83,13 @@ function Cheats:cheatResearch()
 end
 
 function Cheats:cheatEmergency()
-  local err = self.hospital:createEmergency() -- no err is nil
+  local err = self.hospital:createEmergency()
   local ui = self.hospital.world.ui
   if err == "undiscovered_disease" then
-    ui:addWindow(UIInformation(ui,{_S.misc.cant_treat_emergency}))
-  elseif err == "no_helipad" then
+    ui:addWindow(UIInformation(ui, {_S.misc.cant_treat_emergency}))
+  elseif err == "no_heliport" then
     ui:addWindow(UIInformation(ui, {_S.misc.no_heliport}))
+  -- else 'err == nil', meaning success. The case doesn't need special handling
   end
 end
 

--- a/CorsixTH/Lua/cheats.lua
+++ b/CorsixTH/Lua/cheats.lua
@@ -83,7 +83,10 @@ function Cheats:cheatResearch()
 end
 
 function Cheats:cheatEmergency()
-  if not self.hospital:createEmergency() then
+  local outcome, err = self.hospital:createEmergency()
+  if err == "undiscovered_disease" then
+    self.hospital.world.ui:addWindow(UIInformation(self.hospital.world.ui,{_S.misc.cant_treat_emergency}))
+  elseif not outcome then
     self.hospital.world.ui:addWindow(UIInformation(self.hospital.world.ui, {_S.misc.no_heliport}))
   end
 end

--- a/CorsixTH/Lua/cheats.lua
+++ b/CorsixTH/Lua/cheats.lua
@@ -83,11 +83,12 @@ function Cheats:cheatResearch()
 end
 
 function Cheats:cheatEmergency()
-  local outcome, err = self.hospital:createEmergency()
+  local err = self.hospital:createEmergency() -- no err is nil
+  local ui = self.hospital.world.ui
   if err == "undiscovered_disease" then
-    self.hospital.world.ui:addWindow(UIInformation(self.hospital.world.ui,{_S.misc.cant_treat_emergency}))
-  elseif not outcome then
-    self.hospital.world.ui:addWindow(UIInformation(self.hospital.world.ui, {_S.misc.no_heliport}))
+    ui:addWindow(UIInformation(ui,{_S.misc.cant_treat_emergency}))
+  elseif err == "no_helipad" then
+    ui:addWindow(UIInformation(ui, {_S.misc.no_heliport}))
   end
 end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1042,9 +1042,9 @@ end
 
 -- Creates complete emergency with patients, what disease they have, what's needed
 -- to cure them and the fax.
---!return outcome (bool), err (string) If emergency was scheduled, and if not what the error was
+--!return err (string) If emergency failed what was the issue
 function Hospital:createEmergency(emergency)
-  local outcome = false
+  local err = nil
   local random_disease = self.world.available_diseases[math.random(1, #self.world.available_diseases)]
   local disease = TheApp.diseases[random_disease.id]
   local number = math.random(2, disease.emergency_number)
@@ -1063,7 +1063,8 @@ function Hospital:createEmergency(emergency)
 
     -- If disease chosen isn't discovered, cancel emergency
     if not self.disease_casebook[emergency.disease.id].discovered then
-      return outcome, "undiscovered_disease"
+      err = "undiscovered_disease"
+      return err
     end
 
     self.emergency = emergency
@@ -1112,9 +1113,10 @@ function Hospital:createEmergency(emergency)
       },
     }
     self.world.ui.bottom_panel:queueMessage("emergency", message, nil, Date.hoursPerDay() * 16, 2) -- automatically refuse after 16 days
-    outcome = true
+    return err -- sucessfully created
   end
-  return outcome
+  err = "no_helipad"
+  return err
 end
 
 -- Called when the timer runs out during an emergency or when all emergency patients are cured or dead.

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1042,9 +1042,8 @@ end
 
 -- Creates complete emergency with patients, what disease they have, what's needed
 -- to cure them and the fax.
---!return err (string) If emergency failed what was the issue
+--!return (optional string) Textual reason for failure, else nil
 function Hospital:createEmergency(emergency)
-  local err = nil
   local random_disease = self.world.available_diseases[math.random(1, #self.world.available_diseases)]
   local disease = TheApp.diseases[random_disease.id]
   local number = math.random(2, disease.emergency_number)
@@ -1063,8 +1062,7 @@ function Hospital:createEmergency(emergency)
 
     -- If disease chosen isn't discovered, cancel emergency
     if not self.disease_casebook[emergency.disease.id].discovered then
-      err = "undiscovered_disease"
-      return err
+      return "undiscovered_disease"
     end
 
     self.emergency = emergency
@@ -1113,10 +1111,9 @@ function Hospital:createEmergency(emergency)
       },
     }
     self.world.ui.bottom_panel:queueMessage("emergency", message, nil, Date.hoursPerDay() * 16, 2) -- automatically refuse after 16 days
-    return err -- sucessfully created
+    return -- sucessfully created
   end
-  err = "no_helipad"
-  return err
+  return "no heliport"
 end
 
 -- Called when the timer runs out during an emergency or when all emergency patients are cured or dead.

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1042,8 +1042,9 @@ end
 
 -- Creates complete emergency with patients, what disease they have, what's needed
 -- to cure them and the fax.
+--!return outcome (bool), err (string) If emergency was scheduled, and if not what the error was
 function Hospital:createEmergency(emergency)
-  local created_one = false
+  local outcome = false
   local random_disease = self.world.available_diseases[math.random(1, #self.world.available_diseases)]
   local disease = TheApp.diseases[random_disease.id]
   local number = math.random(2, disease.emergency_number)
@@ -1058,6 +1059,11 @@ function Hospital:createEmergency(emergency)
         killed_emergency_patients = 0,
         cured_emergency_patients = 0,
       }
+    end
+
+    -- If disease chosen isn't discovered, cancel emergency
+    if not self.disease_casebook[emergency.disease.id].discovered then
+      return outcome, "undiscovered_disease"
     end
 
     self.emergency = emergency
@@ -1106,9 +1112,9 @@ function Hospital:createEmergency(emergency)
       },
     }
     self.world.ui.bottom_panel:queueMessage("emergency", message, nil, Date.hoursPerDay() * 16, 2) -- automatically refuse after 16 days
-    created_one = true
+    outcome = true
   end
-  return created_one
+  return outcome
 end
 
 -- Called when the timer runs out during an emergency or when all emergency patients are cured or dead.

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -306,7 +306,7 @@ install = {
 
 misc.not_yet_implemented = "(not yet implemented)"
 misc.no_heliport = "Either no diseases have been discovered yet, or there is no heliport on this map. It might be that you need to build a reception desk and hire a receptionist"
-misc.cant_treat_emergency = "Your hospital cannot treat this emergency because its disease has not been discovered. Feel free to try again, cheater."
+misc.cant_treat_emergency = "Your hospital cannot treat this emergency because its disease has not been discovered. Feel free to try again."
 
 main_menu = {
   new_game = "Campaign",

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -306,6 +306,7 @@ install = {
 
 misc.not_yet_implemented = "(not yet implemented)"
 misc.no_heliport = "Either no diseases have been discovered yet, or there is no heliport on this map. It might be that you need to build a reception desk and hire a receptionist"
+misc.cant_treat_emergency = "Your hospital cannot treat this emergency because its disease has not been discovered. Feel free to try again, cheater."
 
 main_menu = {
   new_game = "Campaign",

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1082,6 +1082,7 @@ end
 
 -- Called immediately prior to the ingame day changing.
 function World:onEndDay()
+  local local_hospital = self:getLocalPlayerHospital()
   for _, entity in ipairs(self.entities) do
     if entity.ticks and class.is(entity, Humanoid) then
       self.current_tick_entity = entity
@@ -1095,7 +1096,7 @@ function World:onEndDay()
   --check if it's time for a VIP visit
   if self.game_date:isSameDay(self.next_vip_date) then
     if #self.rooms > 0 and self.ui.hospital:hasStaffedDesk() then
-      self.hospitals[1]:createVip()
+      local_hospital:createVip()
     else
       self.next_vip_date = self:_generateNextVipDate()
     end
@@ -1121,7 +1122,7 @@ function World:onEndDay()
       local control = self.map.level_config.emergency_control
       if control[0].Mean or control[0].Random then
         -- The level uses random emergencies, so just create one.
-        self.hospitals[1]:createEmergency()
+        local_hospital:createEmergency()
       else
         control = control[self.next_emergency_no]
         -- Find out which disease the emergency patients have.
@@ -1134,7 +1135,7 @@ function World:onEndDay()
         end
         if not disease then
           -- Unknown disease! Create a random one instead.
-          self.hospitals[1]:createEmergency()
+          local_hospital:createEmergency()
         else
           local emergency = {
             disease = disease,
@@ -1144,7 +1145,7 @@ function World:onEndDay()
             killed_emergency_patients = 0,
             cured_emergency_patients = 0,
           }
-          self.hospitals[1]:createEmergency(emergency)
+          local_hospital:createEmergency(emergency)
         end
       end
     end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1095,7 +1095,7 @@ function World:onEndDay()
 
   --check if it's time for a VIP visit
   if self.game_date:isSameDay(self.next_vip_date) then
-    if #self.rooms > 0 and self.ui.hospital:hasStaffedDesk() then
+    if #self.rooms > 0 and local_hospital:hasStaffedDesk() then
       local_hospital:createVip()
     else
       self.next_vip_date = self:_generateNextVipDate()


### PR DESCRIPTION
Prevent emergencies being available to player if the relevant disease has not been discovered.

*Fixes #1156 Fixes #506*

**Describe what the proposed change does**
- Checks if the game's generated emergency disease is discovered at the player hospital
- Where the disease isn't discovered, the emergency is discard
- If the player tried to make an emergency by cheating, they get a nice message instead if it failed.
