### PR TITLE
ci: bump github actions

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -35,7 +35,7 @@ jobs:
             catch2: -DENABLE_UNIT_TESTS=ON
     name: Linux and Tests on ${{ matrix.lua }}
     steps:
-      - uses: actions/checkout@v2  # Keeps the git OAuth token after checkout
+      - uses: actions/checkout@v3  # Keeps the git OAuth token after checkout
       - name: Install ${{ matrix.lua }} ${{ matrix.animview }}
         run: |
           sudo apt-get update

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -9,7 +9,7 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/repository-dispatch@v1
+      - uses: peter-evans/repository-dispatch@v2
         with:
           repository: CorsixTH/corsixth.github.io
           token: ${{ secrets.WEBSITE_REPO_TOKEN }}


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->
Bump GitHub Actions to their latest major versions. Main change is they're now using Node 16 instead of 12, which is EOL at end of month.

- Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- Releases for `peter-evans/repository-dispatch` can be [found here](https://github.com/peter-evans/repository-dispatch/releases)

