### PR TITLE
Fix #1902 - invalid code points at end of string

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -1373,7 +1373,7 @@ void line::depersist(lua_persist_reader* pReader) {
 }
 
 #ifdef CORSIX_TH_USE_FREETYPE2
-bool freetype_font::is_monochrome() const { return true; }
+bool freetype_font::is_monochrome() const { return false; }
 
 void freetype_font::free_texture(cached_text* pCacheEntry) const {
   if (pCacheEntry->texture != nullptr) {


### PR DESCRIPTION
First commit fixes #1902 - a crash on the directory dialog with some languages
Second commit significantly improves the rendering of vector fonts by enabling grayscale (subpixel) support.