### PR TITLE
[RDY] Fix updater

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1643,7 +1643,7 @@ function App:checkForUpdates()
   local current_version = self:getVersion()
 
   -- Only URLs that match this list of trusted domains will be accepted.
-  local trusted_domains = { 'corsixth.com', 'code.google.com' }
+  local trusted_domains = { 'corsixth.com', 'github.com', 'corsixth.github.io' }
 
   -- Only check for updates against released versions
   if current_version == "Trunk" then

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1639,7 +1639,7 @@ function App:checkForUpdates()
 
   -- Default language to use for the changelog if no localised version is available
   local default_language = "en"
-  local update_url = 'www.corsixth.com/check-for-updates'
+  local update_url = 'https://corsixth.github.io/CorsixTH/check-for-updates'
   local current_version = self:getVersion()
 
   -- Only URLs that match this list of trusted domains will be accepted.
@@ -1651,25 +1651,14 @@ function App:checkForUpdates()
     return
   end
 
-  local success, _ = pcall(require, "socket")
-
-  if not success then
-    -- LuaSocket is not available, just return
-    print("Cannot check for updates since LuaSocket is not available.")
+  local luasocket, _ = pcall(require, "socket")
+  local luasec, _ = pcall(require, "ssl.https")
+  if not (luasocket and luasec) then
+    print("Cannot check for updates since LuaSocket and/or LuaSec are not available.")
     return
-  else
-    self.lua_socket_available = true
   end
   local http = require("socket.http")
   local url = require("socket.url")
-
-  -- Safely attempt to use luasec
-  local hassec, _ = pcall(require, "ssl.https")
-  if hassec then
-    update_url = "https://" .. update_url
-  else
-    update_url = "http://" .. update_url
-  end
 
   print("Checking for CorsixTH updates...")
   local update_body, status, _ = http.request(update_url)

--- a/CorsixTH/Lua/dialogs/resizables/update.lua
+++ b/CorsixTH/Lua/dialogs/resizables/update.lua
@@ -69,14 +69,6 @@ function UIUpdate:UIUpdate(ui, this_version, new_version, brief_description, dow
   self.white_font = app.gfx:loadFont("QData", "Font01V")
   self.download_url = download_url
 
-  local pathsep = package.config:sub(1, 1)
-
-  if pathsep == "\\" then
-    self.os_is_windows = true
-  else
-    self.os_is_windows = false
-  end
-
   self:addBevelPanel(20, 50, 140, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.update_window.current_version).lowered = true
   self:addBevelPanel(20, 70, 140, 20, col_shadow, col_bg, col_bg)
@@ -109,8 +101,10 @@ end
 
 function UIUpdate:buttonDownload()
 
-  if self.os_is_windows then
+  if self.app.os == "windows" then
     os.execute("start " .. self.download_url)
+  elseif self.app.os == "macos" then
+    os.execute("open " .. self.download_url)
   else
     os.execute("xdg-open " .. self.download_url)
   end


### PR DESCRIPTION
**Describe what the proposed change does**
- Add the two github urls to the trusted domains. This fixes the updater
- Add a different open command for macOS, fixing it on that platform
- Add the requirement for the given download url to be https. This will break the ability to update, can you convert the url?
- When the user doesn't have luasec warn them

I'm not sure on the usefulness of the third and fourth commits. http://github.com is a redirect to https, so this only protects interference local to the user? If the package doesn't have luasec it's just an unhelpful nag? We may do better just asking packagers to add luasec if they've added luasockets to the dependencies.