### PR TITLE
Fix version compare on update

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1678,7 +1678,7 @@ function App:checkForUpdates()
   -- Default language to use for the changelog if no localised version is available
   local default_language = "en"
   local update_url = 'https://corsixth.com/CorsixTH/check-for-updates'
-  local current_version = self:getVersion()
+  local current_version = string.gsub(self:getVersion(), "v", "") -- drop the 'v'
 
   -- Only URLs that match this list of trusted domains will be accepted.
   local trusted_domains = { 'corsixth.com', 'github.com', 'corsixth.github.io' }


### PR DESCRIPTION
**Describe what the proposed change does**
- Current check for update was comparing vx.xx to x.xx, which always resolved that CorsixTH was up to date.
- Bonus points: 0.66 > 0.65.1 (even though our web site only reports 0.65?)
