### PR TITLE
[RDY] Improve blue tint handling at load

### DIFF
--- a/CorsixTH/Lua/persistance.lua
+++ b/CorsixTH/Lua/persistance.lua
@@ -288,8 +288,10 @@ function LoadGame(data)
   TheApp:afterLoad()
   TheApp.world:resetAnimations()
   TheApp.ui:onChangeResolution()
-    -- Possibly add the blueish tone if the game is currently paused.
-  if not TheApp.world.user_actions_allowed then
+  -- Check if the blueish tone should be applied.
+  -- Note: Blue filter control should be handled from world or ui, however when
+  -- loading a game we should let persistance do it.
+  if not TheApp.ui:checkForMustPauseWindows() and TheApp.world:isUserActionProhibited() then
     TheApp.video:setBlueFilterActive(true)
   end
 end


### PR DESCRIPTION
**Describe what the proposed change does**
- In IRC it was reported Autosave1 was loading in with blue tint. This PR changes the checks on when persistance should apply the taint on load.
