### PR TITLE
Fix Quick Save/Load

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1508,7 +1508,7 @@ end
 
 -- Omit the usual file extension so this file cannot be seen from the normal load and save screen and cannot be overwritten
 function App:quickSave()
-  local filename = "quicksave"
+  local filename = "quicksave.qs"
   return SaveGameFile(self.savegame_dir .. filename)
 end
 
@@ -1520,9 +1520,9 @@ function App:load(filepath)
 end
 
 function App:quickLoad()
-  local filename = "quicksave"
+  local filename = "quicksave.qs"
   if lfs.attributes(self.savegame_dir .. filename) then
-    self:load(filename)
+    self:load(self.savegame_dir .. filename)
   else
     self:quickSave()
     self.ui:addWindow(UIInformation(self.ui, {_S.errors.load_quick_save}))


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #1810 #2048*

**Describe what the proposed change does**
- Adds the savegame dir to the to quickload
- Adds a file extension `.qs` -- though that's more personal preference not liking an extensionless file.
