### PR TITLE
[RDY] Use initial reputation and overdraft interest rate if set in level config

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 154
+local SAVEGAME_VERSION = 155
 
 class "App"
 

--- a/CorsixTH/Lua/base_config.lua
+++ b/CorsixTH/Lua/base_config.lua
@@ -28,6 +28,7 @@ local configuration = {
   town = {
     InterestRate = 0.01,
     StartCash = 40000,
+    StartRep = 500,
   },
 
   -- New value, but should only be defined if starting staff is included.
@@ -133,19 +134,19 @@ local configuration = {
   },
 
   towns = {
-    {StartCash = 40000, InterestRate = 100}, -- Level 1
-    {StartCash = 40000, InterestRate = 200}, --  Level 2
-    {StartCash = 50000, InterestRate = 300}, --  Level 3
-    {StartCash = 50000, InterestRate = 400}, --  Level 4
-    {StartCash = 50000, InterestRate = 500}, --  Level 5
-    {StartCash = 50000, InterestRate = 600}, --  Level 6
-    {StartCash = 50000, InterestRate = 700}, --  Level 7
-    {StartCash = 60000, InterestRate = 700}, --  Level 8
-    {StartCash = 60000, InterestRate = 800}, --  Level 9
-    {StartCash = 60000, InterestRate = 800}, --  Level 10
-    {StartCash = 70000, InterestRate = 900}, --  Level 11
-    {StartCash = 70000, InterestRate = 900}, --  Level 12
-    {StartCash = 70000, InterestRate = 900}, --  Level 12
+    {StartCash = 40000, InterestRate = 100, StartRep = 500}, -- Level 1
+    {StartCash = 40000, InterestRate = 200, StartRep = 500}, --  Level 2
+    {StartCash = 50000, InterestRate = 300, StartRep = 500}, --  Level 3
+    {StartCash = 50000, InterestRate = 400, StartRep = 500}, --  Level 4
+    {StartCash = 50000, InterestRate = 500, StartRep = 500}, --  Level 5
+    {StartCash = 50000, InterestRate = 600, StartRep = 500}, --  Level 6
+    {StartCash = 50000, InterestRate = 700, StartRep = 500}, --  Level 7
+    {StartCash = 60000, InterestRate = 700, StartRep = 500}, --  Level 8
+    {StartCash = 60000, InterestRate = 800, StartRep = 500}, --  Level 9
+    {StartCash = 60000, InterestRate = 800, StartRep = 500}, --  Level 10
+    {StartCash = 70000, InterestRate = 900, StartRep = 500}, --  Level 11
+    {StartCash = 70000, InterestRate = 900, StartRep = 500}, --  Level 12
+    {StartCash = 70000, InterestRate = 900, StartRep = 500}, --  Level 12
   },
   popn = {
     [0] = {Month = 0, Change = 4}, -- Standard: 4 patients the first month.

--- a/CorsixTH/Lua/base_config.lua
+++ b/CorsixTH/Lua/base_config.lua
@@ -25,10 +25,13 @@ local configuration = {
   -----------------------------------------------------------
   --      New configuration values added in CorsixTH       --
   -----------------------------------------------------------
+  -- Interest rate and overdraft interest rate differential values will
+  --  be divided by 10,000
   town = {
-    InterestRate = 0.01,
+    InterestRate = 100,
     StartCash = 40000,
     StartRep = 500,
+    OverdraftDiff = 200,
   },
 
   -- New value, but should only be defined if starting staff is included.
@@ -134,19 +137,19 @@ local configuration = {
   },
 
   towns = {
-    {StartCash = 40000, InterestRate = 100, StartRep = 500}, -- Level 1
-    {StartCash = 40000, InterestRate = 200, StartRep = 500}, --  Level 2
-    {StartCash = 50000, InterestRate = 300, StartRep = 500}, --  Level 3
-    {StartCash = 50000, InterestRate = 400, StartRep = 500}, --  Level 4
-    {StartCash = 50000, InterestRate = 500, StartRep = 500}, --  Level 5
-    {StartCash = 50000, InterestRate = 600, StartRep = 500}, --  Level 6
-    {StartCash = 50000, InterestRate = 700, StartRep = 500}, --  Level 7
-    {StartCash = 60000, InterestRate = 700, StartRep = 500}, --  Level 8
-    {StartCash = 60000, InterestRate = 800, StartRep = 500}, --  Level 9
-    {StartCash = 60000, InterestRate = 800, StartRep = 500}, --  Level 10
-    {StartCash = 70000, InterestRate = 900, StartRep = 500}, --  Level 11
-    {StartCash = 70000, InterestRate = 900, StartRep = 500}, --  Level 12
-    {StartCash = 70000, InterestRate = 900, StartRep = 500}, --  Level 12
+    {StartCash = 40000, InterestRate = 100, StartRep = 500, OverdraftDiff = 200}, --  Level 1
+    {StartCash = 40000, InterestRate = 200, StartRep = 500, OverdraftDiff = 200}, --  Level 2
+    {StartCash = 50000, InterestRate = 300, StartRep = 500, OverdraftDiff = 200}, --  Level 3
+    {StartCash = 50000, InterestRate = 400, StartRep = 500, OverdraftDiff = 200}, --  Level 4
+    {StartCash = 50000, InterestRate = 500, StartRep = 500, OverdraftDiff = 200}, --  Level 5
+    {StartCash = 50000, InterestRate = 600, StartRep = 500, OverdraftDiff = 200}, --  Level 6
+    {StartCash = 50000, InterestRate = 700, StartRep = 500, OverdraftDiff = 200}, --  Level 7
+    {StartCash = 60000, InterestRate = 700, StartRep = 500, OverdraftDiff = 200}, --  Level 8
+    {StartCash = 60000, InterestRate = 800, StartRep = 500, OverdraftDiff = 200}, --  Level 9
+    {StartCash = 60000, InterestRate = 800, StartRep = 500, OverdraftDiff = 200}, --  Level 10
+    {StartCash = 70000, InterestRate = 900, StartRep = 500, OverdraftDiff = 200}, --  Level 11
+    {StartCash = 70000, InterestRate = 900, StartRep = 500, OverdraftDiff = 200}, --  Level 12
+    {StartCash = 70000, InterestRate = 900, StartRep = 500, OverdraftDiff = 200}, --  Level 12
   },
   popn = {
     [0] = {Month = 0, Change = 4}, -- Standard: 4 patients the first month.

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -31,18 +31,20 @@ function Hospital:Hospital(world, avail_rooms, name)
   self.world = world
   local level_config = world.map.level_config
   local level = world.map.level_number
-  local balance = 40000
-  local interest_rate = 0.01
-  local reputation
+  local balance, interest_rate_numerator, reputation, overdraft_differential_numerator
+
   if level_config.towns and level_config.towns[level] then
     balance = level_config.towns[level].StartCash
-    interest_rate = level_config.towns[level].InterestRate / 10000
+    interest_rate_numerator = level_config.towns[level].InterestRate
     reputation = level_config.towns[level].StartRep
+    overdraft_differential_numerator = level_config.towns[level].OverdraftDiff
   elseif level_config.town then
     balance = level_config.town.StartCash
-    interest_rate = level_config.town.InterestRate / 10000
+    interest_rate_numerator = level_config.town.InterestRate
     reputation = level_config.town.StartRep
+    overdraft_differential_numerator = level_config.town.OverdraftDiff
   end
+
   self.name = name or "PLAYER"
   -- When playing in free build mode you don't care about money.
   self.balance = not world.free_build_mode and balance or 0
@@ -78,8 +80,9 @@ function Hospital:Hospital(world, avail_rooms, name)
   self.concurrent_epidemic_limit = level_config.gbv.EpidemicConcurrentLimit or 1
 
   -- Initial values
-  self.interest_rate = interest_rate
+  self.interest_rate = interest_rate_numerator / 10000
   self.inflation_rate = 0.045
+  self.overdraft_interest_rate = self.interest_rate + overdraft_differential_numerator / 10000
   self.salary_incr = level_config.gbv.ScoreMaxInc or 300
   self.sal_min = level_config.gbv.ScoreMaxInc / 6 or 50
   self.reputation_min = 0
@@ -641,6 +644,10 @@ function Hospital:afterLoad(old, new)
     self.undiscovered_rooms = nil
   end
 
+  if old < 155 then
+    self.overdraft_interest_rate = self.interest_rate + 0.02
+  end
+
   -- Update other objects in the hospital (added in version 106).
   if self.epidemic then self.epidemic.afterLoad(old, new) end
   for _, future_epidemic in ipairs(self.future_epidemics_pool) do
@@ -902,8 +909,7 @@ function Hospital:onEndDay()
 
   self.show_progress_screen_warnings = math.random(1, 3) -- used in progress report to limit warnings
   if self.balance < 0 then
-    -- TODO: Add the extra interest rate to level configuration.
-    local overdraft_interest = self.interest_rate + 0.02
+    local overdraft_interest = self.overdraft_interest_rate
     local overdraft = math.abs(self.balance)
     local overdraft_payment = (overdraft*overdraft_interest)/365
     self.acc_overdraft = self.acc_overdraft + overdraft_payment

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -33,17 +33,17 @@ function Hospital:Hospital(world, avail_rooms, name)
   local level = world.map.level_number
   local balance = 40000
   local interest_rate = 0.01
-  if level_config then
-    if level_config.towns and level_config.towns[level] then
-      balance = level_config.towns[level].StartCash
-      interest_rate = level_config.towns[level].InterestRate / 10000
-    elseif level_config.town then
-      balance = level_config.town.StartCash
-      interest_rate = level_config.town.InterestRate / 10000
-    end
+  local reputation
+  if level_config.towns and level_config.towns[level] then
+    balance = level_config.towns[level].StartCash
+    interest_rate = level_config.towns[level].InterestRate / 10000
+    reputation = level_config.towns[level].StartRep
+  elseif level_config.town then
+    balance = level_config.town.StartCash
+    interest_rate = level_config.town.InterestRate / 10000
+    reputation = level_config.town.StartRep
   end
   self.name = name or "PLAYER"
-  -- TODO: Variate initial reputation etc based on level
   -- When playing in free build mode you don't care about money.
   self.balance = not world.free_build_mode and balance or 0
   self.loan = 0
@@ -82,9 +82,9 @@ function Hospital:Hospital(world, avail_rooms, name)
   self.inflation_rate = 0.045
   self.salary_incr = level_config.gbv.ScoreMaxInc or 300
   self.sal_min = level_config.gbv.ScoreMaxInc / 6 or 50
-  self.reputation = 500
   self.reputation_min = 0
   self.reputation_max = 1000
+  self.reputation = math.min(math.max(reputation, self.reputation_min), self.reputation_max)
 
   local difficulty = self.world.map:getDifficulty()
   -- Price distortion level under which the patients might consider the
@@ -138,7 +138,7 @@ function Hospital:Hospital(world, avail_rooms, name)
       visitors = 0,
       cures = 0,
       deaths = 0,
-      reputation = 500, -- TODO: Always 500 from the beginning?
+      reputation = self.reputation
     }
   }
   self.money_in = 0


### PR DESCRIPTION
*Previous feedback #1722, #1741*

**Describe what the proposed change does**
- Reputation and the overdraft interest differential can be set in levels
- Change interest and overdraft interest to a number over 10,000. Consistent with how it's set in levels.
