### PR TITLE
Boiler breakdown advice is local player only

### DIFF
--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -750,6 +750,27 @@ function GameUI:onMouseWheel(x, y)
   return UI.onMouseWheel(self, x, y)
 end
 
+--! Announcements to the player.
+--!param msgs (array of string) Messages to select from.
+--!param priority (optional valid AnnouncementPriority selection) Priority of announcement
+--!param chance_to_play (optional float in range (0, 1]) Fraction of times that the
+--    call actually says something.
+--!return (boolean) Whether a message was given to the user.
+function GameUI:playRandomAnnouncement(msgs, priority, chance_to_play, played_callback, played_callback_delay)
+  local max_rnd = #msgs
+  if chance_to_play and chance_to_play > 0 and chance_to_play < 1 then
+    -- Scale by the fraction.
+    max_rnd = math.floor(max_rnd / chance_to_play)
+  end
+
+  local index = (max_rnd == 1) and 1 or math.random(1, max_rnd)
+  if index <= #msgs then
+    self:playAnnouncement(msgs[index], priority, played_callback, played_callback_delay)
+    return true
+  end
+  return false
+end
+
 function GameUI:playAnnouncement(name, priority, played_callback, played_callback_delay)
   self.announcer:playAnnouncement(name, priority, played_callback, played_callback_delay)
 end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -20,8 +20,6 @@ SOFTWARE. --]]
 
 corsixth.require("announcer")
 
-local AnnouncementPriority = _G["AnnouncementPriority"]
-
 class "Hospital"
 
 ---@type Hospital
@@ -777,22 +775,6 @@ function Hospital:isInHospital(x, y)
   local flags = self.world.map.th:getCellFlags(x, y)
   return flags.hospital and flags.owner == self:getPlayerIndex()
 end
-function Hospital:coldWarning()
-  local announcements = {
-    "sorry002.wav", "sorry004.wav",
-  }
-  if announcements and self:isPlayerHospital() then
-    self.world.ui:playAnnouncement(announcements[math.random(1, #announcements)], AnnouncementPriority.Normal)
-  end
-end
-function Hospital:hotWarning()
-  local announcements = {
-    "sorry003.wav", "sorry004.wav",
-  }
-  if announcements and self:isPlayerHospital() then
-    self.world.ui:playAnnouncement(announcements[math.random(1, #announcements)], AnnouncementPriority.Normal)
-  end
-end
 
 --! Decide how many days the hospital functions within specification.
 --!return (int) Number of disaster-free days in the hospital.
@@ -821,16 +803,13 @@ function Hospital:boilerBreakdown(broken_heat)
   heat_vars.boiler_repair_count = math.random(10, 30)
   heat_vars.heating_broke = true
 
-  -- Only show the message when relevant to the local player's hospital.
-  if self:isPlayerHospital() then
-    if heat_vars.radiator_heat == 0 then
-      self.world.ui.adviser:say(_A.boiler_issue.minimum_heat)
-      self:coldWarning()
-    else
-      self.world.ui.adviser:say(_A.boiler_issue.maximum_heat)
-      self:hotWarning()
-    end
-  end
+  -- Warn the player of the boiler's breakdown
+  self:adviseBoilerBreakdown(broken_heat)
+end
+
+--! Select a relevant message to be displayed to the user
+function Hospital:adviseBoilerBreakdown()
+  -- Nothing to do, override in a sub-class.
 end
 
 --! Boiler broke down and work is done to get it fixed.

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -378,6 +378,19 @@ function PlayerHospital:adviseDiscoverDisease(disease)
   end
 end
 
+--! Select a relevant message to be displayed to the user
+--!param broken_heat (0 or 1) Boiler output due to being broken.
+function PlayerHospital:adviseBoilerBreakdown(broken_heat)
+  local ui = self.world.ui
+  if broken_heat == 0 then
+    ui.adviser:say(_A.boiler_issue.minimum_heat)
+    ui:playRandomAnnouncement({ "sorry002.wav", "sorry004.wav" })
+  else
+    ui.adviser:say(_A.boiler_issue.maximum_heat)
+    ui:playRandomAnnouncement({ "sorry003.wav", "sorry004.wav" })
+  end
+end
+
 --! Called at the end of each day.
 function PlayerHospital:onEndDay()
   -- Advise the player.


### PR DESCRIPTION
**Describe what the proposed change does**
- Add PlayerHospital:makeAnnouncement, a copy of giveAdvice adapted for announcements
- Fix plots being unbuyable when walls are transparent
- Add checks for local hospital before telling user
- Move no receptionist advice away from check for receptionists
