### PR TITLE
[RDY] Fix the search for Theme Hospital installs on Windows

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1253,19 +1253,26 @@ function App:checkInstallFolder()
     -- then linux Filesystem Hierarchy Standard, then Windows Program Files
     -- mac_app_dir is the macOS app base directory named CorsixTH.app
     local mac_app_dir = debug.getinfo(1).short_src:match("(.*)/Contents/.")
-    local user_dir = os.getenv("HOME") or os.getenv("HOMEPATH") or ""
-    local possible_locations = { user_dir, user_dir .. pathsep ..  "Documents",
+    local user_dir = os.getenv("HOME") or os.getenv("HOMEPATH")
+    local possible_locations = {
+      user_dir,
+      user_dir and (user_dir .. pathsep ..  "Documents"),
       select(1, corsixth.require("config_finder")):match("(.*[/\\])"):sub(1, -2),
-      mac_app_dir, mac_app_dir and mac_app_dir:match("(.*)/.*%.app"),
+      mac_app_dir,
+      mac_app_dir and mac_app_dir:match("(.*)/.*%.app"),
       "/Applications/Theme Hospital.app/Contents/Resources/game/Theme Hospital.app/" ..
         "Contents/Resources/Theme Hospital.boxer/C.harddisk",
-      "/usr/share/games/corsix-th", "/usr/local/share/games/corsix-th",
-      os.getenv("ProgramFiles"), os.getenv("ProgramFiles(x86)") }
+      "/usr/share/games/corsix-th",
+      "/usr/local/share/games/corsix-th",
+      os.getenv("ProgramFiles"),
+      os.getenv("ProgramFiles(x86)"),
+      [[C:]], [[D:]], [[E:]], [[F:]], [[G:]], [[H:]] }
     local possible_folders = { "ThemeHospital", "Theme Hospital", "HOSP", "TH97",
-      [[GOG.com\Theme Hospital]], [[Origin Games\Theme Hospital\data\Game]] }
-    for _, dir in ipairs(possible_locations) do
+      [[GOG.com\Theme Hospital]], [[GOG Games\Theme Hospital]],
+      [[Origin Games\Theme Hospital\data\Game]] }
+    for _, dir in pairs(possible_locations) do
       if status then break end
-      for _, folder in ipairs(possible_folders) do
+      for _, folder in pairs(possible_folders) do
         local path = dir .. pathsep .. folder
         if lfs.attributes(path, "mode") == "directory" and self:isThemeHospitalPath(path) then
           print("Game data found at: " .. path)


### PR DESCRIPTION
The macos directories were inserting nulls in the array which ipairs
would stop on without iterating through all options. Fixed by replacing
with empty strings. \\ directories in the search caused considerable
pause in windows and were invalid, so skip checking them. Add up to date
"GOG Games" folder which has been the default for awhile now.

This was a somewhat recent regression. Please test non-Windows OSs to ensure I didn't break anything (remove your config.txt and run, with/without a hospital directory that can be located.)