### PR TITLE
Changes supporting falling actions

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 189 -- Refactor earthquakes
+local SAVEGAME_VERSION = 190 -- Improve falling actions for debug purposes
 
 class "App"
 

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -146,6 +146,7 @@ local config_defaults = {
   allow_blocking_off_areas = false,
   direct_zoom = nil,
   new_machine_extra_info = true,
+  debug_falling = false,
   player_name = [[]],
 }
 
@@ -489,9 +490,16 @@ audio_music = nil -- [[X:\ThemeHospital\Music]]
 --]=] .. '\n' ..
 'debug = ' .. tostring(config_values.debug) .. '\n' .. [=[
 
---Optional settings for CorsixTH's Lua DBGp client. Default settings are
--- nil values, platform & workingdir will be autodected if nil.
---https://wiki.eclipse.org/LDT/User_Area/User_Guides/User_Guide_1.2#Attach_session
+-- Experimental setting for falling patients. (debug only!)
+-- CorsixTH does not yet have reliable handling for falling actions and enabling it
+-- could cause dropped action queues or undesired bugs. You should leave this setting
+-- off unless you're developing with it
+--]=] .. '\n' ..
+'debug_falling = ' .. tostring(config_values.debug_falling) .. '\n' .. [=[
+
+-- Optional settings for CorsixTH's Lua DBGp client. Default settings are
+-- nil values, platform & working dir will be autodetected if nil.
+-- https://wiki.eclipse.org/LDT/User_Area/User_Guides/User_Guide_1.2#Attach_session
 --]=] .. '\n' ..
 'idehost = ' .. tostring(config_values.DBGp_client_idehost) .. '\n' ..
 'ideport = ' .. tostring(config_values.DBGp_client_ideport) .. '\n' ..

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -806,6 +806,9 @@ function UIMenuBar:makeGameMenu(app)
   local function allowBlockingAreas(item)
     app.config.allow_blocking_off_areas = item.checked
   end
