### PR TITLE
Fix fired dr

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -753,8 +753,8 @@ end
 -- Check if it is cold or hot around the humanoid and increase/decrease the
 -- feeling of warmth accordingly. Returns whether the calling function should proceed.
 function Humanoid:tickDay()
-  -- No use doing anything if we're going home
-  if self.going_home then
+  -- No use doing anything if we're going home/fired (or dead)
+  if self.going_home or self.dead then
     return false
   end
 

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -33,8 +33,12 @@ function Staff:Staff(...)
   self.parcelNr = 0
 end
 
+--! Handle daily adjustments to staff.
+--!return (boolean) Whether the caller should continue processing
 function Staff:tickDay()
-  Humanoid.tickDay(self)
+  if not Humanoid.tickDay(self) then
+    return false
+  end
   -- Pay too low  --> unhappy
   -- Pay too high -->   happy
   local fair_wage = self.profile:getFairWage()
@@ -110,6 +114,8 @@ function Staff:tickDay()
     -- Greater space helps but in smaller increments
     self:changeAttribute("happiness", math.round(math.log(extraspace)) / 1000)
   end
+
+  return true
 end
 
 function Staff:tick()
@@ -245,10 +251,10 @@ function Staff:fire()
   self:setMood("exit", "activate")
   self:setDynamicInfoText(_S.dynamic_info.staff.actions.fired)
   self.fired = true
+  self.going_home = true
   self.hospital:changeReputation("kicked")
   self:despawn()
   self.hover_cursor = nil
-  self.attributes["fatigue"] = nil
   self:leaveAnnounce()
   -- Unregister any build callbacks or messages.
   self:unregisterCallbacks()

--- a/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
@@ -35,7 +35,10 @@ function Doctor:Doctor(...)
 end
 
 function Doctor:tickDay()
-  Staff.tickDay(self)
+  if not Staff.tickDay(self) then
+    return false
+  end
+
   -- if you overwork your Dr's then there is a chance that they can go crazy
   -- when this happens, find him and get him to rest straight away
   if self.attributes["fatigue"] then

--- a/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
@@ -35,7 +35,9 @@ function Receptionist:Receptionist(...)
 end
 
 function Receptionist:tickDay()
-  Staff.tickDay(self)
+  if not Staff.tickDay(self) then
+    return false
+  end
   self:needsWorkStation()
 end
 


### PR DESCRIPTION
*Fixes #1924*

**Describe what the proposed change does**
Does not nil out the fatigue attribute of doctor's when they are fired. Avoid performing any actions on fired doctors.
