### PR TITLE
Minor fixes related to luacheck

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -28,7 +28,7 @@ globals = { -- Globals
             "lfs", "list_to_set", "loadfile_envcall", "loadstring_envcall",
             "permanent", "print_table", "rangeMapLookup", "rnc",
             "strict_declare_global", "table_length", "unpermanent", "values",
-            "serialize","array_join","shallow_clone",
+            "serialize","array_join","shallow_clone","staff_initials_cache",
 
             -- Game classes
             "AIHospital", "AnimationManager", "AnimationEffect", "App", "Audio",
@@ -228,7 +228,6 @@ add_ignore("CorsixTH/Lua/rooms/ward.lua", "113")
 add_ignore("CorsixTH/Lua/rooms/ward.lua", "211")
 add_ignore("CorsixTH/Lua/rooms/ward.lua", "212")
 add_ignore("CorsixTH/Lua/sprite_viewer.lua", "212")
-add_ignore("CorsixTH/Lua/staff_profile.lua", "113")
 add_ignore("CorsixTH/Lua/strict.lua", "212")
 add_ignore("CorsixTH/Lua/strings.lua", "212")
 add_ignore("CorsixTH/Lua/strings.lua", "122")
@@ -240,7 +239,6 @@ add_ignore("CorsixTH/Lua/window.lua", "212")
 add_ignore("CorsixTH/Lua/window.lua", "542")
 add_ignore("CorsixTH/Lua/world.lua", "111")
 add_ignore("CorsixTH/Lua/world.lua", "112")
-add_ignore("CorsixTH/Lua/world.lua", "113")
 add_ignore("CorsixTH/Lua/world.lua", "212")
 add_ignore("CorsixTH/Lua/world.lua", "542")
 add_ignore("CorsixTH/Luatest/non_strict.lua", "212")

--- a/CorsixTH/Lua/objects/door.lua
+++ b/CorsixTH/Lua/objects/door.lua
@@ -191,5 +191,6 @@ function Door:afterLoad(old, new)
       map:setCellFlags(self.tile_x, self.tile_y - 1, flags_to_set)
     end
   end
+  Object.afterLoad(self, old, new)
 end
 return object

--- a/CorsixTH/Lua/rooms/research.lua
+++ b/CorsixTH/Lua/rooms/research.lua
@@ -209,5 +209,6 @@ function ResearchRoom:afterLoad(old, new)
   if old < 56 then
     self.hospital.research_dep_built = true
   end
+  Room.afterLoad(self, old, new)
 end
 return room


### PR DESCRIPTION
**Describe what the proposed change does**
- Move two helper functions to the one place they're used. 
- Add the staff initials cache to globals list
- Add the two call parent afterloads that are missing, I haven't seen this as a problem in game but the change makes it consistent with the others - https://grep.app/search?q=afterload&filter[repo][0]=CorsixTH/CorsixTH&filter[lang][0]=Lua&filter[path][0]=CorsixTH/Lua/

Each of these could be instead left as is with luacheck ignores