### PR TITLE
[RDY] Add to reception queue only when near reception #372

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -23,6 +23,9 @@ class "SeekReceptionAction" (HumanoidAction)
 ---@type SeekReceptionAction
 local SeekReceptionAction = _G["SeekReceptionAction"]
 
+-- distance from queue that patient can join a reception desk queue
+local can_join_queue_distance = 6
+
 function SeekReceptionAction:SeekReceptionAction()
   self:HumanoidAction("seek_reception")
 end
@@ -71,13 +74,14 @@ local function action_seek_reception_start(action, humanoid)
     local orientation = best_desk.object_type.orientations[best_desk.direction]
     local x = best_desk.tile_x + orientation.use_position[1]
     local y = best_desk.tile_y + orientation.use_position[2]
+    local dist = humanoid.world:getPathDistance(humanoid.tile_x, humanoid.tile_y, x, y)
     humanoid:updateDynamicInfo(_S.dynamic_info.patient.actions.on_my_way_to
       :format(best_desk.object_type.name))
     humanoid.waiting = nil
 
     -- We don't want patients which have just spawned to be joining the queue
     -- immediately, so walk them closer to the desk before joining the queue
-    if can_join_queue_at(humanoid, humanoid.tile_x, humanoid.tile_y) then
+    if can_join_queue_at(humanoid, humanoid.tile_x, humanoid.tile_y) and dist <= can_join_queue_distance then
       local face_x, face_y = best_desk:getSecondaryUsageTile()
       humanoid:setNextAction(QueueAction(x, y, best_desk.queue):setMustHappen(action.must_happen)
           :setFaceDirection(face_x, face_y))
@@ -87,9 +91,11 @@ local function action_seek_reception_start(action, humanoid)
 
       -- Trim the walk to finish once it is possible to join the queue
       for i = #walk.path_x, 2, -1 do
-        if can_join_queue_at(humanoid, walk.path_x[i], walk.path_y[i]) then
+        if can_join_queue_at(humanoid, walk.path_x[i], walk.path_y[i]) and dist - i < can_join_queue_distance then
           walk.path_x[i + 1] = nil
           walk.path_y[i + 1] = nil
+          walk.x = walk.path_x[i]
+          walk.y = walk.path_y[i]
         else
           break
         end


### PR DESCRIPTION
*Fixes #372*

**Describe what the proposed change does**
- Walk is truncated to a distance of 6 tiles away from the reception desk use tile.
- Updates walk actions destination tile to that of the truncated walk (incase of vomit)

