### PR TITLE
[RDY] Stop faxes being openable on pause

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -484,6 +484,7 @@ function UIBottomPanel:createMessageWindow(index)
   if not message_info then
     return
   end
+  -- Create the message window, note this does not show it to the player on creation.
   local alert_window = UIMessage(self.ui, 175, 1 + #message_windows * 30,
     onClose, message_info.type, message_info.message, message_info.owner, message_info.timeout, message_info.default_choice, message_info.callback)
   message_windows[#message_windows + 1] = alert_window

--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -105,6 +105,11 @@ function UIMessage:adjustToggle()
 end
 
 function UIMessage:openMessage()
+  if TheApp.world:checkPauseBehaviour() and not self.ui:checkForMustPauses() then
+    self.ui:playSound("wrong2.wav")
+    self:adjustToggle()
+    return
+  end
   if TheApp.world:isCurrentSpeed("Speed Up") then
     TheApp.world:previousSpeed()
   end

--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -106,7 +106,7 @@ end
 
 --! Displays the fax/strike message to the player when opened from the bottom_panel.
 function UIMessage:openMessage()
-  if TheApp.world:preventActionsWhenPaused() and not self.ui:checkForMustPauseWindows() then
+  if TheApp.world:isUserActionProhibited() and not self.ui:checkForMustPauseWindows() then
     self.ui:playSound("wrong2.wav")
     self:adjustToggle()
     return

--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -104,8 +104,9 @@ function UIMessage:adjustToggle()
   end
 end
 
+--! Displays the fax/strike message to the player when opened from the bottom_panel.
 function UIMessage:openMessage()
-  if TheApp.world:checkPauseBehaviour() and not self.ui:checkForMustPauses() then
+  if TheApp.world:checkPauseBehaviour() and not self.ui:checkForMustPauseWindows() then
     self.ui:playSound("wrong2.wav")
     self:adjustToggle()
     return

--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -106,7 +106,7 @@ end
 
 --! Displays the fax/strike message to the player when opened from the bottom_panel.
 function UIMessage:openMessage()
-  if TheApp.world:checkPauseBehaviour() and not self.ui:checkForMustPauseWindows() then
+  if TheApp.world:preventActionsWhenPaused() and not self.ui:checkForMustPauseWindows() then
     self.ui:playSound("wrong2.wav")
     self:adjustToggle()
     return

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1041,7 +1041,7 @@ end
 
 function UI:removeWindow(closing_window)
   if Window.removeWindow(self, closing_window) then
-    local pauseGame = false
+    local pauseGame
     local class = closing_window.modal_class
     if class and self.modal_windows[class] == closing_window then
       self.modal_windows[class] = nil

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1047,12 +1047,7 @@ function UI:removeWindow(closing_window)
       self.modal_windows[class] = nil
     end
     if self.app.world and self.app.world:isCurrentSpeed("Pause") then
-      for i in pairs(self.windows) do
-        if self.windows[i].mustPause() then
-          pauseGame = true
-          break
-        end
-      end
+      pauseGame = self:checkForMustPauseWindows()
       if not pauseGame and closing_window.mustPause() then
         self.app.world:setSpeed(self.app.world.prev_speed)
       end

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1068,10 +1068,11 @@ end
 
 --! Function to check if we have any must pause windows open
 --!return (bool) Returns true if a must pause window is found
-function UI:checkForMustPauses()
+function UI:checkForMustPauseWindows()
   for i in pairs(self.windows) do
     if self.windows[i].mustPause() then return true end
   end
+  return false
 end
 
 function UI:getCursorPosition(window)

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1047,7 +1047,7 @@ function UI:removeWindow(closing_window)
     end
     if self.app.world and self.app.world:isCurrentSpeed("Pause") then
       local pauseGame = self:checkForMustPauseWindows()
-      if not pauseGame and closing_window.mustPause() then
+      if not pauseGame and closing_window:mustPause() then
         self.app.world:setSpeed(self.app.world.prev_speed)
       end
     end

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1041,13 +1041,12 @@ end
 
 function UI:removeWindow(closing_window)
   if Window.removeWindow(self, closing_window) then
-    local pauseGame
     local class = closing_window.modal_class
     if class and self.modal_windows[class] == closing_window then
       self.modal_windows[class] = nil
     end
     if self.app.world and self.app.world:isCurrentSpeed("Pause") then
-      pauseGame = self:checkForMustPauseWindows()
+      local pauseGame = self:checkForMustPauseWindows()
       if not pauseGame and closing_window.mustPause() then
         self.app.world:setSpeed(self.app.world.prev_speed)
       end

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1066,6 +1066,14 @@ function UI:removeWindow(closing_window)
   end
 end
 
+--! Function to check if we have any must pause windows open
+--!return (bool) Returns true if a must pause window is found
+function UI:checkForMustPauses()
+  for i in pairs(self.windows) do
+    if self.windows[i].mustPause() then return true end
+  end
+end
+
 function UI:getCursorPosition(window)
   -- Given no argument, returns the cursor position in screen space
   -- Otherwise, returns the cursor position in the space of the given window

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1064,8 +1064,8 @@ end
 --! Function to check if we have any must pause windows open
 --!return (bool) Returns true if a must pause window is found
 function UI:checkForMustPauseWindows()
-  for i in pairs(self.windows) do
-    if self.windows[i].mustPause() then return true end
+  for _, window in pairs(self.windows) do
+    if window:mustPause() then return true end
   end
   return false
 end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -956,10 +956,8 @@ end
 
 --! Function to check if player can perform actions when paused
 --!return (bool) Returns true if player hasn't allowed editing while paused
-function World:checkPauseBehaviour()
-  if self:isCurrentSpeed("Pause") and not self.user_actions_allowed then
-    return true
-  end
+function World:preventActionsWhenPaused()
+  return self:isCurrentSpeed("Pause") and not self.user_actions_allowed
 end
 
 -- Outside (air) temperatures based on climate data for Oxford, taken from

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -954,6 +954,14 @@ function World:pauseOrUnpause()
   end
 end
 
+--! Function to check if player can perform actions when paused
+--!return (bool) Returns true if player hasn't allowed editing while paused
+function World:checkPauseBehaviour()
+  if self:isCurrentSpeed("Pause") and not self.user_actions_allowed then
+    return true
+  end
+end
+
 -- Outside (air) temperatures based on climate data for Oxford, taken from
 -- Wikipedia. For scaling, 0 degrees C becomes 0 and 50 degrees C becomes 1
 local outside_temperatures = {

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -956,7 +956,7 @@ end
 
 --! Function to check if player can perform actions when paused
 --!return (bool) Returns true if player hasn't allowed editing while paused
-function World:preventActionsWhenPaused()
+function World:isUserActionProhibited()
   return self:isCurrentSpeed("Pause") and not self.user_actions_allowed
 end
 


### PR DESCRIPTION
*Fixes #1715*

<s>I haven't tested this with staff rise windows yet...</s> works fine. so if anyone is able to tell me something's wrong let me know. Hopefully I've added functions in the right place for once.

**Describe what the proposed change does**
- Prevents fax and staff rise windows being opened on pause where editing is not allowed.
- Added a "wrong2" sound when player tries to click on a message icon when not allowed.
- If the game gets paused because of a fax, then you can still switch between faxes as before.
