### PR TITLE
[RDY] Change spanish language name

### DIFF
--- a/CorsixTH/Lua/languages/spanish.lua
+++ b/CorsixTH/Lua/languages/spanish.lua
@@ -18,7 +18,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
-Language("Castellano", "Spanish", "es", "spa", "esp", "sp")
+Language("Español", "Spanish", "es", "spa", "esp", "sp")
 Inherit("english")
 Inherit("original_strings", 4)
 


### PR DESCRIPTION
Use more generic ``Español`` for Spanish rather than ``Castellano``.

After speaking with @LloydJara in the CorsixTH Discord it was determined that the original Spanish translation files were made generic to be understood by as many variations of the language as possible. As such, Castellano refers generally to "Spain Spanish" than a general Spanish.