### PR TITLE
[RDY] Stop blue filter on UIConfirmDialog

### DIFF
--- a/CorsixTH/Lua/dialogs/confirm_dialog.lua
+++ b/CorsixTH/Lua/dialogs/confirm_dialog.lua
@@ -69,6 +69,10 @@ function UIConfirmDialog:UIConfirmDialog(ui, text, callback_ok, callback_cancel)
   self:registerKeyHandlers()
 end
 
+function UIConfirmDialog:mustPause()
+  return true
+end
+
 function UIConfirmDialog:registerKeyHandlers()
   self:addKeyHandler("global_confirm", self.ok)
   self:addKeyHandler("global_confirm_alt", self.ok)

--- a/CorsixTH/Lua/dialogs/confirm_dialog.lua
+++ b/CorsixTH/Lua/dialogs/confirm_dialog.lua
@@ -69,6 +69,7 @@ function UIConfirmDialog:UIConfirmDialog(ui, text, callback_ok, callback_cancel)
   self:registerKeyHandlers()
 end
 
+-- Confirm dialogs are used for errors and require the game to pause
 function UIConfirmDialog:mustPause()
   return true
 end

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -492,8 +492,6 @@ local function Humanoid_startAction(self)
     elseif class.is(self, Staff) then
       ui:addWindow(UIStaff(ui, self))
     end
-    -- Pause the game.
-    self.world:setSpeed("Pause")
 
     -- Tell the player what just happened.
     self.world:gameLog("")

--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -59,7 +59,7 @@ function Window:Window()
   self.draggable = true
 end
 
--- Most windows don't pause the game. Specific windows: fax, annual report, staff rise do pause and are set in the specific files
+-- Most windows don't pause the game. Specific windows: fax, annual report, staff rise, and errors do pause and are set in the specific files
 function Window:mustPause()
   return false
 end


### PR DESCRIPTION
**Describe what the proposed change does**
- Blue filter was going on top of the ConfirmDialog error messages when they actually should be a mustPause() window.
- humanoid no longer pauses the game on these messages -- all handled by Window.
