### PR TITLE
Make empty_action_queue error translatable

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -629,13 +629,7 @@ function Humanoid:_handleEmptyActionQueue()
   self.world:gameLog("Last action: " .. self.previous_action.name)
   self.world:gameLog(debug.traceback())
 
-  ui:addWindow(UIConfirmDialog(ui, true,
-    "Sorry, a humanoid just had an empty action queue,"..
-    " which means that he or she didn't know what to do next."..
-    " Please consult the command window for more detailed information. "..
-    "A dialog with "..
-    "the offending humanoid has been opened. "..
-    "Would you like him/her to leave the hospital?",
+  ui:addWindow(UIConfirmDialog(ui, true, {_S.errors.dialog_empty_queue},
     --[[persistable:humanoid_leave_hospital]] function()
       self.world:gameLog("The humanoid was told to leave the hospital...")
       if class.is(self, Staff) then

--- a/CorsixTH/Lua/languages/czech.lua
+++ b/CorsixTH/Lua/languages/czech.lua
@@ -2657,6 +2657,7 @@ errors = {
   could_not_find_first_campaign_level = "Nelze načíst první úroveň této kampaně: %s",
   compatibility_error = "Pozor! Tato hra byla uložena v novější verzi CorsixTH a není kompatibilní. Pro hraní aktualizujte na novější verzi CorsixTH.",
   save_to_tmp = "Soubor %s nemohl být použit. Hra byla proto uložena do %s. Chyba: %s",
+  dialog_empty_queue = "Postava aktuálně nemá nic na práci ve své řadě úloh, a tak neví, co má dělat dále. Zkontrolujte příkazové okno pro více informací. Jednáme s tímto potížistou. Chcete ho z nemocnice vyhodit?",
 }
 menu = {
   charts = "  GRAFY  ",

--- a/CorsixTH/Lua/languages/dutch.lua
+++ b/CorsixTH/Lua/languages/dutch.lua
@@ -2187,6 +2187,7 @@ errors = {
   alien_dna = "LET OP: Er zijn geen animaties voor alien patiënten die zitten, op deuren kloppenen, deuren openen, enz. Daarom veranderen ze naar een normaal mens als ze dit doen en veranderen dan weer terug, net als in Them Hospital.  Patiënten met alien-DNA verschijnen alleen wanneer dit in het level is toegestaan.",
   fractured_bones = "LET OP: De animatie voor vrouwelijke patiënten met gebrokken botten is niet goed.",
   no_games_to_contine = "Er zijn geen opgeslagen spellen.",
+  dialog_empty_queue = "Een mensachtige is de weg helemaal kwijt, er was geen informatie meer wat vervolgens te gaan doen. Meer gedetailleerde informatie kun je vinden in het kommando scherm. Een window met deze mensachtige is geopend, wil je dat ze het ziekenhuis verlaten?",
 }
 diseases = {
   diag_ward = {

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -701,6 +701,7 @@ errors = {
   could_not_load_campaign = "Failed to load the campaign: %s",
   could_not_find_first_campaign_level = "Could not find the first level of this campaign: %s",
   save_to_tmp = "The file at %s could not be used. The game has been saved to %s. Error: %s",
+  dialog_empty_queue = "Sorry, a humanoid just had an empty action queue, which means that they didn't know what to do next. Please consult the command window for more detailed information. A dialog with the offending humanoid has been opened. Would you like them to leave the hospital?",
 }
 
 warnings = {

--- a/CorsixTH/Lua/languages/german.lua
+++ b/CorsixTH/Lua/languages/german.lua
@@ -474,6 +474,7 @@ errors = {
   fractured_bones = "BEACHTEN SIE: Die Animation für weibliche Patienten mit gebrochenen Knochen ist nicht perfekt.",
   load_quick_save = "Fehler: Der Schnellspeicherspielstand konnte nicht geladen werden, weil er nicht existiert. Kein Grund zur Sorge, wir haben nun einen für Sie erzeugt!",
   alien_dna = "BEACHTEN SIE: Für außerirdische Patienten gibt es keine Animationen für das Sitzen, das Öffnen von Türen, das Anklopfen, usw. Daher werden sie, wie bei Theme Hospital, normal aussehen und sich dann wieder zurückverwandeln. Patienten mit außerirdischer DNA werden nur auftauchen, wenn sie in der Leveldatei gesetzt sind.",
+  dialog_empty_queue = "Entschuldigung, eine Person hat keine weiteren Aktionen geplant und weiß nicht weiter. Weitere Details hierzu können der Konsole entnommen werden. Soll die Person das Krankenhaus verlassen?",
 }
 
 confirmation = {


### PR DESCRIPTION
An extension to CorsixTH#2084.

- Moves the raw string for the empty action queue error into the english.lua file, to enable translation.
- Czech (thanks to @jansakos ), Dutch (thanks to @Alberth289346 ), and German (thanks to @NettleSoup partner) translation also added.
