### PR TITLE
[RDY] Seek fixes

### DIFF
--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -1176,7 +1176,7 @@ function GameUI:setEditRoom(enabled)
     -- If the actual editing hasn't started yet but is on its way,
     -- activate the room again.
     if class.is(self.edit_room, Room) and self.cursor == self.waiting_cursor then
-      self.edit_room.is_active = true
+      self.app.world:markRoomAsBuilt(self.edit_room)
     else
       -- If we are currently editing a room it may happen that we need to abort it.
       -- Also remove any dialog where the user is buying items.

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -274,10 +274,10 @@ local function action_seek_room_start(action, humanoid)
 
   -- check we can treat the patient - and just shortcut the processing
   local req = humanoid.hospital:checkDiseaseRequirements(humanoid.disease.id)
-  if humanoid.diagnosed and not req then
+  if humanoid.diagnosed then
     local room = action_seek_room_find_room(action, humanoid)
     -- if we have the room but not the staff we shouldn't seek out the room either
-    if room then
+    if room and (not req or not action.treatment_room) then
       if humanoid.message then
         TheApp.ui.bottom_panel:removeMessage(humanoid)
       end
@@ -358,7 +358,7 @@ local function action_seek_room_start(action, humanoid)
         -- don't need this as we unregistered all previous callbacks if we went to research
         local room_req = humanoid.hospital:checkDiseaseRequirements(humanoid.disease.id)
         -- get required staff
-        if not humanoid.diagnosed or not room_req then
+        if not humanoid.diagnosed or (not room_req or not action.treatment_room) then
           action_seek_room_goto_room(rm, humanoid, action.diagnosis_room)
           TheApp.ui.bottom_panel:removeMessage(humanoid)
           humanoid:unregisterRoomBuildCallback(build_callback)


### PR DESCRIPTION
*Fixes #1668*

**Describe what the proposed change does**
- Seek Room fixes the #1668 scenarios
- Game UI fixes a scenario that was mentioned in #1799 - where editing an operating theatre, patient on the walk to the room, mark room for edit, requeues a SeekRoom action. SeekRoom queues a meander. If the room doesn't become available for editing (waiting cursor still active) when the SeekRoom action restarts after the meander, and the edit is cancelled whilst still waiting for the room to clear, the notifyNewRoom callback doesn't get called. Patient goes into limbo until they perform some other action.
