### PR TITLE
[Rdy] Training room speed adjustment

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -351,7 +351,7 @@ function Staff:updateSpeed()
     level = 3
   end
   local room = self:getRoom()
-  if room and room.room_info.id == "training" then
+  if room and room.room_info.id == "training" and self:fulfillsCriterion("Doctor") then
     level = 1
   elseif self.attributes["fatigue"] then
     if self.attributes["fatigue"] >= 0.8 then

--- a/CorsixTH/Lua/rooms/training.lua
+++ b/CorsixTH/Lua/rooms/training.lua
@@ -105,7 +105,7 @@ end
 function TrainingRoom:testStaffCriteria(criteria, extra_humanoid)
   if extra_humanoid and extra_humanoid.profile and
       extra_humanoid.profile.is_consultant and self.staff_member then
-    -- Training room can only have on consultant
+    -- Training room can only have one consultant
     return false
   end
   return Room.testStaffCriteria(self, criteria, extra_humanoid)


### PR DESCRIPTION
**Describe what the proposed change does**
- Allow handymen to move around at their regular speed in training rooms -- as per the original game.