### PR TITLE
[rdy] Save settings from ingame menu when menu closes

### DIFF
--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -71,6 +71,7 @@ function UIMenuBar:onTick()
       self.menu_disappear_counter = nil
     else
       if self.menu_disappear_counter == 0 then
+        self.ui.app:saveConfig()
         self.menu_disappear_counter = nil
         local close_to = self.active_menu and self.active_menu.level or 0
         for i = #self.open_menus, close_to + 1, -1 do
@@ -577,21 +578,18 @@ function UIMenuBar:makeGameMenu(app)
         return level == app.config.music_volume,
           function()
             app.audio:setBackgroundVolume(level)
-            app:saveConfig()
           end,
           ""
       elseif setting == "sound" then
         return level == app.config.sound_volume,
           function()
             app.audio:setSoundVolume(level)
-            app:saveConfig()
           end,
           ""
       else
         return level == app.config.announcement_volume,
           function()
             app.audio:setAnnouncementVolume(level)
-            app:saveConfig()
           end,
           ""
       end
@@ -609,7 +607,6 @@ function UIMenuBar:makeGameMenu(app)
     app.config.play_sounds,
     function(item)
       app.audio:playSoundEffects(item.checked)
-      app:saveConfig()
     end,
     nil,
     function()
@@ -621,7 +618,6 @@ function UIMenuBar:makeGameMenu(app)
     app.config.play_announcements,
     function(item)
       app.config.play_announcements = item.checked
-      app:saveConfig()
     end,
     nil,
     function()
@@ -633,7 +629,6 @@ function UIMenuBar:makeGameMenu(app)
     function(item)
       app.config.play_music = item.checked
       self.ui:togglePlayMusic(item)
-      app:saveConfig()
     end,
     nil,
     function(musicStatus)
@@ -665,7 +660,6 @@ function UIMenuBar:makeGameMenu(app)
   options:appendCheckItem(_S.menu_options.capture_mouse,
     app.config.capture_mouse,
     function(item) app.config.capture_mouse = item.checked
-      app:saveConfig()
       app:setCaptureMouse()
     end)
 
@@ -673,7 +667,6 @@ function UIMenuBar:makeGameMenu(app)
     not app.config.adviser_disabled,
     function(item)
       app.config.adviser_disabled = not item.checked
-      app:saveConfig()
     end,
     nil,
     function()
@@ -684,7 +677,6 @@ function UIMenuBar:makeGameMenu(app)
     app.config.twentyfour_hour_clock,
     function(item)
       app.config.twentyfour_hour_clock = item.checked
-      app:saveConfig()
     end)
 
   local function temperatureDisplay(method)


### PR DESCRIPTION
*Previous feedback #1739, fixes #1311*

**Describe what the proposed change does**
- Saves all menu bar setting changes when the dropdown menus go away (a second after the cursor goes off them)
