### PR TITLE
[RDY] Fix buffer overflow of played_sound_callbacks_ids

### DIFF
--- a/CorsixTH/Src/th_lua_sound.cpp
+++ b/CorsixTH/Src/th_lua_sound.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include <array>
 #include <cctype>
 #include <cstring>
 #include <map>
@@ -31,7 +32,7 @@ SOFTWARE.
 
 namespace {
 
-int played_sound_callback_ids[1000];
+std::array<int, 1000> played_sound_callback_ids;
 int played_sound_callback_index = 0;
 std::map<int, SDL_TimerID> map_sound_timers;
 
@@ -230,7 +231,7 @@ int l_soundfx_play(lua_State* L) {
     if (!lua_isnil(L, 7))
       iPlayedCallbackDelay = static_cast<int>(luaL_checknumber(L, 7));
 
-    if (played_sound_callback_index == sizeof(played_sound_callback_ids))
+    if (played_sound_callback_index == played_sound_callback_ids.size())
       played_sound_callback_index = 0;
 
     played_sound_callback_ids[played_sound_callback_index] =


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #* 

**Describe what the proposed change does**
- Fix buffer overflow 
- Potentially addresses #1380, was also some older bugs (still bugs?) where lava hole spawns but not accessible by Grim, which would also accelerate the overflow as the lava hole stays spawned.

