### PR TITLE
Metainfo: Provide the old app ID

### DIFF
--- a/CorsixTH/com.corsixth.corsixth.metainfo.xml
+++ b/CorsixTH/com.corsixth.corsixth.metainfo.xml
@@ -22,6 +22,7 @@
   </description>
   <provides>
     <binary>corsix-th</binary>
+    <id>com.corsixth.CorsixTH</id>
   </provides>
   <launchable type="desktop-id">com.corsixth.corsixth.desktop</launchable>
   <releases>


### PR DESCRIPTION
Providing the old app ID prevents app stores from showing duplicate entries if some sources still use it.
