### PR TITLE
Add layer constant, refactor line class

### DIFF
--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -260,7 +260,8 @@ bool animation_manager::load_from_th_file(
     oElement.y = static_cast<int>(pTHElement->offy) - 186;
     oElement.layer = static_cast<uint8_t>(
         pTHElement->flags >> 4);  // High nibble, layer of the element.
-    if (oElement.layer > 12) {
+
+    if (oElement.layer >= max_number_of_layers) {
       // Nothing lives on layer 6
       oElement.layer = 6;
     }
@@ -387,7 +388,7 @@ size_t animation_manager::load_elements(
     uint8_t iLayerId = input.read_uint8();
     uint32_t iFlags = input.read_uint16();
 
-    if (iLayerClass > 12) {
+    if (iLayerClass >= max_number_of_layers) {
       // Nothing lives on layer 6
       iLayerClass = 6;
     }
@@ -1463,11 +1464,13 @@ void animation::depersist(lua_persist_reader* pReader) {
 
     if (iNumLayers > max_number_of_layers) {
       if (!pReader->read_byte_stream(layers.layer_contents,
-                                     max_number_of_layers))
+                                     max_number_of_layers)) {
         break;
+      }
       if (!pReader->read_byte_stream(nullptr,
-                                     iNumLayers - max_number_of_layers))
+                                     iNumLayers - max_number_of_layers)) {
         break;
+      }
     } else {
       if (!pReader->read_byte_stream(layers.layer_contents, iNumLayers)) break;
     }
@@ -1674,7 +1677,7 @@ void animation::set_morph_target(animation* pMorphTarget, int iDurationFactor) {
 void animation::set_frame(size_t iFrame) { frame_index = iFrame; }
 
 void animation_base::set_layer(int iLayer, int iId) {
-  if (0 <= iLayer && iLayer <= 12) {
+  if (0 <= iLayer && iLayer < max_number_of_layers) {
     layers.layer_contents[iLayer] = static_cast<uint8_t>(iId);
   }
 }
@@ -1793,7 +1796,7 @@ void sprite_render_list::persist(lua_persist_writer* pWriter) const {
   }
 
   // Write the layers
-  int iNumLayers = 13;
+  int iNumLayers = max_number_of_layers;
   for (; iNumLayers >= 1; --iNumLayers) {
     if (layers.layer_contents[iNumLayers - 1] != 0) {
       break;

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1298,7 +1298,7 @@ bool THAnimation_is_multiple_frame_animation(drawable* pSelf) {
 animation_base::animation_base() : drawable() {
   x_relative_to_tile = 0;
   y_relative_to_tile = 0;
-  for (int i = 0; i < MAX_NUMBER_OF_LAYERS; ++i) {
+  for (int i = 0; i < max_number_of_layers; ++i) {
     layers.layer_contents[i] = 0;
   }
   flags = 0;
@@ -1379,7 +1379,7 @@ void animation::persist(lua_persist_writer* pWriter) const {
   }
 
   // Write the layers
-  int iNumLayers = 13;
+  int iNumLayers = max_number_of_layers;
   for (; iNumLayers >= 1; --iNumLayers) {
     if (layers.layer_contents[iNumLayers - 1] != 0) break;
   }
@@ -1461,9 +1461,13 @@ void animation::depersist(lua_persist_reader* pReader) {
       break;
     }
 
-    if (iNumLayers > MAX_NUMBER_OF_LAYERS) {
-      if (!pReader->read_byte_stream(layers.layer_contents, MAX_NUMBER_OF_LAYERS)) break;
-      if (!pReader->read_byte_stream(nullptr, iNumLayers - MAX_NUMBER_OF_LAYERS)) break;
+    if (iNumLayers > max_number_of_layers) {
+      if (!pReader->read_byte_stream(layers.layer_contents,
+                                     max_number_of_layers))
+        break;
+      if (!pReader->read_byte_stream(nullptr,
+                                     iNumLayers - max_number_of_layers))
+        break;
     } else {
       if (!pReader->read_byte_stream(layers.layer_contents, iNumLayers)) break;
     }
@@ -1834,12 +1838,14 @@ void sprite_render_list::depersist(lua_persist_reader* pReader) {
     return;
   }
 
-  if (iNumLayers > MAX_NUMBER_OF_LAYERS) {
-    if (!pReader->read_byte_stream(layers.layer_contents, MAX_NUMBER_OF_LAYERS)) {
+  if (iNumLayers > max_number_of_layers) {
+    if (!pReader->read_byte_stream(layers.layer_contents,
+                                   max_number_of_layers)) {
       return;
     }
 
-    if (!pReader->read_byte_stream(nullptr, iNumLayers - MAX_NUMBER_OF_LAYERS)) {
+    if (!pReader->read_byte_stream(nullptr,
+                                   iNumLayers - max_number_of_layers)) {
       return;
     }
   } else {

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1298,7 +1298,7 @@ bool THAnimation_is_multiple_frame_animation(drawable* pSelf) {
 animation_base::animation_base() : drawable() {
   x_relative_to_tile = 0;
   y_relative_to_tile = 0;
-  for (int i = 0; i < 13; ++i) {
+  for (int i = 0; i < MAX_NUMBER_OF_LAYERS; ++i) {
     layers.layer_contents[i] = 0;
   }
   flags = 0;
@@ -1461,9 +1461,9 @@ void animation::depersist(lua_persist_reader* pReader) {
       break;
     }
 
-    if (iNumLayers > 13) {
-      if (!pReader->read_byte_stream(layers.layer_contents, 13)) break;
-      if (!pReader->read_byte_stream(nullptr, iNumLayers - 13)) break;
+    if (iNumLayers > MAX_NUMBER_OF_LAYERS) {
+      if (!pReader->read_byte_stream(layers.layer_contents, MAX_NUMBER_OF_LAYERS)) break;
+      if (!pReader->read_byte_stream(nullptr, iNumLayers - MAX_NUMBER_OF_LAYERS)) break;
     } else {
       if (!pReader->read_byte_stream(layers.layer_contents, iNumLayers)) break;
     }
@@ -1834,12 +1834,12 @@ void sprite_render_list::depersist(lua_persist_reader* pReader) {
     return;
   }
 
-  if (iNumLayers > 13) {
-    if (!pReader->read_byte_stream(layers.layer_contents, 13)) {
+  if (iNumLayers > MAX_NUMBER_OF_LAYERS) {
+    if (!pReader->read_byte_stream(layers.layer_contents, MAX_NUMBER_OF_LAYERS)) {
       return;
     }
 
-    if (!pReader->read_byte_stream(nullptr, iNumLayers - 13)) {
+    if (!pReader->read_byte_stream(nullptr, iNumLayers - MAX_NUMBER_OF_LAYERS)) {
       return;
     }
   } else {

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -23,14 +23,14 @@ SOFTWARE.
 #ifndef CORSIX_TH_TH_GFX_H_
 #define CORSIX_TH_TH_GFX_H_
 
-#define MAX_NUMBER_OF_LAYERS 13
-
 #include <map>
 #include <string>
 #include <vector>
 
 #include "th.h"
 #include "th_gfx_sdl.h"
+
+constexpr int max_number_of_layers = 13;
 
 class lua_persist_reader;
 class lua_persist_writer;

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -22,6 +22,9 @@ SOFTWARE.
 
 #ifndef CORSIX_TH_TH_GFX_H_
 #define CORSIX_TH_TH_GFX_H_
+
+#define MAX_NUMBER_OF_LAYERS 13
+
 #include <map>
 #include <string>
 #include <vector>

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -30,8 +30,6 @@ SOFTWARE.
 #include "th.h"
 #include "th_gfx_sdl.h"
 
-constexpr int max_number_of_layers = 13;
-
 class lua_persist_reader;
 class lua_persist_writer;
 
@@ -197,9 +195,13 @@ class chunk_renderer {
   bool skip_eol;
 };
 
+//! Number of available layers, must be less or equal to 16 as it is stored in
+//  a nibble.
+const int max_number_of_layers = 13;
+
 //! Layer information (see animation_manager::draw_frame)
 struct layers {
-  uint8_t layer_contents[13];
+  uint8_t layer_contents[max_number_of_layers];
 };
 
 class memory_reader;
@@ -390,7 +392,8 @@ class animation_manager {
     uint16_t table_position;
     uint8_t offx;
     uint8_t offy;
-    // High nibble: The layer which the element belongs to [0, 12]
+    // High nibble: The layer which the element belongs to
+    //              [0, max_number_of_layers)
     // Low  nibble: Zero or more draw_flags
     uint8_t flags;
     // The layer option / layer id
@@ -436,7 +439,7 @@ class animation_manager {
                        ///< bit 2=draw 50% alpha, bit 3=draw 75% alpha.
     int x;             ///< X offset of the sprite.
     int y;             ///< Y offset of the sprite.
-    uint8_t layer;     ///< Layer class (0..12).
+    uint8_t layer;     ///< Layer class [0..max_number_of_layers).
     uint8_t layer_id;  ///< Value of the layer class to match.
 
     sprite_sheet* element_sprite_sheet;  ///< Sprite sheet to use for this

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -1300,7 +1300,7 @@ void line_sequence::persist(lua_persist_writer* pWriter) const {
   pWriter->write_uint(static_cast<uint32_t>(green));
   pWriter->write_uint(static_cast<uint32_t>(blue));
   pWriter->write_uint(static_cast<uint32_t>(alpha));
-  pWriter->write_float(width);
+  pWriter->write_float<double>(width);
 
   uint32_t numOps = static_cast<uint32_t>(line_elements.size());
   pWriter->write_uint(numOps);
@@ -1308,7 +1308,7 @@ void line_sequence::persist(lua_persist_writer* pWriter) const {
   for (const line_element& op : line_elements) {
     pWriter->write_uint(static_cast<uint32_t>(op.type));
     pWriter->write_float<double>(op.x);
-    pWriter->write_float(op.y);
+    pWriter->write_float<double>(op.y);
   }
 }
 

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -643,7 +643,6 @@ class cursor {
 class line {
  public:
   line();
-  ~line();
 
   void move_to(double fX, double fY);
 
@@ -664,18 +663,15 @@ class line {
 
   enum class line_operation_type : uint32_t { move = 0, line = 1 };
 
-  class line_operation : public link_list {
+  class line_operation {
    public:
     line_operation_type type;
     double x, y;
     line_operation(line_operation_type type, double x, double y)
-        : type(type), x(x), y(y) {
-      next = nullptr;
-    }
+        : type(type), x(x), y(y) { }
   };
 
-  line_operation* first_operation;
-  line_operation* current_operation;
+  std::vector<line_operation> line_operations;
   double width;
   uint8_t red, green, blue, alpha;
 };

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -668,7 +668,7 @@ class line_sequence {
     line_command type;
     double x, y;
     line_element(line_command type, double x, double y)
-        : type(type), x(x), y(y) { }
+        : type(type), x(x), y(y) {}
   };
 
   std::vector<line_element> line_elements;

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -335,7 +335,7 @@ class render_target {
                               const uint32_t* pPixels) const;
   void draw(SDL_Texture* pTexture, const SDL_Rect* prcSrcRect,
             const SDL_Rect* prcDstRect, int iFlags);
-  void draw_line(line* pLine, int iX, int iY);
+  void draw_line(line_sequence* pLine, int iX, int iY);
 
  private:
   SDL_Window* window;
@@ -640,9 +640,9 @@ class cursor {
   int hotspot_y;
 };
 
-class line {
+class line_sequence {
  public:
-  line();
+  line_sequence();
 
   void move_to(double fX, double fY);
 
@@ -661,17 +661,17 @@ class line {
   friend class render_target;
   void initialize();
 
-  enum class line_operation_type : uint32_t { move = 0, line = 1 };
+  enum class line_command : uint32_t { move = 0, line = 1 };
 
-  class line_operation {
+  class line_element {
    public:
-    line_operation_type type;
+    line_command type;
     double x, y;
-    line_operation(line_operation_type type, double x, double y)
+    line_element(line_command type, double x, double y)
         : type(type), x(x), y(y) { }
   };
 
-  std::vector<line_operation> line_operations;
+  std::vector<line_element> line_elements;
   double width;
   uint8_t red, green, blue, alpha;
 };

--- a/CorsixTH/Src/th_lua.h
+++ b/CorsixTH/Src/th_lua.h
@@ -274,9 +274,9 @@ struct luaT_classinfo<cursor> {
   static inline const char* name() { return "Cursor"; }
 };
 
-class line;
+class line_sequence;
 template <>
-struct luaT_classinfo<line> {
+struct luaT_classinfo<line_sequence> {
   static inline const char* name() { return "Line"; }
 };
 

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -745,12 +745,12 @@ int l_surface_set_capture_mouse(lua_State* L) {
 }
 
 int l_line_new(lua_State* L) {
-  luaT_stdnew<line>(L);
+  luaT_stdnew<line_sequence>(L);
   return 1;
 }
 
 int l_move_to(lua_State* L) {
-  line* pLine = luaT_testuserdata<line>(L);
+  line_sequence* pLine = luaT_testuserdata<line_sequence>(L);
   pLine->move_to(luaL_optnumber(L, 2, 0), luaL_optnumber(L, 3, 0));
 
   lua_settop(L, 1);
@@ -758,7 +758,7 @@ int l_move_to(lua_State* L) {
 }
 
 int l_line_to(lua_State* L) {
-  line* pLine = luaT_testuserdata<line>(L);
+  line_sequence* pLine = luaT_testuserdata<line_sequence>(L);
   pLine->line_to(luaL_optnumber(L, 2, 0), luaL_optnumber(L, 3, 0));
 
   lua_settop(L, 1);
@@ -766,7 +766,7 @@ int l_line_to(lua_State* L) {
 }
 
 int l_set_width(lua_State* L) {
-  line* pLine = luaT_testuserdata<line>(L);
+  line_sequence* pLine = luaT_testuserdata<line_sequence>(L);
   pLine->set_width(luaL_optnumber(L, 2, 1));
 
   lua_settop(L, 1);
@@ -774,7 +774,7 @@ int l_set_width(lua_State* L) {
 }
 
 int l_set_colour(lua_State* L) {
-  line* pLine = luaT_testuserdata<line>(L);
+  line_sequence* pLine = luaT_testuserdata<line_sequence>(L);
   pLine->set_colour(static_cast<uint8_t>(luaL_optinteger(L, 2, 0)),
                     static_cast<uint8_t>(luaL_optinteger(L, 3, 0)),
                     static_cast<uint8_t>(luaL_optinteger(L, 4, 0)),
@@ -785,7 +785,7 @@ int l_set_colour(lua_State* L) {
 }
 
 int l_line_draw(lua_State* L) {
-  line* pLine = luaT_testuserdata<line>(L);
+  line_sequence* pLine = luaT_testuserdata<line_sequence>(L);
   render_target* pCanvas = luaT_testuserdata<render_target>(L, 2);
   pLine->draw(pCanvas, static_cast<int>(luaL_optinteger(L, 3, 0)),
               static_cast<int>(luaL_optinteger(L, 4, 0)));
@@ -795,14 +795,14 @@ int l_line_draw(lua_State* L) {
 }
 
 int l_line_persist(lua_State* L) {
-  line* pLine = luaT_testuserdata<line>(L);
+  line_sequence* pLine = luaT_testuserdata<line_sequence>(L);
   lua_persist_writer* pWriter = (lua_persist_writer*)lua_touserdata(L, 2);
   pLine->persist(pWriter);
   return 0;
 }
 
 int l_line_depersist(lua_State* L) {
-  line* pLine = luaT_testuserdata<line>(L);
+  line_sequence* pLine = luaT_testuserdata<line_sequence>(L);
   lua_settop(L, 2);
   lua_insert(L, 1);
   lua_persist_reader* pReader =
@@ -928,7 +928,7 @@ void lua_register_gfx(const lua_register_state* pState) {
 
   // Line
   {
-    lua_class_binding<line> lcb(pState, "line", l_line_new,
+    lua_class_binding<line_sequence> lcb(pState, "line", l_line_new,
                                 lua_metatable::line);
     lcb.add_function(l_move_to, "moveTo");
     lcb.add_function(l_line_to, "lineTo");

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -465,7 +465,9 @@ int l_layers_set(lua_State* L) {
   layers* pLayers = luaT_testuserdata<layers>(L);
   lua_Integer iLayer = luaL_checkinteger(L, 2);
   uint8_t iValue = static_cast<uint8_t>(luaL_checkinteger(L, 3));
-  if (0 <= iLayer && iLayer < max_number_of_layers) pLayers->layer_contents[iLayer] = iValue;
+  if (0 <= iLayer && iLayer < max_number_of_layers) {
+    pLayers->layer_contents[iLayer] = iValue;
+  }
   return 0;
 }
 
@@ -493,8 +495,14 @@ int l_layers_depersist(lua_State* L) {
   int iNumLayers;
   if (!pReader->read_uint(iNumLayers)) return 0;
   if (iNumLayers > max_number_of_layers) {
-    if (!pReader->read_byte_stream(pLayers->layer_contents, max_number_of_layers)) return 0;
-    if (!pReader->read_byte_stream(nullptr, iNumLayers - max_number_of_layers)) return 0;
+    if (!pReader->read_byte_stream(pLayers->layer_contents,
+                                   max_number_of_layers)) {
+      return 0;
+    }
+    if (!pReader->read_byte_stream(nullptr,
+                                   iNumLayers - max_number_of_layers)) {
+      return 0;
+    }
   } else {
     if (!pReader->read_byte_stream(pLayers->layer_contents, iNumLayers))
       return 0;
@@ -929,7 +937,7 @@ void lua_register_gfx(const lua_register_state* pState) {
   // Line
   {
     lua_class_binding<line_sequence> lcb(pState, "line", l_line_new,
-                                lua_metatable::line);
+                                         lua_metatable::line);
     lcb.add_function(l_move_to, "moveTo");
     lcb.add_function(l_line_to, "lineTo");
     lcb.add_function(l_set_width, "setWidth");

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -447,14 +447,14 @@ int l_font_draw_tooltip(lua_State* L) {
 
 int l_layers_new(lua_State* L) {
   layers* pLayers = luaT_stdnew<layers>(L, luaT_environindex, false);
-  for (int i = 0; i < 13; ++i) pLayers->layer_contents[i] = 0;
+  for (int i = 0; i < max_number_of_layers; ++i) pLayers->layer_contents[i] = 0;
   return 1;
 }
 
 int l_layers_get(lua_State* L) {
   layers* pLayers = luaT_testuserdata<layers>(L);
   lua_Integer iLayer = luaL_checkinteger(L, 2);
-  if (0 <= iLayer && iLayer < 13)
+  if (0 <= iLayer && iLayer < max_number_of_layers)
     lua_pushinteger(L, pLayers->layer_contents[iLayer]);
   else
     lua_pushnil(L);
@@ -465,7 +465,7 @@ int l_layers_set(lua_State* L) {
   layers* pLayers = luaT_testuserdata<layers>(L);
   lua_Integer iLayer = luaL_checkinteger(L, 2);
   uint8_t iValue = static_cast<uint8_t>(luaL_checkinteger(L, 3));
-  if (0 <= iLayer && iLayer < 13) pLayers->layer_contents[iLayer] = iValue;
+  if (0 <= iLayer && iLayer < max_number_of_layers) pLayers->layer_contents[iLayer] = iValue;
   return 0;
 }
 
@@ -473,7 +473,7 @@ int l_layers_persist(lua_State* L) {
   layers* pLayers = luaT_testuserdata<layers>(L);
   lua_persist_writer* pWriter = (lua_persist_writer*)lua_touserdata(L, 2);
 
-  int iNumLayers = 13;
+  int iNumLayers = max_number_of_layers;
   for (; iNumLayers >= 1; --iNumLayers) {
     if (pLayers->layer_contents[iNumLayers - 1] != 0) break;
   }
@@ -492,9 +492,9 @@ int l_layers_depersist(lua_State* L) {
   std::memset(pLayers->layer_contents, 0, sizeof(pLayers->layer_contents));
   int iNumLayers;
   if (!pReader->read_uint(iNumLayers)) return 0;
-  if (iNumLayers > 13) {
-    if (!pReader->read_byte_stream(pLayers->layer_contents, 13)) return 0;
-    if (!pReader->read_byte_stream(nullptr, iNumLayers - 13)) return 0;
+  if (iNumLayers > max_number_of_layers) {
+    if (!pReader->read_byte_stream(pLayers->layer_contents, max_number_of_layers)) return 0;
+    if (!pReader->read_byte_stream(nullptr, iNumLayers - max_number_of_layers)) return 0;
   } else {
     if (!pReader->read_byte_stream(pLayers->layer_contents, iNumLayers))
       return 0;


### PR DESCRIPTION
- Introduces the `max_number_of_layers` constant (mostly cherry-picked from driverpt)
- Further reduces layer count magic numbers
- Removes Replaces the `link_list` base class, and replaces it with a `std::vector`
- Renames `line` to `line_sequence`, `line_operation` to `line_element`, `line_operation_type` to `line_command`
- Ensures persistence will always write the float data as `double`.