### PR TITLE
[RFC] Use win and loss criteria for level progress advice

### DIFF
--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -738,6 +738,22 @@ function Map:getParcelTileCount(parcel)
   return self.parcelTileCounts[parcel] or 0
 end
 
+--! Get the starting values of balance and reputation for this level
+--!return start (table)
+function Map:getLevelStartState()
+  local level_config, level, start = self.level_config, self.level_number, {}
+  if level_config.towns and level_config.towns[level] then
+    start["balance"] = level_config.towns[level].StartCash
+    start["reputation"] = level_config.towns[level].StartRep
+  elseif level_config.town then
+    start["balance"] = level_config.town.StartCash
+    start["reputation"] = level_config.town.StartRep
+  end
+  if not start["balance"] then start["balance"] = 0 end
+  if not start["reputation"] then start["reputation"] = 500 end
+  return start
+end
+
 function Map:afterLoad(old, new)
   if old < 6 then
     self.parcelTileCounts = {}


### PR DESCRIPTION
**Describe what the proposed change does**
- Compare world.goals to the current hospital and form a set of relevant advice. Give a random one to the user.

I'm not sure about the halfway to winning/losing messages, they come at some unsuitable times.
I only use original strings, which are somewhat inconsistent. Do we want to add more, eg "Increase your patient cure percentage by 9%"? There's no "You've cured enough patients" without "but the rest of your hospital isn't good enough". Lines 278 and 287 could have the 2 and 3 bumped up 1?
Currently it will print all of the relevant advice, for a nearly winning hospital it looks like this.

> \<LocalisedString> Current value:Okay, your reputation is good enough to win this level. Keep it above 800 and sort out any other problems to finish it.
\<LocalisedString> Current value:You've satisfied the financial criteria for this level. Now keep your balance above 750000, whilst making sure your hospital is running efficiently
\<LocalisedString> Current value:You're getting close to winning. Increase your hospital value by 19270.
\<LocalisedString> Current value:You're about halfway to winning this level.

