### PR TITLE
[RDY] Forbid loading new saves on old versions when outside debug

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1517,7 +1517,7 @@ function App:quickLoad()
   end
 end
 
---! Function to check the savegame version matches or is older than the installation of CorsixTH
+--! Function to check the loaded game is compatible with the program
 --!param save_version (num)
 --!return true if compatible, otherwise false
 function App:checkCompatibility(save_version)
@@ -1525,8 +1525,7 @@ function App:checkCompatibility(save_version)
   if app_version >= save_version or self.config.debug then
     return true
   else
-    local err = _S.errors.compatibility_error
-    UILoadGame:loadError(err)
+    UILoadGame:loadError(_S.errors.compatibility_error)
     return false
   end
 end
@@ -1591,7 +1590,7 @@ function App:afterLoad()
   end
   local first = self.world.original_savegame_version
 
-  -- Generate the human-readable version number (old [loaded save], new [game], first [original])
+  -- Generate the human-readable version number (old [loaded save], new [program], first [original])
   local first_version = first .. " (" .. self:getVersion(first) .. ")"
   local old_version = old .. " (" .. self:getVersion(old) .. ")"
   local new_version = new .. " (" .. self:getVersion() .. ")"

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
@@ -46,7 +46,7 @@ function UILoadGame:choiceMade(name)
 end
 
 --! Output the error when trying to load a game
---!param error The error given
+--!param err The error given
 function UILoadGame:loadError(err)
   print(err)
   TheApp:loadMainMenu()

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
@@ -41,10 +41,14 @@ function UILoadGame:choiceMade(name)
   local status, err = pcall(app.load, app, name)
   if not status then
     err = _S.errors.load_prefix .. err
-    print(err)
-    app:loadMainMenu()
-    app.ui:addWindow(UIInformation(self.ui, {err}))
+    self:loadError(err)
   end
+end
+
+function UILoadGame:loadError(err)
+  print(err)
+  TheApp:loadMainMenu()
+  TheApp.ui:addWindow(UIInformation(TheApp.ui, {err}))
 end
 
 function UILoadGame:close()

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
@@ -45,6 +45,8 @@ function UILoadGame:choiceMade(name)
   end
 end
 
+--! Output the error experience when trying to load a game
+--!param error The error given
 function UILoadGame:loadError(err)
   print(err)
   TheApp:loadMainMenu()

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
@@ -45,7 +45,7 @@ function UILoadGame:choiceMade(name)
   end
 end
 
