### PR TITLE
Fix Negation Errors

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1701,7 +1701,7 @@ function App:checkForUpdates()
   print("Checking for CorsixTH updates...")
   local update_body, status, _ = http.request(update_url)
 
-  if not update_body or not (status == 200) then
+  if not update_body or (status ~= 200) then
     print("Couldn't check for updates. Server returned code: " .. status)
     print("Check that you have an active internet connection and that CorsixTH is allowed in your firewall.")
     return

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1447,9 +1447,9 @@ function UIEditRoom:onCursorWorldPositionChange(x, y)
         self.move_rect = false
         self.resize_rect = {
           n = (wy == rect.y),
-          s = (wy == rect.y + rect.h - 1) and not (wy == rect.y),
+          s = (wy == rect.y + rect.h - 1) and (wy ~= rect.y),
           w = (wx == rect.x),
-          e = (wx == rect.x + rect.w - 1) and not (wx == rect.x),
+          e = (wx == rect.x + rect.w - 1) and (wx ~= rect.x),
         }
 
         if (self.resize_rect.w or self.resize_rect.e) and (self.resize_rect.n or self.resize_rect.s) then

--- a/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
@@ -235,7 +235,7 @@ function Doctor:setCrazy(crazy)
   else
     -- make doctor sane
     if self.is_crazy then
-      if not (self.layers[5] < 5) then
+      if (self.layers[5] >= 5) then
         self:setLayer(5, self.layers[5] - 4)
         self.is_crazy = false
       end

--- a/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
@@ -235,7 +235,7 @@ function Doctor:setCrazy(crazy)
   else
     -- make doctor sane
     if self.is_crazy then
-      if (self.layers[5] >= 5) then
+      if self.layers[5] >= 5 then
         self:setLayer(5, self.layers[5] - 4)
         self.is_crazy = false
       end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1025,7 +1025,7 @@ function World:onTick()
       self.autosave_next_tick = nil
       local pathsep = package.config:sub(1, 1)
       local dir = TheApp.savegame_dir
-      if not dir:sub(-1, -1) == pathsep then
+      if dir:sub(-1, -1) ~= pathsep then
         dir = dir .. pathsep
       end
       if not lfs.attributes(dir .. "Autosaves", "modification") then


### PR DESCRIPTION
Update to luacheck now includes warnings for negation.

This addresses those, but needs to be checked that none of these changes break anything.
@colinjmatt could you check that OSX behaves correctly with the change to `world.lua` for the `pathsep` check?

<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->
