### PR TITLE
Announce fall only when player initiated

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -356,8 +356,9 @@ function Patient:canPeeOrPuke(current)
   return parcel ~= 0 and th:getPlotOwner(parcel) == self.hospital:getPlayerIndex()
 end
 
---! Animations for when there is an earth quake
-function Patient:falling()
+--! Falling animations for when there is an earth quake or the player is being very mean
+--!param player_init (bool) if true, player triggered the fall
+function Patient:falling(player_init)
   local current = self:getCurrentAction()
   current.keep_reserved = true
   if self.falling_anim and self:canPeeOrPuke(current) and self.has_fallen == 1 then
@@ -376,13 +377,14 @@ function Patient:falling()
     if math.random(1, 5) == 3 then
       self:shakeFist()
     end
-    self:fallingAnnounce()
+    if player_init then self:fallingAnnounce() end
     self:changeAttribute("happiness", -0.05) -- falling makes you very unhappy
   else
     return
   end
 end
 
+--! Announcements specific to a patient being pushed over by the player
 function Patient:fallingAnnounce()
   local msg = {
   (_A.warnings.falling_1),

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -665,7 +665,7 @@ function World:tickEarthquake()
         -- they visit reception. Some debugging needed here to get
         -- this working.
 
-        -- patient:falling(false)
+        patient:falling(false)
       end
     end
     --]]

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -664,7 +664,7 @@ function World:tickEarthquake()
         -- they visit reception. Some debugging needed here to get
         -- this working.
 
-        -- patient:falling()
+        -- patient:falling(false)
       end
     end
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**Describe what the proposed change does**
- Adds the code so that players have a chance to push patients over when they right click on them.
- Code has been commented out until falling is more reliable. However, it seems to work quite well with #1848 
- Changes to announcing a fall only when the player caused it (as the adviser messages should be)
- Some updates to the luadoc comments.
