### PR TITLE
[RDY] Disable changing audio or movie settings when compiled without audio

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1706,6 +1706,10 @@ function App:finishVideoUpdate()
   self.video:startFrame()
 end
 
+function App:isAudioEnabled()
+  return TH.GetCompileOptions().audio
+end
+
 -- Do not remove, for savegame compatibility < r1891
 local app_confirm_quit_stub = --[[persistable:app_confirm_quit]] function()
 end

--- a/CorsixTH/Lua/dialogs/resizables/customise.lua
+++ b/CorsixTH/Lua/dialogs/resizables/customise.lua
@@ -61,20 +61,23 @@ function UICustomise:UICustomise(ui, mode)
     .lowered = true
 
   -- Movies, global switch
+  local audio_status = app:isAudioEnabled()
   self:addBevelPanel(15, 40, 165, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.customise_window.movies):setTooltip(_S.tooltip.customise_window.movies).lowered = true
   self.movies_panel =
-    self:addBevelPanel(185, 40, 140, 20, col_bg):setLabel(app.config.movies and _S.customise_window.option_on or _S.customise_window.option_off)
+    self:addBevelPanel(185, 40, 140, 20, col_bg):setLabel(app.config.movies and audio_status and _S.customise_window.option_on or _S.customise_window.option_off)
   self.movies_button = self.movies_panel:makeToggleButton(0, 0, 140, 20, nil, self.buttonMoviesGlobal)
-    :setToggleState(app.config.movies):setTooltip(_S.tooltip.customise_window.movies)
+    :setToggleState(app.config.movies and audio_status):setTooltip(_S.tooltip.customise_window.movies)
+  self.movies_button.enabled = audio_status
 
   -- Intro movie
   self:addBevelPanel(15, 65, 165, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.customise_window.intro):setTooltip(_S.tooltip.customise_window.intro).lowered = true
   self.intro_panel =
-    self:addBevelPanel(185, 65, 140, 20, col_bg):setLabel(app.config.play_intro and _S.customise_window.option_on or _S.customise_window.option_off)
+    self:addBevelPanel(185, 65, 140, 20, col_bg):setLabel(app.config.play_intro and audio_status and _S.customise_window.option_on or _S.customise_window.option_off)
   self.intro_button = self.intro_panel:makeToggleButton(0, 0, 140, 20, nil, self.buttonIntro)
-    :setToggleState(app.config.play_intro):setTooltip(_S.tooltip.customise_window.intro)
+    :setToggleState(app.config.play_intro and audio_status):setTooltip(_S.tooltip.customise_window.intro)
+  self.intro_button.enabled = audio_status
 
   -- Allow user actions when paused
   self:addBevelPanel(15, 90, 165, 20, col_shadow, col_bg, col_bg)

--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -166,13 +166,15 @@ function UIOptions:UIOptions(ui, mode)
   self.language_button = self.language_panel:makeToggleButton(0, 0, BTN_WIDTH, BTN_HEIGHT, nil, self.dropdownLanguage):setTooltip(_S.tooltip.options_window.select_language)
 
   -- add the Audio global switch.
+  local audio_status = app:isAudioEnabled()
   local audio_y_pos = self:_getOptionYPos()
   self:addBevelPanel(20, audio_y_pos, BTN_WIDTH, BTN_HEIGHT, col_shadow, col_bg, col_bg)
     :setLabel(_S.options_window.audio):setTooltip(_S.tooltip.options_window.audio_button).lowered = true
   self.volume_panel =
-    self:addBevelPanel(165, audio_y_pos, BTN_WIDTH, BTN_HEIGHT, col_bg):setLabel(app.config.audio and _S.customise_window.option_on or _S.customise_window.option_off)
+    self:addBevelPanel(165, audio_y_pos, BTN_WIDTH, BTN_HEIGHT, col_bg):setLabel(app.config.audio and audio_status and _S.customise_window.option_on or _S.customise_window.option_off)
   self.volume_button = self.volume_panel:makeToggleButton(0, 0, BTN_WIDTH, BTN_HEIGHT, nil, self.buttonAudioGlobal)
-    :setToggleState(app.config.audio):setTooltip(_S.tooltip.options_window.audio_toggle)
+    :setToggleState(app.config.audio and audio_status):setTooltip(_S.tooltip.options_window.audio_toggle)
+  self.volume_button.enabled = audio_status
 
   -- Set scroll speed.
   local scroll_y_pos = self:_getOptionYPos()


### PR DESCRIPTION
**Describe what the proposed change does**
- Prevents the button up error when changing global audio setting without audio in the build.
