### PR TITLE
Only apply nearest scaling to map textures for direct_zoom.

### DIFF
--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -78,6 +78,8 @@ enum draw_flags : uint32_t {
   thdf_bound_box_hit_test = 1 << 12,
   //! Apply a cropping operation prior to drawing
   thdf_crop = 1 << 13,
+  //! Draw using nearest pixel hinting
+  thdf_nearest = 1 << 14,
 };
 
 /** Helper structure with parameters to create a #render_target. */

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -1070,8 +1070,8 @@ void sprite_sheet::draw_sprite(render_target* pCanvas, size_t iSprite, int iX,
   if (!pTexture) {
     if (sprite.data == nullptr) return;
 
-    uint32_t iSprFlags =
-        (sprite.sprite_flags & ~thdf_alt32_mask) | thdf_alt32_plain | (iFlags & thdf_nearest);
+    uint32_t iSprFlags = (sprite.sprite_flags & ~thdf_alt32_mask) |
+                         thdf_alt32_plain | (iFlags & thdf_nearest);
     pTexture = target->create_palettized_texture(
         sprite.width, sprite.height, sprite.data, palette, iSprFlags);
     sprite.texture = pTexture;

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -296,15 +296,7 @@ bool render_target::create(const render_target_creation_params* pParams) {
 
   direct_zoom = pParams->direct_zoom;
 
-  if (direct_zoom) {
-    // When scaling rendering, linear introduces semi-transparent gaps at
-    // transparent edges within tiles. Using nearest ensures that we can scale
-    // angled transparent tile edges without seams.
-    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
-  } else {
-    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
-  }
-
+  SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
   pixel_format = SDL_AllocFormat(SDL_PIXELFORMAT_ABGR8888);
   window =
       SDL_CreateWindow("CorsixTH", SDL_WINDOWPOS_UNDEFINED,
@@ -658,7 +650,11 @@ SDL_Texture* render_target::create_palettized_texture(
   full_colour_storing oRenderer(pARGBPixels, iWidth, iHeight);
   oRenderer.decode_image(pPixels, pPalette, iSpriteFlags);
 
+  if (iSpriteFlags & thdf_nearest)
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
   SDL_Texture* pTexture = create_texture(iWidth, iHeight, pARGBPixels);
+  if (iSpriteFlags & thdf_nearest)
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
   delete[] pARGBPixels;
   return pTexture;
 }
@@ -1075,7 +1071,7 @@ void sprite_sheet::draw_sprite(render_target* pCanvas, size_t iSprite, int iX,
     if (sprite.data == nullptr) return;
 
     uint32_t iSprFlags =
-        (sprite.sprite_flags & ~thdf_alt32_mask) | thdf_alt32_plain;
+        (sprite.sprite_flags & ~thdf_alt32_mask) | thdf_alt32_plain | (iFlags & thdf_nearest);
     pTexture = target->create_palettized_texture(
         sprite.width, sprite.height, sprite.data, palette, iSprFlags);
     sprite.texture = pTexture;

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1007,13 +1007,13 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
   for (map_tile_iterator itrNode2(this, iScreenX, iScreenY, iWidth, iHeight);
        itrNode2; ++itrNode2) {
     if (itrNode2->flags.shadow_full) {
-      blocks->draw_sprite(
-          pCanvas, 74, itrNode2.tile_x_position_on_screen() + iCanvasX - 32,
+      blocks->draw_sprite(pCanvas, 74,
+                          itrNode2.tile_x_position_on_screen() + iCanvasX - 32,
                           itrNode2.tile_y_position_on_screen() + iCanvasY,
                           thdf_alpha_75 | thdf_nearest);
     } else if (itrNode2->flags.shadow_half) {
-      blocks->draw_sprite(
-          pCanvas, 75, itrNode2.tile_x_position_on_screen() + iCanvasX - 32,
+      blocks->draw_sprite(pCanvas, 75,
+                          itrNode2.tile_x_position_on_screen() + iCanvasX - 32,
                           itrNode2.tile_y_position_on_screen() + iCanvasY,
                           thdf_alpha_75 | thdf_nearest);
     }

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -996,7 +996,8 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
     blocks->draw_sprite(
         pCanvas, iBlock & 0xFF,
         itrNode1.tile_x_position_on_screen() + iCanvasX - 32,
-        itrNode1.tile_y_position_on_screen() + iCanvasY - iH + 32, iBlock >> 8);
+        itrNode1.tile_y_position_on_screen() + iCanvasY - iH + 32,
+        iBlock >> 8 | thdf_nearest);
   }
   pCanvas->finish_nonoverlapping_draws();
 
@@ -1008,11 +1009,13 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
     if (itrNode2->flags.shadow_full) {
       blocks->draw_sprite(
           pCanvas, 74, itrNode2.tile_x_position_on_screen() + iCanvasX - 32,
-          itrNode2.tile_y_position_on_screen() + iCanvasY, thdf_alpha_75);
+                          itrNode2.tile_y_position_on_screen() + iCanvasY,
+                          thdf_alpha_75 | thdf_nearest);
     } else if (itrNode2->flags.shadow_half) {
       blocks->draw_sprite(
           pCanvas, 75, itrNode2.tile_x_position_on_screen() + iCanvasX - 32,
-          itrNode2.tile_y_position_on_screen() + iCanvasY, thdf_alpha_75);
+                          itrNode2.tile_y_position_on_screen() + iCanvasY,
+                          thdf_alpha_75 | thdf_nearest);
     }
 
     if (!itrNode2.is_last_on_scanline()) {
@@ -1028,7 +1031,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
       if (iBlock != 0 && blocks->get_sprite_size(iBlock & 0xFF, nullptr, &iH) &&
           iH > 0) {
         blocks->draw_sprite(pCanvas, iBlock & 0xFF, itrNode.x() - 32,
-                            itrNode.y() - iH + 32, iBlock >> 8);
+                            itrNode.y() - iH + 32, iBlock >> 8 | thdf_nearest);
         if (itrNode->flags.shadow_wall) {
           clip_rect rcOldClip, rcNewClip;
           pCanvas->get_clip_rect(&rcOldClip);
@@ -1040,7 +1043,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
           clip_rect_intersection(rcNewClip, rcOldClip);
           pCanvas->set_clip_rect(&rcNewClip);
           blocks->draw_sprite(pCanvas, 156, itrNode.x() - 32, itrNode.y() - 56,
-                              thdf_alpha_75);
+                              thdf_alpha_75 | thdf_nearest);
           pCanvas->set_clip_rect(&rcOldClip);
         }
       }
@@ -1072,13 +1075,13 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
       if (iBlock != 0 && blocks->get_sprite_size(iBlock & 0xFF, nullptr, &iH) &&
           iH > 0) {
         blocks->draw_sprite(pCanvas, iBlock & 0xFF, itrNode.x() - 32,
-                            itrNode.y() - iH + 32, iBlock >> 8);
+                            itrNode.y() - iH + 32, iBlock >> 8 | thdf_nearest);
       }
       iBlock = itrNode->iBlock[3];
       if (iBlock != 0 && blocks->get_sprite_size(iBlock & 0xFF, nullptr, &iH) &&
           iH > 0) {
         blocks->draw_sprite(pCanvas, iBlock & 0xFF, itrNode.x() - 32,
-                            itrNode.y() - iH + 32, iBlock >> 8);
+                            itrNode.y() - iH + 32, iBlock >> 8 | thdf_nearest);
       }
       iBlock = itrNode->iBlock[1];
       if (iBlock != 0 && blocks->get_sprite_size(iBlock & 0xFF, nullptr, &iH) &&
@@ -1146,7 +1149,8 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
           if (iBlock != 0 &&
               blocks->get_sprite_size(iBlock & 0xFF, nullptr, &iH) && iH > 0) {
             blocks->draw_sprite(pCanvas, iBlock & 0xFF, itrNode.x() - 96,
-                                itrNode.y() - iH + 32, iBlock >> 8);
+                                itrNode.y() - iH + 32,
+                                iBlock >> 8 | thdf_nearest);
             if (itrNode.get_previous_tile()->flags.shadow_wall) {
               clip_rect rcOldClip, rcNewClip;
               pCanvas->get_clip_rect(&rcOldClip);
@@ -1158,7 +1162,8 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
               clip_rect_intersection(rcNewClip, rcOldClip);
               pCanvas->set_clip_rect(&rcNewClip);
               blocks->draw_sprite(pCanvas, 156, itrNode.x() - 96,
-                                  itrNode.y() - 56, thdf_alpha_75);
+                                  itrNode.y() - 56,
+                                  thdf_alpha_75 | thdf_nearest);
               pCanvas->set_clip_rect(&rcOldClip);
             }
           }

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -997,7 +997,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
         pCanvas, iBlock & 0xFF,
         itrNode1.tile_x_position_on_screen() + iCanvasX - 32,
         itrNode1.tile_y_position_on_screen() + iCanvasY - iH + 32,
