### PR TITLE
Seek room action faxes refactoring

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -269,7 +269,7 @@ end
 --! Update the 'guess the cure' faxes of waiting patients.
 --!param disease_id Disease to update.
 function Hospital:updateGuessCureFaxes(disease_id)
-  for _, patient in ipairs(self.hospital.patients) do
+  for _, patient in ipairs(self.patients) do
     if patient.disease.id == disease_id then
       patient:updateMessage("guess_cure")
     end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -266,6 +266,15 @@ function Hospital:isRoomDiscovered(room_id)
   return self.room_discoveries[room_id].is_discovered
 end
 
+--! Update the 'guess the cure' faxes of waiting patients.
+--!param disease_id Disease to update.
+function Hospital:updateGuessCureFaxes(disease_id)
+  for _, patient in ipairs(self.hospital.patients) do
+    if patient.disease.id == disease_id then
+      patient:updateMessage("guess_cure")
+    end
+end
+
 --! Give the user possibly a message about a cured patient.
 function Hospital:msgCured()
   -- Nothing to do, override in a derived class.

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -273,6 +273,7 @@ function Hospital:updateGuessCureFaxes(disease_id)
     if patient.disease.id == disease_id then
       patient:updateMessage("guess_cure")
     end
+  end
 end
 
 --! Give the user possibly a message about a cured patient.

--- a/CorsixTH/Lua/research_department.lua
+++ b/CorsixTH/Lua/research_department.lua
@@ -550,6 +550,7 @@ function ResearchDepartment:discoverDisease(disease)
   local index = #self.hospital.discovered_diseases + 1
   self.hospital.discovered_diseases[index] = disease.id
   self.hospital:adviseDiscoverDisease(disease)
+  self.hospital:updateGuessCureFaxes(disease.id)
 
   -- It may now be possible to continue researching drug improvements
   local casebook_disease = self.hospital.disease_casebook[disease.id]


### PR DESCRIPTION
- Refactor construction of the guess-cure fax and no-treatment-room fax to their own functions.
- Extend Patient:updateMessage() with 'guess_cure' update as already promised by the documentation, and use it in research.

Ignoring whitespace changes is helpful for getting a smaller diff.