### PR TITLE
Let dropdowns close when clicked outside of

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/dropdown.lua
+++ b/CorsixTH/Lua/dialogs/resizables/dropdown.lua
@@ -52,7 +52,6 @@ function UIDropdown:UIDropdown(ui, parent_window, parent_button, items, callback
   local width = panel.w
   local height = panel.h
 
-  -- TODO: Somehow make the dropdown disappear if the user clicks outside it.
   self:setPosition(panel.x, panel.y + panel.h)
 
   local y = 0

--- a/CorsixTH/Lua/dialogs/resizables/dropdown.lua
+++ b/CorsixTH/Lua/dialogs/resizables/dropdown.lua
@@ -88,3 +88,17 @@ function UIDropdown:beginDrag(x, y)
   -- Disable dragging
   return false
 end
+
+--! Let dropdown close when clicked outside of
+--!param button (button) mouseclick
+--!param x (coord) x coordinate
+--!param y (coord) y coordinate
+--!return continue triggering parent function
+function UIDropdown:onMouseDown(button, x, y)
+  if not self:hitTest(x, y) then
+    self.parent_button:toggle()
+    self:close()
+    return false
+  end
+  return Window.onMouseDown(self, button, x, y)
+end

--- a/CorsixTH/Lua/dialogs/resizables/dropdown.lua
+++ b/CorsixTH/Lua/dialogs/resizables/dropdown.lua
@@ -99,5 +99,5 @@ function UIDropdown:onMouseDown(button, x, y)
     self:close()
     return false
   end
-  return Window.onMouseDown(self, button, x, y)
+  return UIResizable.onMouseDown(self, button, x, y)
 end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #553*

**Describe what the proposed change does**
- When you click outside a dropdown it will now automatically dismiss.
