### PR TITLE
Fix warn queue check considering inactive rooms

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2414,3 +2414,23 @@ function Hospital:setCampaignData(campaign_data)
     self[key] = value
   end
 end
+
+--! Finds a random room with significantly long queues
+--!return room or nil The chosen room in the hospital or nil for no room busy enough
+function Hospital:getRandomBusyRoom()
+  local long_queue_rooms, active_rooms, total_queue = {}, 0, 0
+  for _, room in pairs(self.world.rooms) do
+    if room.is_active and room.door.queue then
+      total_queue = total_queue + #room.door.queue
+      active_rooms = active_rooms + 1
+      if #room.door.queue > 7 then
+        long_queue_rooms[#long_queue_rooms + 1] = room
+      end
+    end
+  end
+  if #long_queue_rooms == 0 then return end
+
+  local busy_threshold = 1.5 * total_queue / active_rooms
+  local chosen_room = long_queue_rooms[math.random(1, #long_queue_rooms)]
+  if #chosen_room.door.queue >= busy_threshold then return chosen_room end
+end

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -339,20 +339,8 @@ end
 --! Once a month the advisor may warn about long queues.
 --! Rooms requiring a doctor occasionally trigger the generic message
 function PlayerHospital:warnForLongQueues()
-  local queue_rooms, total_queue = {}, 0
-  for _, room in pairs(self.world.rooms) do
-    if #room.door.queue then
-      total_queue = total_queue + #room.door.queue
-    end
-    if #room.door.queue > 7 then
-      queue_rooms[#queue_rooms + 1] = room
-    end
-  end
-  if #queue_rooms == 0 or total_queue == 0 then return end
-
-  local busy_threshold = 1.5 * total_queue / #self.world.rooms
-  local chosen_room = queue_rooms[math.random(1, #queue_rooms)]
-  if busy_threshold > #chosen_room.door.queue then return end
+  local chosen_room = self:getRandomBusyRoom()
+  if not chosen_room then return end
   chosen_room = chosen_room.room_info
   -- Required staff that is not nurse is doctor, researcher, surgeon or psych
   if chosen_room.required_staff and not chosen_room.required_staff["Nurse"]


### PR DESCRIPTION
*Fixes #1927*

**Describe what the proposed change does**
- Only considers active rooms when calculating the queuing situation.

I think this is because a crashed room's door queue is not always instantly wiped, as patients move to other rooms. It happened when my first operating theatre exploded but not the second.