### PR TITLE
[rdy] Objects belong to a hospital

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 150
+local SAVEGAME_VERSION = 151
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -178,7 +178,7 @@ function UIFax:choice(choice_number)
   end
   local vip_ignores_refusal = math.random(1, 2)
   if choice == "accept_emergency" then
-    self.ui.app.world:newObject("helicopter", self.ui.hospital, "north")
+    self.ui.app.world:newObject("helicopter", "north")
     self.ui:addWindow(UIWatch(self.ui, "emergency"))
     self.ui:playAnnouncement(self.ui.hospital.emergency.disease.emergency_sound, AnnouncementPriority.Critical)
     self.ui.adviser:say(_A.information.emergency)

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -37,7 +37,9 @@ function Object:getDrawingLayer()
   return 4
 end
 
-function Object:Object(world, object_type, x, y, direction, etc)
+function Object:Object(hospital, object_type, x, y, direction, etc)
+  assert(class.is(hospital, Hospital), "First argument is not a Hospital instance.")
+
   local th = TH.animation()
   self:Entity(th)
 
@@ -51,8 +53,8 @@ function Object:Object(world, object_type, x, y, direction, etc)
 
   self.ticks = object_type.ticks
   self.object_type = object_type
-  self.world = world
-  self.hospital = world:getLocalPlayerHospital()
+  self.hospital = hospital
+  self.world = hospital.world
   self.user = false
   self.times_used = -1 -- Incremented in the call on the next line
   self:updateDynamicInfo()

--- a/CorsixTH/Lua/objects/door.lua
+++ b/CorsixTH/Lua/objects/door.lua
@@ -166,6 +166,8 @@ function Door:checkForDeadlock()
     for _, action in ipairs(self.reserved_for.action_queue) do
       if action.name == "queue" then
         if action.queue ~= self.queue or self.queue[1] ~= self.reserved_for then
+          print("Warning: Trying to resolve door deadlock at ("
+              .. self.tile_x .. ", " .. self.tile_y .. ")")
           self.reserved_for = nil
           self:getRoom():tryAdvanceQueue()
         end

--- a/CorsixTH/Lua/objects/door.lua
+++ b/CorsixTH/Lua/objects/door.lua
@@ -166,8 +166,8 @@ function Door:checkForDeadlock()
     for _, action in ipairs(self.reserved_for.action_queue) do
       if action.name == "queue" then
         if action.queue ~= self.queue or self.queue[1] ~= self.reserved_for then
-          print("Warning: Trying to resolve door deadlock at ("
-              .. self.tile_x .. ", " .. self.tile_y .. ")")
+          self.world:gameLog("Warning: Trying to resolve door deadlock at ("
+              .. tostring(self.tile_x) .. ", " .. tostring(self.tile_y) .. ")")
           self.reserved_for = nil
           self:getRoom():tryAdvanceQueue()
         end

--- a/CorsixTH/Lua/objects/doors/entrance_right_door.lua
+++ b/CorsixTH/Lua/objects/doors/entrance_right_door.lua
@@ -36,22 +36,22 @@ class "EntranceDoor" (Object)
 ---@type EntranceDoor
 local EntranceDoor = _G["EntranceDoor"]
 
-function EntranceDoor:EntranceDoor(world, object_type, x, y, direction, etc)
+function EntranceDoor:EntranceDoor(hospital, object_type, x, y, direction, etc)
   self.is_master = object_type == object
-  self:Object(world, object_type, x, y, direction, etc)
+  self:Object(hospital, object_type, x, y, direction, etc)
   self.occupant_count = 0
   self.is_open = false
   -- We need to link the master to the slave but we don't know in which order they will be initialized
   if self.is_master then -- The master will check for an adjacent slave
     local slave_type = "entrance_left_door"
-    self.slave = world:getObject(x - 1, y, slave_type) or world:getObject(x, y - 1, slave_type) or nil
+    self.slave = self.world:getObject(x - 1, y, slave_type) or self.world:getObject(x, y - 1, slave_type) or nil
 
     if self.slave then
       self.slave.master = self
     end
   else -- The slave will check for an adjacent master
     local master_type = "entrance_right_door"
-    self.master = world:getObject(x + 1, y, master_type) or world:getObject(x, y + 1, master_type) or nil
+    self.master = self.world:getObject(x + 1, y, master_type) or self.world:getObject(x, y + 1, master_type) or nil
 
     if self.master then
       self.master.slave = self

--- a/CorsixTH/Lua/objects/helicopter.lua
+++ b/CorsixTH/Lua/objects/helicopter.lua
@@ -34,17 +34,17 @@ object.orientations = {
   },
 }
 
