### PR TITLE
[RDY] Fullscreen Hotkey updates options button

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -292,12 +292,17 @@ function UIOptions:selectResolution(number)
   end
 end
 
-function UIOptions:buttonFullscreen(checked)
-  if not self.ui:toggleFullscreen() then
+function UIOptions:buttonFullscreen()
+  if not self.ui:toggleFullscreen(true) then
       local err = {_S.errors.unavailable_screen_size}
       self.ui:addWindow(UIInformation(self.ui, err))
       self.fullscreen_button:toggle()
   end
+  self.fullscreen_panel:setLabel(self.ui.app.fullscreen and _S.options_window.option_on or _S.options_window.option_off)
+end
+
+function UIOptions:updateFSButtonOnHotkey()
+  self.fullscreen_button:toggle()
   self.fullscreen_panel:setLabel(self.ui.app.fullscreen and _S.options_window.option_on or _S.options_window.option_off)
 end
 

--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -293,16 +293,11 @@ function UIOptions:selectResolution(number)
 end
 
 function UIOptions:buttonFullscreen()
-  if not self.ui:toggleFullscreen(true) then
+  if not self.ui:toggleFullscreen() then
       local err = {_S.errors.unavailable_screen_size}
       self.ui:addWindow(UIInformation(self.ui, err))
       self.fullscreen_button:toggle()
   end
-  self.fullscreen_panel:setLabel(self.ui.app.fullscreen and _S.options_window.option_on or _S.options_window.option_off)
-end
-
-function UIOptions:updateFSButtonOnHotkey()
-  self.fullscreen_button:toggle()
   self.fullscreen_panel:setLabel(self.ui.app.fullscreen and _S.options_window.option_on or _S.options_window.option_off)
 end
 

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -673,7 +673,10 @@ function UI:releaseMouse()
   self:setMouseReleased(true)
 end
 
-function UI:toggleFullscreen()
+--! Turns fullscreen on and off
+--!param from_uioptions (bool) indicate the call came from UIOptions, nil otherwise
+--!return success true if toggle succeeded
+function UI:toggleFullscreen(from_uioptions)
   local modes = self.app.modes
 
   local function toggleMode(index)
@@ -720,6 +723,11 @@ function UI:toggleFullscreen()
     -- Save new setting in config
     self.app.config.fullscreen = self.app.fullscreen
     self.app:saveConfig()
+    -- If options window is open, make sure the button updates on hotkey
+    if not from_uioptions and self:getWindow(UIOptions) then
+      local window = self:getWindow(UIOptions)
+      window:updateFSButtonOnHotkey()
+    end
   end
 
   return success


### PR DESCRIPTION
*Fixes #1955*

**Describe what the proposed change does**
- When using the fullscreen hotkey, the fullscreen button will now update if the Options menu was option.
- The solution feels a little janky, but happy to accept other ideas.
