### PR TITLE
Remove .0 from numbers in saved fullscreen windows

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -521,6 +521,7 @@ function UIAnnualReport:draw(canvas, x, y)
   elseif self.state == 2 then -- Statistics screen
     self:drawStatisticsScreen(canvas, x, y)
   else -- Award and trophy screen
+    -- Note: Each 'amount' is wrapped by string.format("%.0f", x) to persist integer notation
     -- Write out motivation if appropriate
     if self.trophy_motivation then
       -- If it is a plaque showing we write in stone text.
@@ -533,7 +534,7 @@ function UIAnnualReport:draw(canvas, x, y)
       end
       self.stone_font:draw(canvas, award_type, x + 220, y + 330, 200, 0)
       -- Amount won/lost
-      self.stone_font:draw(canvas, "+" .. info.amount, x + 220, y + 355, 200, 0)
+      self.stone_font:draw(canvas, string.format("+%.0f", info.amount), x + 220, y + 355, 200, 0)
     elseif self.award_motivation then
       local info = self.awards[self.award_motivation].info
       self.write_font:drawWrapped(canvas, info.text, x + 235, y + 125, 165, "center")
@@ -544,11 +545,7 @@ function UIAnnualReport:draw(canvas, x, y)
       end
       self.write_font:draw(canvas, award_type, x + 220, y + 290, 200, 0)
       -- The amount won/lost
-      local text = ""
-      if info.amount > 0 then
-        text = "+"
-      end
-      self.write_font:draw(canvas, text .. info.amount, x + 220, y + 315, 200, 0)
+      self.write_font:draw(canvas, string.format("%+.0f", info.amount), x + 220, y + 315, 200, 0)
     end
   end
 end
@@ -588,6 +585,7 @@ function UIAnnualReport:drawStatisticsScreen(canvas, x, y)
   for i, hospital in ipairs(world.hospitals) do
     local name = hospital.name
 
+    -- Note: Each 'value' is wrapped by string.format("%.0f", x) to persist integer notation
     -- Most Money
     local index_m = getindex(self.money_sort, i)
     -- index_* is the returned value of the sorted place for this player.
@@ -595,42 +593,42 @@ function UIAnnualReport:drawStatisticsScreen(canvas, x, y)
     -- duplicate has been found, one additional row lower is the right place to be.
     font:draw(canvas, name:upper(), x + 140,
         y + row_y + row_dy * (index_m - 1))
