### PR TITLE
Put system information at the start of gamelog.txt

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -67,11 +67,11 @@ jobs:
           cd ../../
           rm -rf Catch2
 
-      - name: Install CMake 3.5
+      - name: Install CMake 3.10
         if: matrix.cmake
         run: |
-          # Install CMake version 3.5, the oldest CorsixTH-supported version, which does not support Lua 5.4
-          curl -L https://github.com/Kitware/CMake/releases/download/v3.5.0/cmake-3.5.0-Linux-i386.sh -o cmake.sh
+          # Install CMake version 3.10, the oldest CorsixTH-supported version, which does not support Lua 5.4
+          curl -L https://github.com/Kitware/CMake/releases/download/v3.10.3/cmake-3.10.3-Linux-x86_64.sh -o cmake.sh
           sudo bash cmake.sh --prefix=/usr/local/ --exclude-subdir --skip-license
           cmake --version
       - name: Create CorsixTH ${{ matrix.animview }} makefiles with ${{ matrix.lua }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #   - ENABLE_UNIT_TESTS : Enable Unit Testing Target (requires Catch2) (no)
 #   - BUILD_ANIMVIEW : Generate AnimViewer build files (no)
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
 

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -55,6 +55,13 @@ else()
   set(CORSIX_TH_OS "unix")
 endif()
 
+# Report system architecture in compile_opts.arch
+if(MSVC)
+  set(CORSIX_TH_ARCH ${CMAKE_CXX_COMPILER_ARCHITECTURE_ID})
+else()
+  set(CORSIX_TH_ARCH ${CMAKE_SYSTEM_PROCESSOR})
+endif()
+
 # Ensure config.h is picked up by cmake - moving this into subdir cmake files will
 # prevent it applying to the CorsixTH project
 set(CorsixTH_generated_src_dir ${CMAKE_BINARY_DIR}/CorsixTH/Src/)

--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]]--*/
 
-return 2680;
+return 2681;

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -166,18 +166,7 @@ function App:init()
   SDL.wm.setIconWin32()
 
   self:setCaptureMouse()
-
-  local caption_descs = {self.video:getRendererDetails()}
-  if compile_opts.jit then
-    caption_descs[#caption_descs + 1] = compile_opts.jit
-  else
-    caption_descs[#caption_descs + 1] = _VERSION
-  end
-  if compile_opts.arch_64 then
-    caption_descs[#caption_descs + 1] = "64 bit"
-  end
-  self.caption = "CorsixTH (" .. table.concat(caption_descs, ", ") .. ")"
-  self.video:setCaption(self.caption)
+  self.caption = "CorsixTH"
 
   -- Prereq 2: Load and initialise the graphics subsystem
   corsixth.require("persistance")
@@ -1748,6 +1737,21 @@ end
 
 function App:isAudioEnabled()
   return TH.GetCompileOptions().audio
+end
+
+function App:getSystemInfo()
+  local compile_opts = TH.GetCompileOptions()
+  local comp_details = {}
+  for key, value in pairs(compile_opts) do
+    table.insert(comp_details, key .. ": " .. tostring(value))
+  end
+  table.sort(comp_details)
+  local compiled = string.format("Compiled with %s\nSDL renderer: %s\n",
+      table.concat(comp_details, ", "), self.video:getRendererDetails())
+  local running = string.format("%s run with api version: %s, game version: %s, savegame version: %s\n",
+      compile_opts.jit or _VERSION, tostring(corsixth.require("api_version")),
+      self:getVersion(), tostring(SAVEGAME_VERSION))
+  return(compiled .. running)
 end
 
 -- Do not remove, for savegame compatibility < r1891

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2359,6 +2359,8 @@ function World:dumpGameLog()
   config_path = config_path:match("^(.-)[^" .. pathsep .. "]*$")
   local gamelog_path = config_path .. "gamelog.txt"
   local fi = self.app:writeToFileOrTmp(gamelog_path)
+  -- Start the gamelog file with the system information
+  fi:write(self.app:getSystemInfo())
   for _, str in ipairs(self.game_log) do
     fi:write(str .. "\n")
   end

--- a/CorsixTH/Src/config.h.in
+++ b/CorsixTH/Src/config.h.in
@@ -63,11 +63,6 @@ SOFTWARE.
 #include <cstddef>
 #include <cstdint>
 
-/** Environment detection **/
-#if UINTPTR_MAX == UINT64_MAX
-#define CORSIX_TH_64BIT
-#endif
-
 // We bring in the most common stddef and stdint types to avoid typing
 // clang-format off
 using std::int8_t;
@@ -87,5 +82,8 @@ using std::uint64_t;
 
 /** Report operating system **/
 #cmakedefine CORSIX_TH_OS "@CORSIX_TH_OS@"
+
+/** Report system architecture **/
+#cmakedefine CORSIX_TH_ARCH "@CORSIX_TH_ARCH@"
 
 #endif  // CORSIX_TH_CONFIG_H_

--- a/CorsixTH/Src/th_lua.cpp
+++ b/CorsixTH/Src/th_lua.cpp
@@ -185,15 +185,9 @@ int l_get_compile_options(lua_State* L) {
   lua_settop(L, 0);
   lua_newtable(L);
 
-#ifdef CORSIX_TH_64BIT
-  lua_pushboolean(L, 1);
-#else
-  lua_pushboolean(L, 0);
-#endif
-  lua_setfield(L, -2, "arch_64");
-
-  lua_pushliteral(L, "SDL");
-  lua_setfield(L, -2, "renderer");
+  // Report architecture
+  lua_pushliteral(L, CORSIX_TH_ARCH);
+  lua_setfield(L, -2, "arch");
 
 #ifdef CORSIX_TH_USE_SDL_MIXER
   lua_pushboolean(L, 1);


### PR DESCRIPTION
*Previous feedback #1722*

**Describe what the proposed change does**
- Move the game log from world to app
- Log all available info to the game log, fix #1633, example

> Compiled with api_version: 2679, arch_64: true, os: macos, audio: false, 
Renderer: SDL, metal
Lua 5.4 run with game version: Trunk, savegame version: 152, api version: 2679