### PR TITLE
Turn direct_zoom on by default.

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -157,7 +157,7 @@ function App:init()
   if self.config.track_fps then
     modes[#modes + 1] = "present immediate"
   end
-  if self.config.direct_zoom then
+  if self.config.direct_zoom == nil or self.config.direct_zoom then
     modes[#modes + 1] = "direct zoom"
   end
   self.modes = modes

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -141,7 +141,7 @@ local config_defaults = {
   check_for_updates = true,
   room_information_dialogs = true,
   allow_blocking_off_areas = false,
-  direct_zoom = false
+  direct_zoom = nil
 }
 
 fi = io.open(config_filename, "r")


### PR DESCRIPTION
Sets the default value of direct_zoom to nil which is now interpreted as being enabled. direct_zoom provides a significant rendering performance improvement and a reduction in crashes on low end systems. It also supports zooming on systems which don't support target textures.