### PR TITLE
Fix knockdoor action in flight.

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 167 -- Let hospitals count their tile objects.
+local SAVEGAME_VERSION = 168 -- Sanitize knock-door callback
 
 class "App"
 

--- a/CorsixTH/Lua/humanoid_action.lua
+++ b/CorsixTH/Lua/humanoid_action.lua
@@ -110,4 +110,11 @@ function HumanoidAction:afterLoad(old, new)
       self.is_entering = not not self.is_entering
     end
   end
+
+  if old < 168 and class.type(self) == "KnockDoorAction" then
+    -- When the knock-door animation is running in the action at the time of
+    -- save, the callback at the end of the animation doesn't have a valid
+    -- state variable and crashes.
+    if not self.state then self.state = 1 end
+  end
 end


### PR DESCRIPTION
*Fixes #2142 

**Describe what the proposed change does**
- When the Knockdoor Action is being animated at the time of save, the state variable is never created and the callback at the end of the animation cannot find the next step to perform.
- Fixed by initializing the state to point to that next step. If the action was not running, the `start` calll will initialize state variable, overwriting the fix value.

