### PR TITLE
[RDY]Save to OS temp directory if the intended file can't be written to

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -869,7 +869,8 @@ end
 
 function App:saveConfig()
   -- Load lines from config file
-  local fi = io.open(self.command_line["config-file"] or "config.txt", "r")
+  local config_file = self.command_line["config-file"] or "config.txt"
+  local fi = io.open(config_file, "r")
   local lines = {}
   local handled_ids = {}
   if fi then
@@ -920,7 +921,7 @@ function App:saveConfig()
     lines[#lines] = nil
   end
 
-  fi = io.open(self.command_line["config-file"] or "config.txt", "w")
+  fi = self:writeToFileOrTmp(config_file)
   for _, line in ipairs(lines) do
     fi:write(line .. "\n")
   end

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -927,6 +927,21 @@ function App:saveConfig()
   fi:close()
 end
 
+--! Tries to open the given file or a file in OS's temp dir.
+-- Returns the file handler
+--!param file The full path of the intended file
+function App:writeToFileOrTmp(file)
+  local f, err = io.open(file, "w")
+  if err then
+    local tmp_file = os.tmpname()
+    f = io.open(tmp_file, "w")
+    self.ui:addWindow(UIInformation(self.ui,
+        {_S.errors.save_to_tmp:format(file, tmp_file, err)}))
+  end
+  assert(f, "Error: cannot write to filesystem")
+  return f
+end
+
 function App:fixHotkeys()
   -- Fill in default values for things which don't exist
   local hotkeys_defaults = select(4, corsixth.require("config_finder"))

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -966,7 +966,8 @@ end
 
 function App:saveHotkeys()
   -- Load lines from config file
-  local fi = io.open(self.command_line["hotkeys-file"] or "hotkeys.txt", "r")
+  local hotkeys_filename = self.command_line["hotkeys-file"] or "hotkeys.txt"
+  local fi = io.open(hotkeys_filename, "r")
   local lines = {}
   local handled_ids = {}
 
@@ -1020,7 +1021,7 @@ function App:saveHotkeys()
     lines[#lines] = nil
   end
 
-  fi = io.open(self.command_line["hotkeys-file"] or "hotkeys.txt", "w")
+  fi = self:writeToFileOrTmp(hotkeys_filename)
   for _, line in ipairs(lines) do
     fi:write(line .. "\n")
   end

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -818,11 +818,9 @@ local string_03 = [=[
 -- ]=] .. '\n' ..
 'ingame_patient_gohome = ' .. hotkeys_values.ingame_patient_gohome .. '\n' .. [=[
 ]=]
-  fi = io.open(hotkeys_filename, "w")
-  if fi then
-    fi:write(string_01 .. string_02 .. string_03)
+  fi = TheApp:writeToFileOrTmp(hotkeys_filename)
+  fi:write(string_01 .. string_02 .. string_03)
   fi:close()
-  end
 end
 
 for k, str_val in pairs(hotkeys_values) do

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -518,11 +518,9 @@ audio_music = nil -- [[X:\ThemeHospital\Music]]
 -------------------------------------------------------------------------------------------------------------------------
 
 ]=]
-  fi = io.open(config_filename, "w")
-  if fi then
-    fi:write(string_01 .. string_02)
+  fi = TheApp:writeToFileOrTmp(config_filename)
+  fi:write(string_01 .. string_02)
   fi:close()
-  end
 end
 
 -- Hotkey filename.

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -693,6 +693,7 @@ errors = {
   fractured_bones = "NOTE: The animation for female patients with Fractured Bones is not perfect",
   could_not_load_campaign = "Failed to load the campaign: %s",
   could_not_find_first_campaign_level = "Could not find the first level of this campaign: %s",
+  save_to_tmp = "The file at %s could not be used. The game has been saved to %s. Error: %s",
 }
 
 warnings = {

--- a/CorsixTH/Lua/persistance.lua
+++ b/CorsixTH/Lua/persistance.lua
@@ -255,7 +255,7 @@ end
 --!param filename (string) Path of the file to write.
 function SaveGameFile(filename)
   local data = SaveGame()
-  local f = assert(io.open(filename, "wb"))
+  local f = TheApp:writeToFileOrTmp(filename)
   f:write(data)
   f:close()
 end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2304,15 +2304,11 @@ function World:dumpGameLog()
   local pathsep = package.config:sub(1, 1)
   config_path = config_path:match("^(.-)[^" .. pathsep .. "]*$")
   local gamelog_path = config_path .. "gamelog.txt"
-  local fi, err = io.open(gamelog_path, "w")
-  if fi then
-    for _, str in ipairs(self.game_log) do
-      fi:write(str .. "\n")
-    end
-    fi:close()
-  else
-    print("Warning: Cannot dump game log: " .. tostring(err))
+  local fi = self.app:writeToFileOrTmp(gamelog_path)
+  for _, str in ipairs(self.game_log) do
+    fi:write(str .. "\n")
   end
+  fi:close()
 end
 
 --! Because the save file only saves one thob per tile if they are more that information


### PR DESCRIPTION
*Fixes #470*

**Describe what the proposed change does**
- On failing to write to the intended save game file it saves to a temp file and tells the user