---! An `Object` which drops of emergency patients.
+--! An `Object` which drops off emergency patients.
 class "Helicopter" (Object)
 
 ---@type Helicopter
 local Helicopter = _G["Helicopter"]
 
-function Helicopter:Helicopter(world, object_type, hospital, direction, etc)
+function Helicopter:Helicopter(hospital, object_type, direction, etc)
   local x, y = hospital:getHeliportPosition()
-  -- Helicoptor needs to land below tile to be positioned correctly
+  -- Helicopter needs to land below tile to be positioned correctly
   y = y + 1
-  self:Object(world, object_type, x, y, direction, etc)
+  self:Object(hospital, object_type, x, y, direction, etc)
   self.th:makeInvisible()
   self:setPosition(0, -600)
   self.phase = -120

--- a/CorsixTH/Lua/objects/litter.lua
+++ b/CorsixTH/Lua/objects/litter.lua
@@ -137,11 +137,6 @@ function Litter:anyLitter()
 end
 
 function Litter:afterLoad(old, new)
-  if old < 151 then
-    -- Set first, so next afterloads can use this hospital.
-    self.hospital = self.world:getHospital(self.tile_x, self.tile_y)
-  end
-
   if old < 52 then
     if self.tile_x then
       self.hospital:addHandymanTask(self, "cleaning", 1, self.tile_x, self.tile_y)
@@ -159,6 +154,10 @@ function Litter:afterLoad(old, new)
 
   if old < 121 then
     self.ticks = object.ticks
+  end
+
+  if old < 151 then
+    self.hospital = self.world:getHospital(self.tile_x, self.tile_y)
   end
 end
 

--- a/CorsixTH/Lua/objects/litter.lua
+++ b/CorsixTH/Lua/objects/litter.lua
@@ -53,12 +53,13 @@ class "Litter" (Entity)
 ---@type Litter
 local Litter = _G["Litter"]
 
-function Litter:Litter(world, object_type, x, y, direction, etc)
+function Litter:Litter(hospital, object_type, x, y, direction, etc)
   local th = TH.animation()
   self:Entity(th)
   self.ticks = object_type.ticks
   self.object_type = object_type
-  self.world = world
+  self.hospital = hospital
+  self.world = hospital.world
   self:setTile(x, y)
 end
 
@@ -86,8 +87,7 @@ function Litter:setLitterType(anim_type, mirrorFlag)
       error("Unknown litter type")
     end
     if self:isCleanable() then
-      local hospital = self.world:getHospital(self.tile_x, self.tile_y)
-      hospital:addHandymanTask(self, "cleaning", 1, self.tile_x, self.tile_y)
+      self.hospital:addHandymanTask(self, "cleaning", 1, self.tile_x, self.tile_y)
     end
   end
 end
@@ -99,9 +99,8 @@ function Litter:remove()
   if self.tile_x then
     self.world:removeObjectFromTile(self, self.tile_x, self.tile_y)
 
-    local hospital = self.world:getHospital(self.tile_x, self.tile_y)
-    local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning", self)
-    hospital:removeHandymanTask(taskIndex, "cleaning")
+    local taskIndex = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning", self)
+    self.hospital:removeHandymanTask(taskIndex, "cleaning")
   else
     print("Warning: Removing litter that has already been removed.")
   end
@@ -138,9 +137,14 @@ function Litter:anyLitter()
 end
 
 function Litter:afterLoad(old, new)
+  if old < 151 then
+    -- Set first, so next afterloads can use this hospital.
+    self.hospital = self.world:getHospital(self.tile_x, self.tile_y)
+  end
+
   if old < 52 then
     if self.tile_x then
-      self.world.hospitals[1]:addHandymanTask(self, "cleaning", 1, self.tile_x, self.tile_y)
+      self.hospital:addHandymanTask(self, "cleaning", 1, self.tile_x, self.tile_y)
     else
       -- This object was not properly removed from the world.
       self.world:destroyEntity(self)
@@ -148,9 +152,8 @@ function Litter:afterLoad(old, new)
   end
   if old < 54 then
     if not self:isCleanable() then
-      local hospital = self.world:getHospital(self.tile_x, self.tile_y)
-      local taskIndex = hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning", self)
-      hospital:removeHandymanTask(taskIndex, "cleaning")
+      local taskIndex = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "cleaning", self)
+      self.hospital:removeHandymanTask(taskIndex, "cleaning")
     end
   end
 

