### PR TITLE
[RDY] Stop cheat menu slide

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/cheats_dialog.lua
+++ b/CorsixTH/Lua/dialogs/resizables/cheats_dialog.lua
@@ -70,7 +70,7 @@ function UICheats:UICheats(ui)
   self.modal_class = "cheats"
   self.esc_closes = true
   self.resizable = false
-  self:setDefaultPosition(0.2, 0.4)
+  --self:setDefaultPosition(0.2, 0.4)
 
   local y = 10
   self:addBevelPanel(20, y, 260, 20, col_caption):setLabel(_S.cheats_window.caption)
@@ -106,6 +106,8 @@ function UICheats:UICheats(ui)
 
   y = y + 60
   self:setSize(300, y)
+  -- Position should be set after all panels/buttons are made
+  self:setDefaultPosition(0.2, 0.4)
   self:updateCheatedStatus()
 end
 

--- a/CorsixTH/Lua/dialogs/resizables/cheats_dialog.lua
+++ b/CorsixTH/Lua/dialogs/resizables/cheats_dialog.lua
@@ -70,7 +70,6 @@ function UICheats:UICheats(ui)
   self.modal_class = "cheats"
   self.esc_closes = true
   self.resizable = false
-  --self:setDefaultPosition(0.2, 0.4)
 
   local y = 10
   self:addBevelPanel(20, y, 260, 20, col_caption):setLabel(_S.cheats_window.caption)


### PR DESCRIPTION
*Fixes #1647*

**Describe what the proposed change does**
- Moves the time we call ``setDefaultPosition`` on UICheats to account for dynamically added panels and buttons.
- This means that the window will always stay on screen when it recalls previous position.
