### PR TITLE
[RDY] Fix dynamic info updates during epidemics

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -981,16 +981,14 @@ function Patient:updateDynamicInfo()
   end
   -- Set the centre line of dynamic info based on contagiousness, if appropriate
   local epidemic = self.hospital and self.hospital.epidemic
-  if epidemic and epidemic.coverup_in_progress then
-    if self.infected and not self.vaccinated then
-      self:setDynamicInfo('text',
-        {action_string, _S.dynamic_info.patient.actions.epidemic_contagious, info})
-    elseif self.vaccinated then
+  if epidemic and self.infected and epidemic.coverup_in_progress then
+    if self.vaccinated then
       self:setDynamicInfo('text',
         {action_string, _S.dynamic_info.patient.actions.epidemic_vaccinated, info})
     else
-      self:setDynamicInfo('text', {action_string, "", info})
-    end
+      self:setDynamicInfo('text',
+        {action_string, _S.dynamic_info.patient.actions.epidemic_contagious, info})
+	end
   else
     self:setDynamicInfo('text', {action_string, "", info})
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #1173/#1606*

**Describe what the proposed change does**
- During epidemics patient info don't update correctly as per #1173
- Prevent patients becoming fed up and leaving when in a room, also mentioned in the same issue
- Added a helper method for setting staff_wait, and wrapped it to prevent some invalid scenarios #1606 - method refers to staff_member and staff_member_set also to only operate on staff, seems a handy shortcut for the class.is Staff and not handyman check.