### PR TITLE
[RDY] Change BUILD_ANIMVIEWER to BUILD_ANIMVIEW and add sanity check in AnimView cmake

### DIFF
--- a/AnimView/CMakeLists.txt
+++ b/AnimView/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Sanity check
+if(CORSIX_TH_DONE_TOP_LEVEL_CMAKE)
+else()
+  message(FATAL_ERROR "Please run CMake from the top-level directory instead of here.")
+endif()
+
 # Project Declaration
 project(AnimView)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #   - WITH_LUAROCKS : Install required luarocks in the macOS app (requires luarocks)
 
 #   - ENABLE_UNIT_TESTS : Enable Unit Testing Target (requires Catch2) (no)
-#   - BUILD_ANIMVIEWER : Generate AnimViewer build files (no)
+#   - BUILD_ANIMVIEW : Generate AnimViewer build files (no)
 
 cmake_minimum_required(VERSION 3.5)
 
@@ -59,7 +59,7 @@ if(APPLE)
 endif()
 
 option(ENABLE_UNIT_TESTS "Enables Unit Testing Targets" OFF)
-option(BUILD_ANIMVIEWER "Build the animation viewer as part of the build process" OFF)
+option(BUILD_ANIMVIEW "Build the animation viewer as part of the build process" OFF)
 
 if(WITH_AUDIO)
   set(CORSIX_TH_USE_SDL_MIXER ON)
@@ -129,7 +129,7 @@ add_subdirectory("libs")
 message("Building CorsixTH")
 add_subdirectory(CorsixTH)
 
-if(BUILD_ANIMVIEWER)
+if(BUILD_ANIMVIEW)
   message("Building AnimView")
   add_subdirectory(AnimView)
 endif()

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Sanity check
 if(CORSIX_TH_DONE_TOP_LEVEL_CMAKE)
 else()
-  message(FATAL_ERROR "Please run cmake on the top-level directory, not this one.")
+  message(FATAL_ERROR "Please run CMake from the top-level directory instead of here.")
 endif()
 
 # Project Declaration


### PR DESCRIPTION
*Fixes #1816 *

**Describe what the proposed change does**
- Add the sanity check CorsixTH/CMakeLists.txt uses
- ~~Add BUILD_ANIMVIEW, which mirrors BUILD_ANIMVIEWER. This does mean if the user has one of the two values cached with ON, and set the other as OFF in the cmake command it will still build it. This only happens because the user deliberately changes what they use, and it'll show up as if they wrote ON. Solvable with checking caches, but I don't think it'll surprise anyone at build time.~~
- Rename build_animviewer to build_animview in CMake build options.