### PR TITLE
[RDY] Destroy SDL after destruction of lua owned objects

### DIFF
--- a/CorsixTH/SrcUnshared/main.cpp
+++ b/CorsixTH/SrcUnshared/main.cpp
@@ -54,9 +54,8 @@ static void cleanup(lua_State* L) {
     Mix_CloseAudio();
   }
 #endif
-  SDL_Quit();
-
   lua_close(L);
+  SDL_Quit();
 }
 
 //! Program entry point


### PR DESCRIPTION
This order is particularly important on wayland.
Fixes #1869
-
