### PR TITLE
[RDY] Maintain queue push-priority order

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -208,7 +208,7 @@ local action_queue_on_change_position = permanent"action_queue_on_change_positio
   local queue = action.queue
   if not must_stand then
     for i = 1, queue.bench_threshold do
-      if queue[i] == humanoid then
+      if queue:reportedHumanoid(i) == humanoid then
         must_stand = true
         break
       end

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -168,11 +168,11 @@ function Queue:push(humanoid, callbacks_on)
       increment_reported_size = false
     end
   end
-  if class.is(humanoid, Staff) then
+  if increment_reported_size and class.is(humanoid, Staff) then
     -- Give staff priority over patients
     while index > 1 do
       local before = self[index - 1]
-      if class.is(before, Staff) then
+      if class.is(before, Staff) or (self.same_room_priority and self.same_room_priority:getRoom() == before:getRoom()) then
         break
       end
       index = index - 1
@@ -180,10 +180,10 @@ function Queue:push(humanoid, callbacks_on)
     increment_reported_size = false
   end
   -- Emergencies and any VIP's get put before all the other patients, but AFTER currently queued emergencies.
-  if humanoid.is_emergency or class.is(humanoid, Vip) or class.is(humanoid, Inspector) then
+  if increment_reported_size and humanoid.is_emergency or class.is(humanoid, Vip) or class.is(humanoid, Inspector) then
     while index > 1 do
       local before = self[index - 1]
-      if before.is_emergency then
+      if before.is_emergency or class.is(before, Staff) or (self.same_room_priority and self.same_room_priority:getRoom() == before:getRoom()) then
         break
       end
       index = index - 1


### PR DESCRIPTION
*Fixes #1645*

**Describe what the proposed change does**
- Checking increment_reported_size prevents changes to the queue order when its already been determined from previous priority - staff leaving the room will not move in front of a patient also leaving the room
- Before checks extended to include the priority from the previous checks - if a staff member is entering a room and a staff member and patient are queued to exit, the entering staff member will not move ahead of the leaving patient.

The Vip and Inspector don't actually queue at the moment, they just arrive at the door tile. They do at reception though, but emergency patients probably shouldn't but could go to reception I guess on some rare cases, and staff don't use it either, but the logic should be ok in those cases.