--- a/CorsixTH/Lua/objects/plant.lua
+++ b/CorsixTH/Lua/objects/plant.lua
@@ -90,10 +90,10 @@ class "Plant" (Object)
 ---@type Plant
 local Plant = _G["Plant"]
 
-function Plant:Plant(world, object_type, x, y, direction, etc)
+function Plant:Plant(hospital, object_type, x, y, direction, etc)
   -- It doesn't matter which direction the plant is facing. It will be rotated so that an approaching
   -- handyman uses the correct usage animation when appropriate.
-  self:Object(world, object_type, x, y, direction, etc)
+  self:Object(hospital, object_type, x, y, direction, etc)
   self.current_state = 0
   self.base_frame = self.th:getFrame()
   self.days_left = days_between_states

--- a/CorsixTH/Lua/objects/rathole.lua
+++ b/CorsixTH/Lua/objects/rathole.lua
@@ -55,8 +55,8 @@ class "Rathole" (Object)
 ---@type Rathole
 local Rathole = _G["Rathole"]
 
-function Rathole:Rathole(world, oject_type, x, y, direction, etc)
-  self:Object(world, oject_type, x, y, direction, etc)
+function Rathole:Rathole(hospital, oject_type, x, y, direction, etc)
+  self:Object(hospital, oject_type, x, y, direction, etc)
 end
 
 return object

--- a/CorsixTH/Lua/objects/reception_desk.lua
+++ b/CorsixTH/Lua/objects/reception_desk.lua
@@ -106,7 +106,7 @@ function ReceptionDesk:tick()
           if class.is(queue_front, Inspector) then
             local inspector = queue_front
             if not inspector.going_home  then
-              local epidemic = self.world:getLocalPlayerHospital().epidemic
+              local epidemic = self.hospital.epidemic
               if epidemic then
                 -- The result of the epidemic may already by determined
                 -- i.e if an infected patient has left the hospital
@@ -151,11 +151,10 @@ function ReceptionDesk:checkForNearbyStaff()
   end
 
   local nearest_staff, nearest_d
-  local world = self.world
   local use_x, use_y = self:getSecondaryUsageTile()
   for _, entity in ipairs(self.world.entities) do
     if entity.humanoid_class == "Receptionist" and not entity.associated_desk and not entity.fired then
-      local distance = world.pathfinder:findDistance(entity.tile_x, entity.tile_y, use_x, use_y)
+      local distance = self.world.pathfinder:findDistance(entity.tile_x, entity.tile_y, use_x, use_y)
       if not nearest_d or distance < nearest_d then
         nearest_staff = entity
         nearest_d = distance
@@ -198,14 +197,14 @@ function ReceptionDesk:onDestroy()
     self.reserved_for = nil
 
     -- Find a new reception desk for the receptionist
-    local world = receptionist.world
-    world:findObjectNear(receptionist, "reception_desk", nil, function(x, y)
-      local obj = world:getObject(x, y, "reception_desk")
-      -- Make sure we are not selecting the same desk again
-      if obj and obj ~= self then
-        return obj:occupy(receptionist)
-      end
-    end)
+    self.world:findObjectNear(receptionist, "reception_desk", nil,
+        function(x, y)
+          local obj = self.world:getObject(x, y, "reception_desk")
+          -- Make sure we are not selecting the same desk again
+          if obj and obj ~= self then
+            return obj:occupy(receptionist)
+          end
+        end)
   end
   self.queue:rerouteAllPatients(SeekReceptionAction())
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1872,20 +1872,26 @@ end
 --! Creates a new object by finding the object_type from the "id" variable and
 --  calls its class constructor.
 --!param id (string) The unique id of the object to be created.
+--!param x X position of the new object.
+--!param y Y position of the new object.
+--!param flags Flags of the new object.
+--!param name Name of the new object.
 --!return The created object.
-function World:newObject(id, ...)
+function World:newObject(id, x, y, flags, name)
   local object_type = self.object_types[id]
+  local hospital = self:getLocalPlayerHospital()
+
   local entity
   if object_type.class then
-    entity = _G[object_type.class](self, object_type, ...)
+    entity = _G[object_type.class](hospital, object_type, x, y, flags, name)
   elseif object_type.default_strength then
-    entity = Machine(self, object_type, ...)
+    entity = Machine(hospital, object_type, x, y, flags, name)
     -- Tell the player if there is no handyman to take care of the new machinery.
     if self.hospitals[1]:countStaffOfCategory("Handyman") == 0 then
       self.ui.adviser:say(_A.staff_advice.need_handyman_machines)
     end
   else
