### PR TITLE
Deduplicate staff-type name translations.

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/drug_casebook.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/drug_casebook.lua
@@ -181,17 +181,9 @@ function UICasebook:updateIcons()
       research = research and (_S.tooltip.casebook.cure_requirement.research_machine .. research .. "). ") or ""
       build    = build    and (_S.tooltip.casebook.cure_requirement.build_room .. build .. "). ") or ""
 
-      local staffclass_to_string = {
-        Nurse        = _S.staff_title.nurse,
-        Doctor       = _S.staff_title.doctor,
-        Surgeon      = _S.staff_title.surgeon,
-        Psychiatrist = _S.staff_title.psychiatrist,
-        Researcher   = _S.staff_title.researcher,
-      }
-
       -- Staff requirements
       for sclass, amount in pairs(req.staff) do
-        staff = (staff and (staff .. ", ") or " (") .. staffclass_to_string[sclass] .. ": " .. amount
+        staff = (staff and (staff .. ", ") or " (") .. StaffProfile.translateStaffClass(sclass) .. ": " .. amount
       end
       staff = staff and (_S.tooltip.casebook.cure_requirement.hire_staff .. staff .. "). ") or ""
 

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -1011,13 +1011,7 @@ function Patient:updateMessage(choice)
             output_text = strings.need_to_build:format(room_name)
           end
         elseif #req.rooms == 0 and next(req.staff) then
-          local staffclass_to_string = {
-              Nurse        = _S.staff_title.nurse,
-              Doctor       = _S.staff_title.doctor,
-              Surgeon      = _S.staff_title.surgeon,
-              Psychiatrist = _S.staff_title.psychiatrist,
-          }
-          output_text = strings.need_to_employ:format(staffclass_to_string[next(req.staff)])
+          output_text = strings.need_to_employ:format(StaffProfile.translateStaffClass(next(req.staff)))
         end
         self.message[3].text = output_text
       else

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -145,13 +145,7 @@ local function action_seek_room_no_treatment_room_found(room_type, humanoid)
         output_text = strings.need_to_build:format(room_name)
       end
     elseif #req.rooms == 0 and next(req.staff) then
-      local staffclass_to_string = {
-          Nurse        = _S.staff_title.nurse,
-          Doctor       = _S.staff_title.doctor,
-          Surgeon      = _S.staff_title.surgeon,
-          Psychiatrist = _S.staff_title.psychiatrist,
-      }
-      output_text = strings.need_to_employ:format(staffclass_to_string[next(req.staff)])
+      output_text = strings.need_to_employ:format(StaffProfile.translateStaffClass(next(req.staff)))
     end
   end
 

--- a/CorsixTH/Lua/staff_profile.lua
+++ b/CorsixTH/Lua/staff_profile.lua
@@ -256,3 +256,16 @@ end
 function StaffProfile:getFullName()
   return self.initial .. ". " .. self.name
 end
+
+--! Translate the staff class to its translated text.
+--!param staff_class Class of the staff to translate.
+--!return The translated name.
+function StaffProfile.translateStaffClass(staff_class)
+  local staffclass_to_string = {
+    Nurse        = _S.staff_title.nurse,
+    Doctor       = _S.staff_title.doctor,
+    Surgeon      = _S.staff_title.surgeon,
+    Psychiatrist = _S.staff_title.psychiatrist,
+  }
+  return staffclass_to_string[staff_class]
+end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2321,29 +2321,19 @@ end
 --! Returns localized name of the room, internal required staff name
 -- and localized name of staff required.
 function World:getRoomNameAndRequiredStaffName(room_id)
-  local room_name, required_staff, staff_name
+  local room_name, required_staff
   for _, room in ipairs(TheApp.rooms) do
     if room.id == room_id then
       room_name = room.long_name
       required_staff = room.required_staff
     end
   end
+
+  local staff_name
   for key, _ in pairs(required_staff) do
-    staff_name = key
+    staff_name = key -- This is the "programmatic" name of the staff.
   end
-  required_staff = staff_name -- This is the "programmatic" name of the staff.
-  if staff_name == "Nurse" then
-    staff_name = _S.staff_title.nurse
-  elseif staff_name == "Psychiatrist" then
-    staff_name = _S.staff_title.psychiatrist
-  elseif staff_name == "Researcher" then
-    staff_name = _S.staff_title.researcher
-  elseif staff_name == "Surgeon" then
-    staff_name = _S.staff_title.surgeon
-  elseif staff_name == "Doctor" then
-    staff_name = _S.staff_title.doctor
-  end
-  return room_name, required_staff, staff_name
+  return room_name, staff_name, StaffProfile.translateStaffClass(staff_name)
 end
 
 --! Append a message to the game log.


### PR DESCRIPTION
Remove duplicates of translating staff type-names to human-readable names.
