### PR TITLE
Change how staff find work

### DIFF
--- a/CorsixTH/Lua/calls_dispatcher.lua
+++ b/CorsixTH/Lua/calls_dispatcher.lua
@@ -514,6 +514,11 @@ function CallsDispatcher.getPriorityForRoom(room, attribute, staff)
   -- Prefer the tirer staff (such that less chance to have "resting synchronization issue")
   score = score - staff:getAttribute("fatigue") * 40 -- 40 is just a weighting scale
 
+  -- Prefer a wandering staff member over a staff member in a room
+  if not staff:getRoom() then
+    score = score - 50
+  end
+
   -- TODO: Assign doctor with higher ability
 
   -- Room requires specilitist trumps over normal rooms

--- a/CorsixTH/Lua/calls_dispatcher.lua
+++ b/CorsixTH/Lua/calls_dispatcher.lua
@@ -327,8 +327,8 @@ end
 function CallsDispatcher:answerCall(staff)
   local min_score = 2^30
   local min_call = nil
-  assert(not staff.on_call, "Staff should be idea before he can answer another call")
-  assert(staff.hospital, "Staff should still be a member of the hospital to answer a call")
+  assert(not staff.on_call, "Staff member looking for work while already answering a call.")
+  assert(staff.hospital, "Staff should still be a member of the hospital to answer a call.")
 
   if staff.humanoid_class == "Handyman" then
    staff:searchForHandymanTask()

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -501,7 +501,7 @@ function Staff:adviseWrongPersonForThisRoom()
   end
 end
 
--- Function to decide if staff currently has nothing to do and can be called to a room where he's needed
+-- Function to decide if staff currently has nothing to do and can be called to a room where they're needed
 function Staff:isIdle()
   -- Make sure we're not in an undesired state
   if not self.hospital or self.fired then
@@ -530,25 +530,15 @@ function Staff:isIdle()
     end
 
     -- For handyman - just check the on_call flag
-    if self.humanoid_class == "Handyman" and not self.on_call then
-      return true
-    end
+    if self.humanoid_class == "Handyman" then return not self.on_call end
 
     -- For other staff...
+    -- Staff member might be leaving
+    if self:getCurrentAction().is_leaving then return false end
+
     -- in regular rooms (diagnosis / treatment), if no patient is in sight
     -- or if the only one in sight is actually leaving.
-    if self.humanoid_class ~= "Handyman" and room.door.queue:patientSize() == 0 and
-        not self:getCurrentAction().is_leaving and
-        not (room.door.reserved_for and class.is(room.door.reserved_for, Patient)) then
-      if room:getPatientCount() == 0 then
-        return true
-      else
-        -- It might still be the case that the patient is leaving
-        if room:getPatient():isLeaving() then
-          return true
-        end
-      end
-    end
+    return not room:isRoomInDemand()
   else
     -- In the corridor and not on_call (watering or going to room), the staff is free
     -- unless going back to the training room or research department.
@@ -561,7 +551,6 @@ function Staff:isIdle()
     end
     return true
   end
-  return false
 end
 
 -- Makes the staff member request a raise of 10%, or a wage exactly in the middle of their current and a fair one, whichever is more.

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -518,6 +518,12 @@ function PlayerHospital:onEndDay()
     end
   end
 
+  for _, staff in ipairs(self.staff) do
+    if staff:isIdle() then
+      self.world.dispatcher:answerCall(staff)
+    end
+  end
+
   Hospital.onEndDay(self)
 end
 

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -216,20 +216,6 @@ function Room:dealtWithPatient(patient)
   if self.dealt_patient_callback then
     self.dealt_patient_callback(self.waiting_staff_member)
   end
-  -- The staff member(s) might be needed somewhere else.
-  self:findWorkForStaff()
-end
-
---! Checks if the room still needs the staff in it and otherwise
--- sends them away if they're needed somewhere else.
-function Room:findWorkForStaff()
-  -- If the staff member is idle we can send him/her somewhere else
-  for humanoid in pairs(self.humanoids) do
-    -- Don't check handymen
-    if class.is(humanoid, Staff) and humanoid.humanoid_class ~= "Handyman" and humanoid:isIdle() then
-      self.world.dispatcher:answerCall(humanoid)
-    end
-  end
 end
 
 local profile_attributes = {

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -722,6 +722,20 @@ function Room:roomFinished()
   self:calculateHappinessFactor()
 end
 
+--! Check if a room is actively required by patients
+--! A room is deemed in demand should any patient be in a state of using, or
+--! wanting to use the room.
+--!return (boolean) true if the room is currently needed
+function Room:isRoomInDemand()
+  local door = self.door
+  if self:getPatientCount() > 0 and not self:getPatient():isLeaving() then
+    return true
+  end
+  return (door.queue and door.queue:patientSize() > 0) or
+      (door.reserved_for and class.is(door.reserved_for, Patient)) or
+      (door.user and class.is(door.user, Patient) and door.user:getCurrentAction().is_entering)
+end
+
 --! Try to move a patient from the old room to the new room.
 --!param old_room (Room) Room that currently has the patient in the queue.
 --!param new_room (Room) Room that wants the patient in the queue.

--- a/CorsixTH/Lua/rooms/gp.lua
+++ b/CorsixTH/Lua/rooms/gp.lua
@@ -161,8 +161,6 @@ function GPRoom:dealtWithPatient(patient)
   if self.staff_member then
     self:setStaffMembersAttribute("dealing_with_patient", false)
   end
-  -- Maybe the staff member can go somewhere else
-  self:findWorkForStaff()
 end
 
 function GPRoom:sendPatientToNextDiagnosisRoom(patient)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->
This is a proposal to address these issues. The fix has had some funky behaviour in scenarios where a Dr calls to the room, patient leaves for toilet, before call is completed, then the staff member leaves the room and heads to the next room, where the same thing occurs and ended up returning to the same first room.

There is also a change to prefer wandering staff but not sure how effective that is at the moment to get them, due to the weighting of fatigue beforehand. For when excess staff are employed and they leave staff room after rest and there is no call, they start wandering, but they'll have near 0 fatigue and all else being equal is a distance difference of 10 tiles to have the staff leave the room instead.

*Fixes #1582 
Fixes #2060*

**Describe what the proposed change does**
- Penalise finding work if in a room over a doctor that is wandering
- Move the find work call outside of the dealtWithPatient process
