### PR TITLE
Move staff advice/announcements to player hospital

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- Increment each time a savegame break would occur
 -- and add compatibility code in afterLoad functions
 
-local SAVEGAME_VERSION = 162
+local SAVEGAME_VERSION = 163
 
 class "App"
 

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -20,6 +20,8 @@ SOFTWARE. --]]
 
 corsixth.require("announcer")
 
+local AnnouncementPriority = _G["AnnouncementPriority"]
+
 --! A Doctor, Nurse, Receptionist, Handyman, or Surgeon
 class "Staff" (Humanoid)
 
@@ -31,6 +33,8 @@ function Staff:Staff(...)
   self:Humanoid(...)
   self.hover_cursor = TheApp.gfx:loadMainCursor("staff")
   self.parcelNr = 0
+  self.leave_sounds = {}
+  self.leave_priority = AnnouncementPriority.High
 end
 
 --! Handle daily adjustments to staff.
@@ -200,10 +204,6 @@ function Staff:checkIfWaitedTooLong()
   end
 end
 
-function Staff:leaveAnnounce()
-  return
-end
-
 function Staff:isTiring()
   local tiring = true
 
@@ -256,7 +256,7 @@ function Staff:fire()
   self.hospital:changeReputation("kicked")
   self:despawn()
   self.hover_cursor = nil
-  self:leaveAnnounce()
+  self.hospital:announceStaffLeave(self)
   -- Unregister any build callbacks or messages.
   self:unregisterCallbacks()
   -- Update the staff management window if it is open.

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -475,15 +475,15 @@ function Staff:adviseWrongPersonForThisRoom()
   local required = (room.room_info.maximum_staff or room.room_info.required_staff)
   if required then
     if required.Nurse then
-      self.world.ui.adviser:say(_A.staff_place_advice.only_nurses_in_room:format(room_name))
+      self.hospital:giveAdvice({ _A.staff_place_advice.only_nurses_in_room:format(room_name) })
     elseif required.Surgeon then
-      self.world.ui.adviser:say(_A.staff_place_advice.only_surgeons)
+      self.hospital:giveAdvice({ _A.staff_place_advice.only_surgeons })
     elseif required.Researcher then
-      self.world.ui.adviser:say(_A.staff_place_advice.only_researchers)
+      self.hospital:giveAdvice({ _A.staff_place_advice.only_researchers })
     elseif required.Psychiatrist then
-      self.world.ui.adviser:say(_A.staff_place_advice.only_psychiatrists)
+      self.hospital:giveAdvice({ _A.staff_place_advice.only_psychiatrists })
     else
-      self.world.ui.adviser:say(_A.staff_place_advice.only_doctors_in_room:format(room_name))
+      self.hospital:giveAdvice({ _A.staff_place_advice.only_doctors_in_room:format(room_name) })
     end
   end
 end

--- a/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
@@ -267,9 +267,9 @@ function Doctor:adviseWrongPersonForThisRoom()
   local room = self:getRoom()
   local room_name = room.room_info.long_name
   if room.room_info.id == "toilets" then
-    self.world.ui.adviser:say(_A.staff_place_advice.doctors_cannot_work_in_room:format(room_name))
+    self.hospital:giveAdvice({ _A.staff_place_advice.doctors_cannot_work_in_room:format(room_name) })
   elseif room.room_info.id == "training" then
-    self.world.ui.adviser:say(_A.staff_place_advice.doctors_cannot_work_in_room:format(room_name))
+    self.hospital:giveAdvice({ _A.staff_place_advice.doctors_cannot_work_in_room:format(room_name) })
   else
     Staff.adviseWrongPersonForThisRoom(self)
   end

--- a/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
@@ -32,6 +32,7 @@ local Doctor = _G["Doctor"]
 --!param ... Arguments to base class constructor.
 function Doctor:Doctor(...)
   self:Staff(...)
+  self.leave_sounds = {"sack001.wav", "sack002.wav", "sack003.wav"}
 end
 
 function Doctor:tickDay()
@@ -104,12 +105,6 @@ function Doctor:tick()
   if self:isLearningOnTheJob() then
     self:updateSkill(self.humanoid_class, "skill", 0.000003)
   end
