### PR TITLE
[RDY] Rework Emergencies

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 152
+local SAVEGAME_VERSION = 153
 
 class "App"
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1295,6 +1295,7 @@ function World:nextEmergency()
       self.next_emergency = nil
       return
     end
+    self.next_emergency = emergency
     self.next_emergency_no = self.next_emergency_no + 1
   until self:computeNextEmergencyDates(emergency)
 end
@@ -1322,7 +1323,6 @@ end
 function World:computeNextEmergencyDates(emergency)
   -- Generate the next month and day the emergency should occur at.
   -- Make sure it doesn't happen in the past.
-  self.next_emergency = emergency
   local start = math.max(emergency.StartMonth, self.game_date:monthOfGame())
   if (emergency.EndMonth < start) then
     return false

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2685,7 +2685,6 @@ if old < 153 then
       self.next_emergency_date = Date(1, self.next_emergency_month, self.next_emergency_day)
       -- Complementary afterLoad to see if emergencies got stuck in the level.
       -- There's no guarantee we can unstick the level, however.
-      local hosp = self:getLocalPlayerHospital()
       local next_emer_date = Date(1, self.next_emergency_month, self.next_emergency_day)
       --[[ UIWatch's emergency timer is 52 days but this is local.
       The emergency fax also is held for 16 days.

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -201,7 +201,12 @@ function World:World(app)
   self:calculateSpawnTiles()
 
   -- Next Events dates
+  -- emergencies
+  -- The emergency control level data starts with an array of 0
+  self.next_emergency_no = -1 -- Properly adjusted in nextEmergency()
   self:nextEmergency()
+
+  -- vip
   self.next_vip_date = self:_generateNextVipDate()
 
   -- earthquakes
@@ -1267,56 +1272,67 @@ function World:getReputationImpact(hospital)
   end
 end
 
--- Called when it is time to determine what the
--- next emergency should look like.
+-- Called when it is time to determine when the next emergency should happen
 function World:nextEmergency()
   local control = self.map.level_config.emergency_control
   -- Does this level use random emergencies?
-  if control and (control[0].Random or control[0].Mean) then
-    -- Support standard values for mean and variance
-    local mean = control[0].Mean or 180
-    local variance = control[0].Variance or 30
-    -- How many days until next emergency?
-    local days = math.round(math.n_random(mean, variance))
-    local emergency_date = self.game_date:plusDays(days)
-
-    -- Make it the same format as for "controlled" emergencies
-    self.next_emergency_month = emergency_date:monthOfGame()
-    self.next_emergency_day = emergency_date:dayOfMonth()
-  else
-    if not self.next_emergency_no then
-      self.next_emergency_no = 0
-    else
-      repeat
-        self.next_emergency_no = self.next_emergency_no + 1
-        -- Level three is missing [5].
-        if not control[self.next_emergency_no] and
-            control[self.next_emergency_no + 1] then
-          self.next_emergency_no = self.next_emergency_no + 1
-        end
-      until not control[self.next_emergency_no] or
-            control[self.next_emergency_no].EndMonth >= self.game_date:monthOfGame()
-    end
-
-    local emergency = control[self.next_emergency_no]
-
-    -- No more emergencies?
-    if not emergency or emergency.EndMonth == 0 then
-      self.next_emergency_month = 0
-    else
-      -- Generate the next month and day the emergency should occur at.
-      -- Make sure it doesn't happen in the past.
-      local start = math.max(emergency.StartMonth, self.game_date:monthOfGame())
-      local next_month = math.random(start, emergency.EndMonth)
-      self.next_emergency_month = next_month
-      local day_start = 1
-      if start == emergency.EndMonth then
-        day_start = self.game_date:dayOfMonth()
-      end
-      local day_end = Date(1, next_month):lastDayOfMonth()
-      self.next_emergency_day = math.random(day_start, day_end)
-    end
+  if control[0].Random or control[0].Mean then
+    self:scheduleRandomEmergency(control)
+    return
   end
+  repeat
+    self.next_emergency_no = self.next_emergency_no + 1
+    local emer_num = self.next_emergency_no
+    -- Account for missing Level 3 emergency[5]
+    if not control[emer_num] and control[emer_num + 1] then
+      self.next_emergency_no = emer_num + 1
+    end
+    local emergency = control[emer_num]
+    -- No more emergencies?
+    if not emergency then
+      self.next_emergency_month = 0
+      self.next_emergency_date = nil
+      return
+    end
+  until self:computeNextEmergencyDates(emergency)
+end
+
+--! If a level file specifies random emergencies we make the next one as defined by the mean/variance given
+--!param control (table) Contains emergency information from level file
+function World:scheduleRandomEmergency(control)
+  -- Support standard values for mean and variance
+  local mean = control[0].Mean or 180
+  local variance = control[0].Variance or 30
+  -- How many days until next emergency?
+  local days = math.round(math.n_random(mean, variance))
+  local emergency_date = self.game_date:plusDays(days)
+
+  -- Make it the same format as for "controlled" emergencies
+  self.next_emergency_month = emergency_date:monthOfGame()
+  self.next_emergency_day = emergency_date:dayOfMonth()
+  self.next_emergency_date = Date(1, self.next_emergency_month, self.next_emergency_day) -- TODO: Make more use of this
+end
+
+--! Generate the dates for the next emergency
+--!param emergency The next scheduled emergency to take place
+--!return (boolean) true if emergency sucessfully scheduled
+function World:computeNextEmergencyDates(emergency)
+  -- Generate the next month and day the emergency should occur at.
+  -- Make sure it doesn't happen in the past.
+  local start = math.max(emergency.StartMonth, self.game_date:monthOfGame())
+  if (emergency.EndMonth < start) then
+    return false
+  end
+  local next_month = math.random(start, emergency.EndMonth)
+  self.next_emergency_month = next_month
+  local day_start = 1
+  if start == emergency.EndMonth then
+    day_start = self.game_date:dayOfMonth()
+  end
+  local day_end = Date(1, next_month):lastDayOfMonth()
+  self.next_emergency_day = math.random(day_start, day_end)
+  self.next_emergency_date = Date(1, self.next_emergency_month, self.next_emergency_day) -- TODO: Make more use of this
+  return self.game_date <= self.next_emergency_date
 end
 
 -- Called when it is time to have another VIP
@@ -2659,6 +2675,25 @@ function World:afterLoad(old, new)
   if old < 120 then
     -- Issue #1105 updates to fix any broken saves with travel<dir> flags for side objects
     self:resetSideObjects()
+  end
+
+  if old < 153 then
+    -- Complementary afterLoad to see if emergencies got stuck in the level.
+    -- There's no guarantee we can unstick the level, however.
+    local hosp = self:getLocalPlayerHospital()
+    local next_emer_date = Date(1, self.next_emergency_month, self.next_emergency_day)
+    --[[ UIWatch's emergency timer is 52 days but this is local.
+    The emergency fax also is held for 16 days.
+    Add one extra day to this for compensation = 69. (Unavoidable magic number)]]--
+    if self.game_date > next_emer_date:plusDays(69) then
+      -- The date the emergency should've finished by has passed.
+      -- Next check if the emergency could still be happening.
+      local watch = self.ui:getWindow(UIWatch)
+      if not watch or watch.count_type ~= "emergency" then
+        -- The emergency is likely stuck
+        self:nextEmergency()
+      end
+    end
   end
 
   self.savegame_version = new

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2678,20 +2678,26 @@ function World:afterLoad(old, new)
     self:resetSideObjects()
   end
 
-  if old < 153 then
-    -- Complementary afterLoad to see if emergencies got stuck in the level.
-    -- There's no guarantee we can unstick the level, however.
-    local next_emer_date = Date(1, self.next_emergency_month, self.next_emergency_day)
-    --[[ UIWatch's emergency timer is 52 days but this is local.
-    The emergency fax also is held for 16 days.
-    Add one extra day to this for compensation = 69. (Unavoidable magic number)]]--
-    if self.game_date > next_emer_date:plusDays(69) then
-      -- The date the emergency should've finished by has passed.
-      -- Next check if the emergency could still be happening.
-      local watch = self.ui:getWindow(UIWatch)
-      if not watch or watch.count_type ~= "emergency" then
-        -- The emergency is likely stuck
-        self:nextEmergency()
+if old < 153 then
+    -- Set the new variable next_emergency_date
+    -- In previous code month == 0 meant emergencies were over
+    if self.next_emergency_month ~= 0 then
+      self.next_emergency_date = Date(1, self.next_emergency_month, self.next_emergency_day)
+      -- Complementary afterLoad to see if emergencies got stuck in the level.
+      -- There's no guarantee we can unstick the level, however.
+      local hosp = self:getLocalPlayerHospital()
+      local next_emer_date = Date(1, self.next_emergency_month, self.next_emergency_day)
+      --[[ UIWatch's emergency timer is 52 days but this is local. 
+      The emergency fax also is held for 16 days. 
+      Add one extra day to this for compensation = 69. ]]--
+      if self.game_date > next_emer_date:plusDays(69) then
+        -- The date the emergency should've finished by has passed.
+        -- Next check if the emergency could still be happening.
+        local watch = self.ui:getWindow(UIWatch)
+        if not watch or watch.count_type ~= "emergency" then
+          -- The emergency is likely stuck
+          self:nextEmergency()
+        end
       end
     end
   end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2687,9 +2687,9 @@ if old < 153 then
       -- There's no guarantee we can unstick the level, however.
       local hosp = self:getLocalPlayerHospital()
       local next_emer_date = Date(1, self.next_emergency_month, self.next_emergency_day)
-      --[[ UIWatch's emergency timer is 52 days but this is local. 
-      The emergency fax also is held for 16 days. 
-      Add one extra day to this for compensation = 69. ]]--
+      --[[ UIWatch's emergency timer is 52 days but this is local.
+      The emergency fax also is held for 16 days.
+      Add one extra day to this for compensation = 69. (Unavoidable magic number)]]--
       if self.game_date > next_emer_date:plusDays(69) then
         -- The date the emergency should've finished by has passed.
         -- Next check if the emergency could still be happening.

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1148,11 +1148,11 @@ function World:onEndDay()
         -- The level uses random emergencies, so just create one.
         local_hospital:createEmergency()
       else
-        control = self.next_emergency
+        local next_em = self.next_emergency
         -- Find out which disease the emergency patients have.
         local disease
         for _, dis in ipairs(self.available_diseases) do
-          if dis.expertise_id == control.Illness then
+          if dis.expertise_id == next_em.Illness then
             disease = dis
             break
           end
@@ -1163,9 +1163,9 @@ function World:onEndDay()
         else
           local emergency = {
             disease = disease,
-            victims = math.random(control.Min, control.Max),
-            bonus = control.Bonus,
-            percentage = control.PercWin/100,
+            victims = math.random(next_em.Min, next_em.Max),
+            bonus = next_em.Bonus,
+            percentage = next_em.PercWin/100,
             killed_emergency_patients = 0,
             cured_emergency_patients = 0,
           }

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1315,7 +1315,7 @@ end
 
 --! Generate the dates for the next emergency
 --!param emergency The next scheduled emergency to take place
---!return (boolean) true if emergency sucessfully scheduled
+--!return (boolean) true if emergency successfully scheduled
 function World:computeNextEmergencyDates(emergency)
   -- Generate the next month and day the emergency should occur at.
   -- Make sure it doesn't happen in the past.

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2680,7 +2680,6 @@ function World:afterLoad(old, new)
   if old < 153 then
     -- Complementary afterLoad to see if emergencies got stuck in the level.
     -- There's no guarantee we can unstick the level, however.
-    local hosp = self:getLocalPlayerHospital()
     local next_emer_date = Date(1, self.next_emergency_month, self.next_emergency_day)
     --[[ UIWatch's emergency timer is 52 days but this is local.
     The emergency fax also is held for 16 days.

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1306,6 +1306,7 @@ function World:scheduleRandomEmergency(control)
   local variance = control[0].Variance or 30
   -- How many days until next emergency?
   local days = math.round(math.n_random(mean, variance))
+  days = days > 1 and days or 1  -- Don't schedule in the past
   local emergency_date = self.game_date:plusDays(days)
 
   -- Make it the same format as for "controlled" emergencies

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1285,7 +1285,8 @@ function World:nextEmergency()
     local emer_num = self.next_emergency_no
     -- Account for missing Level 3 emergency[5]
     if not control[emer_num] and control[emer_num + 1] then
-      self.next_emergency_no = emer_num + 1
+      emer_num = emer_num + 1
+      self.next_emergency_no = emer_num
     end
     local emergency = control[emer_num]
     -- No more emergencies?


### PR DESCRIPTION
*Fixes #1839*

**Describe what the proposed change does**
- nextEmergency code will now more decisively schedule the next emergency
- New functions separate the random emergency scheduling from controlled emergencies
- Should an emergency end up scheduled in the past, the code will attempt the next emergency
- A complementary afterLoad has been added to try and fix any previous saves where emergencies got "stuck" because they were scheduled in the past. There isn't a guarantee this will work and has a small risk of skipping an emergency.

Ideally I need to make a separate PR to handle ``cheatMonth()`` and ``cheatYear()`` as these can break emergencies (and other things).