### PR TITLE
[WIP] Show replacement machine strength in the HUD info area

### DIFF
--- a/CorsixTH/Levels/original08.level
+++ b/CorsixTH/Levels/original08.level
@@ -19,7 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 -- This is an extra configuration file loaded at level 8 from the original game.
--- The win and lose on repution would appear to be the wrong way round
+-- The win and lose on reputation would appear to be the wrong way round
 
 #win_criteria[0].Criteria.MaxMin.Value.Group.Bound 2 1 300000 1 0
 #win_criteria[1].Criteria.MaxMin.Value.Group.Bound	3 1 55 1 0

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -358,7 +358,8 @@ function Machine:updateDynamicInfo(only_update)
   if self.strength then
     self:setDynamicInfo("text", {
       self.object_type.name,
-      _S.dynamic_info.object.strength:format(self.strength),
+      -- _S.dynamic_info.object.strength:format(self.strength),
+      _S.dynamic_info.object.strength:format(self.strength, self.world.ui.hospital.research.research_progress[self.object_type].start_strength),
       _S.dynamic_info.object.times_used:format(self.times_used),
     })
   end

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -268,6 +268,7 @@ dynamic_info.staff.actions.heading_for = "Heading for %s"
 dynamic_info.staff.actions.fired = "Fired"
 dynamic_info.staff.actions.vaccine = "Vaccinating a patient"
 dynamic_info.patient.actions.epidemic_vaccinated = "I am no longer contagious"
+dynamic_info.object.strength = "Strength %d (Replacement %d)"
 
 progress_report.free_build = "FREE BUILD"
 

--- a/CorsixTH/Lua/research_department.lua
+++ b/CorsixTH/Lua/research_department.lua
@@ -479,6 +479,17 @@ function ResearchDepartment:improveMachine(machine)
       + improve_rate
     research_info.strength_imp = research_info.strength_imp + 1
   end
+  
+  -- Update dyanic info for replacement machine strength.
+  for _, room in ipairs(self.world.rooms) do
+    for obj, no in pairs(room.objects) do
+      if(obj.object_type.id == machine.id) then
+        obj:updateDynamicInfo(false)
+        break
+      end
+    end
+  end
+  
   -- Tell the player that something has been improved
   if self.hospital:isPlayerHospital() then
     self.world.ui.adviser:say(_A.research.machine_improved

--- a/CorsixTH/Lua/research_department.lua
+++ b/CorsixTH/Lua/research_department.lua
@@ -480,7 +480,7 @@ function ResearchDepartment:improveMachine(machine)
     research_info.strength_imp = research_info.strength_imp + 1
   end
   
-  -- Update dyanic info for replacement machine strength.
+  -- Update dynamic info for replacement machine strength.
   for _, room in ipairs(self.world.rooms) do
     for obj, no in pairs(room.objects) do
       if(obj.object_type.id == machine.id) then


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*
1. Updated the dynamic info method for machine.lua to format the strength string with the replacement machine strength value.

2. Updated english.lua so the machine strength string displays this new value.

3.  Updated the research_department.lua so dynamic text for any matching machine is updated when machine strength improvements are researched.

**Describe what the proposed change does**
- The HUD displays strength and replacement machine strength when the mouse cursor hovers over a machine.
