### PR TITLE
[RDY] Select insurance companies from all available company names

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -183,18 +183,22 @@ function Hospital:Hospital(world, avail_rooms, name)
   self.policies["stop_procedure"] = 1 -- Note that this is between 1 and 2 ( = 100% - 200%)
   self.policies["goto_staffroom"] = 0.6
   self.policies["grant_wage_increase"] = TheApp.config.grant_wage_increase
-  -- Randomly select three insurance companies to use, only different by name right now.
-  -- The first ones are more likely to come
+
+  -- Semi-randomly select three insurance companies to use, only different by name right now.
+  -- The companies in the first quarter of the list are more likely to be selected
   self.insurance = {}
+  -- Make a local writeable copy table of the translated company names.
+  local companies = {}
   for no, local_name in ipairs(_S.insurance_companies) do
-    -- NOTE: Will not work if more companies are added
-    if math.random(1, 11) < 4 or 11 - no < #self.insurance + 3 then
-      self.insurance[#self.insurance + 1] = local_name
-    end
-    if #self.insurance > 2 then
-      break
-    end
+    companies[no] = local_name
   end
+  while #self.insurance < 3 and #companies > 0 do
+    local num = math.random(1, 2) == 1 and math.random(1, math.ceil(#companies / 4)) or
+        math.random(1, #companies)
+    self.insurance[#self.insurance + 1] = companies[num]
+    table.remove(companies, num)
+  end
+
   -- A list of how much each insurance company owes you. The first entry for
   -- each company is the current month's dept, the second the previous
   -- month and the third the month before that.


### PR DESCRIPTION
Previous feedback #1722 

**Describe what the proposed change does**
- Picks three insurance companies, keeping the preference for early ones, from the full range in the language file.