### PR TITLE
Humanoid start action move

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -460,7 +460,7 @@ function Humanoid:getCurrentMood()
   end
 end
 
-local function Humanoid_startAction(self)
+function Humanoid:startAction()
   local action = self.action_queue[1]
 
   -- Handle an empty action queue in some way instead of crashing.
@@ -599,7 +599,7 @@ function Humanoid:setNextAction(action, high_priority)
     end
   else
     -- Start the action if it has become the current action
-    Humanoid_startAction(self)
+    self:startAction()
   end
   return self
 end
@@ -608,7 +608,7 @@ function Humanoid:queueAction(action, pos)
   if pos then
     table.insert(self.action_queue, pos + 1, action)
     if pos == 0 then
-      Humanoid_startAction(self)
+      self:startAction()
     end
   else
     self.action_queue[#self.action_queue + 1] = action
@@ -624,7 +624,7 @@ function Humanoid:finishAction(action)
   -- Save the previous action just a while longer.
   self.previous_action = self.action_queue[1]
   table.remove(self.action_queue, 1)
-  Humanoid_startAction(self)
+  self:startAction()
 end
 
 -- Check if the humanoid is running actions intended to leave the room, as indicated by the flag

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -466,7 +466,7 @@ function Humanoid:startAction()
 
   -- Handle an empty action queue in some way instead of crashing.
   if not action then
-    self:handleEmptyActionQueue() -- Inserts an action into the action queue.
+    self:_handleEmptyActionQueue() -- Inserts an action into the action queue.
 
     action = self.action_queue[1]
     assert(action)
@@ -593,7 +593,7 @@ function Humanoid:hasLeavingAction()
 end
 
 --! Handle an empty action queue in some way instead of crashing.
-function Humanoid:handleEmptyActionQueue()
+function Humanoid:_handleEmptyActionQueue()
   -- if this is a patient that is going home, an empty
   -- action queue is not a problem
   if class.is(self, Patient) and self.going_home then
@@ -609,7 +609,7 @@ function Humanoid:handleEmptyActionQueue()
   -- Give the humanoid an action to avoid crashing.
   if class.is(self, Staff) then
     self:queueAction(MeanderAction())
-  elseif class.is(self,GrimReaper) then
+  elseif class.is(self, GrimReaper) then
     self:queueAction(IdleAction())
   else
     self:queueAction(SeekReceptionAction())


### PR DESCRIPTION
Make the `Humanoid_startAction` a normal `Humanoid:startAction` method.

Also, move empty action queue handling to its own method to reduce clutter in starting actions code.