-    entity = Object(self, object_type, ...)
+    entity = Object(hospital, object_type, x, y, flags, name)
   end
   self:objectPlaced(entity, id)
   return entity

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -727,26 +727,28 @@ local flag_cache = {}
 function World:createMapObjects(objects)
   self.delayed_map_objects = {}
   local map = self.map.th
-  for _, object in ipairs(objects) do repeat
+  for _, object in ipairs(objects) do
     local x, y, thob, flags = unpack(object)
     local object_id = self.object_id_by_thob[thob]
     if not object_id then
       print("Warning: Map contained object with unrecognised THOB (" .. thob .. ") at " .. x .. "," .. y)
-      break -- continue
-    end
-    local object_type = self.object_types[object_id]
-    if not object_type or not object_type.supports_creation_for_map then
-      print("Warning: Unable to create map object " .. object_id .. " at " .. x .. "," .. y)
-      break -- continue
-    end
-    -- Delay making objects which are on plots which haven't been purchased yet
-    local parcel = map:getCellFlags(x, y, flag_cache).parcelId
-    if parcel ~= 0 and map:getPlotOwner(parcel) == 0 then
-      self.delayed_map_objects[{object_id, x, y, flags, "map object"}] = parcel
+      -- Ignore object.
     else
-      self:newObject(object_id, x, y, flags, "map object")
+      local object_type = self.object_types[object_id]
+      if not object_type or not object_type.supports_creation_for_map then
+        print("Warning: Unable to create map object " .. object_id .. " at " .. x .. "," .. y)
+        -- Ignore object.
+      else
+        -- Delay making objects which are on plots which haven't been purchased yet
+        local parcel = map:getCellFlags(x, y, flag_cache).parcelId
+        if parcel ~= 0 and map:getPlotOwner(parcel) == 0 then
+          self.delayed_map_objects[{object_id, x, y, flags, "map object"}] = parcel
+        else
+          self:newObject(object_id, x, y, flags, "map object")
+        end
+      end
     end
-  until true end
+  end -- for
 end
 
 --! Change owner of a plot.

--- a/CorsixTH/Luatest/spec/entities/machine_spec.lua
+++ b/CorsixTH/Luatest/spec/entities/machine_spec.lua
@@ -28,10 +28,12 @@ require("entities/machine")
 
 describe("object.lua: ", function()
   local stub_world = {map = {}}
+  local stub_hospital = {world = stub_world}
+  _G["Hospital"] = stub_hospital
+
   local tile_x, tile_y, direction = 10, 10, "west"
 
   local function createMachineWithFakeInput()
-    stub(stub_world, "getLocalPlayerHospital")
     stub(stub_world, "addObjectToTile")
     stub(stub_world, "clearCaches")
     local offset = {0, 0}
@@ -44,7 +46,7 @@ describe("object.lua: ", function()
       idle_animations = {west = true},
       orientations = {west = orientation}
       }
-    return Machine(stub_world, fake_object_type, tile_x, tile_y, direction)
+    return Machine(stub_hospital, fake_object_type, tile_x, tile_y, direction)
   end
 
   it("can update dynamic Info", function()

--- a/CorsixTH/Luatest/spec/entities/object_spec.lua
+++ b/CorsixTH/Luatest/spec/entities/object_spec.lua
@@ -25,6 +25,9 @@ require("entities.object")
 
 describe("object.lua: ", function()
   local stub_world = {map = {}}
+  local stub_hospital = {world = stub_world}
+  _G["Hospital"] = stub_hospital
+
   local fake_object_type = {ticks = false, idle_animations = {west = true}}
   local tile_x, tile_y, direction = 10, 10, "west"
 
@@ -32,7 +35,7 @@ describe("object.lua: ", function()
     stub(stub_world, "getLocalPlayerHospital")
     stub(stub_world, "addObjectToTile")
     stub(stub_world, "clearCaches")
-    return Object(stub_world, fake_object_type, tile_x, tile_y, direction)
+    return Object(stub_hospital, fake_object_type, tile_x, tile_y, direction)
   end
 
   it("can create Object objects", function()


### PR DESCRIPTION
**Describe what the proposed change does**
- Previously, objects just lived in 'world', and sometimes used `world:getLocalPlayerHospital()` or `ui.hospital` for hospital access.
- This patch gives all objects a hospital reference of their own.
- Currently, the used hospital is always `world:getLocalPlayerHospital()`

*Other changes*
- Door deadlock resolve code didn't output anything which may be useful, so added that.
- Object creation code used continue magic, which was eliminated.
