### PR TITLE
Implement zoom using scaled SDL_RenderCopy.

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -157,6 +157,9 @@ function App:init()
   if self.config.track_fps then
     modes[#modes + 1] = "present immediate"
   end
+  if self.config.direct_zoom then
+    modes[#modes + 1] = "direct zoom"
+  end
   self.modes = modes
   self.video = assert(TH.surface(self.config.width, self.config.height, unpack(modes)))
   self.video:setBlueFilterActive(false)

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -139,7 +139,9 @@ local config_defaults = {
   new_graphics_folder = nil,
   use_new_graphics = false,
   check_for_updates = true,
-  room_information_dialogs = true
+  room_information_dialogs = true,
+  allow_blocking_off_areas = false,
+  direct_zoom = false
 }
 
 fi = io.open(config_filename, "r")
@@ -502,6 +504,12 @@ audio_music = nil -- [[X:\ThemeHospital\Music]]
 -- ]=] .. '\n' ..
 'allow_blocking_off_areas = ' .. tostring(config_values.allow_blocking_off_areas) .. '\n' .. [=[
 
+-------------------------------------------------------------------------------------------------------------------------
+-- Direct Zoom: An experimental enhancement to avoid rendering to an
+-- intermediate texture when zooming. Improves performance and reliability on
+-- some hardware.
+-- ]=] .. '\n' ..
+'direct_zoom = ' .. tostring(config_values.direct_zoom) .. '\n' .. [=[
 
 -------------------------------------------------------------------------------------------------------------------------
 

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -88,6 +88,8 @@ struct render_target_creation_params {
   bool fullscreen;         ///< Run full-screen.
   bool present_immediate;  ///< Whether to present immediately to the user
                            ///< (else wait for Vsync).
+  bool direct_zoom;  ///< Scale each texture when copying if true, otherwise
+                     ///< render to intermediate texture and scale.
 };
 
 /*!

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -275,18 +275,18 @@ void wx_storing::store_argb(uint32_t pixel) {
   *alpha_data++ = palette::get_alpha(pixel);
 }
 
-render_target::render_target() {
-  window = nullptr;
-  renderer = nullptr;
-  pixel_format = nullptr;
-  game_cursor = nullptr;
-  scale_bitmaps = false;
-  blue_filter_active = false;
-  apply_opengl_clip_fix = false;
-  global_scale_factor = 1.0;
-  width = -1;
-  height = -1;
-}
+render_target::render_target()
+    : window(nullptr),
+      renderer(nullptr),
+      pixel_format(nullptr),
+      blue_filter_active(false),
+      game_cursor(nullptr),
+      global_scale_factor(1.0),
+      width(-1),
+      height(-1),
+      scale_bitmaps(false),
+      apply_opengl_clip_fix(false),
+      direct_zoom(false) {}
 
 render_target::~render_target() { destroy(); }
 
@@ -347,6 +347,8 @@ bool render_target::update(const render_target_creation_params* pParams) {
   if (bUpdateSize) {
     SDL_RenderSetLogicalSize(renderer, width, height);
   }
+
+  direct_zoom = pParams->direct_zoom;
 
   return true;
 }

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -356,6 +356,7 @@ class render_target {
   // ClipRects in opengl and opengles.
   // see: https://bugzilla.libsdl.org/show_bug.cgi?id=2700
   bool apply_opengl_clip_fix;
+  bool direct_zoom;
 };
 
 //! Stored image.

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -340,6 +340,7 @@ class render_target {
  private:
   SDL_Window* window;
   SDL_Renderer* renderer;
+  SDL_Texture* zoom_texture;
   SDL_PixelFormat* pixel_format;
   bool blue_filter_active;
   cursor* game_cursor;
@@ -357,6 +358,8 @@ class render_target {
   // see: https://bugzilla.libsdl.org/show_bug.cgi?id=2700
   bool apply_opengl_clip_fix;
   bool direct_zoom;
+
+  void flush_zoom_buffer();
 };
 
 //! Stored image.

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -340,11 +340,11 @@ class render_target {
  private:
   SDL_Window* window;
   SDL_Renderer* renderer;
-  SDL_Texture* zoom_texture;
   SDL_PixelFormat* pixel_format;
   bool blue_filter_active;
   cursor* game_cursor;
   double bitmap_scale_factor;  ///< Bitmap scale factor.
+  double global_scale_factor;  ///< Global scale factor.
   int width;
   int height;
   int cursor_x;
@@ -356,8 +356,6 @@ class render_target {
   // ClipRects in opengl and opengles.
   // see: https://bugzilla.libsdl.org/show_bug.cgi?id=2700
   bool apply_opengl_clip_fix;
-
-  void flush_zoom_buffer();
 };
 
 //! Stored image.

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -549,6 +549,7 @@ render_target_creation_params l_surface_creation_params(lua_State* L,
 
   oParams.fullscreen = false;
   oParams.present_immediate = false;
+  oParams.direct_zoom = false;
 
   // Parse string arguments, looking for matching parameter names.
   for (int iArg = iArgStart + 2, iArgCount = lua_gettop(L); iArg <= iArgCount;
@@ -556,9 +557,15 @@ render_target_creation_params l_surface_creation_params(lua_State* L,
     const char* sOption = luaL_checkstring(L, iArg);
     if (sOption[0] == 0) continue;
 
-    if (std::strcmp(sOption, "fullscreen") == 0) oParams.fullscreen = true;
-    if (std::strcmp(sOption, "present immediate") == 0)
+    if (std::strcmp(sOption, "fullscreen") == 0) {
+      oParams.fullscreen = true;
+    }
+    if (std::strcmp(sOption, "present immediate") == 0) {
       oParams.present_immediate = true;
+    }
+    if (std::strcmp(sOption, "direct zoom") == 0) {
+      oParams.direct_zoom = true;
+    }
   }
 
   return oParams;


### PR DESCRIPTION
This allows removing the zoom texture allocations and removing an intermediate draw to that texture before drawing to the screen noticeably increasing the frame rate which may address issues such as #1420.