### PR TITLE
Missed the swing door and a constructor in 23582e74

### DIFF
--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -120,8 +120,8 @@ function Object.slaveMixinClass(class_method_table)
   local super_constructor = super[class.name(super)]
 
   -- Constructor
-  class_method_table[name] = function(self, world, object_type, x, y, direction, ...)
-    super_constructor(self, world, object_type, x, y, direction, ...)
+  class_method_table[name] = function(self, hospital, object_type, x, y, direction, ...)
+    super_constructor(self, hospital, object_type, x, y, direction, ...)
     if object_type.slave_id then
       local orientation = object_type.orientations
       orientation = orientation and orientation[direction]
@@ -129,7 +129,7 @@ function Object.slaveMixinClass(class_method_table)
         x = x + orientation.slave_position[1]
         y = y + orientation.slave_position[2]
       end
-      self.slave = world:newObject(object_type.slave_id, x, y, direction, ...)
+      self.slave = hospital.world:newObject(object_type.slave_id, x, y, direction, ...)
       self.slave.master = self
     end
   end

--- a/CorsixTH/Lua/objects/doors/swing_door_right.lua
+++ b/CorsixTH/Lua/objects/doors/swing_door_right.lua
@@ -35,14 +35,14 @@ class "SwingDoor" (Door)
 ---@type SwingDoor
 local SwingDoor = _G["SwingDoor"]
 
-function SwingDoor:SwingDoor(world, object_type, x, y, direction, etc)
+function SwingDoor:SwingDoor(hospital, object_type, x, y, direction, etc)
   self.is_master = object_type == object
-  self:Door(world, object_type, x, y, direction, etc)
+  self:Door(hospital, object_type, x, y, direction, etc)
   if self.is_master then
     -- Wait one tick before finding the slave so that we're sure it has been created.
     local --[[persistable:swing_door_creation]] function callback()
       local slave_type = "swing_door_left"
-      self.slave = world:getObject(x - 1, y, slave_type) or world:getObject(x, y - 1, slave_type) or nil
+      self.slave = self.world:getObject(x - 1, y, slave_type) or self.world:getObject(x, y - 1, slave_type) or nil
       self.slave:setAsSlave(self)
       self.ticks = false
     end


### PR DESCRIPTION
*Fixes Swing doors crash:

```
Running: The timer handler.
A stack trace is included below, and the handler has been disconnected.
CorsixTH/Lua/objects/doors/swing_door_right.lua:45: attempt to call a nil value (method 'getObject')
stack traceback:
	CorsixTH/Lua/objects/doors/swing_door_right.lua:45: in local 'timer_function'
	CorsixTH/Lua/entity.lua:216: in function <CorsixTH/Lua/entity.lua:193>
	(...tail calls...)
	CorsixTH/Lua/world.lua:1065: in method 'onTick'
	CorsixTH/Lua/app.lua:1127: in function <CorsixTH/Lua/app.lua:1124>
	(...tail calls...)
	CorsixTH/Lua/app.lua:1027: in function <CorsixTH/Lua/app.lua:1022>

Error in timer handler:
```