### PR TITLE
[RDY] Recalculate sound effect boundary on resolution change

### DIFF
--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -228,10 +228,17 @@ function Audio:initSpeech(speech_file)
       self.speech_file_name = speech_file
       self.sound_fx = TH.soundEffects()
       self.sound_fx:setSoundArchive(self.sound_archive)
-      local w, h = self.app.config.width / 2, self.app.config.height / 2
-      self.sound_fx:setCamera(math.floor(w), math.floor(h), math.floor((w^2 + h^2)^0.5))
+      self:setSoundStage()
       --self:dumpSoundArchive[[E:\CPP\2K8\CorsixTH\DataRaw\Sound\]]
     end
+  end
+end
+
+--! Set the visual area for sound effects playback
+function Audio:setSoundStage()
+  if self.sound_fx then
+    local w, h = self.app.config.width / 2, self.app.config.height / 2
+    self.sound_fx:setCamera(math.floor(w), math.floor(h), math.floor((w^2 + h^2)^0.5))
   end
 end
 

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -593,6 +593,7 @@ function UI:onChangeResolution()
   for _, window in ipairs(self.windows) do
     window:onChangeResolution()
   end
+  self.app.audio:setSoundStage()
 end
 
 function UI:registerTextBox(box)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #None*

**Describe what the proposed change does**
- If you start with a smaller windowed game and increase the size, the sound effects outside the original centered window size won't play. This just recalls the function to calculate the camera size again
