### PR TITLE
[RDY] Use competitor names from level configs

### DIFF
--- a/CorsixTH/Levels/avatar.level
+++ b/CorsixTH/Levels/avatar.level
@@ -209,7 +209,7 @@ Divides research input to get the amount of research points. must be > 0
 
 --------------------- Competitor Information -----------------------
 
-| Index in the away "computer" | Is that opponent playing? | 1 is yes, 0 no | Comment |
-#computer[12].Playing 1 CORSIX
-#computer[13].Playing 1 ROUJIN
-#computer[14].Playing 1 EDVIN
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing.Name 1 CORSIX
+#computer[13].Playing.Name 1 ROUJIN
+#computer[14].Playing.Name 1 EDVIN

--- a/CorsixTH/Levels/confined_v5.level
+++ b/CorsixTH/Levels/confined_v5.level
@@ -206,10 +206,10 @@ Divides research input to get the amount of research points. must be > 0
 
 --------------------- Competitor Information -----------------------
 
-| Index in the away "computer" | Is that opponent playing? | 1 is yes, 0 no | Comment |
-#computer[12].Playing 1 CORSIX
-#computer[13].Playing 1 ROUJIN
-#computer[14].Playing 1 EDVIN
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing.Name 1 CORSIX
+#computer[13].Playing.Name 1 ROUJIN
+#computer[14].Playing.Name 1 EDVIN
 
 ----------------------- Emergency Control --------------------------
 

--- a/CorsixTH/Levels/demo.level
+++ b/CorsixTH/Levels/demo.level
@@ -108,6 +108,7 @@ When a drug is researched, what effectiveness does it have
 
 --------------------- Competitor Information -----------------------
 
-#computer[12].Playing 1 CORSIX
-#computer[13].Playing 1 ROUJIN
-#computer[14].Playing 1 EDVIN
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing.Name 1 CORSIX
+#computer[13].Playing.Name 1 ROUJIN
+#computer[14].Playing.Name 1 EDVIN

--- a/CorsixTH/Levels/example.level
+++ b/CorsixTH/Levels/example.level
@@ -55,7 +55,7 @@ InterestRate is defined as centiprocent to allow for two decimals precision, i.e
 -------------------- Disease Configuration -------------------------
 
 When a drug is researched, what effectiveness does it have
-#gbv.StartRating 100 
+#gbv.StartRating 100
 
 The following table contains all diagnoses and treatments that shows up in the drug casebook
 in the game. Known specifies whether it should show up from the beginning of the level and
@@ -230,10 +230,10 @@ But we don't want any such conditions on the example level!
 
 --------------------- Competitor Information -----------------------
 
-| Index in the away "computer" | Is that opponent playing? | 1 is yes, 0 no | Comment |
-#computer[12].Playing 1 CORSIX
-#computer[13].Playing 1 ROUJIN
-#computer[14].Playing 1 EDVIN
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing 1.Name CORSIX
+#computer[13].Playing 1.Name ROUJIN
+#computer[14].Playing 1.Name EDVIN
 
 ----------------------- Emergency Control --------------------------
 

--- a/CorsixTH/Levels/finisham.level
+++ b/CorsixTH/Levels/finisham.level
@@ -280,7 +280,7 @@ But we don't want any such conditions on the example level!
 
 --------------------- Competitor Information -----------------------
 
-| Index in the away "computer" | Is that opponent playing? | 1 is yes, 0 no | Comment |
-#computer[12].Playing 1 CORSIX
-#computer[13].Playing 1 ROUJIN
-#computer[14].Playing 1 EDVIN
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing.Name 1 CORSIX
+#computer[13].Playing.Name 1 ROUJIN
+#computer[14].Playing.Name 1 EDVIN

--- a/CorsixTH/Levels/st.peter's.level
+++ b/CorsixTH/Levels/st.peter's.level
@@ -372,7 +372,7 @@ But we don't want any such conditions on the example level!
 
 --------------------- Competitor Information -----------------------
 
