### PR TITLE
Use t_random for randomness in research points

### DIFF
--- a/CorsixTH/Lua/research_department.lua
+++ b/CorsixTH/Lua/research_department.lua
@@ -375,7 +375,7 @@ function ResearchDepartment:addResearchPoints(points)
         local research_info = self.research_progress[info.current]
         local stored = research_info.points
         -- Add just a little randomness
-        research_info.points = stored + math.n_random(1, 0.2) * points * info.frac / 100
+        research_info.points = stored + math.t_random(0.75, 1, 1.25) * points * info.frac / 100
         local required = self:getResearchRequired(info.current)
         if required and required < research_info.points then
           research_info.points = 0


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
- Switches the random bonus to awarding research points to `t_random` instead of `n_random` for the same reasons as #2194 (rare cases of a negative output)