-        iBlock >> 8 | thdf_nearest);
+        (iBlock >> 8) | thdf_nearest);
   }
   pCanvas->finish_nonoverlapping_draws();
 
@@ -1031,7 +1031,8 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
       if (iBlock != 0 && blocks->get_sprite_size(iBlock & 0xFF, nullptr, &iH) &&
           iH > 0) {
         blocks->draw_sprite(pCanvas, iBlock & 0xFF, itrNode.x() - 32,
-                            itrNode.y() - iH + 32, iBlock >> 8 | thdf_nearest);
+                            itrNode.y() - iH + 32,
+                            (iBlock >> 8) | thdf_nearest);
         if (itrNode->flags.shadow_wall) {
           clip_rect rcOldClip, rcNewClip;
           pCanvas->get_clip_rect(&rcOldClip);
@@ -1075,13 +1076,15 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
       if (iBlock != 0 && blocks->get_sprite_size(iBlock & 0xFF, nullptr, &iH) &&
           iH > 0) {
         blocks->draw_sprite(pCanvas, iBlock & 0xFF, itrNode.x() - 32,
-                            itrNode.y() - iH + 32, iBlock >> 8 | thdf_nearest);
+                            itrNode.y() - iH + 32,
+                            (iBlock >> 8) | thdf_nearest);
       }
       iBlock = itrNode->iBlock[3];
       if (iBlock != 0 && blocks->get_sprite_size(iBlock & 0xFF, nullptr, &iH) &&
           iH > 0) {
         blocks->draw_sprite(pCanvas, iBlock & 0xFF, itrNode.x() - 32,
-                            itrNode.y() - iH + 32, iBlock >> 8 | thdf_nearest);
+                            itrNode.y() - iH + 32,
+                            (iBlock >> 8) | thdf_nearest);
       }
       iBlock = itrNode->iBlock[1];
       if (iBlock != 0 && blocks->get_sprite_size(iBlock & 0xFF, nullptr, &iH) &&
@@ -1150,7 +1153,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
               blocks->get_sprite_size(iBlock & 0xFF, nullptr, &iH) && iH > 0) {
             blocks->draw_sprite(pCanvas, iBlock & 0xFF, itrNode.x() - 96,
                                 itrNode.y() - iH + 32,
-                                iBlock >> 8 | thdf_nearest);
+                                (iBlock >> 8) | thdf_nearest);
             if (itrNode.get_previous_tile()->flags.shadow_wall) {
               clip_rect rcOldClip, rcNewClip;
               pCanvas->get_clip_rect(&rcOldClip);


### PR DESCRIPTION
*Mostly fixes aliased rendering issues in #1930*

**Describe what the proposed change does**
- Applies SDL_HINT_RENDER_SCALE_QUALITY nearest only to map textures

Note:
- We could now also make direct_zoom a runtime configurable parameter as long as we reset the global_scale_factor and zoom_texture accordingly.

**Screenshot:**
![titlescreen-linear-antialiasing](https://user-images.githubusercontent.com/366761/121821570-d3ad9b80-cc67-11eb-8d38-eb05ed03a463.png)