### PR TITLE
Set startup project for Visual Studio

### DIFF
--- a/AnimView/CMakeLists.txt
+++ b/AnimView/CMakeLists.txt
@@ -98,3 +98,5 @@ else()
   install(TARGETS AnimView RUNTIME DESTINATION AnimView)
   install(FILES ../LICENSE.txt DESTINATION AnimView)
 endif()
+
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT AnimView)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ add_subdirectory("libs")
 if(BUILD_CORSIXTH)
   message("Building CorsixTH")
   add_subdirectory(CorsixTH)
+  set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT CorsixTH)
 endif()
 
 if(BUILD_ANIMVIEW)

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -298,5 +298,7 @@ if(NOT USE_SOURCE_DATADIRS)
   endif()
 endif()
 
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT CorsixTH)
+
 add_custom_target(windowsconfig ${LUA_PROGRAM_PATH} ${CMAKE_SOURCE_DIR}/scripts/generate_windows_config.lua
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Minor convenience for Visual Studio users.

If CorsixTH is built, set it as the startup project for the top level
sln

Set CorsixTH as the startup project for the CorsixTH.sln
Set AnimView as the startup project for the AnimView.sln