### PR TITLE
Use proper actions (hopefully) everywhere

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -688,7 +688,7 @@ function UIEditRoom:returnToDoorPhase()
   local room = self.room
   room.built = false
   if room.door and room.door.queue then
-    room.door.queue:rerouteAllPatients(SeekRoomAction(room.room_info.id))
+    room.door.queue:rerouteAllPatients(room.room_info.id)
   end
 
   self.purchase_button:enable(false)

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -1139,7 +1139,7 @@ function Patient:interruptAndRequeueAction(current_action, queue_pos, meander_be
     -- need to copy the reserve_on_resume, otherwise the new queued action will not
     -- unreserve on interrupt
     requeue_action.reserve_on_resume = current_action.reserve_on_resume
-    requeue_action:setIsentering(current_action.is_entering)
+    requeue_action:setIsEntering(current_action.is_entering)
   else
     -- We were seeking a room, start that action from the beginning
     -- i.e. do not set the must_happen flag.

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -185,6 +185,7 @@ local function action_seek_room_no_diagnosis_room_found(action, humanoid)
     -- Send home automatically
     humanoid:goHome("kicked")
     humanoid:updateDynamicInfo(_S.dynamic_info.patient.actions.no_diagnoses_available)
+
   elseif humanoid.diagnosis_progress < humanoid.hospital.policies["guess_cure"] or
       not humanoid.hospital.disease_casebook[humanoid.disease.id].discovered then
     -- If the disease hasn't been discovered yet it cannot be guessed, go here instead.
@@ -220,11 +221,9 @@ local function action_seek_room_no_diagnosis_room_found(action, humanoid)
     humanoid:unregisterRoomRemoveCallback(action.remove_callback)
     humanoid:unregisterStaffChangeCallback(action.staff_change_callback)
     if humanoid:agreesToPay(humanoid.disease.id) then
-      humanoid:queueAction({
-        name = "seek_room",
-        room_type = humanoid.disease.treatment_rooms[1],
-        treatment_room = true,
-      }, 1)
+      local seek_action = SeekRoomAction(humanoid.disease.treatment_rooms[1])
+      seek_action:enableTreatmentRoom()
+      humanoid:queueAction(seek_action, 1)
     else
       humanoid:goHome("over_priced", humanoid.disease.id)
     end

--- a/CorsixTH/Lua/objects/door.lua
+++ b/CorsixTH/Lua/objects/door.lua
@@ -145,7 +145,7 @@ end
 
 function Door:closeDoor()
   if self.queue then
-    self.queue:rerouteAllPatients(SeekRoomAction(self:getRoom().room_info.id))
+    self.queue:rerouteAllPatients(self:getRoom().room_info.id)
     self.queue = nil
   end
   self:clearDynamicInfo(nil)

--- a/CorsixTH/Lua/objects/reception_desk.lua
+++ b/CorsixTH/Lua/objects/reception_desk.lua
@@ -206,7 +206,7 @@ function ReceptionDesk:onDestroy()
           end
         end)
   end
-  self.queue:rerouteAllPatients(SeekReceptionAction())
+  self.queue:rerouteAllPatients(nil)
 
   self.being_destroyed = nil
   return Object.onDestroy(self)

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -313,16 +313,22 @@ function Queue:movePatient(index, new_index)
 end
 
 --! Called when reception desk is destroyed, or when a room is destroyed from a crashed machine.
-function Queue:rerouteAllPatients(action)
+--!param room_id Id of the room to reroute to, 'nil' for reception.
+function Queue:rerouteAllPatients(room_id)
   for _, humanoid in ipairs(self) do
     -- check by class type as staff/vips shouldn't get a SeekRoomAction
     if class.is(humanoid, Patient) then
       -- slight delay so the desk is really destroyed before rerouting
       humanoid:setNextAction(IdleAction():setCount(1))
-      -- Don't queue the same action table, but clone it for each patient.
-      local clone = {}
-      for k, v in pairs(action) do clone[k] = v end
-      humanoid:queueAction(clone)
+
+      local action
+      if room_id then
+        action = SeekRoomAction(room_id)
+      else
+        action = SeekReceptionAction()
+      end
+      humanoid:queueAction(action)
+
     elseif class.is(humanoid, Staff) then
       -- likewise believe we need action here to stop
       humanoid:setNextAction(IdleAction():setCount(1))

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -937,7 +937,7 @@ function Room:deactivate()
 
   -- crashRoom might have deactivated the door already
   if self.door.queue then
-    self.door.queue:rerouteAllPatients(SeekRoomAction(self.room_info.id))
+    self.door.queue:rerouteAllPatients(self.room_info.id)
   end
 
   self.hospital:removeRatholesAroundRoom(self)


### PR DESCRIPTION
At a few points, actions were created as tables with properties rather than by instantiating the required class.
This patch fixes that.

Note that 41b3d1dee77a9393713589ca9c9fd50389e255e2 makes a mess in patient.lua due to whitespace changes.