### PR TITLE
PoC: Add "OK" on filebrowser

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/file_browser.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browser.lua
@@ -207,8 +207,8 @@ function UIFileBrowser:UIFileBrowser(ui, mode, title, vertical_size, root, show_
   local indent = math.floor((h_size - (2*button_size))/3)
   self:addBevelPanel(indent, 340, button_size, 30, self.col_bg):setLabel(_S.menu_list_window.back)
     :makeButton(0, 0, button_size, 40, nil, self.buttonBack):setTooltip(_S.tooltip.menu_list_window.back)
-  
-  self:addBevelPanel(h_size - button_size - indent, 340, button_size, 30, 
+
+  self:addBevelPanel(h_size - button_size - indent, 340, button_size, 30,
   self.col_bg):setLabel(_S.menu_list_window.ok)
     :makeButton(0, 0, button_size, 40, nil, (--[[persistable:filebrowser_ok_callback]] function()
       if (self.origin.new_savegame_textbox and self.origin.new_savegame_textbox.text ~= "") or (self.origin.new_map_textbox and self.origin.new_map_textbox.text ~= "") then

--- a/CorsixTH/Lua/dialogs/resizables/file_browser.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browser.lua
@@ -213,8 +213,6 @@ function UIFileBrowser:UIFileBrowser(ui, mode, title, vertical_size, root, show_
       if self.control.selected_node then
         self:openFile(self.control.selected_node)
       end
-      elseif self.new_savegame_textbox and self.new_savegame_textbox.text then
-        self:
     end)):setTooltip(_S.tooltip.menu_list_window.ok)
 end
 

--- a/CorsixTH/Lua/dialogs/resizables/file_browser.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browser.lua
@@ -197,20 +197,36 @@ function UIFileBrowser:UIFileBrowser(ui, mode, title, vertical_size, root, show_
   -- Initialize the tree control
   self.control = FilteredTreeControl(root, 5, 35, h_size - 10, vertical_size, self.col_bg, self.col_scrollbar, true, show_dates)
     :setSelectCallback(--[[persistable:file_browser_select_callback]] function(node)
-      if node.is_valid_file and (lfs.attributes(node.path, "mode") ~= "directory") then
-        self:choiceMade(node.path)
-      end
+      self:openFile(node)
     end)
   self:addWindow(self.control)
 
   -- Create the back button.
-  self:addBevelPanel((h_size - 160) / 2, 340, 160, 30, self.col_bg):setLabel(_S.menu_list_window.back)
-    :makeButton(0, 0, 160, 40, nil, self.buttonBack):setTooltip(_S.tooltip.menu_list_window.back)
+  local button_size = 135
+  local indent = math.floor((h_size - (2*button_size))/3)
+  self:addBevelPanel(indent, 340, button_size, 30, self.col_bg):setLabel(_S.menu_list_window.back)
+    :makeButton(0, 0, button_size, 40, nil, self.buttonBack):setTooltip(_S.tooltip.menu_list_window.back)
+  
+  self:addBevelPanel(h_size - button_size - indent, 340, button_size, 30, 
+  self.col_bg):setLabel(_S.menu_list_window.ok)
+    :makeButton(0, 0, button_size, 40, nil, (--[[persistable:filebrowser_ok_callback]] function()
+      if self.control.selected_node then
+        self:openFile(self.control.selected_node)
+      end
+      elseif self.new_savegame_textbox and self.new_savegame_textbox.text then
+        self:
+    end)):setTooltip(_S.tooltip.menu_list_window.ok)
 end
 
 -- Function stub for dialogs to override. This function is called each time a file is chosen.
 --!param name (string) Name of the file chosen.
 function UIFileBrowser:choiceMade(name)
+end
+
+function UIFileBrowser:openFile(node)
+  if node.is_valid_file and (lfs.attributes(node.path, "mode") ~= "directory") then
+    self:choiceMade(node.path)
+  end
 end
 
 function UIFileBrowser:buttonBack()

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/choose_font.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/choose_font.lua
@@ -39,7 +39,7 @@ function UIChooseFont:UIChooseFont(ui, mode)
   else
     root = FilteredFileTreeNode(roots[1], {".ttc", ".otf", ".ttf"})
   end
-  self:UIFileBrowser(ui, mode, _S.font_location_window.caption:format(".ttc, .otf, .ttf"), 265, root)
+  self:UIFileBrowser(ui, mode, _S.font_location_window.caption:format(".ttc, .otf, .ttf"), 265, root, nil, self)
 end
 
 --! Function called by clicking button of existing save #num

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
@@ -27,7 +27,7 @@ local UILoadGame = _G["UILoadGame"]
 function UILoadGame:UILoadGame(ui, mode)
   local treenode = FilteredFileTreeNode(ui.app.savegame_dir, ".sav")
   treenode.label = "Saves"
-  self:UIFileBrowser(ui, mode, _S.load_game_window.caption:format(".sav"), 295, treenode, true)
+  self:UIFileBrowser(ui, mode, _S.load_game_window.caption:format(".sav"), 295, treenode, true, self)
   -- The most probable preference of sorting is by date - what you played last
   -- is the thing you want to play soon again.
   self.control:sortByDate()

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/load_map.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/load_map.lua
@@ -28,7 +28,7 @@ function UILoadMap:UILoadMap(ui, mode)
   local path = ui.app.user_level_dir
   local treenode = FilteredFileTreeNode(path, ".map")
   treenode.label = "Maps"
-  self:UIFileBrowser(ui, mode, _S.load_game_window.caption:format(".map"), 295, treenode, true)
+  self:UIFileBrowser(ui, mode, _S.load_game_window.caption:format(".map"), 295, treenode, true, self)
   -- The most probable preference of sorting is by date - what you played last
   -- is the thing you want to play soon again.
   self.control:sortByDate()

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
@@ -45,7 +45,7 @@ local col_shadow = {
 function UISaveGame:UISaveGame(ui)
   local treenode = FilteredFileTreeNode(ui.app.savegame_dir, ".sav")
   treenode.label = "Saves"
-  self:UIFileBrowser(ui, "game", _S.save_game_window.caption:format(".sav"), 265, treenode, true)
+  self:UIFileBrowser(ui, "game", _S.save_game_window.caption:format(".sav"), 265, treenode, true, self)
   -- The most probable preference of sorting is by date - what you played last
   -- is the thing you want to play soon again.
   self.control:sortByDate()
@@ -61,6 +61,13 @@ end
 function UISaveGame:abortName()
   self.new_savegame_textbox.text = ""
   self.new_savegame_textbox.panel:setLabel(_S.save_game_window.new_save_game)
+end
+
+--! Updates the textbox to selected file
+--!param node (table) Selected file
+function UISaveGame:updateTextbox(node)
+  self.new_savegame_textbox.text = node
+  self.new_savegame_textbox.panel:setLabel(node)
 end
 
 --! Function called when textbox is confirmed (e.g. by pressing enter)

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_map.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_map.lua
@@ -45,7 +45,7 @@ local col_shadow = {
 function UISaveMap:UISaveMap(ui)
   local treenode = FilteredFileTreeNode(ui.app.user_level_dir, ".map")
   treenode.label = "Maps"
-  self:UIFileBrowser(ui, "map", _S.save_map_window.caption:format(".map"), 265, treenode, true)
+  self:UIFileBrowser(ui, "map", _S.save_map_window.caption:format(".map"), 265, treenode, true, self)
   -- The most probable preference of sorting is by date - what you played last
   -- is the thing you want to play soon again.
   self.control:sortByDate()
@@ -61,6 +61,13 @@ end
 function UISaveMap:abortName()
   self.new_map_textbox.text = ""
   self.new_map_textbox.panel:setLabel(_S.save_map_window.new_map)
+end
+
+--! Updates the textbox to selected file
+--!param node (table) Selected file
+function UISaveMap:updateTextbox(node)
+  self.new_map_textbox.text = node
+  self.new_map_textbox.panel:setLabel(node)
 end
 
 --! Function called when textbox is confirmed (e.g. by pressing enter)

--- a/CorsixTH/Lua/dialogs/tree_ctrl.lua
+++ b/CorsixTH/Lua/dialogs/tree_ctrl.lua
@@ -498,7 +498,7 @@ local TreeControl = _G["TreeControl"]
 -- a table with `red`, `green`, and `blue` fields, each an integer between 0
 -- and 255.
 --!param col_fg (table) The colour used for the scrollbar and highlighted items.
-function TreeControl:TreeControl(root, x, y, width, height, col_bg, col_fg, y_offset, has_font)
+function TreeControl:TreeControl(root, x, y, width, height, col_bg, col_fg, y_offset, has_font, origin)
   -- Setup the base window
   self:Window()
   self.x = x
@@ -517,6 +517,7 @@ function TreeControl:TreeControl(root, x, y, width, height, col_bg, col_fg, y_of
   self.tree_sprites = gfx:loadSpriteTable("Bitmap", "tree_ctrl", true,
     gfx:loadPalette("Bitmap", "tree_ctrl.pal"))
 
+  self.origin = origin
   -- Calculate sizes and counts
   local scrollbar_width = 20
   self.row_height = 14
@@ -622,6 +623,11 @@ function TreeControl:onMouseUp(button, x, y)
       redraw = true
     else
       self.selected_node = node
+      if self.origin and self.origin.new_savegame_textbox then
+        self.origin:updateTextbox(string.gsub(node:getLabel(),".sav",""))
+      elseif self.origin and self.origin.new_map_textbox then
+        self.origin:updateTextbox(string.gsub(node:getLabel(),".map",""))
+      end
       node:select()
       redraw = true
     end

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -394,12 +394,14 @@ menu_list_window = {
   name = "Name",
   save_date = "Modified",
   back = "Back",
+  ok = "OK",
 }
 
 tooltip.menu_list_window = {
   name = "Click here to sort the list by name",
   save_date = "Click here to sort the list by last modification date",
   back = "Close this window",
+  ok = "Open the selected file",
 }
 
 options_window = {


### PR DESCRIPTION
A mock-up of a solution for #1913 . It is not elegant, but hopefully a starting block.
Also missing doc stuff.

**Describe what the proposed change does**
- Adds OK button to all file browsers (load, save, font)
- Sends the original window through the file browser system to reference back
- On saves, it appends the filename selected into the save textbox when single-clicked.

![image](https://user-images.githubusercontent.com/20030128/120487875-3e302300-c3ae-11eb-86a7-fcb6fc87a027.png)
![image](https://user-images.githubusercontent.com/20030128/120487984-52742000-c3ae-11eb-8ea9-93cc0668a32b.png)
