### PR TITLE
The scope of the variable's can be reduced.

### DIFF
--- a/AnimView/frmMain.cpp
+++ b/AnimView/frmMain.cpp
@@ -759,8 +759,8 @@ void frmMain::_drawCoordinates(wxPaintDC& DC, int i, int j) {
 
 wxString frmMain::_getCaseSensitivePath(const wxString& sInsensitivePathPart,
                                         const wxString& sPath) {
-  bool found;
-  bool cont;
+  
+  
 
   if (!wxFileName::IsCaseSensitive()) {
     return sPath + sInsensitivePathPart;
@@ -779,9 +779,9 @@ wxString frmMain::_getCaseSensitivePath(const wxString& sInsensitivePathPart,
     wxString pathPart = pathTokenizer.GetNextToken();
 
     wxString realName;
-    cont = dir.GetFirst(&realName, wxEmptyString,
+    bool cont = dir.GetFirst(&realName, wxEmptyString,
                         wxDIR_DIRS | wxDIR_FILES | wxDIR_HIDDEN | wxDIR_DOTDOT);
-    found = false;
+    bool found = false;
     while (cont) {
       if (realName.Upper() == pathPart.Upper()) {
         if (retStr.Last() != wxFileName::GetPathSeparator()) {


### PR DESCRIPTION
The scope of the variable 'found' can be reduced.
The scope of the variable 'cont' can be reduced.

*Fixes #*

**
Reducing the scope of variables, in my opinion, will make the code more readable.
**
-
-
-
