### PR TITLE
Use the watch to show tutorial progress and ability to skip

### DIFF
--- a/CorsixTH/Lua/dialogs/adviser.lua
+++ b/CorsixTH/Lua/dialogs/adviser.lua
@@ -123,6 +123,7 @@ function UIAdviser:hide()
   self.th:setAnimation(self.ui.app.world.anims, 440)
   self.frame = 1
   self.number_frames = 4
+  self.ui:tutorialStep(1, 1, 2)
 end
 
 -- Makes the adviser say something

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -621,7 +621,7 @@ function UIBottomPanel:dialogFurnishCorridor()
       local dlg = UIFurnishCorridor(self.ui)
       self.ui:setEditRoom(false)
       self.ui:addWindow(dlg)
-      self.ui:tutorialStep(1, 1, 2)
+      self.ui:tutorialStep(1, 2, 3)
     end
   end
 end

--- a/CorsixTH/Lua/dialogs/furnish_corridor.lua
+++ b/CorsixTH/Lua/dialogs/furnish_corridor.lua
@@ -146,9 +146,9 @@ function UIFurnishCorridor:purchaseItem(index, quantity)
     self.total_price = self.total_price + quantity * hospital:getObjectBuildCost(o.object.id)
     if o.object.id == "reception_desk" then
       if o.qty > 0 then
-        self.ui:tutorialStep(1, 2, 3)
+        self.ui:tutorialStep(1, 3, 4)
       else
-        self.ui:tutorialStep(1, 3, 2)
+        self.ui:tutorialStep(1, 4, 3)
       end
     end
   else
@@ -158,7 +158,7 @@ function UIFurnishCorridor:purchaseItem(index, quantity)
 end
 
 function UIFurnishCorridor:confirm()
-  self.ui:tutorialStep(1, 3, 4)
+  self.ui:tutorialStep(1, 4, 5)
 
   local to_purchase = {}
   local to_sell = {}
@@ -189,7 +189,7 @@ function UIFurnishCorridor:confirm()
 end
 
 function UIFurnishCorridor:close()
-  self.ui:tutorialStep(1, {2, 3}, 1)
+  self.ui:tutorialStep(1, {3, 4}, 2)
   if self.edit_dialog then
     self.edit_dialog:addObjects() -- No objects added. Call the function anyway to handle visibility etc.
   end

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -308,7 +308,7 @@ function UIPlaceObjects:removeObjects(object_list, refund)
 end
 
 function UIPlaceObjects:close()
-  self.ui:tutorialStep(1, {4, 5}, 1)
+  self.ui:tutorialStep(1, {5, 6}, 2)
   self:removeAllObjects(true)
   self:clearBlueprint()
   self.ui:setWorldHitTest(true)
@@ -327,9 +327,9 @@ function UIPlaceObjects:setActiveIndex(index)
 
   local object = self.objects[self.active_index].object
   if object.id == "reception_desk" then
-    self.ui:tutorialStep(1, 6, 4)
+    self.ui:tutorialStep(1, 7, 5)
   else
-    self.ui:tutorialStep(1, {4, 5}, 6)
+    self.ui:tutorialStep(1, {5, 6}, 7)
   end
   local anims = self.anims
   local grey_scale = anims.Alt32_GreyScale
@@ -483,7 +483,7 @@ function UIPlaceObjects:placeObject(dont_close_if_empty)
   end
 
   local object = self.objects[self.active_index]
-  if object.object.id == "reception_desk" then self.ui:tutorialStep(1, 4, "next") end
+  if object.object.id == "reception_desk" then self.ui:tutorialStep(1, {2, 5}, "next") end
 
   local real_obj
   -- There might be an existing object that has been picked up.

--- a/CorsixTH/Lua/dialogs/watch.lua
+++ b/CorsixTH/Lua/dialogs/watch.lua
@@ -40,6 +40,9 @@ function UIWatch:UIWatch(ui, count_type)
   if count_type == "emergency" then
     self.tick_rate = math.floor((TICK_DAYS_EMERGENCY * Date.hoursPerDay()) / TIMER_SEGMENTS)
     self.tick_timer = self.tick_rate
