### PR TITLE
Use intermediate screen-sized buffer for direct_zoom

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -390,9 +390,9 @@ bool render_target::set_scale_factor(double fScale, scaled_items eWhatToScale) {
   } else if (eWhatToScale == scaled_items::all && direct_zoom) {
     global_scale_factor = fScale;
     if ((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN_DESKTOP) ==
-         SDL_WINDOW_FULLSCREEN_DESKTOP) {
-      // Drawing to an intermediate screen sized buffer when fullscreen results in
-      // noticeably better text rendering quality.
+        SDL_WINDOW_FULLSCREEN_DESKTOP) {
+      // Drawing to an intermediate screen sized buffer when fullscreen results
+      // in noticeably better text rendering quality.
       init_zoom_buffer(width, height);
     }
     return true;
@@ -593,11 +593,9 @@ bool render_target::should_scale_bitmaps(double* pFactor) {
 }
 
 bool render_target::init_zoom_buffer(int iWidth, int iHeight) {
-  if (!supports_target_textures)
-    return false;
-  zoom_texture =
-      SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ABGR8888,
-                        SDL_TEXTUREACCESS_TARGET, iWidth, iHeight);
+  if (!supports_target_textures) return false;
+  zoom_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ABGR8888,
+                                   SDL_TEXTUREACCESS_TARGET, iWidth, iHeight);
   SDL_RenderSetLogicalSize(renderer, iWidth, iHeight);
   if (SDL_SetRenderTarget(renderer, zoom_texture) != 0) {
     SDL_RenderSetLogicalSize(renderer, width, height);

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -389,10 +389,12 @@ bool render_target::set_scale_factor(double fScale, scaled_items eWhatToScale) {
     return false;
   } else if (eWhatToScale == scaled_items::all && direct_zoom) {
     global_scale_factor = fScale;
-    // Drawing to an intermediate buffer seems to support better blending than
-    // drawing directly to the screen resulting in noticeably better fullscreen
-    // text rendering.
-    init_zoom_buffer(width, height);
+    if ((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN_DESKTOP) ==
+         SDL_WINDOW_FULLSCREEN_DESKTOP) {
+      // Drawing to an intermediate screen sized buffer when fullscreen results in
+      // noticeably better text rendering quality.
+      init_zoom_buffer(width, height);
+    }
     return true;
   } else if (eWhatToScale == scaled_items::all && supports_target_textures) {
     // Draw everything from now until the next scale to zoom_texture

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -389,6 +389,9 @@ bool render_target::set_scale_factor(double fScale, scaled_items eWhatToScale) {
     return false;
   } else if (eWhatToScale == scaled_items::all && direct_zoom) {
     global_scale_factor = fScale;
+    // Drawing to an intermediate buffer seems to support better blending than
+    // drawing directly to the screen resulting in noticeably better fullscreen
+    // text rendering.
     init_zoom_buffer(width, height);
     return true;
   } else if (eWhatToScale == scaled_items::all && supports_target_textures) {

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -359,6 +359,7 @@ class render_target {
   bool apply_opengl_clip_fix;
   bool direct_zoom;
 
+  bool init_zoom_buffer(int iWidth, int iHeight);
   void flush_zoom_buffer();
 };
 


### PR DESCRIPTION
*In combination with #1931 this fixes #1930*

**Describe what the proposed change does**
- Initialize and use an intermediate screen sized buffer when in fullscreen.

Note that this still has the advantage over indirect zoom that the buffer will always be screen-sized, rather than growing larger as you zoom out so it should still should fix the original crash issue that direct_zoom fixed with hopefully full parity in render quality.

**Screenshot:**
![titlescreen-intermediate-buffer](https://user-images.githubusercontent.com/366761/121821520-921cf080-cc67-11eb-81eb-5d6e0be7e7a1.png)

