### PR TITLE
[RDY] Cancel any saved screen movement from edge scrolling

### DIFF
--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1096,6 +1096,10 @@ function UI:afterLoad(old, new)
     self.editing_allowed = true
   end
   self:setupGlobalKeyHandlers()
+
+  -- Cancel any saved screen movement from edge scrolling
+  self.tick_scroll_amount_mouse = nil
+
   Window.afterLoad(self, old, new)
 end
 


### PR DESCRIPTION
*Fixes #525 *

**Describe what the proposed change does**
- Deletes the existing screen movement when loading a world.
