### PR TITLE
Make couches fully passable

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 172 -- Re-moved wall-info
+local SAVEGAME_VERSION = 173 -- Make couches fully passable objects
 
 class "App"
 

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -740,6 +740,13 @@ function Object:afterLoad(old, new)
       self:setTile(self.tile_x, self.tile_y)
     end
   end
+  if old < 173 then
+    -- Fix bug with couch not being fully passable
+    if self.object_type.id == "couch" then
+      self:initOrientation(self.direction)
+      self:setTile(self.tile_x, self.tile_y)
+    end
+  end
   self:updateDynamicInfo(true)
   return Entity.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/objects/couch.lua
+++ b/CorsixTH/Lua/objects/couch.lua
@@ -54,11 +54,11 @@ object.usage_animations = copy_north_to_south {
 }
 object.orientations = {
   north = {
-    footprint = { {-1, -1, complete_cell = true}, {-1, 0, complete_cell = true}, {0, -1}, {0, 0, only_passable = true} },
+    footprint = { {-1, -1, complete_cell = true}, {-1, 0, complete_cell = true}, {0, -1, only_passable = true}, {0, 0, only_passable = true} },
     render_attach_position = {-1, 0},
   },
   east = {
-    footprint = { {-1, -1, complete_cell = true}, {-1, 0}, {0, -1, complete_cell = true}, {0, 0, only_passable = true} }
+    footprint = { {-1, -1, complete_cell = true}, {-1, 0, only_passable = true}, {0, -1, complete_cell = true}, {0, 0, only_passable = true} }
   },
 }
 


### PR DESCRIPTION


<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2211*

**Describe what the proposed change does**
- Sets both tiles adjacent to couch as passable.
- Previously, the non-passable tile could have a small object put on it. If this is the case, pathfinding will still work as intended after this PR (doctor sees blocked path). However, the player will not be able to place an object on the tile again if they edit the room.

