### PR TITLE
[RDY] Fired staff handling for multi_use objects

### DIFF
--- a/CorsixTH/Lua/rooms/fracture_clinic.lua
+++ b/CorsixTH/Lua/rooms/fracture_clinic.lua
@@ -65,6 +65,7 @@ function FractureRoom:commandEnteringPatient(patient)
     patient:setLayer(2, 0) -- Remove casts
     patient:setLayer(3, 0)
     patient:setLayer(4, 0)
+    -- if no other actions for staff member meander in room
     if #staff.action_queue == 1 then
       staff:setNextAction(MeanderAction())
     else

--- a/CorsixTH/Lua/rooms/fracture_clinic.lua
+++ b/CorsixTH/Lua/rooms/fracture_clinic.lua
@@ -65,7 +65,11 @@ function FractureRoom:commandEnteringPatient(patient)
     patient:setLayer(2, 0) -- Remove casts
     patient:setLayer(3, 0)
     patient:setLayer(4, 0)
-    staff:setNextAction(MeanderAction())
+    if #staff.action_queue == 1 then
+      staff:setNextAction(MeanderAction())
+    else
+      staff:finishAction(staff:getCurrentAction())
+    end
     self:dealtWithPatient(patient)
   end
 

--- a/CorsixTH/Lua/rooms/inflation.lua
+++ b/CorsixTH/Lua/rooms/inflation.lua
@@ -63,7 +63,11 @@ function InflationRoom:commandEnteringPatient(patient)
 
   local inflation_after_use = --[[persistable:inflation_after_use]] function()
     patient:setLayer(0, patient.layers[0] - 10) -- Change to normal head
-    staff:setNextAction(MeanderAction())
+    if #staff.action_queue == 1 then
+      staff:setNextAction(MeanderAction())
+    else
+      staff:finishAction(staff:getCurrentAction())
+    end
     self:dealtWithPatient(patient)
   end
 

--- a/CorsixTH/Lua/rooms/inflation.lua
+++ b/CorsixTH/Lua/rooms/inflation.lua
@@ -63,6 +63,7 @@ function InflationRoom:commandEnteringPatient(patient)
 
   local inflation_after_use = --[[persistable:inflation_after_use]] function()
     patient:setLayer(0, patient.layers[0] - 10) -- Change to normal head
+    -- if no other actions for staff member meander in room
     if #staff.action_queue == 1 then
       staff:setNextAction(MeanderAction())
     else

--- a/CorsixTH/Lua/rooms/slack_tongue.lua
+++ b/CorsixTH/Lua/rooms/slack_tongue.lua
@@ -67,7 +67,11 @@ function SlackTongueRoom:commandEnteringPatient(patient)
     else
       patient:setLayer(0, patient.layers[0] - 8) -- Change to normal head
     end
-    staff:setNextAction(MeanderAction())
+    if #staff.action_queue == 1 then
+      staff:setNextAction(MeanderAction())
+    else
+      staff:finishAction(staff:getCurrentAction())
+    end
     self:dealtWithPatient(patient)
   end
 

--- a/CorsixTH/Lua/rooms/slack_tongue.lua
+++ b/CorsixTH/Lua/rooms/slack_tongue.lua
@@ -67,6 +67,7 @@ function SlackTongueRoom:commandEnteringPatient(patient)
     else
       patient:setLayer(0, patient.layers[0] - 8) -- Change to normal head
     end
+    -- if no other actions for staff member meander in room
     if #staff.action_queue == 1 then
       staff:setNextAction(MeanderAction())
     else

--- a/CorsixTH/Lua/rooms/ultrascan.lua
+++ b/CorsixTH/Lua/rooms/ultrascan.lua
@@ -62,7 +62,11 @@ function UltrascanRoom:commandEnteringPatient(patient)
   patient:setNextAction(WalkAction(pat_x, pat_y))
 
   local after_use_scan = --[[persistable:ultrascan_after_use]] function()
-    staff:setNextAction(MeanderAction())
+    if #staff.action_queue == 1 then
+      staff:setNextAction(MeanderAction())
+    else
+      staff:finishAction(staff:getCurrentAction())
+    end
     self:dealtWithPatient(patient)
   end
 

--- a/CorsixTH/Lua/rooms/ultrascan.lua
+++ b/CorsixTH/Lua/rooms/ultrascan.lua
@@ -62,6 +62,7 @@ function UltrascanRoom:commandEnteringPatient(patient)
   patient:setNextAction(WalkAction(pat_x, pat_y))
 
   local after_use_scan = --[[persistable:ultrascan_after_use]] function()
+    -- if no other actions for staff member meander in room
     if #staff.action_queue == 1 then
       staff:setNextAction(MeanderAction())
     else


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #1926*

**Describe what the proposed change does**
- As discussed in the issue, puts the workaround dealing with the action queue changed when multi use object ends

