### PR TITLE
[RDY] Move advisor check on raise request

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -547,6 +547,7 @@ end
 
 -- Makes the staff member request a raise of 10%, or a wage exactly in the middle of their current and a fair one, whichever is more.
 function Staff:requestRaise()
+  assert(self.hospital, "A staff member asked for a pay rise who doesn't belong to a hospital!")
   -- Check whether there is already a request for raise.
   if not self:isMoodActive("pay_rise") then
     local amount = math.floor(math.max(self.profile.wage * 1.1, (self.profile:getFairWage() + self.profile.wage) / 2) - self.profile.wage)
@@ -555,13 +556,8 @@ function Staff:requestRaise()
       self.timer_until_raise = nil
       return -- too timid
     end
-  -- They fought their timidness, time to put the raise in motion!
-  -- Is this the first time a member of staff is requesting a raise?
-  -- Only show the help if the player is playing the campaign though
-  if self.hospital and not self.hospital.has_seen_pay_rise and tonumber(self.world.map.level_number) then
-    self.world.ui.adviser:say(_A.information.pay_rise)
-    self.hospital.has_seen_pay_rise = true
-  end
+    -- The staff member can now successfully ask for a raise
+    self.hospital:adviseRaiseRequest()
     self.quitting_in = 25*30 -- Time until the staff members quits anyway
     self:setMood("pay_rise", "activate")
     self.world.ui.bottom_panel:queueMessage("strike", amount, self)

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -547,20 +547,21 @@ end
 
 -- Makes the staff member request a raise of 10%, or a wage exactly in the middle of their current and a fair one, whichever is more.
 function Staff:requestRaise()
-  -- Is this the first time a member of staff is requesting a raise?
-  -- Only show the help if the player is playing the campaign though
-  if self.hospital and not self.hospital.has_seen_pay_rise and tonumber(self.world.map.level_number) then
-    self.world.ui.adviser:say(_A.information.pay_rise)
-    self.hospital.has_seen_pay_rise = true
-  end
   -- Check whether there is already a request for raise.
   if not self:isMoodActive("pay_rise") then
     local amount = math.floor(math.max(self.profile.wage * 1.1, (self.profile:getFairWage() + self.profile.wage) / 2) - self.profile.wage)
     -- At least for now, staff are timid, and only ask for raises 1/5th of the time
     if math.random(1, 5) ~= 1 or amount <= 0 then
       self.timer_until_raise = nil
-      return
+      return -- too timid
     end
+  -- They fought their timidness, time to put the raise in motion!
+  -- Is this the first time a member of staff is requesting a raise?
+  -- Only show the help if the player is playing the campaign though
+  if self.hospital and not self.hospital.has_seen_pay_rise and tonumber(self.world.map.level_number) then
+    self.world.ui.adviser:say(_A.information.pay_rise)
+    self.hospital.has_seen_pay_rise = true
+  end
     self.quitting_in = 25*30 -- Time until the staff members quits anyway
     self:setMood("pay_rise", "activate")
     self.world.ui.bottom_panel:queueMessage("strike", amount, self)

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -557,10 +557,9 @@ function Staff:requestRaise()
       return -- too timid
     end
     -- The staff member can now successfully ask for a raise
-    self.hospital:adviseRaiseRequest()
+    self.hospital:makeRaiseRequest(amount, self)
     self.quitting_in = 25*30 -- Time until the staff members quits anyway
     self:setMood("pay_rise", "activate")
-    self.world.ui.bottom_panel:queueMessage("strike", amount, self)
   end
 end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2441,3 +2441,7 @@ function Hospital:getRandomBusyRoom()
   local chosen_room = long_queue_rooms[math.random(1, #long_queue_rooms)]
   if #chosen_room.door.queue >= busy_threshold then return chosen_room end
 end
+
+function:Hospital:makeRaiseRequest()
+  -- Nothing to do, override in a derived class.
+end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2442,6 +2442,6 @@ function Hospital:getRandomBusyRoom()
   if #chosen_room.door.queue >= busy_threshold then return chosen_room end
 end
 
-function:Hospital:makeRaiseRequest()
+function Hospital:makeRaiseRequest()
   -- Nothing to do, override in a derived class.
 end

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -409,6 +409,16 @@ function PlayerHospital:advisePriceLevelImpact(judgment, name)
   self.world.ui.adviser:say(message)
 end
 
+--! Show advice if it is the first time the player has experienced
+--! a staff member requesting a raise.
+--! Only show the help if the player is playing the campaign.
+function PlayerHospital:adviseRaiseRequest()
+  if self.has_seen_pay_rise and tonumber(self.world.map.level_number) then
+    self.world.ui.adviser:say(_A.information.pay_rise)
+    self.has_seen_pay_rise = true
+  end
+end
+
 function PlayerHospital:afterLoad(old, new)
   if old < 145 then
     self.hosp_cheats = Cheats(self)

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -438,7 +438,7 @@ function PlayerHospital:makeRaiseRequest(amount, staff)
   -- Show advice if it is the first time the player has experienced
   -- a staff member requesting a raise.
   -- Only show the help if the player is playing the campaign.
-  if self.has_seen_pay_rise and tonumber(self.world.map.level_number) then
+  if not self.has_seen_pay_rise and tonumber(self.world.map.level_number) then
     self.world.ui.adviser:say(_A.information.pay_rise)
     self.has_seen_pay_rise = true
   end

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -409,14 +409,18 @@ function PlayerHospital:advisePriceLevelImpact(judgment, name)
   self.world.ui.adviser:say(message)
 end
 
---! Show advice if it is the first time the player has experienced
---! a staff member requesting a raise.
---! Only show the help if the player is playing the campaign.
-function PlayerHospital:adviseRaiseRequest()
+--! Makes the raise request for a staff member
+--!param amount (num) the requested raise increase
+--!param staff (table) the staff member
+function PlayerHospital:makeRaiseRequest(amount, staff)
+  -- Show advice if it is the first time the player has experienced
+  -- a staff member requesting a raise.
+  -- Only show the help if the player is playing the campaign.
   if self.has_seen_pay_rise and tonumber(self.world.map.level_number) then
     self.world.ui.adviser:say(_A.information.pay_rise)
     self.has_seen_pay_rise = true
   end
+  self.world.ui.bottom_panel:queueMessage("strike", amount, staff)
 end
 
 function PlayerHospital:afterLoad(old, new)


### PR DESCRIPTION
**Describe what the proposed change does**
- The adviser message for a staff member threatening to resign could occur without the staff member actually making a raise request
- Moves it below the "timidness" check so it will now only execute if they are successful.
