### PR TITLE
[RDY] Make computing price impact warnings local player specific

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2368,18 +2368,22 @@ function Hospital:computePriceLevelImpact(patient, casebook)
 
   if price_distortion < self.under_priced_threshold then
     if math.random(1, 100) == 1 then
-      self.world.ui.adviser:say(_A.warnings.low_prices:format(casebook.disease.name))
+      self:advisePriceLevelImpact("under", casebook.disease.name)
       self:changeReputation("under_priced")
     end
   elseif price_distortion > self.over_priced_threshold then
     if math.random(1, 100) == 1 then
-      self.world.ui.adviser:say(_A.warnings.high_prices:format(casebook.disease.name))
+      self:advisePriceLevelImpact("over", casebook.disease.name)
       self:changeReputation("over_priced")
     end
   elseif math.abs(price_distortion) <= 0.15 and math.random(1, 200) == 1 then
     -- When prices are well adjusted (i.e. abs(price distortion) <= 0.15)
-    self.world.ui.adviser:say(_A.warnings.fair_prices:format(casebook.disease.name))
+    self:advisePriceLevelImpact("fair", casebook.disease.name)
   end
+end
+
+function Hospital:advisePriceLevelImpact()
+  -- Nothing to do, override in a derived class.
 end
 
 --! Notify patients of a change to hospital staff members

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -392,6 +392,23 @@ function PlayerHospital:adviseCannotAffordPlot()
   self.world.ui.adviser:say(_A.warnings.cannot_afford_2, true, true)
 end
 
+--! Tell the player, through the advisor, about the impact of casebook prices
+--!param judgment (string - under, over, fair) The judgment of the price,
+-- from Hospital:computePriceLevelImpact
+--!param name (string) The name of the casebook entry of the diagnosis or disease
+function PlayerHospital:advisePriceLevelImpact(judgment, name)
+  local message
+  if judgment == "under" then
+    message = _A.warnings.low_prices:format(name)
+  elseif judgment == "over" then
+    message = _A.warnings.high_prices:format(name)
+  else
+    assert(judgment == "fair", "Price level impact judgements must be under, over or fair")
+    message = _A.warnings.fair_prices:format(name)
+  end
+  self.world.ui.adviser:say(message)
+end
+
 function PlayerHospital:afterLoad(old, new)
   if old < 145 then
     self.hosp_cheats = Cheats(self)


### PR DESCRIPTION
**Describe what the proposed change does**
- Only advise the local hospital of the price level impacts.
