### PR TITLE
Update references to luasocket for their v3 release

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -154,10 +154,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------------------------------------------------------------------------
 
 Uses the luasocket library available from
-https://github.com/diegonehab/luasocket under the following terms:
+https://github.com/lunarmodules/luasocket under the following terms:
 
-LuaSocket 3.0 license
-Copyright © 2004-2013 Diego Nehab
+Copyright (C) 2004-2022 Diego Nehab
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/scripts/macos_luarocks
+++ b/scripts/macos_luarocks
@@ -59,7 +59,7 @@ elif [ -e "$dir/lib/lua/$lua/lfs.so" ] && [ -e "$dir/lib/lua/$lua/lpeg.so" ] &&
 else
   luarocks install --lua-version "$lua" --tree . luafilesystem
   luarocks install --lua-version "$lua" --tree . lpeg
-  luarocks install --lua-version "$lua" --tree . luasocket --from=http://luarocks.org/dev
+  luarocks install --lua-version "$lua" --tree . luasocket
   luarocks install --lua-version "$lua" --tree . luasec OPENSSL_DIR=/usr/local/opt/openssl || true
   echo "Installed local luarocks $lua."
 fi


### PR DESCRIPTION
**Describe what the proposed change does**
- Update the url and dates of luasocket in licence.txt
- Use the latest release, rather than dev, of luasocket in macos_luarocks

A connected todo: Update vcpkg. Should both happen at the same time? The windows and macos setups already result in using different commits of luasocket
