### PR TITLE
Remove .0 from negatives in Annual Report

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -40,11 +40,6 @@ local function setActive(button, active)
   end
 end
 
--- Helper function to make sure all values are whole numbers
-local function toInt(number)
-  return math.floor(number)
-end
-
 function UIAnnualReport:UIAnnualReport(ui, world)
 
   self:UIFullscreen(ui)
@@ -352,7 +347,7 @@ function UIAnnualReport:addTrophy(text, award_type, amount)
     trophy_parts.info = {
       text = text,
       award_type = award_type,
-      amount = toInt(amount)
+      amount = math.floor(amount)
     }
 
     local --[[persistable:annual_report_show_trophy_motivation]] function change() self:showTrophyMotivation(no) end
@@ -388,7 +383,7 @@ function UIAnnualReport:addAward(text, award_type, amount)
     award_parts.info = {
       text = text,
       award_type = award_type,
-      amount = toInt(amount)
+      amount = math.floor(amount)
     }
 
     -- The plaque

--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -40,6 +40,11 @@ local function setActive(button, active)
   end
 end
 
+-- Helper function to make sure all values are whole numbers
+local function toInt(number)
+  return math.floor(number)
+end
+
 function UIAnnualReport:UIAnnualReport(ui, world)
 
   self:UIFullscreen(ui)
@@ -347,7 +352,7 @@ function UIAnnualReport:addTrophy(text, award_type, amount)
     trophy_parts.info = {
       text = text,
       award_type = award_type,
-      amount = amount
+      amount = toInt(amount)
     }
 
     local --[[persistable:annual_report_show_trophy_motivation]] function change() self:showTrophyMotivation(no) end
@@ -383,7 +388,7 @@ function UIAnnualReport:addAward(text, award_type, amount)
     award_parts.info = {
       text = text,
       award_type = award_type,
-      amount = amount
+      amount = toInt(amount)
     }
 
     -- The plaque


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2032*

**Describe what the proposed change does**
- Adds a helper function to make sure we represent awards with whole numbers only.

Only question is should it be in utility? If it is meant to be utility, it would need more documenting for use cases.

Edit: I don't think this calls for an afterload really. It would fix itself in the next annual report anyway.