### PR TITLE
Refactor clipping on render_target to keep a stack of clips.

### DIFF
--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -84,10 +84,9 @@ function UIMessage:draw(canvas, x, y)
   if self.on_top then
     Window.draw(self, canvas, x, y)
   else
-    local x_, y_, w, h = canvas:getClip()
-    canvas:setClip(x_, y + self.stop_y, w, self.height, true)
+    canvas:pushClip(0, y + self.stop_y, canvas:getWidth(), self.height, true)
     Window.draw(self, canvas, x, y)
-    canvas:setClip(x_, y_, w, h)
+    canvas:popClip()
   end
 end
 

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1205,7 +1205,8 @@ void animation::draw_morph(render_target* pCanvas, int iDestX, int iDestY) {
   oMorphRect.x = 0;
   oMorphRect.w = pCanvas->get_width();
   oMorphRect.y = iDestY + morph_target->x_relative_to_tile;
-  oMorphRect.h = morph_target->y_relative_to_tile - morph_target->x_relative_to_tile;
+  oMorphRect.h =
+      morph_target->y_relative_to_tile - morph_target->x_relative_to_tile;
   {
     render_target::scoped_clip clip(pCanvas, &oMorphRect);
     manager->draw_frame(pCanvas, frame_index, layers, iDestX, iDestY, flags);
@@ -1214,8 +1215,9 @@ void animation::draw_morph(render_target* pCanvas, int iDestX, int iDestY) {
   oMorphRect.h = morph_target->speed.dx - morph_target->y_relative_to_tile;
   {
     render_target::scoped_clip clip(pCanvas, &oMorphRect);
-    manager->draw_frame(pCanvas, morph_target->frame_index, morph_target->layers,
-                        iDestX, iDestY, morph_target->flags);
+    manager->draw_frame(pCanvas, morph_target->frame_index,
+                        morph_target->layers, iDestX, iDestY,
+                        morph_target->flags);
   }
 }
 

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1152,9 +1152,9 @@ void animation::draw(render_target* pCanvas, int iDestX, int iDestY) {
   }
   if (manager) {
     if (flags & thdf_crop) {
-      clip_rect rcOld, rcNew;
-      rcNew.y = rcOld.y;
-      rcNew.h = rcOld.h;
+      clip_rect rcNew;
+      rcNew.y = 0;
+      rcNew.h = pCanvas->get_height();
       rcNew.x = iDestX + (crop_column - 1) * 32;
       rcNew.w = 64;
       render_target::scoped_clip clip(pCanvas, &rcNew);

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1157,10 +1157,9 @@ void animation::draw(render_target* pCanvas, int iDestX, int iDestY) {
       rcNew.h = rcOld.h;
       rcNew.x = iDestX + (crop_column - 1) * 32;
       rcNew.w = 64;
-      pCanvas->push_clip_rect(&rcNew);
+      render_target::scoped_clip clip(pCanvas, &rcNew);
       manager->draw_frame(pCanvas, frame_index, layers, iDestX, iDestY, flags,
                           patient_effect, patient_effect_offset);
-      pCanvas->pop_clip_rect();
     } else
       manager->draw_frame(pCanvas, frame_index, layers, iDestX, iDestY, flags,
                           patient_effect, patient_effect_offset);
@@ -1207,15 +1206,17 @@ void animation::draw_morph(render_target* pCanvas, int iDestX, int iDestY) {
   oMorphRect.w = pCanvas->get_width();
   oMorphRect.y = iDestY + morph_target->x_relative_to_tile;
   oMorphRect.h = morph_target->y_relative_to_tile - morph_target->x_relative_to_tile;
-  pCanvas->push_clip_rect(&oMorphRect);
-  manager->draw_frame(pCanvas, frame_index, layers, iDestX, iDestY, flags);
-  pCanvas->pop_clip_rect();
+  {
+    render_target::scoped_clip clip(pCanvas, &oMorphRect);
+    manager->draw_frame(pCanvas, frame_index, layers, iDestX, iDestY, flags);
+  }
   oMorphRect.y = iDestY + morph_target->y_relative_to_tile;
   oMorphRect.h = morph_target->speed.dx - morph_target->y_relative_to_tile;
-  pCanvas->push_clip_rect(&oMorphRect);
-  manager->draw_frame(pCanvas, morph_target->frame_index, morph_target->layers,
-                      iDestX, iDestY, morph_target->flags);
-  pCanvas->pop_clip_rect();
+  {
+    render_target::scoped_clip clip(pCanvas, &oMorphRect);
+    manager->draw_frame(pCanvas, morph_target->frame_index, morph_target->layers,
+                        iDestX, iDestY, morph_target->flags);
+  }
 }
 
 bool animation::hit_test(int iDestX, int iDestY, int iTestX, int iTestY) {

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -121,7 +121,6 @@ uint8_t convert_6bit_to_8bit_colour_component(uint8_t colour_component) {
       (colour_component & mask_6bit) * static_cast<double>(0xFF) / mask_6bit));
 }
 
-
 //! Get the intersection of two SDL_Rects. The output rect can be a
 //  pointer to either of the two input rects.
 /*!
@@ -641,13 +640,13 @@ bool render_target::fill_rect(uint32_t iColour, int iX, int iY, int iW,
   return true;
 }
 
-render_target::scoped_clip::scoped_clip(render_target* pTarget, const clip_rect* pRect): target(pTarget) {
+render_target::scoped_clip::scoped_clip(render_target* pTarget,
+                                        const clip_rect* pRect)
+    : target(pTarget) {
   target->push_clip_rect(pRect);
 }
 
-render_target::scoped_clip::~scoped_clip() {
-  target->pop_clip_rect();
-}
+render_target::scoped_clip::~scoped_clip() { target->pop_clip_rect(); }
 
 void render_target::push_clip_rect(const clip_rect* pRect) {
   const SDL_Rect* previous_clip = nullptr;

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -121,6 +121,31 @@ uint8_t convert_6bit_to_8bit_colour_component(uint8_t colour_component) {
       (colour_component & mask_6bit) * static_cast<double>(0xFF) / mask_6bit));
 }
 
+
+//! Get the intersection of two SDL_Rects. The output rect can be a
+//  pointer to either of the two input rects.
+/*!
+    @param a Pointer to first SDL_Rect to be intersected
+    @param b Pointer to second SDL_Rect to be intersected
+    @param[out] out The intersection of SDL_Rect |a| and |b|.
+ */
+void intersectRect(const SDL_Rect& a, const SDL_Rect& b, SDL_Rect* out) {
+  // The intersection of the rectangles is the higher of the lower bounds and
+  // the lower of the higher bounds, clamped to a zero size.
+  clip_rect::x_y_type maxX = std::min(a.x + a.w, b.x + b.w);
+  clip_rect::x_y_type maxY = std::min(a.y + a.h, b.y + b.h);
+  out->x = std::max(a.x, b.x);
+  out->y = std::max(a.y, b.y);
+  out->w = maxX - out->x;
+  out->h = maxY - out->y;
+
+  // Make sure that we clamp the values to 0.
+  if (out->w <= 0 || out->h <= 0) {
+    out->w = 0;
+    out->h = 0;
+  }
+}
+
 //! Get the enclosing rect of an SDL_Rect scaled by the given scale factor.
 //  Scaling the rect is location dependent, as non-integer scale factors
 //  require that same size rects be +/-1 pixel different in size depending
@@ -616,49 +641,50 @@ bool render_target::fill_rect(uint32_t iColour, int iX, int iY, int iW,
   return true;
 }
 
-void render_target::get_clip_rect(clip_rect* pRect) const {
-  SDL_RenderGetClipRect(renderer, reinterpret_cast<SDL_Rect*>(pRect));
-  // SDL returns empty rect when clipping is disabled -> return full rect for
-  // CTH
-  if (SDL_RectEmpty(pRect)) {
-    pRect->x = pRect->y = 0;
-    pRect->w = width;
-    pRect->h = height;
-  }
-
-  if (apply_opengl_clip_fix) {
-    int renderWidth, renderHeight;
-    SDL_RenderGetLogicalSize(renderer, &renderWidth, &renderHeight);
-    pRect->y = renderHeight - pRect->y - pRect->h;
-  }
-
-  getEnclosingScaleRect(pRect, 1.0 / draw_scale(), pRect);
+render_target::scoped_clip::scoped_clip(render_target* pTarget, const clip_rect* pRect): target(pTarget) {
+  target->push_clip_rect(pRect);
 }
 
-void render_target::set_clip_rect(const clip_rect* pRect) {
-  // Full clip rect for CTH means clipping disabled
-  if (pRect == nullptr || (pRect->w == width && pRect->h == height)) {
-    SDL_RenderSetClipRect(renderer, nullptr);
-    return;
-  }
+render_target::scoped_clip::~scoped_clip() {
+  target->pop_clip_rect();
+}
 
-  SDL_Rect SDLRect;
-  getEnclosingScaleRect(pRect, draw_scale(), &SDLRect);
+void render_target::push_clip_rect(const clip_rect* pRect) {
+  const SDL_Rect* previous_clip = nullptr;
+  if (!clip_rects.empty()) {
+    previous_clip = &clip_rects.top();
+  }
+  clip_rects.push(SDL_Rect());
+  SDL_Rect& clip = clip_rects.top();
+  getEnclosingScaleRect(pRect, draw_scale(), &clip);
+  if (previous_clip) {
+    // Ensure that this new clip does not escape any previous clips applied.
+    intersectRect(clip, *previous_clip, &clip);
+  }
 
   // For some reason, SDL treats an empty rect (h or w <= 0) as if you turned
   // off clipping, so we replace it with a rect that's outside our viewport.
   const SDL_Rect rcBogus = {-2, -2, 1, 1};
-  if (SDL_RectEmpty(&SDLRect)) {
-    SDLRect = rcBogus;
+  if (SDL_RectEmpty(&clip)) {
+    clip = rcBogus;
   }
 
   if (apply_opengl_clip_fix) {
     int renderWidth, renderHeight;
     SDL_RenderGetLogicalSize(renderer, &renderWidth, &renderHeight);
-    SDLRect.y = renderHeight - SDLRect.y - SDLRect.h;
+    clip.y = renderHeight - clip.y - clip.h;
   }
 
-  SDL_RenderSetClipRect(renderer, &SDLRect);
+  SDL_RenderSetClipRect(renderer, &clip);
+}
+
+void render_target::pop_clip_rect() {
+  clip_rects.pop();
+  if (clip_rects.empty()) {
+    SDL_RenderSetClipRect(renderer, nullptr);
+  } else {
+    SDL_RenderSetClipRect(renderer, &clip_rects.top());
+  }
 }
 
 int render_target::get_width() const {

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -388,7 +388,7 @@ class render_target {
   int cursor_x;
   int cursor_y;
 
-  std::stack<SDL_Rect> clip_rects; ///< Stack of requested clip rects.
+  std::stack<SDL_Rect> clip_rects;  ///< Stack of requested clip rects.
 
   bool scale_bitmaps;  ///< Whether bitmaps should be scaled.
   bool supports_target_textures;

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -28,6 +28,7 @@ SOFTWARE.
 #include <SDL.h>
 
 #include <memory>
+#include <stack>
 #include <stdexcept>
 
 #include "persist_lua.h"
@@ -271,17 +272,17 @@ class render_target {
   //! Fill a rectangle of the render target with a solid colour
   bool fill_rect(uint32_t iColour, int iX, int iY, int iW, int iH);
 
-  //! Get the current clip rectangle
-  void get_clip_rect(clip_rect* pRect) const;
+  //! Push a new clip rectangle.
+  void push_clip_rect(const clip_rect* pRect);
+
+  //! Restore the previous clip rectangle.
+  void pop_clip_rect();
 
   //! Get the width of the render target (in pixels)
   int get_width() const;
 
   //! Get the height of the render target (in pixels)
   int get_height() const;
-
-  //! Set the new clip rectangle
-  void set_clip_rect(const clip_rect* pRect);
 
   //! Enable optimisations for non-overlapping draws
   void start_nonoverlapping_draws();
@@ -377,6 +378,9 @@ class render_target {
   int height;
   int cursor_x;
   int cursor_y;
+
+  std::stack<SDL_Rect> clip_rects; ///< Stack of requested clip rects.
+
   bool scale_bitmaps;  ///< Whether bitmaps should be scaled.
   bool supports_target_textures;
 

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -272,6 +272,15 @@ class render_target {
   //! Fill a rectangle of the render target with a solid colour
   bool fill_rect(uint32_t iColour, int iX, int iY, int iW, int iH);
 
+  class scoped_clip {
+   public:
+    scoped_clip(render_target*, const clip_rect* pRect);
+    ~scoped_clip();
+
+   private:
+    render_target* target = nullptr;
+  };
+
   //! Push a new clip rectangle.
   void push_clip_rect(const clip_rect* pRect);
 

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -708,6 +708,18 @@ int l_surface_pop_clip(lua_State* L) {
   return 1;
 }
 
+int l_surface_get_width(lua_State* L) {
+  render_target* pCanvas = luaT_testuserdata<render_target>(L);
+  lua_pushinteger(L, pCanvas->get_width());
+  return 1;
+}
+
+int l_surface_get_height(lua_State* L) {
+  render_target* pCanvas = luaT_testuserdata<render_target>(L);
+  lua_pushinteger(L, pCanvas->get_height());
+  return 1;
+}
+
 int l_surface_scale(lua_State* L) {
   render_target* pCanvas = luaT_testuserdata<render_target>(L);
   scaled_items eToScale = scaled_items::none;
@@ -925,6 +937,8 @@ void lua_register_gfx(const lua_register_state* pState) {
     lcb.add_function(l_surface_rect, "drawRect");
     lcb.add_function(l_surface_push_clip, "pushClip");
     lcb.add_function(l_surface_pop_clip, "popClip");
+    lcb.add_function(l_surface_get_width, "getWidth");
+    lcb.add_function(l_surface_get_height, "getHeight");
     lcb.add_function(l_surface_screenshot, "takeScreenshot");
     lcb.add_function(l_surface_scale, "scale");
     lcb.add_function(l_surface_set_caption, "setCaption");

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -689,30 +689,21 @@ int l_surface_screenshot(lua_State* L) {
   return 2;
 }
 
-int l_surface_get_clip(lua_State* L) {
-  render_target* pCanvas = luaT_testuserdata<render_target>(L);
-  clip_rect rcClip;
-  pCanvas->get_clip_rect(&rcClip);
-  lua_pushinteger(L, rcClip.x);
-  lua_pushinteger(L, rcClip.y);
-  lua_pushinteger(L, rcClip.w);
-  lua_pushinteger(L, rcClip.h);
-  return 4;
-}
-
-int l_surface_set_clip(lua_State* L) {
+int l_surface_push_clip(lua_State* L) {
   render_target* pCanvas = luaT_testuserdata<render_target>(L);
   clip_rect rcClip;
   rcClip.x = static_cast<clip_rect::x_y_type>(luaL_checkinteger(L, 2));
   rcClip.y = static_cast<clip_rect::x_y_type>(luaL_checkinteger(L, 3));
   rcClip.w = static_cast<clip_rect::w_h_type>(luaL_checkinteger(L, 4));
   rcClip.h = static_cast<clip_rect::w_h_type>(luaL_checkinteger(L, 5));
-  if (lua_toboolean(L, 6) != 0) {
-    clip_rect rcExistingClip;
-    pCanvas->get_clip_rect(&rcExistingClip);
-    clip_rect_intersection(rcClip, rcExistingClip);
-  }
-  pCanvas->set_clip_rect(&rcClip);
+  pCanvas->push_clip_rect(&rcClip);
+  lua_settop(L, 1);
+  return 1;
+}
+
+int l_surface_pop_clip(lua_State* L) {
+  render_target* pCanvas = luaT_testuserdata<render_target>(L);
+  pCanvas->pop_clip_rect();
   lua_settop(L, 1);
   return 1;
 }
@@ -932,8 +923,8 @@ void lua_register_gfx(const lua_register_state* pState) {
     lcb.add_function(l_surface_map, "mapRGB");
     lcb.add_function(l_surface_set_blue_filter_active, "setBlueFilterActive");
     lcb.add_function(l_surface_rect, "drawRect");
-    lcb.add_function(l_surface_get_clip, "getClip");
-    lcb.add_function(l_surface_set_clip, "setClip");
+    lcb.add_function(l_surface_push_clip, "pushClip");
+    lcb.add_function(l_surface_pop_clip, "popClip");
     lcb.add_function(l_surface_screenshot, "takeScreenshot");
     lcb.add_function(l_surface_scale, "scale");
     lcb.add_function(l_surface_set_caption, "setCaption");

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -966,7 +966,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
   rcClip.y = static_cast<clip_rect::x_y_type>(iCanvasY);
   rcClip.w = static_cast<clip_rect::w_h_type>(iWidth);
   rcClip.h = static_cast<clip_rect::w_h_type>(iHeight);
-  pCanvas->push_clip_rect(&rcClip);
+  render_target::scoped_clip clip(pCanvas, &rcClip);
 
   for (map_tile_iterator itrNode1(this, iScreenX, iScreenY, iWidth, iHeight);
        itrNode1; ++itrNode1) {
@@ -1021,10 +1021,9 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
               static_cast<clip_rect::x_y_type>(itrNode.y() - iH + 32 + 4);
           rcNewClip.w = static_cast<clip_rect::w_h_type>(64);
           rcNewClip.h = static_cast<clip_rect::w_h_type>(86 - 4);
-          pCanvas->push_clip_rect(&rcNewClip);
+          render_target::scoped_clip clip(pCanvas, &rcNewClip);
           blocks->draw_sprite(pCanvas, 156, itrNode.x() - 32, itrNode.y() - 56,
                               thdf_alpha_75 | thdf_nearest);
-          pCanvas->pop_clip_rect();
         }
       }
       drawable* pItem = static_cast<drawable*>(itrNode->oEarlyEntities.next);
@@ -1140,11 +1139,10 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
                   static_cast<clip_rect::x_y_type>(itrNode.y() - iH + 32 + 4);
               rcNewClip.w = static_cast<clip_rect::w_h_type>(64);
               rcNewClip.h = static_cast<clip_rect::w_h_type>(86 - 4);
-              pCanvas->push_clip_rect(&rcNewClip);
+              render_target::scoped_clip clip(pCanvas, &rcNewClip);
               blocks->draw_sprite(pCanvas, 156, itrNode.x() - 96,
                                   itrNode.y() - 56,
                                   thdf_alpha_75 | thdf_nearest);
-              pCanvas->pop_clip_rect();
             }
           }
 
@@ -1180,8 +1178,6 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
                          itrNode.tile_x(), itrNode.tile_y());
     }
   }
-
-  pCanvas->pop_clip_rect();
 }
 
 drawable* level_map::hit_test(int iTestX, int iTestY) const {


### PR DESCRIPTION
**Adds a clip stack on render_target which allows for temporarily adding and removing clips.**
- Since we never need to get the clip anymore, imprecision resulting from the scale factor no longer accumulates.
- Simplifies calling code as it doesn't need to explicitly remember the old clip and restore it.
- Adds a convenience class which automatically restores old clip when it goes out of scope.