### PR TITLE
[RDY] Handle errors in confirm dialogs

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1086,7 +1086,7 @@ function App:run()
       elseif class.is(entity, Staff) then
         self.ui:addWindow(UIStaff(self.ui, entity))
       end
-      self.ui:addWindow(UIConfirmDialog(self.ui,
+      self.ui:addWindow(UIConfirmDialog(self.ui, true,
           "Sorry, but an error has occurred. There can be many reasons - see the " ..
           "log window for details. Would you like to attempt a recovery?",
           --[[persistable:app_attempt_recovery]] function()
@@ -1541,7 +1541,7 @@ end
 --! Restarts the current level (offers confirmation window first)
 function App:restart()
   assert(self.map, "Trying to restart while no map is loaded.")
-  self.ui:addWindow(UIConfirmDialog(self.ui, _S.confirmation.restart_level,
+  self.ui:addWindow(UIConfirmDialog(self.ui, false, _S.confirmation.restart_level,
   --[[persistable:app_confirm_restart]] function()
     self:worldExited()
     local level = self.map.level_number

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -800,7 +800,7 @@ function UIBottomPanel:addDialog(dialog_class, extra_function)
   local edit_window = self.ui:getWindow(UIEditRoom)
   -- If we are currently editing a room, ask for abortion before adding any dialog.
   if edit_window then
-    self.ui:addWindow(UIConfirmDialog(self.ui,
+    self.ui:addWindow(UIConfirmDialog(self.ui, false,
       _S.confirmation.abort_edit_room,
       --[[persistable:abort_edit_room_confirm_dialog]]function()
         self.ui:setEditRoom(false)

--- a/CorsixTH/Lua/dialogs/confirm_dialog.lua
+++ b/CorsixTH/Lua/dialogs/confirm_dialog.lua
@@ -75,7 +75,7 @@ function UIConfirmDialog:UIConfirmDialog(ui, is_error, text, callback_ok, callba
     :setTooltip(_S.tooltip.window_general.confirm):setSound"YesX.wav"
 
   self:registerKeyHandlers()
-  if self.is_error then self:forcePause() end
+  if self.is_error then self:systemPause() end
 end
 
 -- Confirm dialogs are used for errors, if it is an error then pause the game
@@ -84,7 +84,7 @@ function UIConfirmDialog:mustPause()
 end
 
 --! Function to tell the game a system pause is needed
-function UIConfirmDialog:forcePause()
+function UIConfirmDialog:systemPause()
   TheApp.world:setSystemPause(true)
 end
 

--- a/CorsixTH/Lua/dialogs/confirm_dialog.lua
+++ b/CorsixTH/Lua/dialogs/confirm_dialog.lua
@@ -83,7 +83,7 @@ function UIConfirmDialog:mustPause()
   return self.is_error
 end
 
--- Errors force pausing
+--! Function to tell the game a system pause is needed
 function UIConfirmDialog:forcePause()
   TheApp.world:setSystemPause(true)
 end

--- a/CorsixTH/Lua/dialogs/confirm_dialog.lua
+++ b/CorsixTH/Lua/dialogs/confirm_dialog.lua
@@ -105,7 +105,7 @@ end
 --!param confirmed (boolean or nil) whether to call the confirm callback (true) or cancel callback (false/nil)
 function UIConfirmDialog:close(confirmed)
   -- NB: Window is closed before executing the callback in order to not save the confirmation dialog in a savegame
-  TheApp.world:setSystemPause(false) -- Error dealt with
+  if self.is_error then TheApp.world:setSystemPause(false) end -- Error dealt with
   Window.close(self)
   if confirmed then
     if self.callback_ok then

--- a/CorsixTH/Lua/dialogs/confirm_dialog.lua
+++ b/CorsixTH/Lua/dialogs/confirm_dialog.lua
@@ -34,11 +34,11 @@ local text_width = 153
 
 --! Initialise the Confirmation Dialog
 --!param ui The UI
---!param is_error (boolean) set whether this dialog is a result of an error (true) or not (false)
+--!param must_pause (boolean) set whether this dialog should pause the game
 --!param text (string) message to show
 --!param callback_ok (function) what to do on yes/ok
 --!param callback_cancel (function) what to do on no/cancel/close
-function UIConfirmDialog:UIConfirmDialog(ui, is_error, text, callback_ok, callback_cancel)
+function UIConfirmDialog:UIConfirmDialog(ui, must_pause, text, callback_ok, callback_cancel)
   self:Window()
 
   local app = ui.app
@@ -54,7 +54,7 @@ function UIConfirmDialog:UIConfirmDialog(ui, is_error, text, callback_ok, callba
   self.text = text
   self.callback_ok = callback_ok  -- Callback function to launch if user chooses ok
   self.callback_cancel = callback_cancel -- Callback function to launch if user chooses cancel
-  self.is_error = is_error
+  self.must_pause = must_pause
 
   -- Check how "high" the dialog must be
   local _, text_height = self.white_font:sizeOf(text, text_width)
@@ -75,12 +75,12 @@ function UIConfirmDialog:UIConfirmDialog(ui, is_error, text, callback_ok, callba
     :setTooltip(_S.tooltip.window_general.confirm):setSound"YesX.wav"
 
   self:registerKeyHandlers()
-  if self.is_error then self:systemPause() end
+  if self.must_pause then self:systemPause() end
 end
 
 -- Confirm dialogs are used for errors, if it is an error then pause the game
 function UIConfirmDialog:mustPause()
-  return self.is_error
+  return self.must_pause
 end
 
 --! Function to tell the game a system pause is needed
@@ -105,7 +105,7 @@ end
 --!param confirmed (boolean or nil) whether to call the confirm callback (true) or cancel callback (false/nil)
 function UIConfirmDialog:close(confirmed)
   -- NB: Window is closed before executing the callback in order to not save the confirmation dialog in a savegame
-  if self.is_error then TheApp.world:setSystemPause(false) end -- Error dealt with
+  if self.must_pause then TheApp.world:setSystemPause(false) end -- Error dealt with
   Window.close(self)
   if confirmed then
     if self.callback_ok then

--- a/CorsixTH/Lua/dialogs/confirm_dialog.lua
+++ b/CorsixTH/Lua/dialogs/confirm_dialog.lua
@@ -32,7 +32,7 @@ local middle_frame_height = 11
 local bottom_frame = 359
 local text_width = 153
 
---!Initialise the Confirmation Dialog
+--! Initialise the Confirmation Dialog
 --!param ui The UI
 --!param is_error (boolean) set whether this dialog is a result of an error (true) or not (false)
 --!param text (string) message to show
@@ -102,7 +102,7 @@ function UIConfirmDialog:ok()
 end
 
 --! Closes the confirm dialog
---!param cofirmed (boolean or nil) whether to call the confirm callback (true) or cancel callback (false/nil)
+--!param confirmed (boolean or nil) whether to call the confirm callback (true) or cancel callback (false/nil)
 function UIConfirmDialog:close(confirmed)
   -- NB: Window is closed before executing the callback in order to not save the confirmation dialog in a savegame
   TheApp.world:setSystemPause(false) -- Error dealt with

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -175,7 +175,7 @@ function UIEditRoom:cancel()
       self.confirm_button:enable(false)
       self.confirm_dialog_open = true
       -- Ask if the user really wish to sell this room
-      self.ui:addWindow(UIConfirmDialog(self.ui,
+      self.ui:addWindow(UIConfirmDialog(self.ui, false,
         _S.confirmation.delete_room,
         --[[persistable:delete_room_confirm_dialog]]function()
           self:abortRoom()

--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -548,7 +548,7 @@ end
 
 function UIStaffManagement:fire()
   if self.selected_staff then
-    self.ui:addWindow(UIConfirmDialog(self.ui, _S.confirmation.sack_staff, --[[persistable:staff_management_confirm_sack]] function()
+    self.ui:addWindow(UIConfirmDialog(self.ui, false, _S.confirmation.sack_staff, --[[persistable:staff_management_confirm_sack]] function()
       local current_category = self.staff_members[self.category]
       current_category[self.selected_staff]:fire()
       -- Close the staff window if open

--- a/CorsixTH/Lua/dialogs/machine_dialog.lua
+++ b/CorsixTH/Lua/dialogs/machine_dialog.lua
@@ -109,7 +109,7 @@ function UIMachine:replaceMachine()
     self.ui:playSound("wrong2.wav")
     return
   end
-  self.ui:addWindow(UIConfirmDialog(self.ui,
+  self.ui:addWindow(UIConfirmDialog(self.ui, false,
     _S.confirmation.replace_machine:format(machine.object_type.name, cost),
     --[[persistable:replace_machine_confirm_dialog]]function()
       -- Charge for new machine

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
@@ -82,7 +82,7 @@ end
 --! Try to save the game with given filename; if already exists, create confirmation window first.
 function UISaveGame:trySave(filename)
   if lfs.attributes(filename, "size") ~= nil then
-    self.ui:addWindow(UIConfirmDialog(self.ui, _S.confirmation.overwrite_save, --[[persistable:save_game_confirmation]] function() self:doSave(filename) end))
+    self.ui:addWindow(UIConfirmDialog(self.ui, false, _S.confirmation.overwrite_save, --[[persistable:save_game_confirmation]] function() self:doSave(filename) end))
   else
     self:doSave(filename)
   end

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_map.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_map.lua
@@ -82,7 +82,7 @@ end
 --! Try to save the game with given filename; if already exists, create confirmation window first.
 function UISaveMap:trySave(filename)
   if lfs.attributes(filename, "size") ~= nil then
-    self.ui:addWindow(UIConfirmDialog(self.ui, _S.confirmation.overwrite_save, --[[persistable:save_map_confirmation]] function() self:doSave(filename) end))
+    self.ui:addWindow(UIConfirmDialog(self.ui, false, _S.confirmation.overwrite_save, --[[persistable:save_map_confirmation]] function() self:doSave(filename) end))
   else
     self:doSave(filename)
   end

--- a/CorsixTH/Lua/dialogs/resizables/main_menu.lua
+++ b/CorsixTH/Lua/dialogs/resizables/main_menu.lua
@@ -154,7 +154,7 @@ function UIMainMenu:buttonMapEdit()
 end
 
 function UIMainMenu:buttonExit()
-  self.ui:addWindow(UIConfirmDialog(self.ui,
+  self.ui:addWindow(UIConfirmDialog(self.ui, false,
   _S.tooltip.main_menu.quit,
   --[[persistable:quit_confirm_dialog]]function()
   self.ui.app:exit()

--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -444,7 +444,7 @@ function UIResolution:ok()
     local err = {_S.errors.minimum_screen_size}
     self.ui:addWindow(UIInformation(self.ui, err))
   elseif width > 3000 or height > 2000 then
-    self.ui:addWindow(UIConfirmDialog(self.ui,
+    self.ui:addWindow(UIConfirmDialog(self.ui, false,
       _S.confirmation.maximum_screen_size,
       --[[persistable:maximum_screen_size_confirm_dialog]]function()
       self:close(true)

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -308,7 +308,7 @@ function UIStaff:placeStaff()
 end
 
 function UIStaff:fireStaff()
-  self.ui:addWindow(UIConfirmDialog(self.ui, _S.confirmation.sack_staff, --[[persistable:staff_dialog_confirm_sack]] function()
+  self.ui:addWindow(UIConfirmDialog(self.ui, false, _S.confirmation.sack_staff, --[[persistable:staff_dialog_confirm_sack]] function()
     self.staff:fire()
   end))
 end

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -499,7 +499,7 @@ local function Humanoid_startAction(self)
     self.world:gameLog("Last action: " .. self.previous_action.name)
     self.world:gameLog(debug.traceback())
 
-    ui:addWindow(UIConfirmDialog(ui,
+    ui:addWindow(UIConfirmDialog(ui, true,
       "Sorry, a humanoid just had an empty action queue,"..
       " which means that he or she didn't know what to do next."..
       " Please consult the command window for more detailed information. "..
@@ -516,15 +516,8 @@ local function Humanoid_startAction(self)
           self.hospital = self.world:getLocalPlayerHospital()
           self:goHome("kicked")
         end
-        if TheApp.world:isCurrentSpeed("Pause") then
-          TheApp.world:setSpeed(TheApp.world.prev_speed)
-        end
       end,
-      --[[persistable:humanoid_stay_in_hospital]] function()
-        if TheApp.world:isCurrentSpeed("Pause") then
-          TheApp.world:setSpeed(TheApp.world.prev_speed)
-        end
-      end
+      nil -- Do nothing on cancel
     ))
     action = self.action_queue[1]
 

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -654,7 +654,7 @@ function GameUI:onMouseUp(code, x, y)
               local room_cost = room:calculateRemovalCost()
               self:setEditRoom(false)
               -- show confirmation dialog for removing the room
-              self:addWindow(UIConfirmDialog(self,_S.confirmation.remove_destroyed_room:format(room_cost),
+              self:addWindow(UIConfirmDialog(self, false, _S.confirmation.remove_destroyed_room:format(room_cost),
               --[[persistable:remove_destroyed_room_confirm_dialog]]function()
                 local world = room.world
                 UIEditRoom:removeRoom(false, room, world)
@@ -1248,7 +1248,7 @@ end
 --! Offers a confirmation window to quit the game and return to main menu
 -- NB: overrides UI.quit, do NOT call it from here
 function GameUI:quit()
-  self:addWindow(UIConfirmDialog(self, _S.confirmation.quit, --[[persistable:gameui_confirm_quit]] function()
+  self:addWindow(UIConfirmDialog(self, false, _S.confirmation.quit, --[[persistable:gameui_confirm_quit]] function()
     self.app:loadMainMenu()
   end))
 end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -111,6 +111,9 @@ function World:World(app)
   -- This is false when the game is paused.
   self.user_actions_allowed = true
 
+  -- Flag for forcing to deal with recoverable errors
+  self.system_pause = false
+
   -- In Free Build mode?
   if tonumber(self.map.level_number) then
     self.free_build_mode = false
@@ -920,7 +923,7 @@ function World:setSpeed(speed)
   if self:isCurrentSpeed(speed) then
     return
   end
-  if speed == "Pause" then
+  if speed == "Pause" or self.system_pause then
     -- stop screen shaking if there was an earthquake in progress
     if self.next_earthquake.active then
       self.ui:endShakeScreen()
@@ -956,6 +959,7 @@ end
 
 --! Dedicated function to allow unpausing by pressing 'p' again
 function World:pauseOrUnpause()
+  if self:isSystemPauseActive() then return end -- System pause takes precedence
   if not self:isCurrentSpeed("Pause") then
     self:setSpeed("Pause")
   elseif self.prev_speed then
@@ -963,9 +967,23 @@ function World:pauseOrUnpause()
   end
 end
 
+--! Sets whether the game should be forcefully paused
+--!param state (bool)
+function World:setSystemPause(state)
+  print("System pause is", state)
+  self.system_pause = state
+end
+
+--! Reports the system pause status
+--!return (bool) true is system pause is active, else false
+function World:isSystemPauseActive()
+  return self.system_pause or false
+end
+
 --! Function to check if player can perform actions when paused
 --!return (bool) Returns true if player hasn't allowed editing while paused
 function World:isUserActionProhibited()
+  if self:isSystemPauseActive() then return true end
   return self:isCurrentSpeed("Pause") and not self.user_actions_allowed
 end
 
@@ -2716,6 +2734,7 @@ if old < 153 then
 
   self.savegame_version = new
   self.release_version = TheApp:getVersion(new)
+  self.system_pause = false -- Reset flag on load
 end
 
 function World:playLoadedEntitySounds()

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -111,7 +111,7 @@ function World:World(app)
   -- This is false when the game is paused.
   self.user_actions_allowed = true
 
-  -- Flag for forcing to deal with recoverable errors
+  -- Flag to force pausing to deal with recoverable errors
   self.system_pause = false
 
   -- In Free Build mode?
@@ -976,7 +976,7 @@ end
 --! Reports the system pause status
 --!return (bool) true is system pause is active, else false
 function World:isSystemPauseActive()
-  return self.system_pause or false
+  return self.system_pause
 end
 
 --! Function to check if player can perform actions when paused

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -111,7 +111,8 @@ function World:World(app)
   -- This is false when the game is paused.
   self.user_actions_allowed = true
 
-  -- Flag to force pausing to deal with recoverable errors
+  -- The system pause method is used as an additional layer to pause the game, where the user
+  -- needs to deal with a recoverable error
   self.system_pause = false
 
   -- In Free Build mode?
@@ -967,7 +968,7 @@ function World:pauseOrUnpause()
   end
 end
 
---! Sets whether the game should be forcefully paused
+--! Sets the system_pause parameter
 --!param state (bool)
 function World:setSystemPause(state)
   self.system_pause = state

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -970,7 +970,6 @@ end
 --! Sets whether the game should be forcefully paused
 --!param state (bool)
 function World:setSystemPause(state)
-  print("System pause is", state)
   self.system_pause = state
 end
 


### PR DESCRIPTION
Alternative to #1867

*Fixes #1865*

**Describe what the proposed change does**
- Adds a parameter to UIConfirmDialog to declare if the window is due to an error or not
- If it is an error, a pause is forced
- Game will not unpause until error is dealt with
