### PR TITLE
Support ffmpeg 5

### DIFF
--- a/CorsixTH/Src/th_movie.cpp
+++ b/CorsixTH/Src/th_movie.cpp
@@ -338,7 +338,7 @@ bool movie_player::load(const char* szFilepath) {
     return false;
   }
 
-  AVCodec* video_decoder;  // unowned, do not free
+  av_codec_ptr video_decoder;  // unowned, do not free
   video_stream_index = av_find_best_stream(format_context, AVMEDIA_TYPE_VIDEO,
                                            -1, -1, &video_decoder, 0);
   if (video_stream_index < 0) {
@@ -350,7 +350,7 @@ bool movie_player::load(const char* szFilepath) {
       video_decoder, format_context->streams[video_stream_index]);
   avcodec_open2(video_codec_context.get(), video_decoder, nullptr);
 
-  AVCodec* audio_decoder;  // unowned, do not free
+  av_codec_ptr audio_decoder;  // unowned, do not free
   audio_stream_index = av_find_best_stream(format_context, AVMEDIA_TYPE_AUDIO,
                                            -1, -1, &audio_decoder, 0);
   if (audio_stream_index >= 0) {
@@ -363,7 +363,7 @@ bool movie_player::load(const char* szFilepath) {
 }
 
 av_codec_context_unique_ptr movie_player::get_codec_context_for_stream(
-    AVCodec* codec, AVStream* stream) const {
+    av_codec_ptr codec, AVStream* stream) const {
   av_codec_context_unique_ptr ctx(avcodec_alloc_context3(codec));
   avcodec_parameters_to_context(ctx.get(), stream->codecpar);
   return ctx;

--- a/CorsixTH/Src/th_movie.h
+++ b/CorsixTH/Src/th_movie.h
@@ -50,6 +50,12 @@ extern "C" {
 #include <libswscale/swscale.h>
 }
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 0, 100)
+using av_codec_ptr = AVCodec*;
+#else
+using av_codec_ptr = const AVCodec*;
+#endif
+
 //! \brief Functor for deleting AVPackets
 //!
 //! Deletes AVPacket pointers that are allocated with av_malloc
@@ -359,7 +365,7 @@ class movie_player {
 
   //! Get the AVCodecContext associated with a given stream
   av_codec_context_unique_ptr get_codec_context_for_stream(
-      AVCodec* codec, AVStream* stream) const;
+      av_codec_ptr codec, AVStream* stream) const;
 
   //! Get the time the given frame should be played (from the start of the
   //! stream)


### PR DESCRIPTION
AVCodec* was made const in lavc 59.0.100 and lavf 59.0.100

<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2109*