---! Output the error experience when trying to load a game
+--! Output the error when trying to load a game
 --!param error The error given
 function UILoadGame:loadError(err)
   print(err)

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -683,7 +683,7 @@ errors = {
   dialog_missing_graphics = "Sorry, the demo data files don't contain this dialog.",
   save_prefix = "Error while saving game: ",
   load_prefix = "Error while loading game: ",
-  compatibility_error = "Sorry, this save was created with a newer version of CorsixTH (%s) than the one currently installed (%s). Please update your game to a more recent version. Alternatively you can turn on debug options in the configuration file to access this save.",
+  compatibility_error = "Sorry, this save was created with a newer version of CorsixTH and is not compatible. Please update to a more recent version.",
   no_games_to_contine = "There are no saved games.",
   load_quick_save = "Error, cannot load the quicksave as it does not exist, not to worry as we have now created one for you!",
   map_file_missing = "Could not find the map file %s for this level!",
@@ -698,7 +698,7 @@ errors = {
 warnings = {
   levelfile_variable_is_deprecated = "Notice: The level '%s' contains a deprecated variable definition in the level file." ..
                                      "'%LevelFile' has been renamed to '%MapFile'. Please advise the map creator to update the level.",
-  newersave = "Warning, you have loaded a save from a newer version of CorsixTH. It is not recommended to continue as crashes may occur. You may want to look at updating to a newer version of the game."
+  newersave = "Warning, you have loaded a save from a newer version of CorsixTH. It is not recommended to continue as crashes may occur. Play at your own risk."
 }
 
 confirmation = {

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -683,6 +683,7 @@ errors = {
   dialog_missing_graphics = "Sorry, the demo data files don't contain this dialog.",
   save_prefix = "Error while saving game: ",
   load_prefix = "Error while loading game: ",
+  compatibility_error = "Sorry, this save was created with a newer version of CorsixTH (%s) than the one currently installed (%s). Please update your game to a more recent version. Alternatively you can turn on debug options in the configuration file to access this save.",
   no_games_to_contine = "There are no saved games.",
   load_quick_save = "Error, cannot load the quicksave as it does not exist, not to worry as we have now created one for you!",
   map_file_missing = "Could not find the map file %s for this level!",
@@ -697,6 +698,7 @@ errors = {
 warnings = {
   levelfile_variable_is_deprecated = "Notice: The level '%s' contains a deprecated variable definition in the level file." ..
                                      "'%LevelFile' has been renamed to '%MapFile'. Please advise the map creator to update the level.",
+  newersave = "Warning, you have loaded a save from a newer version of CorsixTH. It is not recommended to continue as crashes may occur. You may want to look at updating to a newer version of the game."
 }
 
 confirmation = {

--- a/CorsixTH/Lua/persistance.lua
+++ b/CorsixTH/Lua/persistance.lua
@@ -260,13 +260,14 @@ function SaveGameFile(filename)
   f:close()
 end
 
---! Loads the game's save into the game
+--! Puts loaded file into the game
+--!param data The file
 function LoadGame(data)
   --local status, res = xpcall(function()
   local objtable = MakePermanentObjectsTable(true)
   local state = assert(persist.load(data, objtable))
-  -- Here we want to check the game we're loading is same or older than the current version
-  if not TheApp:checkCompatibility(state.world.savegame_version, state.world.release_version) then return end
+  -- Check the game we're loading is same or older than the current version
+  if not TheApp:checkCompatibility(state.world.savegame_version) then return end
   state.ui:resync(TheApp.ui)
   TheApp.ui = state.ui
   TheApp.world = state.world

--- a/CorsixTH/Lua/persistance.lua
+++ b/CorsixTH/Lua/persistance.lua
@@ -260,10 +260,13 @@ function SaveGameFile(filename)
   f:close()
 end
 
+--! Loads the game's save into the game
 function LoadGame(data)
   --local status, res = xpcall(function()
   local objtable = MakePermanentObjectsTable(true)
   local state = assert(persist.load(data, objtable))
+  -- Here we want to check the game we're loading is same or older than the current version
+  if not TheApp:checkCompatibility(state.world.savegame_version, state.world.release_version) then return end
   state.ui:resync(TheApp.ui)
   TheApp.ui = state.ui
   TheApp.world = state.world

--- a/CorsixTH/Lua/persistance.lua
+++ b/CorsixTH/Lua/persistance.lua
@@ -266,7 +266,7 @@ function LoadGame(data)
   --local status, res = xpcall(function()
   local objtable = MakePermanentObjectsTable(true)
   local state = assert(persist.load(data, objtable))
-  -- Check the game we're loading is same or older than the current version
+  -- Check the game we're loading is compatible with program
   if not TheApp:checkCompatibility(state.world.savegame_version) then return end
   state.ui:resync(TheApp.ui)
   TheApp.ui = state.ui

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -129,8 +129,8 @@ function World:World(app)
   self.hospitals = {}
   self.floating_dollars = {}
   self.game_log = {} -- saves list of useful debugging information
-  self.savegame_version = app.savegame_version
-  self.release_version = app:getVersion(self.savegame_version)
+  self.savegame_version = app.savegame_version -- Savegame version number
+  self.release_version = app:getVersion(self.savegame_version) -- Savegame release version (e.g. 0.60), or Trunk
   -- Also preserve this throughout future updates.
   self.original_savegame_version = app.savegame_version
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -130,6 +130,7 @@ function World:World(app)
   self.floating_dollars = {}
   self.game_log = {} -- saves list of useful debugging information
   self.savegame_version = app.savegame_version
+  self.release_version = app:getVersion(self.savegame_version)
   -- Also preserve this throughout future updates.
   self.original_savegame_version = app.savegame_version
 
@@ -2660,6 +2661,7 @@ function World:afterLoad(old, new)
   end
 
   self.savegame_version = new
+  self.release_version = TheApp:getVersion(new)
 end
 
 function World:playLoadedEntitySounds()


### PR DESCRIPTION
**Describe what the proposed change does**
- Completing a TODO to prevent newer saves opening in older games.
- This change will only have a real effect post savegame 152.
- Also saves the savegame_release version to world so an old game knows where the newer save came from (for compatibility it uses Trunk as fallback/nil). 
- Allows saves to be opened in debug but shows a similar warning.

When debug is on: (NB: updated 29/12)
![image](https://user-images.githubusercontent.com/20030128/103283695-2dc7e680-49d1-11eb-91cf-718ac403a297.png)

When debug is off: (NB: updated 29/12)
![image](https://user-images.githubusercontent.com/20030128/103283743-46380100-49d1-11eb-9f24-7d529d3f423b.png)
