### PR TITLE
[RDY] Date Skipping won't break emergencies

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1090,26 +1090,34 @@ function World:onTick()
 end
 
 function World:setEndMonth()
-  local current_date = self.game_date
-  local emer_date = self.next_emergency_date
+  local previous_date = self.game_date
   local first_day_of_next_month = Date(self.game_date:year(), self.game_date:monthOfYear() + 1)
   self.game_date = first_day_of_next_month:plusHours(-1)
   -- Has the date jump caused an emergency to be missed?
-  if emer_date and emer_date < self.game_date and current_date < emer_date then
+  if self:wasEmergencySkipped(previous_date, self.game_date) then
     self:nextEmergency()
   end
 end
 
 function World:setEndYear()
-  local current_date = self.game_date
-  local emer_date = self.next_emergency_date
+  local previous_date = self.game_date
   local first_day_of_next_year = Date(self.game_date:year() + 1)
   self.game_date = first_day_of_next_year:plusHours(-1)
   -- Has the date jump caused an emergency to be missed?
-  if emer_date and emer_date < self.game_date and current_date < emer_date then
+  if self:wasEmergencySkipped(previous_date, self.game_date) then
     self:nextEmergency()
   end
 end
+
+--! Checks if a time jump caused an emergency to be missed
+--!param prev_date (Date) Original game date before jump
+--!param new_date (Date) Game date after time jump
+--!return (boolean) true if emergency has been skipped
+function World:wasEmergencySkipped(prev_date, new_date)
+  local emer_date = self.next_emergency_date
+  return emer_date and emer_date < new_date and prev_date < emer_date
+end
+  
 
 -- Called immediately prior to the ingame day changing.
 function World:onEndDay()

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1090,13 +1090,25 @@ function World:onTick()
 end
 
 function World:setEndMonth()
+  local current_date = self.game_date
+  local emer_date = self.next_emergency_date
   local first_day_of_next_month = Date(self.game_date:year(), self.game_date:monthOfYear() + 1)
   self.game_date = first_day_of_next_month:plusHours(-1)
+  -- Has the date jump caused an emergency to be missed?
+  if emer_date and emer_date < self.game_date and current_date < emer_date then
+    self:nextEmergency()
+  end
 end
 
 function World:setEndYear()
+  local current_date = self.game_date
+  local emer_date = self.next_emergency_date
   local first_day_of_next_year = Date(self.game_date:year() + 1)
   self.game_date = first_day_of_next_year:plusHours(-1)
+  -- Has the date jump caused an emergency to be missed?
+  if emer_date and emer_date < self.game_date and current_date < emer_date then
+    self:nextEmergency()
+  end
 end
 
 -- Called immediately prior to the ingame day changing.

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1117,7 +1117,7 @@ function World:wasEmergencySkipped(prev_date, new_date)
   local emer_date = self.next_emergency_date
   return emer_date and emer_date < new_date and prev_date < emer_date
 end
-  
+
 
 -- Called immediately prior to the ingame day changing.
 function World:onEndDay()


### PR DESCRIPTION
**Describe what the proposed change does**
- Cheating to end of Month or end of Year will no longer break emergencies.
- Relies on #1843 to be merged