### PR TITLE
[RDY] Avoid using recently depreacted FFMpeg functionality

### DIFF
--- a/CorsixTH/Src/th_movie.cpp
+++ b/CorsixTH/Src/th_movie.cpp
@@ -311,7 +311,7 @@ void av_packet_queue::push(AVPacket* pPacket) {
   }
 #endif
 
-  AVPacketList* pNode = (AVPacketList*)av_malloc(sizeof(AVPacketList));
+  th_packet_list* pNode = (th_packet_list*)av_malloc(sizeof(th_packet_list));
   pNode->pkt = *pPacket;
   pNode->next = nullptr;
 
@@ -331,7 +331,7 @@ void av_packet_queue::push(AVPacket* pPacket) {
 AVPacket* av_packet_queue::pull(bool fBlock) {
   std::unique_lock<std::mutex> lock(mutex);
 
-  AVPacketList* pNode = first_packet;
+  th_packet_list* pNode = first_packet;
   if (pNode == nullptr && fBlock) {
     cond.wait(lock);
     pNode = first_packet;

--- a/CorsixTH/Src/th_movie.cpp
+++ b/CorsixTH/Src/th_movie.cpp
@@ -384,10 +384,12 @@ movie_player::movie_player()
   av_register_all();
 #endif
 
+#ifndef CORSIX_TH_MOVIE_USE_SEND_PACKET_API
   flush_packet = (AVPacket*)av_malloc(sizeof(AVPacket));
   av_init_packet(flush_packet);
   flush_packet->data = (uint8_t*)"FLUSH";
   flush_packet->size = 5;
+#endif
 
   audio_chunk_buffer =
       (uint8_t*)std::calloc(audio_chunk_buffer_capacity, sizeof(uint8_t));
@@ -396,8 +398,10 @@ movie_player::movie_player()
 movie_player::~movie_player() {
   unload();
 
+#ifndef CORSIX_TH_MOVIE_USE_SEND_PACKET_API
   av_packet_unref(flush_packet);
   av_free(flush_packet);
+#endif
   free(audio_chunk_buffer);
   delete movie_picture_buffer;
 }

--- a/CorsixTH/Src/th_movie.h
+++ b/CorsixTH/Src/th_movie.h
@@ -68,6 +68,14 @@ extern "C" {
 #define CORSIX_TH_MOVIE_USE_SEND_PACKET_API
 #endif
 
+//! \brief Drop in replacement for AVPacketList
+//!
+//! AVPacketList which was deprecated with FFMpeg 4.4.
+struct th_packet_list {
+  AVPacket pkt;
+  th_packet_list* next;
+};
+
 //! \brief A picture in movie_picture_buffer
 //!
 //! Stores the picture from a frame in the movie from the time that it is
@@ -213,9 +221,9 @@ class av_packet_queue {
   void release();
 
  private:
-  AVPacketList* first_packet;  ///< The packet at the front of the queue
-  AVPacketList* last_packet;   ///< The packet at the end of the queue
-  int count;                   ///< The number of packets in the queue
+  th_packet_list* first_packet;  ///< The packet at the front of the queue
+  th_packet_list* last_packet;   ///< The packet at the end of the queue
+  int count;                     ///< The number of packets in the queue
   std::mutex mutex;  ///< A mutex restricting access to the packet queue to a
                      ///< single thread
   std::condition_variable

--- a/CorsixTH/Src/th_movie.h
+++ b/CorsixTH/Src/th_movie.h
@@ -418,8 +418,10 @@ class movie_player {
                         ///< stereo)
   int mixer_frequency;  ///< The frequency of audio expected by SDL_Mixer
 
+#ifndef CORSIX_TH_MOVIE_USE_SEND_PACKET_API
   AVPacket* flush_packet;  ///< A representative packet indicating a flush is
                            ///< required.
+#endif
 
   std::thread stream_thread;  ///< The thread responsible for reading the
                               ///< movie streams


### PR DESCRIPTION
*Fixes #1890*

**Describe what the proposed change does**
- The only call to the now deprecated av_init_packet() was specific to an old path, so ifndef that out unless we are on very old FFMpeg versions
- The use of AVPacketList is still fairly critical and my attempts to replace it with modern collections tended to spiral. As a short term fix for the 0.65 release, implement our own struct with the same layout as AVPacketList as a drop in replacement.