### PR TITLE
[RDY] Guard against world not existing when opening a window

### DIFF
--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1029,7 +1029,7 @@ function UI:addWindow(window)
     end
     self.modal_windows[window.modal_class] = window
   end
-  if window:mustPause() then
+  if self.app.world and window:mustPause() then
     self.app.world:setSpeed("Pause")
     self.app.video:setBlueFilterActive(false) -- mustPause windows shouldn't cause tainting
   end


### PR DESCRIPTION
Fixes #1774

Guards against condition where a window opens but there is no world because we are in the main menu.