### PR TITLE
Fix spelling, duplicate call, incorrect original strings

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -159,7 +159,6 @@ function UIEditRoom:abortRoom()
   self:close()
   -- Finally remove the room from the world (close() needs the reference)
   if self.room then
-    self.room:deactivate() -- TODO: may be superfluous since already called in Room:tryToEdit
     self.world.rooms[self.room.id] = nil
   end
 end

--- a/CorsixTH/Lua/entities/humanoids/vip.lua
+++ b/CorsixTH/Lua/entities/humanoids/vip.lua
@@ -90,7 +90,7 @@ function Vip:Vip(...)
 
 end
 
---[[--VIP while on premesis--]]
+--[[--VIP while on premises--]]
 function Vip:tickDay()
   -- for the vip
   if self.waiting then

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1148,7 +1148,7 @@ end
 function Hospital:spawnContagiousPatient()
   --[[ Gets the available non-visual disease in the current world
     @return non_visuals (table) table of available non-visual diseases]]
-  local function get_avaliable_contagious_diseases()
+  local function get_available_contagious_diseases()
     local contagious = {}
     for _, disease in ipairs(self.world.available_diseases) do
       if disease.contagious then
@@ -1160,7 +1160,7 @@ function Hospital:spawnContagiousPatient()
 
   if self:hasStaffedDesk() then
     local patient = self.world:newEntity("Patient", 2)
-    local contagious_diseases = get_avaliable_contagious_diseases()
+    local contagious_diseases = get_available_contagious_diseases()
     if #contagious_diseases > 0 then
       local disease = contagious_diseases[math.random(1,#contagious_diseases)]
       patient:setDisease(disease)

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -24,8 +24,8 @@ Inherit("original_strings", 0)
 --Note: All strings should use a single space after full-stops. Only exception is level descriptions.
 -------------------------------  OVERRIDE  ----------------------------------
 adviser.warnings.money_low = "Your money is getting low!" -- Funny. Exists in German translation, but not existent in english?
--- TODO: tooltip.graphs.reputation -- this tooltip talks about hospital value. Actually it should say reputation.
--- TODO: tooltip.status.close -- it's called status window, not overview window.
+tooltip.graphs.reputation = "Toggle reputation" -- Incorrectly said "toggle hospital value"
+tooltip.status.close = "Close status window" -- Incorrectly said "close overview window"
 
 -- tooltip.staff_list.next_person, prev_person is rather next/prev page (also in german, maybe more languages?)
 tooltip.staff_list.next_person = "Show next page"

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -364,7 +364,7 @@ end
 --!param ... Additional arguments to `callback`.
 function UI:addKeyHandler(keys, window, callback, ...)
   -- It is necessary to clone the key table into another temporary table, as if we don't the original table that we take it from will lose
-  -- the last key of that table permenently in the next line of code after this one, until the program is restarted.
+  -- the last key of that table permanently in the next line of code after this one, until the program is restarted.
   -- I.E. if the "ingame_quitLevel" hotkey from the "hotkeys_values" table in "config_finder.lua" is a table that looks like this:
   --   {"shift", "q"}
   -- We would lose the "q" element until we restarted the game and the "hotkey.txt" was read from again, causing the "ingame_quitLevel"


### PR DESCRIPTION
**Describe what the proposed change does**
- Correct some spelling.
- Remove duplicate call to deactivate room (the removed comment is correct)
- Correct two incorrect strings in English. I think Italian is correct and Brazilian PR is wrong, so we should ask translators. This is before the fix.
![Screen 2022-05-04 at 16 58 37](https://user-images.githubusercontent.com/552285/166723136-d2ff940f-ad7f-4231-b705-363f0e7b19af.png)
![Screen 2022-05-04 at 16 59 46](https://user-images.githubusercontent.com/552285/166723142-aaf3ca23-9354-4039-9607-9fb6aff26d1c.png)

