### PR TITLE
Make app:fixConfig and app:fixHotkeys use defaults

### DIFF
--- a/CorsixTH/CorsixTH.lua
+++ b/CorsixTH/CorsixTH.lua
@@ -135,7 +135,7 @@ TheApp = App()
 TheApp:setCommandLine(
   "--bitmap-dir=" ..base_dir.. "Bitmap",
   "--config-file=" .. select(1, corsixth.require("config_finder")),
-  "--hotkeys-file=" .. select(3, corsixth.require("config_finder")),
+  "--hotkeys-file=" .. select(4, corsixth.require("config_finder")),
   -- If a command line option is given twice, the later one is used, hence
   -- if the user gave one of the above, that will be used instead.
   ...

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -805,7 +805,7 @@ end
 
 function App:fixConfig()
   -- Fill in default values for things which don't exist
-  local config_defaults = select(2, corsixth.require("config_finder"))
+  local config_defaults = select(3, corsixth.require("config_finder"))
   for k, v in pairs(config_defaults) do
     if self.config[k] == nil then
       self.config[k] = v
@@ -925,7 +925,7 @@ end
 
 function App:fixHotkeys()
   -- Fill in default values for things which don't exist
-  local hotkeys_defaults = select(4, corsixth.require("config_finder"))
+  local hotkeys_defaults = select(6, corsixth.require("config_finder"))
 
   for k, v in pairs(hotkeys_defaults) do
     if self.hotkeys[k] == nil then

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -855,4 +855,4 @@ for k, str_val in pairs(hotkeys_values) do
   end
 end
 
-return config_filename, config_values, hotkeys_filename, hotkeys_values, hotkeys_defaults, config_data
+return config_filename, config_values, config_defaults, hotkeys_filename, hotkeys_values, hotkeys_defaults, config_data

--- a/CorsixTH/Lua/dialogs/resizables/hotkey_assign.lua
+++ b/CorsixTH/Lua/dialogs/resizables/hotkey_assign.lua
@@ -503,7 +503,7 @@ end
 
 function UIHotkeyAssign:buttonDefaults()
   -- Copy the default hotkeys into the app's current hotkey table.
-  self.app.hotkeys = shallow_clone(select(5, corsixth.require("config_finder")))
+  self.app.hotkeys = shallow_clone(select(6, corsixth.require("config_finder")))
 
   -- Reload all hotkey boxes' text.
   for k, _ in pairs(self.hotkey_buttons) do

--- a/scripts/generate_windows_config.lua
+++ b/scripts/generate_windows_config.lua
@@ -29,7 +29,7 @@ local function path(tbl)
 end
 
 local config_path = path({"CorsixTH", "Lua", "config_finder.lua"})
-local config_data = select(6, dofile(config_path))
+local config_data = select(7, dofile(config_path))
 
 local template_path = path({"WindowsInstaller", "config_template.txt"})
 local f, err = io.open(template_path, "w")


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2082*

**Describe what the proposed change does**
Currently, the `app:fixConfig` and `app:fixHotkeys` functions were using the config.txt values as default.
This patch now points them to actually use the default values in our lua files.

This touches some files outside my usual scope. Let me know if I need to add anything else for those changes.