-    font:draw(canvas, self.money_sort[index_m].value, x + 240,
+    font:draw(canvas, string.format("%.0f", self.money_sort[index_m].value), x + 240,
         y + row_y + row_dy * (index_m - 1), 70, 0, "right")
 
     -- Highest Salary
     local index_s = getindex(self.salary_sort, i)
     font:draw(canvas, name:upper(), x + 140 + col_x,
         y + row_y + row_dy * (index_s - 1))
-    font:draw(canvas, self.salary_sort[index_s].value, x + 240 + col_x,
+    font:draw(canvas, string.format("%.0f", self.salary_sort[index_s].value), x + 240 + col_x,
         y + row_y + row_dy * (index_s - 1), 70, 0, "right")
 
     -- Most Cures
     local index_c = getindex(self.cures_sort, i)
     font:draw(canvas, name:upper(), x + 140,
         y + row_y + row_no_y + row_dy * (index_c - 1))
-    font:draw(canvas, self.cures_sort[index_c].value, x + 240,
+    font:draw(canvas, string.format("%.0f", self.cures_sort[index_c].value), x + 240,
         y + row_y + row_no_y + row_dy * (index_c - 1), 70, 0, "right")
 
     -- Most Deaths
     local index_d = getindex(self.deaths_sort, i)
     font:draw(canvas, name:upper(), x + 140 + col_x,
         y + row_y + row_no_y + row_dy * (index_d - 1))
-    font:draw(canvas, self.deaths_sort[index_d].value, x + 240 + col_x,
+    font:draw(canvas, string.format("%.0f", self.deaths_sort[index_d].value), x + 240 + col_x,
         y + row_y + row_no_y + row_dy * (index_d - 1), 70, 0, "right")
 
     -- Most Visitors
     local index_v = getindex(self.visitors_sort, i)
     font:draw(canvas, name:upper(), x + 140,
         y + row_y + row_no_y * 2 + row_dy * (index_v - 1))
-    font:draw(canvas, self.visitors_sort[index_v].value, x + 240,
+    font:draw(canvas, string.format("%.0f", self.visitors_sort[index_v].value), x + 240,
         y + row_y + row_no_y * 2 + row_dy * (index_v - 1), 70, 0, "right")
 
     -- Highest Value
     local index_v2 = getindex(self.value_sort, i)
     font:draw(canvas, name:upper(), x + 140 + col_x,
         y + row_y + row_no_y * 2 + row_dy * (index_v2 - 1))
-    font:draw(canvas, self.value_sort[index_v2].value, x + 240 + col_x,
+    font:draw(canvas, string.format("%.0f", self.value_sort[index_v2].value), x + 240 + col_x,
         y + row_y + row_no_y * 2 + row_dy * (index_v2 - 1), 70, 0, "right")
   end
 end

--- a/CorsixTH/Lua/dialogs/fullscreen/bank_manager.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/bank_manager.lua
@@ -232,14 +232,18 @@ function UIBankManager:draw(canvas, x, y)
     font:draw(canvas, _S.bank_manager.statistics_page.money_in, x + 449, y + 41, 70, 0)
     font:draw(canvas, _S.bank_manager.statistics_page.balance, x + 525, y + 40, 70, 0)
 
-    -- Lua < 5.3 stored integer money amount in floating point values.
-    -- Lua 5.3 introduced an integer representation, and started printing
-    -- integer floating point numbers with a trailing .0 .
-    --
-    -- As a result, CorsixTH games converted from earlier Lua versions print a
-    -- trailing .0 in the bank manager window. The "math.floor" around all
-    -- numbers printed below avoids that problem by converting to integer
-    -- representation for Lua 5.3, and doing nothing in Lua < 5.3.
+    --[[
+      Lua < 5.3 stored integer money amount in floating point values.
+      Lua 5.3 introduced an integer representation, and started printing
+      integer floating point numbers with a trailing .0 .
+
+      As a result, CorsixTH games converted from earlier Lua versions print a
+      trailing .0 in the bank manager window. The "math.floor" around all
+      numbers printed below avoids that problem by converting to integer
+      representation for Lua 5.3, and doing nothing in Lua < 5.3.
+      Note: hospital.balance is a special case and needs string conversion to
+      persist as an integer
+    --]]
 
     -- Each transaction
     -- A for loop going backwards
@@ -258,7 +262,7 @@ function UIBankManager:draw(canvas, x, y)
 
     -- Summary
     font:draw(canvas, _S.bank_manager.statistics_page.current_balance, x + 373, y + 420, 140, 0)
-    font:draw(canvas, "$ " .. hospital.balance, x + 526, y + 421, 70, 0)
+    font:draw(canvas, string.format("$%.0f", hospital.balance), x + 526, y + 421, 70, 0)
   else
     local font = self.font
     self.background:draw(canvas, self.x + x, self.y + y)

--- a/CorsixTH/Lua/dialogs/fullscreen/graphs.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/graphs.lua
@@ -387,7 +387,7 @@ function UIGraphs:draw(canvas, x, y)
     if label.pos_y then
       local ypos = label.pos_y + label.shift_y
       self.black_font:draw(canvas, label.text, x + RIGHT_X + 3, y + ypos)
-      self.black_font:draw(canvas, label.value, x + RIGHT_X + 60, y + ypos)
+      self.black_font:draw(canvas, string.format("%.0f", label.value), x + RIGHT_X + 60, y + ypos)
     end
   end
 

--- a/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
@@ -84,6 +84,8 @@ function UIProgressReport:UIProgressReport(ui)
       world_goals[crit_name].visible = false
     end
     if res_value then
+      -- FIXME: res_value and cure_value are depersisted as floating points, using
+      -- string.format("%.0f", x) is not suitable due to %d (num) param in _S string
       local tooltip
       if world.level_criteria[tab.criterion].formats == 2 then
         tooltip = _S.tooltip.status[crit_name]:format(math.floor(res_value), math.floor(cur_value))


### PR DESCRIPTION
Suggest #2183 is merged before this one.

<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2038* except for `progress_report.lua`

**Describe what the proposed change does**
- Fixes integer values on some windows where saving with the open would cause a .0 to appear when loading the game.
- Progress Report can't be fixed using this PR. A fixme was added instead with reasons.
