### PR TITLE
Show queueing patients when hovering the door

### DIFF
--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -476,9 +476,15 @@ function GameUI:onCursorWorldPositionChange()
   if not overwindow and wx > 0 and wy > 0 and wx < self.app.map.width and wy < self.app.map.height then
     room = self.app.world:getRoom(wx, wy)
   end
-   -- Enable queue icons for patients when hovering the door as well
-  if entity and not room and entity.room then
-    room = entity.room
+  -- Find the room associated with the current entity (Usually only applies to doors)
+  if entity and not room then
+    if entity.room then
+      room = entity.room
+    end
+    -- Special case to catch the non-dominant side of a double-door
+    if not room and entity.object_type and entity.object_type.class == "SwingDoor" then
+      room = entity.master.room
+    end
   end
   if room ~= self.cursor_room then
     -- Unset queue mood for patients queueing the old room

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -480,7 +480,7 @@ function GameUI:onCursorWorldPositionChange()
   if entity and not room then
     if entity.room then
       room = entity.room
-    elseif entity.object_type and entity.object_type.class == "SwingDoor" then
+    elseif entity.object_type and entity.object_type.id == "swing_door_left" then
       -- Special case to catch the non-dominant side of a double-door
       room = entity.master.room
     end

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -476,6 +476,10 @@ function GameUI:onCursorWorldPositionChange()
   if not overwindow and wx > 0 and wy > 0 and wx < self.app.map.width and wy < self.app.map.height then
     room = self.app.world:getRoom(wx, wy)
   end
+   -- Enable queue icons for patients when hovering the door as well
+  if entity and not room and entity.room then
+    room = entity.room
+  end
   if room ~= self.cursor_room then
     -- Unset queue mood for patients queueing the old room
     if self.cursor_room then

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -480,9 +480,8 @@ function GameUI:onCursorWorldPositionChange()
   if entity and not room then
     if entity.room then
       room = entity.room
-    end
-    -- Special case to catch the non-dominant side of a double-door
-    if not room and entity.object_type and entity.object_type.class == "SwingDoor" then
+    elseif entity.object_type and entity.object_type.class == "SwingDoor" then
+      -- Special case to catch the non-dominant side of a double-door
       room = entity.master.room
     end
   end

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -90,6 +90,7 @@ Copyright (C) 2022 "TotalCaesar659"
 Copyright (C) 2022 Manuel K
 Copyright (C) 2022 lokpro
 Copyirght (C) 2022 Ryan "ryan-edgewurth" Penfold
+Copyright (C) 2022 "SilPho"
 
 et al.
 


### PR DESCRIPTION
*Fixes #2016*

When hovering the door to a room (assuming the door is on the north or west edge), show the queue icon above patients that are queueing for that room.

(First time submitting a PR to this repo, so hopefully I'm doing it right)