### PR TITLE
Update URL for checking updates

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1650,7 +1650,7 @@ function App:checkForUpdates()
 
   -- Default language to use for the changelog if no localised version is available
   local default_language = "en"
-  local update_url = 'https://corsixth.github.io/CorsixTH/check-for-updates'
+  local update_url = 'https://corsixth.com/CorsixTH/check-for-updates'
   local current_version = self:getVersion()
 
   -- Only URLs that match this list of trusted domains will be accepted.


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2040*

**Describe what the proposed change does**
- github.io is causing a 301 permanent redirect.
- Bear in mind this does mean trying to update 0.65 to 0.66 through the application won't work.
