### PR TITLE
Implement jelly rendering effect.

### DIFF
--- a/CorsixTH/Lua/utility.lua
+++ b/CorsixTH/Lua/utility.lua
@@ -220,7 +220,7 @@ DrawFlags.Crop            = 2^13
 AnimationEffect = {}
 AnimationEffect.None = 0
 AnimationEffect.Glowing = 1
-AnimationEffect.Jelly = 2 -- Not yet fully implemented
+AnimationEffect.Jelly = 2
 
 -- Compare values of two simple (non-nested) tables
 function compare_tables(t1, t2)


### PR DESCRIPTION
*Fixes #1946 *

**Describe what the proposed change does**
- Implements a rendering of the jellyitus effect by splitting the drawing of sprites up into multiple slices which are each offset horizontally by an animating sine wave.