-| Index in the away "computer" | Is that opponent playing? | 1 is yes, 0 no | Comment |
-#computer[12].Playing 1 Corsix
-#computer[13].Playing 1 Roujin
-#computer[14].Playing 1 Edvin
+| Index in the away "computer" | Is that opponent playing? 1 is yes, 0 no | Name |
+#computer[12].Playing.Name 1 Corsix
+#computer[13].Playing.Name 1 Roujin
+#computer[14].Playing.Name 1 Edvin

--- a/CorsixTH/Lua/base_config.lua
+++ b/CorsixTH/Lua/base_config.lua
@@ -372,21 +372,21 @@ local configuration = {
     [0] = {StartMonth = 0, EndMonth = 0, Min = 0, Max = 0, Illness = 0, PercWin = 0, Bonus = 0},
   },
   computer = {
-    [0] = {Playing = 0}, -- ORAC
-    {Playing = 0}, -- COLOSSUS
-    {Playing = 0}, -- HAL
-    {Playing = 0}, -- MULTIVAC
-    {Playing = 0}, -- HOLLY
-    {Playing = 0}, -- DEEP THOUGHT
-    {Playing = 0}, -- ZEN
-    {Playing = 0}, -- SKYNET
-    {Playing = 0}, -- MARVIN
-    {Playing = 0}, -- CEREBRO
-    {Playing = 0}, -- MOTHER
-    {Playing = 0}, -- JAYNE
-    {Playing = 0}, -- CORSIX
-    {Playing = 0}, -- ROUJIN
-    {Playing = 0}, -- EDVIN
+    [0] = {Playing = 0, Name = "ORAC"},
+    {Playing = 0, Name = "COLOSSUS"},
+    {Playing = 0, Name = "HAL"},
+    {Playing = 0, Name = "MULTIVAC"},
+    {Playing = 0, Name = "HOLLY"},
+    {Playing = 0, Name = "DEEP THOUGHT"},
+    {Playing = 0, Name = "ZEN"},
+    {Playing = 0, Name = "SKYNET"},
+    {Playing = 0, Name = "MARVIN"},
+    {Playing = 0, Name = "CEREBRO"},
+    {Playing = 0, Name = "MOTHER"},
+    {Playing = 0, Name = "JAYNE"},
+    {Playing = 0, Name = "CORSIX"},
+    {Playing = 0, Name = "ROUJIN"},
+    {Playing = 0, Name = "EDVIN"},
   },
   awards_trophies = {
 

--- a/CorsixTH/Lua/hospitals/ai_hospital.lua
+++ b/CorsixTH/Lua/hospitals/ai_hospital.lua
@@ -23,9 +23,11 @@ class "AIHospital" (Hospital)
 ---@type AIHospital
 local AIHospital = _G["AIHospital"]
 
-function AIHospital:AIHospital(competitor, ...)
-  self:Hospital(...)
-  if _S.competitor_names[competitor] then
+function AIHospital:AIHospital(competitor, world, avail_rooms, name)
+  self:Hospital(world, avail_rooms, name)
+  if name then
+    self.name = name
+  elseif _S.competitor_names[competitor] then
     self.name = _S.competitor_names[competitor]
   else
     self.name = "NONAME"

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -154,7 +154,8 @@ function World:World(app)
   local level_config = self.map.level_config
   for key, value in pairs(level_config.computer) do
     if value.Playing == 1 then
-      self.hospitals[#self.hospitals + 1] = AIHospital(tonumber(key) + 1, self, avail_rooms)
+      self.hospitals[#self.hospitals + 1] = AIHospital(tonumber(key) + 1,
+          self, avail_rooms, value.Name)
     end
   end
 


### PR DESCRIPTION
*Previous feedback #1741*

**Describe what the proposed change does**
- Use competitor names if set in the level config
- Minor edit to the level files to use the names already included
