### PR TITLE
[RDY] Bump clang version to keep up with GitHub

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install static analysis requirements
         if: matrix.static_analysis
         run: |
-          sudo apt-get install doxygen yamllint clang-tidy-9
+          sudo apt-get install doxygen yamllint clang-tidy-11
 
           sudo pip3 install -I codespell==2.0 cmakelint==1.4
 
@@ -124,11 +124,11 @@ jobs:
         if: matrix.static_analysis
         run: |
           # Check cpp format
-          clang-format-9 -i CorsixTH/Src/*.cpp CorsixTH/Src/*.h AnimView/*.cpp \
+          clang-format-11 -i CorsixTH/Src/*.cpp CorsixTH/Src/*.h AnimView/*.cpp \
             AnimView/*.h libs/rnc/*.cpp libs/rnc/*.h CorsixTH/SrcUnshared/main.cpp
           git diff --exit-code
           # Clang-tidy linter
-          clang-tidy-9 -p build --warnings-as-errors=\* \
+          clang-tidy-11 -p build --warnings-as-errors=\* \
             CorsixTH/Src/*.c CorsixTH/Src/*.cpp libs/rnc/*.cpp CorsixTH/SrcUnshared/main.cpp
       - name: Generate documentation
         if: matrix.docs

--- a/CorsixTH/Src/config.h.in
+++ b/CorsixTH/Src/config.h.in
@@ -62,9 +62,6 @@ SOFTWARE.
 #endif
 
 /** Standard includes **/
-#ifndef __STDC_CONSTANT_MACROS
-#define __STDC_CONSTANT_MACROS
-#endif
 #include <cstddef>
 #include <cstdint>
 


### PR DESCRIPTION
GitHub removed clang-9 as part of their last 3 version policy so we are forced to bump.

The documentation seemed mixed on support for 12. In my tests it wasn't available for clang-tidy so I've opted to go with 11 (which is their new default as well.)