### PR TITLE
[RDY] Service Quality affects treatment

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -301,8 +301,13 @@ function Patient:isTreatmentEffective()
   local cure_chance = self.hospital.disease_casebook[self.disease.id].cure_effectiveness
   cure_chance = cure_chance * self.diagnosis_progress
 
-  local die = self.die_anims and math.random(1, 100) > cure_chance
-  return not die
+  -- Service quality has a factor on cure chance +/- 10%
+  local room = self:getRoom()
+  local base, divisor = 0.9, 5
+  local service_factor = base + (room:getStaffServiceQuality() / divisor)
+  cure_chance = cure_chance * service_factor
+
+  return (cure_chance >= math.random(1,100))
 end
 
 --! Change patient internal state to "cured".

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -303,9 +303,11 @@ function Patient:isTreatmentEffective()
 
   -- Service quality has a factor on cure chance
   local room = self:getRoom()
-  local min, base, divisor = 20, -0.1, 5
-  local service_base = math.max(100 - cure_chance, min)
-  local service_factor = base + (room:getStaffServiceQuality() / divisor)
+  local min_impact = 20
+  local service_base = math.max(100 - cure_chance, min_impact)
+
+  local scale = 0.2 -- Quality scaled to +-10%
+  local service_factor = (room:getStaffServiceQuality() - 0.5) * scale
   cure_chance = cure_chance + (service_base * service_factor)
 
   return (cure_chance >= math.random(1,100))

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -301,11 +301,12 @@ function Patient:isTreatmentEffective()
   local cure_chance = self.hospital.disease_casebook[self.disease.id].cure_effectiveness
   cure_chance = cure_chance * self.diagnosis_progress
 
-  -- Service quality has a factor on cure chance +/- 10%
+  -- Service quality has a factor on cure chance
   local room = self:getRoom()
-  local base, divisor = 0.9, 5
+  local min, base, divisor = 20, -0.1, 5
+  local service_base = math.max(100 - cure_chance, min)
   local service_factor = base + (room:getStaffServiceQuality() / divisor)
-  cure_chance = cure_chance * service_factor
+  cure_chance = cure_chance + (service_base * service_factor)
 
   return (cure_chance >= math.random(1,100))
 end


### PR DESCRIPTION
*Closes #1829*

**Describe what the proposed change does**
- Service Quality now considered in treatment. As realistically the fatigue/skill etc or the doctor/nurse can affect effectiveness of a cure.
- Service Quality will only have a small impact cure_chance to not become unbalanced. Though now has a higher impact where cure_chance is lower, and less when higher.

Just a side note, inside staff_profile we actually set the midpoint as skill 0.55; should we copy that here too with service quality's midpoint?