### PR TITLE
Skip the level board movie on level restart

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -662,10 +662,6 @@ function App:loadLevel(level, difficulty, level_name, level_file, level_intro, m
   self.ui = GameUI(self, self.world:getLocalPlayerHospital(), map_editor)
   self.world:setUI(self.ui) -- Function call allows world to set up its keyHandlers
 
-  if tonumber(level) then
-    self.moviePlayer:playAdvanceMovie(level)
-  end
-
   -- Now restore progress from previous levels.
   if carry_to_next_level then
     self.world:initFromPreviousLevel(carry_to_next_level)

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -209,7 +209,9 @@ function UIFax:choice(choice_number)
     -- Set the new salary.
     self.ui.hospital.player_salary = self.ui.hospital.salary_offer
     if tonumber(self.ui.app.world.map.level_number) then
-      self.ui.app:loadLevel(self.ui.app.world.map.level_number + 1, self.ui.app.map.difficulty)
+      local next_level = self.ui.app.world.map.level_number + 1
+      self.ui.app:loadLevel(next_level, self.ui.app.map.difficulty)
+      self.ui.app.moviePlayer:playAdvanceMovie(next_level)
     else
       for i, level in ipairs(self.ui.app.world.campaign_info.levels) do
         if self.ui.app.world.map.level_number == level then

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -773,7 +773,9 @@ function UIMenuBar:makeGameMenu(app)
   for L = 1, 12 do
     levels_menu:appendItem(("  L%i  "):format(L), function()
       local status, err = pcall(app.loadLevel, app, L)
-      if not status then
+      if status then
+        self.ui.app.moviePlayer:playAdvanceMovie(L)
+      else
         err = _S.errors.load_prefix .. err
         print(err)
         self.ui:addWindow(UIInformation(self.ui, {err}))

--- a/CorsixTH/Lua/dialogs/resizables/new_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/new_game.lua
@@ -197,6 +197,8 @@ end
 
 function UINewGame:startGame(difficulty)
   self.ui.app:loadLevel(1, difficulty)
+  self.ui.app.moviePlayer:playAdvanceMovie(1)
+
   -- Initiate campaign progression. The UI above may now have changed.
   if not TheApp.using_demo_files then
     TheApp.world.campaign_info = "TH.campaign"


### PR DESCRIPTION
*Fixes #1534*
Previous feedback #1739 

**Describe what the proposed change does**
- Play the advance level board movie after the level is loaded only when - a new game is played, a new level is started, or the level select in the debug menu is used. Avoids playing the movie on a level restart.
