### PR TITLE
[RDY] Add advisor warnings for room queues

### DIFF
--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -180,6 +180,10 @@ function PlayerHospital:dailyAdviceChecks()
     end
   end
 
+  if day == 10 then
+    self:warnForLongQueues()
+  end
+
   -- Reset advise flags at the end of the month.
   if day == 28 then
     self.adviser_data.temperature_advice = false
@@ -329,6 +333,37 @@ function PlayerHospital:msgKilled()
       _A.level_progress.another_patient_killed:format(self.num_deaths)
     }
     self.adviser_data.cured_died_message = self:giveAdvice(died_msgs, 6/10)
+  end
+end
+
+--! Once a month the advisor may warn about long queues.
+--! Rooms requiring a doctor occasionally trigger the generic message
+function PlayerHospital:warnForLongQueues()
+  local queue_rooms, total_queue = {}, 0
+  for _, room in pairs(self.world.rooms) do
+    if #room.door.queue then
+      total_queue = total_queue + #room.door.queue
+    end
+    if #room.door.queue > 7 then
+      queue_rooms[#queue_rooms + 1] = room
+    end
+  end
+  if #queue_rooms == 0 or total_queue == 0 then return end
+
+  local busy_threshold = 1.5 * total_queue / #self.world.rooms
+  local chosen_room = queue_rooms[math.random(1, #queue_rooms)]
+  if busy_threshold > #chosen_room.door.queue then return end
+  chosen_room = chosen_room.room_info
+  -- Required staff that is not nurse is doctor, researcher, surgeon or psych
+  if chosen_room.required_staff and not chosen_room.required_staff["Nurse"]
+      and math.random(1, 3) > 1 then
+    local warn_msgs = {
+      _A.warnings.queue_too_long_send_doctor:format(chosen_room.name),
+      _A.staff_advice.need_doctors
+    }
+    self:giveAdvice(warn_msgs)
+  else
+    self.world.ui.adviser:say(_A.warnings.queues_too_long)
   end
 end
 


### PR DESCRIPTION
Previous feedback #1739

**Describe what the proposed change does**
- Uses two strings to warn the user of long queues. I chose to define long as 6+, and to check monthly. Do we know what TH97 does?
