### PR TITLE
Use raw pointer for line_elements

### DIFF
--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -825,6 +825,7 @@ int l_line_depersist(lua_State* L) {
   lua_insert(L, 1);
   lua_persist_reader* pReader =
       static_cast<lua_persist_reader*>(lua_touserdata(L, 1));
+  new (pLine) line_sequence();
   pLine->depersist(pReader);
   return 0;
 }


### PR DESCRIPTION
When depersisting the constructor isn't called so the vector didn't
work.

Use placement constructor to ensure the vector is constructed.

Fixes #2182 