+  elseif count_type == "tutorial" then
+    self.tick_rate = 0
+    self.tick_timer = 0
   else
     self.tick_rate = math.floor((TICK_DAYS * Date.hoursPerDay()) / TIMER_SEGMENTS)
     self.tick_timer = self.tick_rate  -- Initialize tick timer
@@ -64,6 +67,7 @@ function UIWatch:UIWatch(ui, count_type)
     ["initial_opening"] = _S.tooltip.watch.hospital_opening,
     ["emergency"]       = _S.tooltip.watch.emergency,
     ["epidemic"]        = _S.tooltip.watch.epidemic,
+    ["tutorial"]        = _S.tooltip.watch.tutorial,
   }
 
   if count_type == "epidemic" then
@@ -88,6 +92,14 @@ function UIWatch:UIWatch(ui, count_type)
   self:addPanel(1, 2, 47)
 end
 
+--! Manually set the watch position
+--!param num (int) Numerator
+--!param den (int) Denominator of the fraction the watch is set to
+function UIWatch:setWatch(num, den)
+  local new_position = num / den * TIMER_SEGMENTS
+  self.panels[#self.panels].sprite_index = math.ceil(new_position)
+end
+
 function UIWatch:onCountdownEnd()
   self:close()
   if self.count_type == "emergency" then
@@ -103,10 +115,13 @@ function UIWatch:onCountdownEnd()
   elseif self.count_type == "initial_opening" then
     self.ui.hospital.opened = true
     self.ui:playSound("fanfare.wav")
+  elseif self.count_type == "tutorial" then
+    self.ui:tutorialStep("end")
   end
 end
 
 function UIWatch:onWorldTick()
+  if self.count_type == "tutorial" then return end
   if self.tick_timer == 0 and self.open_timer >= 0 then -- Used for making a smooth animation
     self.tick_timer = self.tick_rate
     self.open_timer = self.open_timer - 1

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -1080,7 +1080,8 @@ tutorial_phases = {
 }
 end
 
-local TUTORIAL_LENGTH = 32 -- Does not count phase 5
+local TUTORIAL_LENGTH = 35 -- Does not count phase 5
+local TUTORIAL_CHAPTER_PROGRESS = { 0, 7, 14, 30 }
 
 tutorial_phases = setmetatable({}, {__index = function(t, k)
   make_tutorial_phases()
@@ -1136,7 +1137,7 @@ function GameUI:tutorialStep(chapter, phase_from, phase_to, ...)
   end
   local timer = self:getWindow(UIWatch)
   if timer and timer.count_type == "tutorial" then
-    self.tutorial_progress = self.tutorial_progress + 1
+    self.tutorial_progress = math.max(self.tutorial_progress + 1, TUTORIAL_CHAPTER_PROGRESS[chapter])
     timer:setWatch(self.tutorial_progress, TUTORIAL_LENGTH)
   end
 

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -963,19 +963,20 @@ local tutorial_phases
 local function make_tutorial_phases()
 tutorial_phases = {
   {
+    _A.tutorial.start,                                 -- 1
     -- 1) build reception
-    { text = _A.tutorial.build_reception,              -- 1
+    { text = _A.tutorial.build_reception,              -- 2
       begin_callback = function() TheApp.ui:getWindow(UIBottomPanel):startButtonBlinking(3) end,
       end_callback = function() TheApp.ui:getWindow(UIBottomPanel):stopButtonBlinking() end, },
-    { text = _A.tutorial.order_one_reception,          -- 2
+    { text = _A.tutorial.order_one_reception,          -- 3
       begin_callback = function() TheApp.ui:getWindow(UIFurnishCorridor):startButtonBlinking(3) end,
       end_callback = function() TheApp.ui:getWindow(UIFurnishCorridor):stopButtonBlinking(3) end, },
-    { text = _A.tutorial.accept_purchase,              -- 3
+    { text = _A.tutorial.accept_purchase,              -- 4
       begin_callback = function() TheApp.ui:getWindow(UIFurnishCorridor):startButtonBlinking(2) end,
       end_callback = function() TheApp.ui:getWindow(UIFurnishCorridor):stopButtonBlinking(2) end, },
-    _A.tutorial.rotate_and_place_reception,            -- 4
-    _A.tutorial.reception_invalid_position,            -- 5
-                                                       -- 6: object other than reception selected. currently no text for this phase.
+    _A.tutorial.rotate_and_place_reception,            -- 5
+    _A.tutorial.reception_invalid_position,            -- 6
+                                                       -- 7: object other than reception selected. currently no text for this phase.
   },
 
   {

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -1137,8 +1137,9 @@ function GameUI:tutorialStep(chapter, phase_from, phase_to, ...)
   end
   local timer = self:getWindow(UIWatch)
   if timer and timer.count_type == "tutorial" then
-    self.tutorial_progress = math.max(self.tutorial_progress + 1, TUTORIAL_CHAPTER_PROGRESS[chapter])
-    timer:setWatch(self.tutorial_progress, TUTORIAL_LENGTH)
+    local step = TUTORIAL_CHAPTER_PROGRESS[chapter] + self.tutorial.phase - 1
+    if step > self.tutorial_progress then self.tutorial_progress = step end
+    timer:setWatch(self.tutorial_progress / TUTORIAL_LENGTH)
   end
 
   if TheApp.config.debug then print("Tutorial: Now in " .. self.tutorial.chapter .. ", " .. self.tutorial.phase) end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1307,7 +1307,8 @@ end
  appropriate epidemic if so.
  @param patient (Patient) patient to determine if contagious]]
 function Hospital:determineIfContagious(patient)
-  if patient.is_emergency or not patient.disease.contagious then
+  if patient.is_emergency or not patient.disease.contagious or
+      self.world.ui:getWindow(UIWatch) then
     return false
   end
   -- ContRate treated like a percentage with ContRate% of patients with

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -130,6 +130,8 @@ tooltip.casebook.cure_type.unknown = "You do not yet know how to treat this dise
 tooltip.research_policy.no_research = "No research is being carried out in this category at the moment"
 tooltip.research_policy.research_progress = "Progress towards the next discovery in this category: %1%/%2%"
 
+tooltip.watch.tutorial = "Quit tutorial"
+
 menu["player_count"] = "PLAYER COUNT"
 
 menu_file = {

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -263,6 +263,9 @@ adviser = {
     roujin_on_cheat = "Roujin's challenge activated! Good luck in the coming months...",
     roujin_off_cheat = "Roujin's challenge deactivated. Everything will be back to normal soon.",
   },
+  tutorial = {
+    start = "Welcome to the tutorial. Click me or my speech bubble to move to the next step. Click the button above the watch to leave the tutorial.",
+  },
 }
 
 dynamic_info.patient.actions.no_gp_available = "Waiting for you to build a GP's office"

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1031,9 +1031,13 @@ function World:onTick()
         print("Error while autosaving game: " .. err)
       end
     end
-    if self.game_date == Date() and not self.ui.start_tutorial then
-      self.ui:addWindow(UIWatch(self.ui, "initial_opening"))
-      self.ui:showBriefing()
+    if self.game_date == Date() then
+      if self.ui.start_tutorial then
+        self.ui:addWindow(UIWatch(self.ui, "tutorial"))
+      else
+        self.ui:addWindow(UIWatch(self.ui, "initial_opening"))
+        self.ui:showBriefing()
+      end
     end
     self.tick_timer = self.tick_rate
 


### PR DESCRIPTION
*I believe this would fix #1828*

**Describe what the proposed change does**
- Add tutorial as a watch type, which is pushed forward with tutorial progress
- Prevent epidemics happening during other watch events (to match emergencies)

todo: The tutorial watch looks identical to the following initial opening watch, it could be blue?. The watch progress doesn't yet take into account any tutorial steps the user skips, such as looking through available staff or invalid room/staff placement. The watch doesn't fill in segment by segment, how is that done?
