### PR TITLE
Use tilde in release versions

### DIFF
--- a/CorsixTH/com.corsixth.corsixth.metainfo.xml
+++ b/CorsixTH/com.corsixth.corsixth.metainfo.xml
@@ -26,7 +26,7 @@
   </provides>
   <launchable type="desktop-id">com.corsixth.corsixth.desktop</launchable>
   <releases>
-    <release version="0.65-beta1" date="2021-05-23" type="development"></release>
+    <release version="0.65~beta1" date="2021-05-23" type="development"></release>
     <release version="0.64" date="2020-06-16" type="stable"></release>
   </releases>
   <screenshots>


### PR DESCRIPTION
**Describe what the proposed change does**
- Prevent an ordering metainfo validation issue, see https://github.com/Beep6581/RawTherapee/issues/5303

The PR is against the `release/v0.65` branch, will the changes in this branch be merged into `master`?