+  local function allowFalling(item)
+    app.config.debug_falling = item.checked
+  end
   local levels_menu = UIMenu()
   for L = 1, 12 do
     levels_menu:appendItem(("  L%i  "):format(L), function()
@@ -821,6 +824,7 @@ function UIMenuBar:makeGameMenu(app)
       :appendCheckItem(_S.menu_debug.limit_camera,         true, limit_camera, nil, function() return self.ui.limit_to_visible_diamond end)
       :appendCheckItem(_S.menu_debug.disable_salary_raise, false, disable_salary_raise, nil, function() return self.ui.app.world.debug_disable_salary_raise end)
       :appendCheckItem(_S.menu_debug.allow_blocking_off_areas, false, allowBlockingAreas, nil, function() return self.ui.app.config.allow_blocking_off_areas end)
+      :appendCheckItem(_S.menu_debug.allow_falling, false, allowFalling, nil, function() return self.ui.app.config.debug_falling end)
       :appendItem(_S.menu_debug.make_debug_fax,     function() self.ui:makeDebugFax() end)
       :appendItem(_S.menu_debug.make_debug_patient, function() self.ui:addWindow(UIMakeDebugPatient(self.ui)) end)
       :appendItem(_S.menu_debug.cheats:format(hotkey_value_label("ingame_showCheatWindow", hotkeys)),             function() self.ui:addWindow(UICheats(self.ui)) end)

--- a/CorsixTH/Lua/earthquake.lua
+++ b/CorsixTH/Lua/earthquake.lua
@@ -145,7 +145,18 @@ function Earthquake:tick()
   self.remaining_damage = self.remaining_damage - 1
   self.damage_timer = self.damage_timer + damage_time
 
-  -- Patient falling: work in progress, see PR 1848
+  -- The below code triggers random patient falls during an earthquake.
+  -- It is currently disabled except for debugging purposes in the config file.
+  -- Current behaviour can cause empty action queues or other undesired behaviours.
+  -- Once working, the debugging flag can be removed.
+  if not TheApp.config.debug_falling then return end
+  local hospital = self.world:getLocalPlayerHospital()
+  -- loop through the patients and allow the possibility for them to fall over
+  for _, patient in ipairs(hospital.patients) do
+    if not patient.in_room and patient.falling_anim then
+      patient:falling(false)
+    end
+  end
 end
 
 --! Check if it's time for an earthquake

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -171,7 +171,7 @@ falling_anim("Standard Female Patient",   3116)
 --  | Name                                 |Anim| Notes
 ----+--------------------------------+-----+-----+-----+-----+------+------+
 on_ground_anim("Standard Male Patient",     1258)
-on_ground_anim("Standard Female Patient",   3116)
+on_ground_anim("Standard Female Patient",   1764)
 
 --  | Get_up Animations                   |
 --  | Name                                 |Anim| Notes

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -361,20 +361,14 @@ function Patient:falling()
   local current = self:getCurrentAction()
   current.keep_reserved = true
   if self.falling_anim and self:canPeeOrPuke(current) and self.has_fallen == 1 then
-    self:setNextAction(FallingAction(), 0)
     self.has_fallen = 2
-    if self.has_fallen == 2 then
-      self:setNextAction(OnGroundAction())
-      self.on_ground = true
-    end
-    if self.on_ground then
-      self:setNextAction(GetUpAction())
-    end
-    -- TODO: falls are broken, the will change once implemented
-    self:interruptAndRequeueAction(current, 2)
-    self.on_ground = false
-    if math.random(1, 5) == 3 then
-      self:shakeFist()
+    self:queueAction(FallingAction(), 1)
+    self:queueAction(OnGroundAction(), 2)
+    self:queueAction(GetUpAction(), 3)
+    if math.random(1, 5) == 3 and self:shakeFist() then
+      self:interruptAndRequeueAction(current, 5)
+    else
+      self:interruptAndRequeueAction(current, 4)
     end
     self:fallingAnnounce()
     self:changeAttribute("happiness", -0.05) -- falling makes you very unhappy
@@ -398,7 +392,8 @@ end
 --! Perform 'shake fist' action.
 function Patient:shakeFist()
   if self.shake_fist_anim then
-    self:queueAction(ShakeFistAction(), 1)
+    self:queueAction(ShakeFistAction(), 4)
+    return true
   end
 end
 
@@ -1124,6 +1119,11 @@ function Patient:afterLoad(old, new)
           action.must_happen = false
         end
       end
+    end
+  end
+  if old < 190 then
+    if self.humanoid_class == "Standard Female Patient" then
+      self.on_ground_anim = 1764
     end
   end
   self:updateDynamicInfo()

--- a/CorsixTH/Lua/humanoid_actions/falling.lua
+++ b/CorsixTH/Lua/humanoid_actions/falling.lua
@@ -41,7 +41,7 @@ local function action_falling_start(action, humanoid)
   end
 
   assert(humanoid.falling_anim, "Error: no falling animation for humanoid " .. humanoid.humanoid_class)
-  action.must_happen = true
+
   humanoid:setAnimation(humanoid.falling_anim, humanoid.last_move_direction == "east" and 0 or 1)
   humanoid:setTimer(humanoid.world:getAnimLength(humanoid.falling_anim), action_falling_end)
 end

--- a/CorsixTH/Lua/humanoid_actions/falling.lua
+++ b/CorsixTH/Lua/humanoid_actions/falling.lua
@@ -25,7 +25,7 @@ local FallingAction = _G["FallingAction"]
 
 function FallingAction:FallingAction()
   self:HumanoidAction("falling")
-  self.setMustHappen(true)
+  self:setMustHappen(true)
 end
 
 local action_falling_end = permanent"action_falling_end"( function(humanoid)

--- a/CorsixTH/Lua/humanoid_actions/get_up.lua
+++ b/CorsixTH/Lua/humanoid_actions/get_up.lua
@@ -25,6 +25,7 @@ local GetUpAction = _G["GetUpAction"]
 
 function GetUpAction:GetUpAction()
   self:HumanoidAction("get_up")
+  self:setMustHappen(true)
 end
 
 local action_get_up_end = permanent"action_get_up_end"( function(humanoid)
@@ -33,14 +34,8 @@ end)
 
 
 local function action_get_up_start(action, humanoid)
-  if math.random(0, 1) == 1 then
-    humanoid.last_move_direction = "east"
-  else
-    humanoid.last_move_direction = "south"
-  end
-
   assert(humanoid.get_up_anim, "Error: no getting up animation for humanoid " .. humanoid.humanoid_class)
-  action.must_happen = true
+
   humanoid:setAnimation(humanoid.get_up_anim, humanoid.last_move_direction == "east" and 0 or 1)
   humanoid:setTimer(humanoid.world:getAnimLength(humanoid.get_up_anim), action_get_up_end)
 end

--- a/CorsixTH/Lua/humanoid_actions/on_ground.lua
+++ b/CorsixTH/Lua/humanoid_actions/on_ground.lua
@@ -25,6 +25,7 @@ local OnGroundAction = _G["OnGroundAction"]
 
 function OnGroundAction:OnGroundAction()
   self:HumanoidAction("on_ground")
+  self:setMustHappen(true)
 end
 
 local action_on_ground_end = permanent"action_on_ground_end"( function(humanoid)
@@ -33,14 +34,8 @@ end)
 
 
 local function action_on_ground_start(action, humanoid)
-  if math.random(0, 1) == 1 then
-    humanoid.last_move_direction = "east"
-  else
-    humanoid.last_move_direction = "south"
-  end
-
   assert(humanoid.on_ground_anim, "Error: no on the ground animation for humanoid " .. humanoid.humanoid_class)
-  action.must_happen = true
+
   humanoid:setAnimation(humanoid.on_ground_anim, humanoid.last_move_direction == "east" and 0 or 1)
   humanoid:setTimer(humanoid.world:getAnimLength(humanoid.on_ground_anim), action_on_ground_end)
 end

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -193,6 +193,7 @@ menu_debug = {
   limit_camera                = "  LIMIT CAMERA  ",
   disable_salary_raise        = "  DISABLE SALARY RAISE  ",
   allow_blocking_off_areas    = "  ALLOW BLOCKING OFF AREAS  ",
+  allow_falling               = "  ALLOW FALLING  ",
   make_debug_fax              = "  MAKE DEBUG FAX  ",
   make_debug_patient          = "  MAKE DEBUG PATIENT  ",
   cheats                      = "  (%1%) CHEATS  ",

--- a/WindowsInstaller/config_template.txt
+++ b/WindowsInstaller/config_template.txt
@@ -293,9 +293,16 @@ audio_buffer_size = 2048
 --
 debug = false
 
---Optional settings for CorsixTH's Lua DBGp client. Default settings are
--- nil values, platform & workingdir will be autodected if nil.
---https://wiki.eclipse.org/LDT/User_Area/User_Guides/User_Guide_1.2#Attach_session
+-- Experimental setting for falling patients. (debug only!)
+-- CorsixTH does not yet have reliable handling for falling actions and enabling it
+-- could cause dropped action queues or undesired bugs. You should leave this setting
+-- off unless you're developing with it
+--
+debug_falling = false
+
+-- Optional settings for CorsixTH's Lua DBGp client. Default settings are
+-- nil values, platform & working dir will be autodetected if nil.
+-- https://wiki.eclipse.org/LDT/User_Area/User_Guides/User_Guide_1.2#Attach_session
 --
 idehost = nil
 ideport = nil


### PR DESCRIPTION

<img width="314" height="151" alt="Screenshot 2026-06-15 at 14 11 37" src="https://github.com/user-attachments/assets/55fa8037-8c23-4a61-9f51-8fd042cb27b2" />


*Fixes #476*

**Describe what the proposed change does**
- Corrects animations for Female patient (this probably doesn't work if they are a Stripped version at the time)
- Fixes the must happen to be in the constructor, otherwise any setNextAction calls will remove them
- Patients randomly choose a fall direction then that direction doesn't change, the random would have them fall one way, lay another and then stand up again in another
- Queues the actions more correctly for falling

I didn't activate the falling code in world, so these don't actually initiate anything but can be used for testing.

Doesn't as pointed out in the discussion #1846 attempt to address the issue of interrupted actions being incorrectly requeued for example, walking to room that is destroyed at the same time the fall action starts, which would requeue the interrupted walk to that room.

I had put a has_interrupted flag on the action and detected it as not to requeue, but not all interruptions are driven through setNextAction (interrupt_head in queue for example) and I think the other issue was actions like the walk which starts and does something, sets the interrupt handler, which means the action starts, rather than a todo_interrupt being detected to basically skip the action in the action start (seek_toilets_action_start for example and this is same issue with teleporting the drinks machine or jumping to/from bench when queue actions are interrupted as use_object also must start)