### PR TITLE
Draw map to enclosing scaled rect when zoomed - fixes #2164

### DIFF
--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -244,7 +244,7 @@ function GameUI:draw(canvas)
   local dy = self.screen_offset_y +
       math.floor((0.5 - math.random()) * self.shake_screen_intensity * shake_screen_max_movement * 2)
   if canvas:scale(zoom) then
-    app.map:draw(canvas, dx, dy, math.floor(config.width / zoom), math.floor(config.height / zoom), 0, 0)
+    app.map:draw(canvas, dx, dy, math.ceil(config.width / zoom), math.ceil(config.height / zoom), 0, 0)
     canvas:scale(1)
   else
     self:setZoom(1)


### PR DESCRIPTION
* Fixes #2164

All zoomed draw operations must draw to enclosing rectangles to ensure that there are no unpainted pixels. The lua code was passing in a width and height rounded down which occasionally resulted in not covering the entire screen while zooming.