### PR TITLE
Create scoped class for temporary allocation and commit of textures.

### DIFF
--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1749,6 +1749,7 @@ void sprite_render_list::draw(render_target* pCanvas, int iDestX, int iDestY) {
   iDestY += y_relative_to_tile;
   sprite* pLast = sprites + sprite_count;
 
+  std::unique_ptr<render_target::scoped_buffer> intermediate_buffer;
   if (use_intermediate_buffer) {
     int minX = INT_MAX, minY = INT_MAX, maxX = INT_MIN, maxY = INT_MIN;
     for (sprite* pSprite = sprites; pSprite != pLast; ++pSprite) {
@@ -1762,14 +1763,14 @@ void sprite_render_list::draw(render_target* pCanvas, int iDestX, int iDestY) {
       maxX = std::max(maxX, spriteX + spriteWidth);
       maxY = std::max(maxY, spriteY + spriteHeight);
     }
-    pCanvas->begin_intermediate_drawing(minX, minY, maxX - minX, maxY - minY);
+    intermediate_buffer = pCanvas->begin_intermediate_drawing(
+        minX, minY, maxX - minX, maxY - minY);
   }
 
   for (sprite* pSprite = sprites; pSprite != pLast; ++pSprite) {
     sheet->draw_sprite(pCanvas, pSprite->index, iDestX + pSprite->x,
                        iDestY + pSprite->y, flags);
   }
-  pCanvas->finish_intermediate_drawing();
 }
 
 bool sprite_render_list::hit_test(int iDestX, int iDestY, int iTestX,

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -492,8 +492,9 @@ bool render_target::set_scale_factor(double fScale, scaled_items eWhatToScale) {
         SDL_WINDOW_FULLSCREEN_DESKTOP) {
       // Drawing to an intermediate screen sized buffer when fullscreen results
       // in noticeably better text rendering quality.
-      zoom_buffer.reset(new scoped_target_texture(this, 0, 0, width, height,
-                                                  /* bScale = */ true));
+      zoom_buffer =
+          std::make_unique<scoped_target_texture>(this, 0, 0, width, height,
+                                                  /* bScale = */ true);
     }
     return true;
   } else if (eWhatToScale == scaled_items::all && supports_target_textures) {
@@ -503,8 +504,8 @@ bool render_target::set_scale_factor(double fScale, scaled_items eWhatToScale) {
     int virtWidth = static_cast<int>(width / fScale);
     int virtHeight = static_cast<int>(height / fScale);
 
-    zoom_buffer.reset(new scoped_target_texture(
-        this, 0, 0, virtWidth, virtHeight, /* bScale = */ false));
+    zoom_buffer = std::make_unique<scoped_target_texture>(
+        this, 0, 0, virtWidth, virtHeight, /* bScale = */ false);
     if (!zoom_buffer->is_target()) {
       global_scale_factor = 1.0;
       std::cout << "Warning: Could not render to zoom texture - "

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -27,6 +27,7 @@ SOFTWARE.
 
 #include <SDL.h>
 
+#include <memory>
 #include <stdexcept>
 
 #include "persist_lua.h"
@@ -319,6 +320,11 @@ class render_target {
   // to the other rendering engines.
 
  public:  // Internal (this rendering engine only) API
+  class scoped_buffer {
+   public:
+    virtual ~scoped_buffer() = default;
+  };
+
   SDL_Renderer* get_renderer() const { return renderer; }
 
   //! Should bitmaps be scaled?
@@ -340,26 +346,28 @@ class render_target {
   void draw_line(line_sequence* pLine, int iX, int iY);
 
   //! Begin drawing to an intermediate unscaled texture targeting the given
-  //! location and size. Any drawing outside of this rectangle may be cropped.
-  //! Call finish_intermediate_drawing once all draw calls are complete.
+  //! location and size. The intermediate drawing will be committed once
+  //! the returned scoped_buffer is destroyed.
   /*!
       @param iX X-coordinate of left side of drawing rectangle.
       @param iY Y-coordinate of top side of drawing rectangle.
       @param iWidth Width of drawing rectangle.
       @param iHeight Height of drawing rectangle.
    */
-  void begin_intermediate_drawing(int iX, int iY, int iWidth, int iHeight);
-
-  //! Copies the intermediate drawing which was started with a call to
-  //! begin_intermediate_drawing to the screen at the current scale factor.
-  void finish_intermediate_drawing();
+  std::unique_ptr<scoped_buffer> begin_intermediate_drawing(int iX, int iY,
+                                                            int iWidth,
+                                                            int iHeight);
 
  private:
+  class scoped_target_texture;
+  friend class scoped_target_texture;
+
+  double draw_scale();
+
   SDL_Window* window;
   SDL_Renderer* renderer;
-  SDL_Texture* zoom_texture;
-  SDL_Texture* intermediate_texture;
-  SDL_Rect intermediate_texture_location;
+  scoped_target_texture* current_target = nullptr;
+  std::unique_ptr<scoped_target_texture> zoom_buffer;
   SDL_PixelFormat* pixel_format;
   bool blue_filter_active;
   cursor* game_cursor;
@@ -377,10 +385,6 @@ class render_target {
   // see: https://bugzilla.libsdl.org/show_bug.cgi?id=2700
   bool apply_opengl_clip_fix;
   bool direct_zoom;
-
-  bool init_buffer(SDL_Texture** texture, int iWidth, int iHeight);
-  void flush_buffer(SDL_Texture** texture, SDL_Texture* target = nullptr,
-                    const SDL_Rect* dstRect = nullptr);
 };
 
 //! Stored image.

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -362,7 +362,7 @@ class render_target {
   class scoped_target_texture;
   friend class scoped_target_texture;
 
-  double draw_scale();
+  double draw_scale() const;
 
   SDL_Window* window;
   SDL_Renderer* renderer;


### PR DESCRIPTION
**Describe what the proposed change does**
- Creates a scoped target texture class to replace required explicit begin / finish and init / flush function calls.
- Uses this class for both the zoom buffer and intermediate draw buffer.
- Remove obsolete methods replaced by class constructor / destructor.