### PR TITLE
Set volume straight after music is set playing

### DIFF
--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -617,8 +617,8 @@ function Audio:playBackgroundTrack(index)
       end)
       return
     end
-    SDL.audio.setMusicVolume(self.app.config.music_volume)
     assert(SDL.audio.playMusic(music))
+    SDL.audio.setMusicVolume(self.app.config.music_volume)
     self.background_music = music
 
     self:notifyJukebox()


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #1978*

**Describe what the proposed change does**
- Sets the volume after starting playing the track - SDL2_mixers midi volume function on windows uses a handle to the stream to set the volume which requires that Mix_PlayMusic is called to open that handle initially.

