### PR TITLE
Prevent epidemic infection outside hospital

### DIFF
--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -144,6 +144,13 @@ function Epidemic:infectOtherPatients()
     -- Patient is not infectious.
     if patient.cured or patient.vaccinated then return false end
 
+    -- Don't allow infection outside the hospital grounds
+    -- Also check both patients to prevent infecting through outer walls
+    local ppx, ppy = patient.tile_x, patient.tile_y
+    if ppx and ppy and not self.hospital:isInHospital(ppx, ppy) then return false end
+    local opx, opy = other.tile_x, other.tile_y
+    if opx and opy and not self.hospital:isInHospital(opx, opy) then return false end
+
     -- 'other' is already infected or is going home.
     if other.infected or other.cured or other.vaccinated then return false end
     if other.is_emergency then return false end -- Don't interact with emergencies.


### PR DESCRIPTION
Infection outside the hospital could cause a player to unfairly lose an epidemic by infecting a kicked/fed up/too pricey patient outside the hospital grounds.

For sake of fairness as discussed, they should remain able to be infected while in the grounds.
*May fix #2129*

**Describe what the proposed change does**
- Adds a check on the infected patient and the target patient to make sure both are inside hospital grounds to pass the infection.

