### PR TITLE
Make jellyitus effect intermittent.

### DIFF
--- a/CorsixTH/Lua/diseases/jellyitis.lua
+++ b/CorsixTH/Lua/diseases/jellyitis.lua
@@ -45,7 +45,6 @@ disease.initPatient = function(patient)
   patient:setLayer(3, 0)
   patient:setLayer(4, 0)
 end
--- TODO: visual jelly effect should be applied from time to time while walking
 
 -- Diagnosis rooms are the rooms other than the GPs office which can be visited
 -- to aid in diagnosis. The need not be visited, and if they are visited, the

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -342,7 +342,8 @@ class animation_manager {
   */
   void draw_frame(render_target* pCanvas, size_t iFrame,
                   const ::layers& oLayers, int iX, int iY, uint32_t iFlags,
-                  animation_effect effect = animation_effect::none) const;
+                  animation_effect patient_effect = animation_effect::none,
+                  size_t patient_effect_offset = 0) const;
 
   void get_frame_extent(size_t iFrame, const ::layers& oLayers, int* pMinX,
                         int* pMaxX, int* pMinY, int* pMaxY,
@@ -605,6 +606,9 @@ class animation : public animation_base {
   size_t sound_to_play;
   int crop_column;
   animation_effect patient_effect;
+  //! Number of game_ticks to offset animation by so they aren't all
+  //! running in sync.
+  size_t patient_effect_offset;
 };
 
 class sprite_render_list : public animation_base {

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -1071,7 +1071,7 @@ bool sprite_sheet::get_sprite_average_colour(size_t iSprite,
 }
 
 void sprite_sheet::draw_sprite(render_target* pCanvas, size_t iSprite, int iX,
-                               int iY, uint32_t iFlags, size_t game_ticks,
+                               int iY, uint32_t iFlags, size_t effect_ticks,
                                animation_effect effect) {
   if (iSprite >= sprite_count || pCanvas == nullptr || pCanvas != target)
     return;
@@ -1101,14 +1101,15 @@ void sprite_sheet::draw_sprite(render_target* pCanvas, size_t iSprite, int iX,
     // Use the target cycle length (15 cycles) to calculate the angle from 0 to
     // 2*pi.
     int currentVariation = static_cast<int>(
-        sin(static_cast<double>(game_ticks % 15) / 15.0 * 2 * pi) * 50);
+        sin(static_cast<double>(effect_ticks % 15) / 15.0 * 2 * pi) * 50);
     int err = SDL_SetTextureColorMod(pTexture, 0, 205 + currentVariation, 0);
     if (err < 0) {
       throw std::runtime_error(SDL_GetError());
     }
   }
 
-  if (effect == animation_effect::jelly) {
+  // TODO: Adjust jelly frequency and duration.
+  if (effect == animation_effect::jelly && effect_ticks % 200 < 30) {
     // Draw the sprite a few lines at a time following a sine wave x offset.
     // To cut down on the number of draw calls, we will draw all of the lines
     // that have the same x offset in a single draw call. This results in about
@@ -1123,7 +1124,7 @@ void sprite_sheet::draw_sprite(render_target* pCanvas, size_t iSprite, int iX,
       // at the same vertical line. We can't just use iY because it varies as
       // the user scrolls or zooms or the character walks.
       int offset = static_cast<int>(
-          sin((y2 / 14.0 + static_cast<double>(game_ticks % 30) / 30) * 2 *
+          sin((y2 / 14.0 + static_cast<double>(effect_ticks % 30) / 30) * 2 *
               pi) *
           2);
       if (x_offset != offset || y2 == sprite.height) {

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -47,13 +47,13 @@ full_colour_renderer::full_colour_renderer(int iWidth, int iHeight)
 
 namespace {
 
-const double pi = 3.14159265358979323846;
+constexpr double pi = 3.14159265358979323846;
 
 //! The number of game ticks between jelly the jelly effect activating.
-const int jelly_effect_period = 540;
+constexpr int jelly_effect_period = 540;
 
 //! The number of game ticks the jelly effect is active for when it runs.
-const int jelly_effect_duration = 90;
+constexpr int jelly_effect_duration = 90;
 
 //! Convert a colour to an equivalent grey scale level.
 /*!

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -50,10 +50,10 @@ namespace {
 const double pi = 3.14159265358979323846;
 
 //! The number of game ticks between jelly the jelly effect activating.
-const int jelly_effect_period = 360;
+const int jelly_effect_period = 540;
 
 //! The number of game ticks the jelly effect is active for when it runs.
-const int jelly_effect_duration = 60;
+const int jelly_effect_duration = 90;
 
 //! Convert a colour to an equivalent grey scale level.
 /*!

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -529,7 +529,7 @@ class sprite_sheet {
       @param iFlags Flags to apply for drawing.
   */
   void draw_sprite(render_target* pCanvas, size_t iSprite, int iX, int iY,
-                   uint32_t iFlags, size_t game_ticks = 0u,
+                   uint32_t iFlags, size_t effect_ticks = 0u,
                    animation_effect effect = animation_effect::none);
 
   //! Test whether a sprite was hit.


### PR DESCRIPTION
**Describe what the proposed change does**
- Adds an effect offset per animation so that patient effects are not in sync.
- Only applies jellyitus for the first M out of every N frames.