### PR TITLE
[RDY] Fix Lua Console

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1497,6 +1497,9 @@ end
 
 -- Omit the usual file extension so this file cannot be seen from the normal load and save screen and cannot be overwritten
 function App:quickSave()
+  if self.ui:isLuaConsoleOpen() then
+    return self.ui:addWindow(UIInformation(self.ui, {_S.warnings.lua_console_open}))
+  end
   local filename = "quicksave"
   return SaveGameFile(self.savegame_dir .. filename)
 end

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
@@ -82,7 +82,7 @@ end
 --! Try to save the game with given filename; if already exists, create confirmation window first.
 function UISaveGame:trySave(filename)
   -- Saving without closing the Lua Console will break the save
-  if self.ui:getWindow(UILuaConsole) then
+  if self.ui:isLuaConsoleOpen() then
     return self.ui:addWindow(UIInformation(self.ui, {_S.warnings.lua_console_open}))
   end
   if lfs.attributes(filename, "size") ~= nil then

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
@@ -81,6 +81,10 @@ end
 
 --! Try to save the game with given filename; if already exists, create confirmation window first.
 function UISaveGame:trySave(filename)
+  -- Saving without closing the Lua Console will break the save
+  if self.ui:getWindow(UILuaConsole) then
+    return self.ui:addWindow(UIInformation(self.ui, {_S.warnings.lua_console_open}))
+  end
   if lfs.attributes(filename, "size") ~= nil then
     self.ui:addWindow(UIConfirmDialog(self.ui, _S.confirmation.overwrite_save, --[[persistable:save_game_confirmation]] function() self:doSave(filename) end))
   else

--- a/CorsixTH/Lua/dialogs/resizables/lua_console.lua
+++ b/CorsixTH/Lua/dialogs/resizables/lua_console.lua
@@ -125,6 +125,7 @@ function UILuaConsole:buttonExecute()
 end
 
 function UILuaConsole:buttonClose()
+  _ = nil
   self:close()
 end
 

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -698,7 +698,8 @@ errors = {
 warnings = {
   levelfile_variable_is_deprecated = "Notice: The level '%s' contains a deprecated variable definition in the level file." ..
                                      "'%LevelFile' has been renamed to '%MapFile'. Please advise the map creator to update the level.",
-  newersave = "Warning, you have loaded a save from a newer version of CorsixTH. It is not recommended to continue as crashes may occur. Play at your own risk."
+  newersave = "Warning, you have loaded a save from a newer version of CorsixTH. It is not recommended to continue as crashes may occur. Play at your own risk.",
+  lua_console_open = "You can't save the game with the Lua Console open!",
 }
 
 confirmation = {

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1111,6 +1111,11 @@ end
 function UI:tutorialStep(...)
 end
 
+-- The lua console doesn't play nice with saves, so this function checks if it's open.
+function UI:isLuaConsoleOpen()
+  return self:getWindow(UILuaConsole)
+end
+
 function UI:makeScreenshot()
    -- Find an index for screenshot which is not already used
   local i = 0

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -247,6 +247,8 @@ function UI:runDebugScript()
   _ = TheApp.ui and TheApp.ui.debug_cursor_entity
   local script = assert(loadfile(lua_dir .. path_sep .. "debug_script.lua"))
   script()
+  -- Clear _ after the script to prevent save corruption
+  _ = nil
 end
 
 function UI:setupGlobalKeyHandlers()

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -997,17 +997,21 @@ function World:onTick()
   if self.tick_timer == 0 then
     if self.autosave_next_tick then
       self.autosave_next_tick = nil
-      local pathsep = package.config:sub(1, 1)
-      local dir = TheApp.savegame_dir
-      if not dir:sub(-1, -1) == pathsep then
-        dir = dir .. pathsep
-      end
-      if not lfs.attributes(dir .. "Autosaves", "modification") then
-        lfs.mkdir(dir .. "Autosaves")
-      end
-      local status, err = pcall(TheApp.save, TheApp, dir .. "Autosaves" .. pathsep .. "Autosave" .. self.game_date:monthOfYear() .. ".sav")
-      if not status then
-        print("Error while autosaving game: " .. err)
+      if self.ui:isLuaConsoleOpen() then
+        self:gameLog("Warning: Autosave not created because the Lua Console is open.")
+      else
+        local pathsep = package.config:sub(1, 1)
+        local dir = TheApp.savegame_dir
+        if not dir:sub(-1, -1) == pathsep then
+          dir = dir .. pathsep
+        end
+        if not lfs.attributes(dir .. "Autosaves", "modification") then
+          lfs.mkdir(dir .. "Autosaves")
+        end
+        local status, err = pcall(TheApp.save, TheApp, dir .. "Autosaves" .. pathsep .. "Autosave" .. self.game_date:monthOfYear() .. ".sav")
+        if not status then
+          print("Error while autosaving game: " .. err)
+        end
       end
     end
     if self.game_date == Date() and not self.ui.start_tutorial then

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -998,7 +998,7 @@ function World:onTick()
     if self.autosave_next_tick then
       self.autosave_next_tick = nil
       if self.ui:isLuaConsoleOpen() then
-        self:gameLog("Warning: Autosave not created because the Lua Console is open.")
+        self.app:gameLog("Warning: Autosave not created because the Lua Console is open.")
       else
         local pathsep = package.config:sub(1, 1)
         local dir = TheApp.savegame_dir


### PR DESCRIPTION
Clears the ``strict_declare_global`` of ``_`` whenever the Lua console closes so it does not kill saves.

For some reason the save seems to try to preserve whatever value _ was set to when using the console -- and when you reopen the game it no longer exists.