### PR TITLE
Switch draw order of walls when north wall continues to next row.

### DIFF
--- a/CorsixTH/Src/th_map.h
+++ b/CorsixTH/Src/th_map.h
@@ -564,6 +564,7 @@ class map_scanline_iterator {
   inline int y() const { return y_relative_to_screen; }
   inline const map_tile* get_next_tile() { return tile + tile_step; }
   inline const map_tile* get_previous_tile() { return tile - tile_step; }
+  inline const map_tile* get_adjacent_tile() { return tile + 1; }
   map_scanline_iterator operator=(const map_scanline_iterator& iterator);
   inline const map_tile* get_tile() { return tile; }
 


### PR DESCRIPTION
This fixes #1953 by ensuring that the north wall face edge is drawn on
top of the next west wall face edge.

*Fixes #1953*

**Describe what the proposed change does**
- Removes right-to-left pass drawing of north walls, drawing all walls in left-to-right order as it is impossible for north walls to overlap each other in scan order so this right-to-left ordering should be unnecessary.
- When the north wall adjoins with a wall in the next row (i.e. map x + 1), draw the west wall from the next tile first, so that the north wall edge will be on top of it to seamlessly join with the next row.