-end
-
-function Doctor:leaveAnnounce()
-  local announcement_priority = AnnouncementPriority.High
-  local dr_leave_sounds = {"sack001.wav", "sack002.wav", "sack003.wav",}
-  self.world.ui:playAnnouncement(dr_leave_sounds[math.random(1, #dr_leave_sounds)], announcement_priority)
 end
 
 -- Determine if the staff member should contribute to research
@@ -281,6 +276,10 @@ function Doctor:adviseWrongPersonForThisRoom()
 end
 
 function Doctor:afterLoad(old, new)
+  if old < 163 then
+    self.leave_priority = AnnouncementPriority.High
+    self.leave_sounds = {"sack001.wav", "sack002.wav", "sack003.wav"}
+  end
   Staff.afterLoad(self, old, new)
 end
 

--- a/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
@@ -32,11 +32,7 @@ local Handyman = _G["Handyman"]
 --!param ... Arguments to base class constructor.
 function Handyman:Handyman(...)
   self:Staff(...)
-end
-
-function Handyman:leaveAnnounce()
-  local announcement_priority = AnnouncementPriority.High
-  self.world.ui:playAnnouncement("sack006.wav", announcement_priority)
+  self.leave_sounds = {"sack006.wav"}
 end
 
 function Handyman:die()
@@ -90,6 +86,10 @@ function Handyman:fulfillsCriterion(criterion)
 end
 
 function Handyman:afterLoad(old, new)
+  if old < 163 then
+    self.leave_priority = AnnouncementPriority.High
+    self.leave_sounds = {"sack006.wav"}
+  end
   Staff.afterLoad(self, old, new)
 end
 

--- a/CorsixTH/Lua/entities/humanoids/staff/nurse.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/nurse.lua
@@ -32,13 +32,7 @@ local Nurse = _G["Nurse"]
 --!param ... Arguments to base class constructor.
 function Nurse:Nurse(...)
   self:Staff(...)
-end
-
-function Nurse:leaveAnnounce()
-  local announcement_priority = AnnouncementPriority.High
-
-  local nurse_leave_sounds = {"sack004.wav", "sack005.wav",}
-  self.world.ui:playAnnouncement(nurse_leave_sounds[math.random(1, #nurse_leave_sounds)], announcement_priority)
+  self.leave_sounds = {"sack004.wav", "sack005.wav"}
 end
 
 -- Helper function to decide if Staff fulfills a criterion
@@ -54,5 +48,9 @@ function Nurse:adviseWrongPersonForThisRoom()
 end
 
 function Nurse:afterLoad(old, new)
+  if old < 163 then
+    self.leave_priority = AnnouncementPriority.High
+    self.leave_sounds = {"sack004.wav", "sack005.wav"}
+  end
   Staff.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/entities/humanoids/staff/nurse.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/nurse.lua
@@ -44,7 +44,7 @@ end
 function Nurse:adviseWrongPersonForThisRoom()
   local room = self:getRoom()
   local room_name = room.room_info.long_name
-  self.world.ui.adviser:say(_A.staff_place_advice.nurses_cannot_work_in_room:format(room_name))
+  self.hospital:giveAdvice({ _A.staff_place_advice.nurses_cannot_work_in_room:format(room_name) })
 end
 
 function Nurse:afterLoad(old, new)

--- a/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
@@ -32,6 +32,8 @@ local Receptionist = _G["Receptionist"]
 --!param ... Arguments to base class constructor.
 function Receptionist:Receptionist(...)
   self:Staff(...)
+  self.leave_sounds = {"sack007.wav", "sack008.wav"}
+  self.leave_priority = AnnouncementPriority.Critical -- must always be played even without receptionist
 end
 
 function Receptionist:tickDay()
@@ -39,11 +41,6 @@ function Receptionist:tickDay()
     return false
   end
   self:needsWorkStation()
-end
-
-function Receptionist:leaveAnnounce()
-  local receptionist_leave_sounds = {"sack007.wav", "sack008.wav",}
-  self.world.ui:playAnnouncement(receptionist_leave_sounds[math.random(1, #receptionist_leave_sounds)], AnnouncementPriority.Critical) -- must always be played even without receptionist
 end
 
 function Receptionist:isTiring()
@@ -96,6 +93,10 @@ function Receptionist:getDrawingLayer()
 end
 
 function Receptionist:afterLoad(old, new)
+  if old < 163 then
+    self.leave_sounds = {"sack007.wav", "sack008.wav"}
+    self.leave_priority = AnnouncementPriority.Critical -- must always be played even without receptionist
+  end
   Staff.afterLoad(self, old, new)
 end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2432,3 +2432,7 @@ end
 function Hospital:onSpawnVIP()
   -- Nothing to do, override in a derived class.
 end
+
+function Hospital:announceStaffLeave()
+  -- Nothing to do, override in a derived class.
+end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2417,6 +2417,10 @@ function Hospital:getRandomBusyRoom()
   if #chosen_room.door.queue >= busy_threshold then return chosen_room end
 end
 
+function Hospital:giveAdvice()
+  -- Nothing to do, override in a derived class.
+end
+
 function Hospital:adviseDiscoverDisease()
   -- Nothing to do, override in a derived class.
 end

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -536,6 +536,12 @@ function PlayerHospital:makeRaiseRequest(amount, staff)
   self.world.ui.bottom_panel:queueMessage("strike", amount, staff)
 end
 
+--! Announce to the player that a staff member is leaving the hospital
+--!param staff (table) The staff member
+function PlayerHospital:announceStaffLeave(staff)
+  self.world.ui:playRandomAnnouncement(staff.leave_sounds, staff.leave_priority)
+end
+
 function PlayerHospital:afterLoad(old, new)
   if old < 145 then
     self.hosp_cheats = Cheats(self)

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -328,12 +328,12 @@ function Room:onHumanoidEnter(humanoid)
     self:tryAdvanceQueue()
     return
   end
-  local msg = {
+  local researcher_desks = {
     (_A.warnings.researcher_needs_desk_1),
     (_A.warnings.researcher_needs_desk_2),
     (_A.warnings.researcher_needs_desk_3),
   }
-  local msg_nurse = {
+  local nurse_desks = {
     (_A.warnings.nurse_needs_desk_1),
     (_A.warnings.nurse_needs_desk_2),
   }
@@ -345,10 +345,10 @@ function Room:onHumanoidEnter(humanoid)
         local staff_member = self:getStaffMember()
         self.humanoids[humanoid] = true
           if staff_member.profile.is_researcher and self.room_info.id == "research" then
-            self.world.ui.adviser:say(msg[math.random(1, #msg)])
+            self.hospital:giveAdvice(researcher_desks)
           end
           if staff_member.humanoid_class == "Nurse" and self.room_info.id == "ward" then
-            self.world.ui.adviser:say(msg_nurse[math.random(1, #msg_nurse)])
+            self.hospital:giveAdvice(nurse_desks)
           end
         if not staff_member.dealing_with_patient then
           staff_member:setNextAction(self:createLeaveAction())


### PR DESCRIPTION
**Describe what the proposed change does**
Move to player hospital:
- Advice for staff entering a room they can't staff or sit at a desk
- Announcements for sacking staff
