### PR TITLE
[rdy] Clean up global _

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/lua_console.lua
+++ b/CorsixTH/Lua/dialogs/resizables/lua_console.lua
@@ -122,6 +122,7 @@ function UILuaConsole:buttonExecute()
     print("Error while executing UserFunction:")
     print(err)
   end
+  _ = nil -- Clean up the global after use or it'll corrupt saves
 end
 
 function UILuaConsole:buttonClose()

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -247,6 +247,8 @@ function UI:runDebugScript()
   _ = TheApp.ui and TheApp.ui.debug_cursor_entity
   local script = assert(loadfile(lua_dir .. path_sep .. "debug_script.lua"))
   script()
+  -- Clear _ after the script to prevent save corruption
+  _ = nil
 end
 
 function UI:setupGlobalKeyHandlers()


### PR DESCRIPTION
After executing a debug script the global _ must be cleared to avoid corruption in a save.

Better solution to #1836
There's questions why ``strict_declare global "ui"`` exists but I don't want to really go into touching that.