### PR TITLE
Make disease discovery advice local player only

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2434,3 +2434,7 @@ function Hospital:getRandomBusyRoom()
   local chosen_room = long_queue_rooms[math.random(1, #long_queue_rooms)]
   if #chosen_room.door.queue >= busy_threshold then return chosen_room end
 end
+
+function Hospital:adviseDiscoverDisease()
+  -- Nothing to do, override in a derived class.
+end

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -355,6 +355,26 @@ function PlayerHospital:warnForLongQueues()
   end
 end
 
+function PlayerHospital:adviseDiscoverDisease(disease)
+ -- Generate a message about the discovery
+  local message = {
+    {text = _S.fax.disease_discovered.discovered_name:format(disease.name)},
+    {text = disease.cause, offset = 12},
+    {text = disease.symptoms, offset = 12},
+    {text = disease.cure, offset = 12},
+    choices = {
+      {text = _S.fax.disease_discovered.close_text, choice = "close"},
+    },
+  }
+  self.world.ui.bottom_panel:queueMessage("disease", message, nil, 25*24, 1)
+
+  -- If the drug casebook is open, update it.
+  local window = self.world.ui:getWindow(UICasebook)
+  if window then
+    window:updateDiseaseList()
+  end
+end
+
 --! Called at the end of each day.
 function PlayerHospital:onEndDay()
   -- Advise the player.

--- a/CorsixTH/Lua/research_department.lua
+++ b/CorsixTH/Lua/research_department.lua
@@ -548,25 +548,10 @@ end
 !param disease The disease to discover, a table from world.available_diseases
 --]]
 function ResearchDepartment:discoverDisease(disease)
-  -- Generate a message about the discovery
-  local message = {
-    {text = _S.fax.disease_discovered.discovered_name:format(disease.name)},
-    {text = disease.cause, offset = 12},
-    {text = disease.symptoms, offset = 12},
-    {text = disease.cure, offset = 12},
-    choices = {
-      {text = _S.fax.disease_discovered.close_text, choice = "close"},
-    },
-  }
-  self.world.ui.bottom_panel:queueMessage("disease", message, nil, 25*24, 1)
   self.hospital.disease_casebook[disease.id].discovered = true
   local index = #self.hospital.discovered_diseases + 1
   self.hospital.discovered_diseases[index] = disease.id
-  -- If the drug casebook is open, update it.
-  local window = self.world.ui:getWindow(UICasebook)
-  if window then
-    window:updateDiseaseList()
-  end
+  self.hospital:adviseDiscoverDisease(disease)
 
   -- It may now be possible to continue researching drug improvements
   local casebook_disease = self.hospital.disease_casebook[disease.id]


### PR DESCRIPTION
**Describe what the proposed change does**
- Disease discovery fax and casebook updates are local player only.
