### PR TITLE
Replace hospitals[1] in code

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -502,7 +502,12 @@ function UIAnnualReport:draw(canvas, x, y)
   local font = self.stat_font
   local world = self.ui.app.world
 
-  if self.state == 1 then -- Fame screen (TODO: Make accessible)
+  if self.state == 1 then -- Fame/Shame screen (High Scores)
+    -- TODO: This screen should be displayed at the start of the annual report, but currently
+    -- it is not shown, likely as the code for this being unfinished. When implemented
+    -- we only show this screen at the very start, and once they go to the next screen
+    -- it no longer becomes accessible.
+
     -- Title and column names
     font:draw(canvas, _S.high_score.best_scores, x + 220, y + 104, 200, 0)
     font:draw(canvas, _S.high_score.pos, x + 218, y + 132)

--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -502,7 +502,7 @@ function UIAnnualReport:draw(canvas, x, y)
   local font = self.stat_font
   local world = self.ui.app.world
 
-  if self.state == 1 then -- Fame screen
+  if self.state == 1 then -- Fame screen (TODO: Make accessible)
     -- Title and column names
     font:draw(canvas, _S.high_score.best_scores, x + 220, y + 104, 200, 0)
     font:draw(canvas, _S.high_score.pos, x + 218, y + 132)
@@ -514,7 +514,7 @@ function UIAnnualReport:draw(canvas, x, y)
     local dy = 0
     --for i = 1, 10 do
       font:draw(canvas, i .. ".", x + 220, y + 160 + dy)
-      font:draw(canvas, world.hospitals[1].name:upper(), x + 260, y + 160 + dy)
+      font:draw(canvas, world:getLocalPlayerHospital().name:upper(), x + 260, y + 160 + dy)
       font:draw(canvas, "NA", x + 360, y + 160 + dy)
       -- dy = dy + 25
     --end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -817,9 +817,10 @@ end
 --!param room (Room) The new room.
 function World:markRoomAsBuilt(room)
   room:roomFinished()
-  local diag_disease = self.hospitals[1].disease_casebook["diag_" .. room.room_info.id]
+  local hosp = self:getLocalPlayerHospital()
+  local diag_disease = hosp.disease_casebook["diag_" .. room.room_info.id]
   if diag_disease and not diag_disease.discovered then
-    self.hospitals[1].disease_casebook["diag_" .. room.room_info.id].discovered = true
+    hosp.disease_casebook["diag_" .. room.room_info.id].discovered = true
   end
   for _, entity in ipairs(self.entities) do
     if entity.notifyNewRoom then

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -817,7 +817,7 @@ end
 --!param room (Room) The new room.
 function World:markRoomAsBuilt(room)
   room:roomFinished()
-  local hosp = self:getLocalPlayerHospital()
+  local hosp = room.hospital
   local diag_disease = hosp.disease_casebook["diag_" .. room.room_info.id]
   if diag_disease and not diag_disease.discovered then
     hosp.disease_casebook["diag_" .. room.room_info.id].discovered = true


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
- Replaces a use of `hospitals[1]` in World and Annual Report with `getLocalPlayerHospital`
- With the upcoming changes to spawns in #1986 I haven't touched the `hospitals[1]` in spawn.
- Also didn't touch the `hospitals[1]` for `initStaff` -- as changes need to be made to the called function to work on all hospitals.
- Added a note that the Fame Screen isn't currently accessible from Annual Report (though looks like someone started coding it years ago).