### PR TITLE
Move 'receptionist_msg' removal to Hospital.

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 158
+local SAVEGAME_VERSION = 159
 
 class "App"
 

--- a/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
@@ -60,11 +60,8 @@ function Receptionist:setProfile(profile)
 end
 
 function Receptionist:needsWorkStation()
-  if self.hospital and not self.hospital.receptionist_msg then
-    if self.hospital:countReceptionDesks() == 0 then
-      self.world.ui.adviser:say(_A.warnings.no_desk_4)
-      self.hospital.receptionist_msg = true
-    end
+  if self.hospital then
+    self.hospital:msgNeedFirstReceptionDesk()
   end
 end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -644,6 +644,9 @@ function Hospital:afterLoad(old, new)
   if old < 155 then
     self.overdraft_interest_rate = self.interest_rate + 0.02
   end
+  if old < 159 then
+    self.receptionist_msg = nil
+  end
 
   -- Update other objects in the hospital (added in version 106).
   if self.epidemic then self.epidemic.afterLoad(old, new) end
@@ -1725,8 +1728,18 @@ function Hospital:objectPlaced(entity, id)
   end
 end
 
+--! Give advice to the user about the need to buy the first reception desk.
+function Hospital:msgNeedFirstReceptionDesk()
+  -- Nothing to do, override in a sub-class.
+end
+
 --! Give advice to the user about having bought a reception desk.
 function Hospital:msgReceptionDesk()
+  -- Nothing to do, override in a sub-class.
+end
+
+--! Give advice about having more desks.
+function Hospital:msgMultiReceptionDesks()
   -- Nothing to do, override in a sub-class.
 end
 

--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -38,7 +38,6 @@ local function action_seek_reception_start(action, humanoid)
   local world = humanoid.world
   local best_desk
   local score
-  local queuetotal = 0
 
   assert(humanoid.hospital, "humanoid must be associated with a hospital to seek reception")
 
@@ -63,7 +62,6 @@ local function action_seek_reception_start(action, humanoid)
         score = this_score
         best_desk = desk
       end
-      queuetotal = queuetotal + #desk.queue
     end
   end
   if best_desk then
@@ -95,18 +93,7 @@ local function action_seek_reception_start(action, humanoid)
         end
       end
     end
-  local desks = #humanoid.hospital:findReceptionDesks()
-  local receptionists = humanoid.hospital:countStaffOfCategory("Receptionist")
-  if (receptionists > 1 and desks > 0) or (receptionists > 0 and desks > 1) then
-    local queueavg = math.floor(queuetotal / desks)
-    if receptionists < desks and queueavg > 5 then
-      world.ui.adviser:say(_A.warnings.reception_bottleneck)
-    elseif queueavg > 4 then
-      world.ui.adviser:say(_A.warnings.queue_too_long_at_reception)
-    elseif receptionists > desks then
-      world.ui.adviser:say(_A.warnings.another_desk)
-    end
-  end
+    humanoid.hospital:msgMultiReceptionDesks()
 
   else
     -- No reception desk found. One will probably be built soon, somewhere in


### PR DESCRIPTION
**Describe what the proposed change does**
- Eliminate 'self.receptionist_msg' (again).
- Move first-desk advice to the player hospital.
- Move queue advice with reception when having several desks and/or receptionists to player hospital.
