### PR TITLE
Re-add doxygen config line for no dot

### DIFF
--- a/DoxyGen/animview.doxygen.in
+++ b/DoxyGen/animview.doxygen.in
@@ -159,3 +159,16 @@ HTML_TIMESTAMP         = NO
 # The default value is: YES.
 
 GENERATE_LATEX         = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+
+# If you set the HAVE_DOT tag to YES then doxygen will assume the dot tool is
+# available from the path. This tool is part of Graphviz (see:
+# http://www.graphviz.org/), a graph visualization toolkit from AT&T and Lucent
+# Bell Labs. The other options in this section have no effect if this option is
+# set to NO
+# The default value is: NO.
+
+HAVE_DOT               = NO

--- a/DoxyGen/corsixth_engine.doxygen.in
+++ b/DoxyGen/corsixth_engine.doxygen.in
@@ -159,3 +159,16 @@ HTML_TIMESTAMP         = NO
 # The default value is: YES.
 
 GENERATE_LATEX         = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+
+# If you set the HAVE_DOT tag to YES then doxygen will assume the dot tool is
+# available from the path. This tool is part of Graphviz (see:
+# http://www.graphviz.org/), a graph visualization toolkit from AT&T and Lucent
+# Bell Labs. The other options in this section have no effect if this option is
+# set to NO
+# The default value is: NO.
+
+HAVE_DOT               = NO

--- a/DoxyGen/leveledit.doxygen.in
+++ b/DoxyGen/leveledit.doxygen.in
@@ -159,3 +159,16 @@ HTML_TIMESTAMP         = NO
 # The default value is: YES.
 
 GENERATE_LATEX         = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+
+# If you set the HAVE_DOT tag to YES then doxygen will assume the dot tool is
+# available from the path. This tool is part of Graphviz (see:
+# http://www.graphviz.org/), a graph visualization toolkit from AT&T and Lucent
+# Bell Labs. The other options in this section have no effect if this option is
+# set to NO
+# The default value is: NO.
+
+HAVE_DOT               = NO


### PR DESCRIPTION
**Describe what the proposed change does**
- Revert a small portion of #1971 by putting the no dot line back in. Perhaps it won't be needed when doxy 1.9 is in Ubuntu LTS.