### PR TITLE
[WIP] Introduce Error Confirmations

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -49,7 +49,7 @@ globals = { -- Globals
             "UIBottomPanel", "UIBuildRoom", "UICallsDispatcher", "UICasebook",
             "UICheats", "UIChooseFont", "UIConfirmDialog", "UICustomCampaign",
             "UICustomGame", "UICustomise", "UIDirectoryBrowser", "UIDropdown",
-            "UIEditRoom", "UIFax", "UIFileBrowser", "UIFolder", "UIFullscreen",
+            "UIEditRoom", "UIErrConfirm", "UIFax", "UIFileBrowser", "UIFolder", "UIFullscreen",
             "UIFurnishCorridor", "UIGraphs", "UIHireStaff" ,"UIInformation",
             "UIJukebox", "UILoadGame", "UILoadMap", "UILuaConsole", "UIMachine",
             "UIMakeDebugPatient", "UIMainMenu", "UIMapEditor", "UIMenuBar",

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1101,7 +1101,7 @@ function App:run()
       elseif class.is(entity, Staff) then
         self.ui:addWindow(UIStaff(self.ui, entity))
       end
-      self.ui:addWindow(UIConfirmDialog(self.ui,
+      self.ui:addWindow(UIErrConfirm(self.ui,
           "Sorry, but an error has occurred. There can be many reasons - see the " ..
           "log window for details. Would you like to attempt a recovery?",
           --[[persistable:app_attempt_recovery]] function()

--- a/CorsixTH/Lua/dialogs/error_confirm.lua
+++ b/CorsixTH/Lua/dialogs/error_confirm.lua
@@ -76,7 +76,7 @@ function UIErrConfirm:mustPause()
 end
 
 -- Errors force pausing
-function UIErrConfirm:forcedPause()  
+function UIErrConfirm:forcedPause()
   TheApp.world:systemPause(true)
 end
 

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -499,7 +499,7 @@ local function Humanoid_startAction(self)
     self.world:gameLog("Last action: " .. self.previous_action.name)
     self.world:gameLog(debug.traceback())
 
-    ui:addWindow(UIConfirmDialog(ui,
+    ui:addWindow(UIErrConfirm(ui,
       "Sorry, a humanoid just had an empty action queue,"..
       " which means that he or she didn't know what to do next."..
       " Please consult the command window for more detailed information. "..
@@ -515,14 +515,6 @@ local function Humanoid_startAction(self)
           self.going_home = false
           self.hospital = self.world:getLocalPlayerHospital()
           self:goHome("kicked")
-        end
-        if TheApp.world:isCurrentSpeed("Pause") then
-          TheApp.world:setSpeed(TheApp.world.prev_speed)
-        end
-      end,
-      --[[persistable:humanoid_stay_in_hospital]] function()
-        if TheApp.world:isCurrentSpeed("Pause") then
-          TheApp.world:setSpeed(TheApp.world.prev_speed)
         end
       end
     ))

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -980,7 +980,7 @@ function World:pauseOrUnpause()
 end
 
 --! Sets whether the game should be forcefully paused
---!param state (bool) 
+--!param state (bool)
 function World:systemPause(state)
   self.system_pause = state
 end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -935,7 +935,7 @@ function World:setSpeed(speed)
   if self:isCurrentSpeed(speed) then
     return
   end
-  if speed == "Pause" then
+  if speed == "Pause" or self.system_pause then
     -- stop screen shaking if there was an earthquake in progress
     if self.next_earthquake.active then
       self.ui:endShakeScreen()
@@ -971,6 +971,7 @@ end
 
 --! Dedicated function to allow unpausing by pressing 'p' again
 function World:pauseOrUnpause()
+  if self:systemPauseStatus() then return end -- System pause takes precedence
   if not self:isCurrentSpeed("Pause") then
     self:setSpeed("Pause")
   elseif self.prev_speed then
@@ -978,9 +979,22 @@ function World:pauseOrUnpause()
   end
 end
 
+--! Sets whether the game should be forcefully paused
+--!param state (bool) 
+function World:systemPause(state)
+  self.system_pause = state
+end
+
+--! Reports the system pause status
+--!return (bool) true is system pause is active, else false
+function World:systemPauseStatus()
+  return self.system_pause
+end
+
 --! Function to check if player can perform actions when paused
 --!return (bool) Returns true if player hasn't allowed editing while paused
 function World:isUserActionProhibited()
+  if self:systemPauseStatus() then return true end
   return self:isCurrentSpeed("Pause") and not self.user_actions_allowed
 end
 


### PR DESCRIPTION

*Fixes #1865*

**Describe what the proposed change does**
- Separate out recoverable errors in the game from regular UIConfirmDialog boxes.
- Introduces a system/forced pause when these appear.
