### PR TITLE
Extra info on replacing machines

### DIFF
--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -141,7 +141,8 @@ local config_defaults = {
   check_for_updates = true,
   room_information_dialogs = true,
   allow_blocking_off_areas = false,
-  direct_zoom = nil
+  direct_zoom = nil,
+  new_machine_extra_info = true,
 }
 
 fi = io.open(config_filename, "r")
@@ -511,6 +512,12 @@ audio_music = nil -- [[X:\ThemeHospital\Music]]
 -- ]=] .. '\n' ..
 'direct_zoom = ' .. tostring(config_values.direct_zoom) .. '\n' .. [=[
 
+-------------------------------------------------------------------------------------------------------------------------
+-- Replacing Machines: By default, you will see a new machines
+-- initial strength before purchasing it. If you don't want this
+-- change the value to false.
+-- ]=] .. '\n' ..
+'new_machine_extra_info = ' .. tostring(config_values.new_machine_extra_info)  .. '\n' .. [=[
 -------------------------------------------------------------------------------------------------------------------------
 
 ------------------------------------------------ CAMPAIGN MENU -----------------------------------------------

--- a/CorsixTH/Lua/dialogs/machine_dialog.lua
+++ b/CorsixTH/Lua/dialogs/machine_dialog.lua
@@ -120,7 +120,7 @@ function UIMachine:replaceMachine()
     prompt = (_S.confirmation.replace_machine_extra_info):format(new_strength, current_strength) .. "//" .. prompt
   end
 
-  self.ui:addWindow(UIConfirmDialog(self.ui, true, prompt, 
+  self.ui:addWindow(UIConfirmDialog(self.ui, true, prompt,
     --[[persistable:replace_machine_confirm_dialog]]function() machine:replaceMachine(cost)
     end
   ))

--- a/CorsixTH/Lua/dialogs/machine_dialog.lua
+++ b/CorsixTH/Lua/dialogs/machine_dialog.lua
@@ -99,8 +99,8 @@ function UIMachine:callHandyman()
   end
 end
 
---!Function checks we can afford a new machine
---!Then offers player to purchase
+--! Function checks we can afford a new machine
+--! Then offers player to purchase
 function UIMachine:replaceMachine()
   -- Maybe TODO: Prevent purchase of a machine of same strength?
   local machine = self.machine

--- a/CorsixTH/Lua/dialogs/machine_dialog.lua
+++ b/CorsixTH/Lua/dialogs/machine_dialog.lua
@@ -99,24 +99,29 @@ function UIMachine:callHandyman()
   end
 end
 
+--!Function checks we can afford a new machine
+--!Then offers player to purchase
 function UIMachine:replaceMachine()
+  -- Maybe TODO: Prevent purchase of a machine of same strength?
   local machine = self.machine
   local hosp = self.ui.hospital
   local cost = hosp.research.research_progress[machine.object_type].cost
-  if self.ui.hospital.balance < cost then
+  if hosp.balance < cost then
     -- give visual warning that player doesn't have enough $ to buy
     self.ui.adviser:say(_A.warnings.cannot_afford_2, false, true)
     self.ui:playSound("wrong2.wav")
     return
   end
-  self.ui:addWindow(UIConfirmDialog(self.ui, false,
-    _S.confirmation.replace_machine:format(machine.object_type.name, cost),
-    --[[persistable:replace_machine_confirm_dialog]]function()
-      -- Charge for new machine
-      hosp:spendMoney(cost, _S.transactions.machine_replacement)
 
-      -- Tell the machine to pretend it's a shiny new one
-      machine:machineReplaced()
+  local prompt = _S.confirmation.replace_machine:format(machine.object_type.name, cost)
+  if self.ui.app.config.new_machine_extra_info then
+    local new_strength = hosp.research.research_progress[machine.object_type].start_strength
+    local current_strength = machine.strength
+    prompt = (_S.confirmation.replace_machine_extra_info):format(new_strength, current_strength) .. "//" .. prompt
+  end
+
+  self.ui:addWindow(UIConfirmDialog(self.ui, true, prompt, 
+    --[[persistable:replace_machine_confirm_dialog]]function() machine:replaceMachine(cost)
     end
   ))
 end

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -261,7 +261,11 @@ function Machine:createHandymanActions(handyman)
 end
 
 --! Replace this machine (make it pretend it's brand new)
-function Machine:machineReplaced()
+--!param cost (int) Cost to replace the machine
+function Machine:replaceMachine(cost)
+  -- Pay for the new machine
+  self.hospital:spendMoney(cost, _S.transactions.machine_replacement)
+  
   -- Reset usage stats
   self.total_usage = 0
   self.times_used = 0

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -265,7 +265,7 @@ end
 function Machine:replaceMachine(cost)
   -- Pay for the new machine
   self.hospital:spendMoney(cost, _S.transactions.machine_replacement)
-  
+
   -- Reset usage stats
   self.total_usage = 0
   self.times_used = 0

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -714,6 +714,7 @@ confirmation = {
   abort_edit_room = "You are currently building or editing a room. If all required objects are placed it will be finished, but otherwise it will be deleted. Continue?",
   maximum_screen_size = "The screen size you have entered is greater than 3000 x 2000. Larger resolutions are possible but will require better hardware in order to maintain a playable frame rate. Are you sure you want to continue?",
   remove_destroyed_room = "Would you like to remove the room for $%d?",
+  replace_machine_extra_info = "The new machine will have %d strength (currently %d).",
 }
 
 information = {


### PR DESCRIPTION
*Fixes #2049*

**Describe what the proposed change does**
- Adds extra information to the replace machine dialog (current machine strength and new machine strength)
- Made into a config setting. But later down the line should likely form part of a QoL settings menu.
- Also moves the hospital spend money line into the `replaceMachine()` function in Machine (renamed from `machineReplaced()`.
- Game pauses on the confirmation dialog -- so a machine can't explode while replacing it.

![image](https://user-images.githubusercontent.com/20030128/133680968-205141d9-8880-4760-a333-cbe95ac280c9.png)