### PR TITLE
[rdy] Allow cheats menu use from fax

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/cheats_dialog.lua
+++ b/CorsixTH/Lua/dialogs/resizables/cheats_dialog.lua
@@ -117,7 +117,8 @@ function UICheats:updateCheatedStatus()
 end
 
 function UICheats:buttonClicked(num)
-  if self.ui.hospital.world:isUserActionProhibited() then
+  -- If the menu was opened by fax code, allow player to use it
+  if self.ui.hospital.world:isUserActionProhibited() and not self.ui:getWindow(UIFax) then
     --TODO: Prevent selectx.wav playing with this
     return self.ui:playSound("wrong2.wav")
   end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -961,7 +961,7 @@ function World:setSpeed(speed)
   end
 
   -- Set the blue filter according to whether the user can build or not.
-  TheApp.video:setBlueFilterActive(not self.user_actions_allowed)
+  TheApp.video:setBlueFilterActive(not self.user_actions_allowed and not self.ui:checkForMustPauseWindows())
   return false
 end
 


### PR DESCRIPTION
*Fixes #2102*

**Describe what the proposed change does**
- Allows the player to utilise the cheats menu if it was opened via fax code. For simplicity, allow behaviour if any fax is open.
- Also prevents a blue filter if unpausing on a fax, then pausing again.

One day I'll get this all right 
