### PR TITLE
[RDY] Deal with staff attribute checks

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -174,9 +174,8 @@ function UIStaffManagement:updateStaffList(staff_member_removed)
     Handyman = {},
     Receptionist = {},
   }
-  staff_members.Surgeon = staff_members.Doctor
   for _, staff in ipairs(hosp.staff) do
-    local list = staff_members[staff.humanoid_class]
+    local list = staff_members[staff.profile.humanoid_class]
     list[#list + 1] = staff
     -- The selected staff might have been moved because someone else was removed from the list.
     if selected_staff == staff then
@@ -225,7 +224,7 @@ end
 -- Function to select a given staff member.
 -- Includes switching to correct category and page.
 function UIStaffManagement:selectStaff(staff)
-  self:setCategory(staff.humanoid_class == "Surgeon" and "Doctor" or staff.humanoid_class)
+  self:setCategory(staff.profile.humanoid_class)
   for i, s in ipairs(self.staff_members[self.category]) do
     if s == staff then
       self:selectIndex(i)

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -255,11 +255,6 @@ function UIStaff:onMouseDown(button, x, y)
   return Window.onMouseDown(self, button, x, y)
 end
 
--- Helper function to facilitate humanoid_class comparison wrt. Surgeons
-local function surg_compat(class)
-  return class == "Surgeon" and "Doctor" or class
-end
-
 function UIStaff:onMouseUp(button, x, y)
   local ui = self.ui
   if button == "left" then
@@ -271,7 +266,7 @@ function UIStaff:onMouseUp(button, x, y)
     -- Right click goes to the next staff member of the same category (NB: Surgeon in same Category as Doctor)
     local staff_index = nil
     for i, staff in ipairs(ui.hospital.staff) do
-      if staff_index and surg_compat(staff.humanoid_class) == surg_compat(self.staff.humanoid_class) then
+      if staff_index and staff.profile.humanoid_class == self.staff.profile.humanoid_class then
         ui:addWindow(UIStaff(ui, staff))
         return false
       end
@@ -282,7 +277,7 @@ function UIStaff:onMouseUp(button, x, y)
     -- Try again from beginning of list until staff_index
     for i = 1, staff_index - 1 do
       local staff = ui.hospital.staff[i]
-      if surg_compat(staff.humanoid_class) == surg_compat(self.staff.humanoid_class) then
+      if staff.profile.humanoid_class == self.staff.profile.humanoid_class then
         ui:addWindow(UIStaff(ui, staff))
         return false
       end

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -452,7 +452,7 @@ function Staff:setHospital(hospital)
 end
 
 -- Helper function to decide if Staff fulfills a criterion
--- (one of "Doctor", "Nurse", "Psychiatrist", "Surgeon", "Researcher" and "Handyman")
+-- (one of "Doctor", "Nurse", "Psychiatrist", "Surgeon", "Researcher" and "Handyman", "Receptionist", "Junior", "Consultant")
 function Staff:fulfillsCriterion(criterion)
   return false
 end

--- a/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
@@ -249,17 +249,18 @@ local profile_attributes = {
   Psychiatrist = "is_psychiatrist",
   Surgeon = "is_surgeon",
   Researcher = "is_researcher",
+  Junior = "is_junior",
+  Consultant = "is_consultant",
 }
 
 -- Helper function to decide if Staff fulfills a criterion
--- (one of "Doctor", "Nurse", "Psychiatrist", "Surgeon", "Researcher" and "Handyman")
+-- (one of "Doctor", "Nurse", "Psychiatrist", "Surgeon", "Researcher" and "Handyman", "Receptionist", "Junior", "Consultant")
 function Doctor:fulfillsCriterion(criterion)
   if criterion == "Doctor" then
     return true
-  elseif criterion == "Psychiatrist" or criterion == "Surgeon" or criterion == "Researcher" then
-    if self.profile and self.profile[profile_attributes[criterion]] == 1.0 then
-      return true
-    end
+  end
+  if self.profile and self.profile[profile_attributes[criterion]] == 1.0 then
+    return true
   end
   return false
 end

--- a/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
@@ -84,12 +84,9 @@ function Handyman:onPlaceInCorridor()
 end
 
 -- Helper function to decide if Handyman fulfills a criterion
--- (one of "Doctor", "Nurse", "Psychiatrist", "Surgeon", "Researcher" and "Handyman")
+-- (one of "Doctor", "Nurse", "Psychiatrist", "Surgeon", "Researcher" and "Handyman", "Receptionist", "Junior", "Consultant")
 function Handyman:fulfillsCriterion(criterion)
-  if criterion == "Handyman" then
-    return true
-  end
-  return false
+  return criterion == "Handyman"
 end
 
 function Handyman:afterLoad(old, new)

--- a/CorsixTH/Lua/entities/humanoids/staff/nurse.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/nurse.lua
@@ -42,12 +42,9 @@ function Nurse:leaveAnnounce()
 end
 
 -- Helper function to decide if Staff fulfills a criterion
--- (one of "Doctor", "Nurse", "Psychiatrist", "Surgeon", "Researcher" and "Handyman")
+-- (one of "Doctor", "Nurse", "Psychiatrist", "Surgeon", "Researcher" and "Handyman", "Receptionist", "Junior", "Consultant")
 function Nurse:fulfillsCriterion(criterion)
-  if criterion == "Nurse" then
-    return true
-  end
-  return false
+  return criterion == "Nurse"
 end
 
 function Nurse:adviseWrongPersonForThisRoom()

--- a/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
@@ -83,9 +83,9 @@ end
 
 
 -- Helper function to decide if Staff fulfills a criterion
--- (one of "Doctor", "Nurse", "Psychiatrist", "Surgeon", "Researcher" and "Handyman")
-function Receptionist:fulfillsCriterion(criterion) -- luacheck: no unused args
-  return false
+-- (one of "Doctor", "Nurse", "Psychiatrist", "Surgeon", "Researcher" and "Handyman", "Receptionist", "Junior", "Consultant")
+function Receptionist:fulfillsCriterion(criterion)
+  return criterion == "Receptionist"
 end
 
 function Receptionist:getDrawingLayer()

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1614,16 +1614,8 @@ end
 function Hospital:countStaffOfCategory(category, max_count)
   local result = 0
   for _, staff in ipairs(self.staff) do
-    if staff.humanoid_class == category then
+    if staff:fulfillsCriterion(category) then
       result = result + 1
-    elseif staff.humanoid_class == "Doctor" then
-      if (category == "Psychiatrist" and staff.profile.is_psychiatrist >= 1.0) or
-          (category == "Surgeon" and staff.profile.is_surgeon >= 1.0) or
-          (category == "Researcher" and staff.profile.is_researcher >= 1.0) or
-          (category == "Consultant" and staff.profile.is_consultant) or
-          (category == "Junior" and staff.profile.is_junior) then
-        result = result + 1
-      end
     end
     if max_count ~= nil and result >= max_count then break end
   end


### PR DESCRIPTION


*Fixes #1838*

**Describe what the proposed change does**
- Use staff.profile to avoid inline class conversions, for Surgeons
- Reuse fulfillsCriterion function to support counting staff Category

fulfillsCriterion seemed to only really be used for flow of logic when a room was in scope in the calls dispatcher where a room is in scope or a room calling it within its methods so Receptionist seems safe to implement.
