### PR TITLE
[rdy] cpp cleanup of animation data

### DIFF
--- a/CorsixTH/Src/th.cpp
+++ b/CorsixTH/Src/th.cpp
@@ -28,7 +28,6 @@ SOFTWARE.
 #include <stdexcept>
 
 link_list::link_list() {
-  drawing_layer = 0;
   prev = nullptr;
   next = nullptr;
 }

--- a/CorsixTH/Src/th.h
+++ b/CorsixTH/Src/th.h
@@ -36,13 +36,6 @@ class link_list {
   link_list* next;
 
   void remove_from_list();
-
-  // TODO: drawing layer doesn't belong in a generic link list.
-  int get_drawing_layer() { return drawing_layer; }
-  void set_drawing_layer(int layer) { drawing_layer = layer; }
-
- private:
-  int drawing_layer;
 };
 
 //! \brief Theme Hospital localised string list

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1295,7 +1295,7 @@ bool THAnimation_is_multiple_frame_animation(drawable* pSelf) {
 
 }  // namespace
 
-animation_base::animation_base() {
+animation_base::animation_base() : drawable() {
   x_relative_to_tile = 0;
   y_relative_to_tile = 0;
   for (int i = 0; i < 13; ++i) {
@@ -1305,7 +1305,8 @@ animation_base::animation_base() {
 }
 
 animation::animation()
-    : manager(nullptr),
+    : animation_base(),
+      manager(nullptr),
       morph_target(nullptr),
       animation_index(0),
       frame_index(0),
@@ -1513,7 +1514,7 @@ void animation_base::attach_to_tile(map_tile* pMapNode, int layer) {
 
   this->set_drawing_layer(layer);
 
-  while (pList->next && pList->next->get_drawing_layer() < layer) {
+  while (pList->next && ((drawable*)pList->next)->get_drawing_layer() < layer) {
     pList = pList->next;
   }
 
@@ -1692,7 +1693,7 @@ bool THSpriteRenderList_is_multiple_frame_animation(drawable* pSelf) {
 
 }  // namespace
 
-sprite_render_list::sprite_render_list() {
+sprite_render_list::sprite_render_list() : animation_base() {
   draw_fn = THSpriteRenderList_draw;
   hit_test_fn = THSpriteRenderList_hit_test;
   is_multiple_frame_animation_fn =

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1450,7 +1450,7 @@ void animation::depersist(lua_persist_reader* pReader) {
       if (!pReader->read_int(speed.dy)) break;
     } else {
       if (!pReader->read_stack_object()) break;
-      parent = (animation*)lua_touserdata(L, -1);
+      parent = static_cast<animation*>(lua_touserdata(L, -1));
       lua_pop(L, 1);
     }
 
@@ -1470,7 +1470,7 @@ void animation::depersist(lua_persist_reader* pReader) {
 
     // Fix the m_pAnimator field
     luaT_getenvfield(L, 2, "animator");
-    manager = (animation_manager*)lua_touserdata(L, -1);
+    manager = static_cast<animation_manager*>(lua_touserdata(L, -1));
     lua_pop(L, 1);
 
     return;
@@ -1514,7 +1514,8 @@ void animation_base::attach_to_tile(map_tile* pMapNode, int layer) {
 
   this->set_drawing_layer(layer);
 
-  while (pList->next && ((drawable*)pList->next)->get_drawing_layer() < layer) {
+  while (pList->next &&
+         static_cast<drawable*>(pList->next)->get_drawing_layer() < layer) {
     pList = pList->next;
   }
 
@@ -1860,6 +1861,6 @@ void sprite_render_list::depersist(lua_persist_reader* pReader) {
 
   // Fix the sheet field
   luaT_getenvfield(L, 2, "sheet");
-  sheet = (sprite_sheet*)lua_touserdata(L, -1);
+  sheet = static_cast<sprite_sheet*>(lua_touserdata(L, -1));
   lua_pop(L, 1);
 }

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1508,7 +1508,7 @@ void animation_base::attach_to_tile(map_tile* pMapNode, int layer) {
   if (flags & thdf_early_list) {
     pList = &pMapNode->oEarlyEntities;
   } else {
-    pList = pMapNode;
+    pList = &pMapNode->entities;
   }
 
   this->set_drawing_layer(layer);

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -97,6 +97,8 @@ struct render_target_creation_params {
 */
 // TODO: Replace this struct with something cleaner
 struct drawable : public link_list {
+  drawable() : link_list() { drawing_layer = 0; }
+
   //! Draw the object at a specific point on a render target
   /*!
       Can also "draw" the object to the speakers, i.e. play sounds.
@@ -119,6 +121,12 @@ struct drawable : public link_list {
       Should be overloaded in derived class.
   */
   bool (*is_multiple_frame_animation_fn)(drawable* pSelf);
+
+  int get_drawing_layer() { return drawing_layer; }
+  void set_drawing_layer(int layer) { drawing_layer = layer; }
+
+ private:
+  int drawing_layer;
 };
 
 /*!

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -509,8 +509,8 @@ bool level_map::load_from_th_file(const uint8_t* pData, size_t iDataLength,
       }
 
       if (pData[1] != 0 && fnObjectCallback != nullptr) {
-        fnObjectCallback(pCallbackToken, iX, iY, (object_type)pData[1],
-                         pData[0]);
+        fnObjectCallback(pCallbackToken, iX, iY,
+                         static_cast<object_type>(pData[1]), pData[0]);
       }
 
       ++pNode;
@@ -1041,10 +1041,10 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
           pCanvas->set_clip_rect(&rcOldClip);
         }
       }
-      drawable* pItem = (drawable*)(itrNode->oEarlyEntities.next);
+      drawable* pItem = static_cast<drawable*>(itrNode->oEarlyEntities.next);
       while (pItem) {
         pItem->draw_fn(pItem, pCanvas, itrNode.x(), itrNode.y());
-        pItem = (drawable*)(pItem->next);
+        pItem = static_cast<drawable*>(pItem->next);
       }
     }
 
@@ -1088,7 +1088,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
 
       bool bRedrawAnimations = false;
 
-      drawable* pItem = (drawable*)(itrNode->entities.next);
+      drawable* pItem = static_cast<drawable*>(itrNode->entities.next);
       while (pItem) {
         pItem->draw_fn(pItem, pCanvas, itrNode.x(), itrNode.y());
         if (pItem->is_multiple_frame_animation_fn(pItem)) {
@@ -1097,7 +1097,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
         if (pItem->get_drawing_layer() == 1) {
           bNeedsRedraw = true;
         }
-        pItem = (drawable*)(pItem->next);
+        pItem = static_cast<drawable*>(pItem->next);
       }
 
       // if the current tile contained a multiple frame animation (e.g. a
@@ -1110,26 +1110,28 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
 
         // check if an object in the adjacent tile to the left of the
         // current tile needs to be redrawn and if necessary draw it
-        pItem = (drawable*)(formerIterator.get_previous_tile()->entities.next);
+        pItem = static_cast<drawable*>(
+            formerIterator.get_previous_tile()->entities.next);
         while (pItem) {
           if (pItem->get_drawing_layer() == 9) {
             pItem->draw_fn(pItem, pCanvas, formerIterator.x() - 64,
                            formerIterator.y());
             bTileNeedsRedraw = true;
           }
-          pItem = (drawable*)(pItem->next);
+          pItem = static_cast<drawable*>(pItem->next);
         }
 
         // check if an object in the adjacent tile above the current
         // tile needs to be redrawn and if necessary draw it
-        pItem = formerIterator ? (drawable*)(formerIterator->entities.next)
-                               : nullptr;
+        pItem = formerIterator
+                    ? static_cast<drawable*>(formerIterator->entities.next)
+                    : nullptr;
         while (pItem) {
           if (pItem->get_drawing_layer() == 8) {
             pItem->draw_fn(pItem, pCanvas, formerIterator.x(),
                            formerIterator.y());
           }
-          pItem = (drawable*)(pItem->next);
+          pItem = static_cast<drawable*>(pItem->next);
         }
 
         // if an object was redrawn in the tile to the left of the
@@ -1158,13 +1160,15 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
             }
           }
 
-          pItem = (drawable*)(itrNode.get_previous_tile()->oEarlyEntities.next);
-          for (; pItem; pItem = (drawable*)(pItem->next)) {
+          pItem = static_cast<drawable*>(
+              itrNode.get_previous_tile()->oEarlyEntities.next);
+          for (; pItem; pItem = static_cast<drawable*>(pItem->next)) {
             pItem->draw_fn(pItem, pCanvas, itrNode.x() - 64, itrNode.y());
           }
 
-          pItem = (drawable*)(itrNode.get_previous_tile())->entities.next;
-          for (; pItem; pItem = (drawable*)(pItem->next)) {
+          pItem = static_cast<drawable*>(
+              itrNode.get_previous_tile()->entities.next);
+          for (; pItem; pItem = static_cast<drawable*>(pItem->next)) {
             pItem->draw_fn(pItem, pCanvas, itrNode.x() - 64, itrNode.y());
           }
         }
@@ -1240,7 +1244,7 @@ drawable* level_map::hit_test_drawables(link_list* pListStart, int iXs, int iYs,
   while (pListEnd->next) {
     pListEnd = pListEnd->next;
   }
-  drawable* pList = (drawable*)pListEnd;
+  drawable* pList = static_cast<drawable*>(pListEnd);
 
   while (true) {
     if (pList->hit_test_fn(pList, iXs, iYs, iTestX, iTestY)) return pList;
@@ -1248,7 +1252,7 @@ drawable* level_map::hit_test_drawables(link_list* pListStart, int iXs, int iYs,
     if (pList == pListStart) {
       return nullptr;
     } else {
-      pList = (drawable*)pList->prev;
+      pList = static_cast<drawable*>(pList->prev);
     }
   }
 }
@@ -1602,7 +1606,7 @@ void level_map::depersist(lua_persist_reader* pReader) {
     }
 
     if (!pReader->read_stack_object()) return;
-    pNode->entities.next = (link_list*)lua_touserdata(L, -1);
+    pNode->entities.next = static_cast<link_list*>(lua_touserdata(L, -1));
     if (pNode->entities.next) {
       if (pNode->entities.next->prev != nullptr) {
         std::fprintf(stderr, "Warning: THMap linked-lists are corrupted.\n");
@@ -1612,7 +1616,7 @@ void level_map::depersist(lua_persist_reader* pReader) {
     lua_pop(L, 1);
 
     if (!pReader->read_stack_object()) return;
-    pNode->oEarlyEntities.next = (link_list*)lua_touserdata(L, -1);
+    pNode->oEarlyEntities.next = static_cast<link_list*>(lua_touserdata(L, -1));
     if (pNode->oEarlyEntities.next) {
       if (pNode->oEarlyEntities.next->prev != nullptr) {
         std::fprintf(stderr, "Warning: THMap linked-lists are corrupted.\n");

--- a/CorsixTH/Src/th_map.h
+++ b/CorsixTH/Src/th_map.h
@@ -171,13 +171,12 @@ enum class temperature_theme {
   yellow_red     //!< Gradients of yellow, orange, and red
 };
 
-struct map_tile : public link_list {
+struct map_tile {
   map_tile();
   ~map_tile() = default;
 
   // Linked list for entities rendered at this tile
-  // THLinkList::pPrev (will always be nullptr)
-  // THLinkList::pNext
+  link_list entities;
 
   //! Linked list for entities rendered in an early (right-to-left) pass
   link_list oEarlyEntities;


### PR DESCRIPTION
- Remove `link_list` inheritance of map_tile for storing entities
- Move `drawing_layer` value to `drawable` struct.