### PR TITLE
Use SDL_RenderCopyF on SDL 2.0.10 and newer for better scaling

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -749,8 +749,8 @@ void render_target::draw(SDL_Texture* pTexture, const SDL_Rect* prcSrcRect,
   SDL_FRect scaledDstRect;
   getScaleRect(prcDstRect, global_scale_factor, &scaledDstRect);
   if (iSDLFlip != 0) {
-    SDL_RenderCopyExF(renderer, pTexture, prcSrcRect, &scaledDstRect, 0, nullptr,
-                     (SDL_RendererFlip)iSDLFlip);
+    SDL_RenderCopyExF(renderer, pTexture, prcSrcRect, &scaledDstRect, 0,
+                      nullptr, (SDL_RendererFlip)iSDLFlip);
   } else {
     SDL_RenderCopyF(renderer, pTexture, prcSrcRect, &scaledDstRect);
   }

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -37,6 +37,14 @@ SOFTWARE.
 
 #include "th_map.h"
 
+#if !SDL_VERSION_ATLEAST(2, 0, 10)
+// On older SDL versions, floating point rendering was not available so we fall
+// back to integer methods / types.
+#define SDL_FRect SDL_Rect
+#define SDL_RenderCopyF SDL_RenderCopy
+#define SDL_RenderCopyExF SDL_RenderCopyEx
+#endif
+
 full_colour_renderer::full_colour_renderer(int iWidth, int iHeight)
     : width(iWidth), height(iHeight) {
   x = 0;
@@ -119,32 +127,28 @@ void getEnclosingScaleRect(const SDL_Rect* rect, double scale_factor,
   dst_rect->y = dst_y;
 }
 
-#if SDL_VERSION_ATLEAST(2, 0, 10)
-
-// If using SDL 2.0.10 or newer, use SDL_FRect to get better precision on scaled
-// rendering.
+//! Get the scaled rect of an SDL_Rect scaled by the given scale factor.
+//  On SDL < 2.0.10 this falls back to using getEnclosingScaleRect.
+/*!
+    @param rect Pointer to the SDL_Rect to be scaled.
+    @param scale_factor Scale to be applied to the rectangle.
+    @param[out] dst_rect Enclosing SDL_FRect of rect scaled by scale_factor.
+ */
 void getScaleRect(const SDL_Rect* rect, double scale_factor,
                   SDL_FRect* dst_rect) {
+#if SDL_VERSION_ATLEAST(2, 0, 10)
+  // If using SDL 2.0.10 or newer, we can use floats to get better precision
+  // on scaled rendering.
   dst_rect->x = static_cast<float>(rect->x * scale_factor);
   dst_rect->y = static_cast<float>(rect->y * scale_factor);
   dst_rect->w = static_cast<float>(rect->w * scale_factor);
   dst_rect->h = static_cast<float>(rect->h * scale_factor);
-}
-
 #else
-
-// Prior to SDL 2.0.10, fallback to using the enclosing integer SDL_Rect for
-// scaled rendering.
-#define SDL_FRect SDL_Rect
-#define SDL_RenderCopyF SDL_RenderCopy
-#define SDL_RenderCopyExF SDL_RenderCopyEx
-
-void getScaleRect(const SDL_Rect* rect, double scale_factor,
-                  SDL_Rect* dst_rect) {
+  // Prior to SDL 2.0.10, fallback to using the enclosing integer SDL_Rect for
+  // scaled rendering.
   getEnclosingScaleRect(rect, scale_factor, dst_rect);
-}
-
 #endif
+}
 
 }  // namespace
 


### PR DESCRIPTION
*Fixes #1953*

**Describe what the proposed change does**
- When using SDL 2.0.10 or newer, uses SDL_FRect and SDL_RenderCopyF to improve scaling precision.
- When using SDL 2.0.9 or older, uses SDL_Rect and the enclosing integer SDL_Rect for compatibility.