### PR TITLE
[RDY] afterLoad for emergencies with undiscovered diseases

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 151
+local SAVEGAME_VERSION = 152
 
 class "App"
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -599,7 +599,7 @@ function Hospital:afterLoad(old, new)
   if old < 148 then
     self.msg_counter = nil
   end
-  if old < 150 then
+  if old < 152 then
     -- If old save has an emergency fax, or emergency active, of an undiscovered disease
     -- make the disease discovered to prevent crashing (see #1754, #1799)
     local em = self.emergency

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -604,7 +604,6 @@ function Hospital:afterLoad(old, new)
     -- make the disease discovered to prevent crashing (see #1754, #1799)
     local em = self.emergency
     if em and not self.disease_casebook[em.disease.id].discovered then
-      self.disease_casebook[em.disease.id].discovered = true
       self.research:discoverDisease(em.disease)
     end
   end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -600,7 +600,7 @@ function Hospital:afterLoad(old, new)
     self.msg_counter = nil
   end
   if old < 150 then
-    -- If old save has an emergency fax, or emergency active,
+    -- If old save has an emergency fax, or emergency active, of an undiscovered disease
     -- make the disease discovered to prevent crashing (see #1754, #1799)
     local em = self.emergency
     if em and not self.disease_casebook[em.disease.id].discovered then

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -599,6 +599,15 @@ function Hospital:afterLoad(old, new)
   if old < 148 then
     self.msg_counter = nil
   end
+  if old < 150 then
+    -- If old save has an emergency fax, or emergency active,
+    -- make the disease discovered to prevent crashing (see #1754, #1799)
+    local em = self.emergency
+    if em and not self.disease_casebook[em.disease.id].discovered then
+      self.disease_casebook[em.disease.id].discovered = true
+      self.research:discoverDisease(em.disease)
+    end
+  end
 
   -- Update other objects in the hospital (added in version 106).
   if self.epidemic then self.epidemic.afterLoad(old, new) end


### PR DESCRIPTION
Complementary PR to #1754 to allow for emergencies that slip through the net from old saves to be course-corrected.
For clarity, I tracked down the savegame version that 1754 sat on and adjusted the afterload's old number as necessary.

*Closes #1799*

**Describe what the proposed change does**
- Afterload added for emergencies of undiscovered diseases in old saves that are active to prevent the casebook bug fixed by 1754
- In above case, the disease is automatically discovered to prevent crashing (too late to try and cancel the emergency now!)
