### PR TITLE
Re-moving walls as edit_room doesn't work.

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 171 -- Moved wall-info and merged month-length table
+local SAVEGAME_VERSION = 172 -- Re-moved wall-info
 
 class "App"
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

Fixes #2204

**Describe what the proposed change does**
- Move the wall types back to world, as edit_room isn't always available.
- Adds another savegame version
- Makes me sooo very tired of this stuff
