### PR TITLE
Changes to max_salary behaviour

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 173 -- Make couches fully passable objects
+local SAVEGAME_VERSION = 174 -- Max salary improvements
 
 class "App"
 

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 174 -- Max salary improvements
+local SAVEGAME_VERSION = 175 -- Max salary improvements
 
 class "App"
 

--- a/CorsixTH/Lua/base_config.lua
+++ b/CorsixTH/Lua/base_config.lua
@@ -39,6 +39,11 @@ local configuration = {
   --  {Doctor = 0, Shrink = 0, Skill = 0},
   --},
 
+  -- Maximum salary value, staff will no longer become unhappy at this stage
+  payroll = {
+    MaxSalary = 2000,
+  },
+
   -----------------------------------------------------------
   --           Original configuration values               --
   -----------------------------------------------------------

--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -67,9 +67,9 @@ function UIStaffManagement:UIStaffManagement(ui)
   -- Other buttons
   self:addPanel(0, 12, 86):makeButton(0, 0, 31, 74, 2, self.scrollUp):setTooltip(_S.tooltip.staff_list.prev_person)
   self:addPanel(0, 12, 274):makeButton(0, 0, 31, 74, 3, self.scrollDown):setTooltip(_S.tooltip.staff_list.next_person)
-  self:addPanel(0, 319, 372):makeButton(0, 0, 112, 39, 7, self.payBonus):setTooltip(_S.tooltip.staff_list.bonus)
-  self:addPanel(0, 319, 418):makeButton(0, 0, 112, 39, 8, self.increaseSalary):setTooltip(_S.tooltip.staff_list.pay_rise)
-  self:addPanel(0, 438, 372):makeButton(0, 0, 45, 85, 9, self.fire):setTooltip(_S.tooltip.staff_list.sack)
+  self:addPanel(0, 319, 372):makeButton(0, 0, 112, 39, 7, self.payBonus):setTooltip(_S.tooltip.staff_list.bonus):setSound() -- custom sound
+  self:addPanel(0, 319, 418):makeButton(0, 0, 112, 39, 8, self.increaseSalary):setTooltip(_S.tooltip.staff_list.pay_rise):setSound() -- custom sound
+  self:addPanel(0, 438, 372):makeButton(0, 0, 45, 85, 9, self.fire):setTooltip(_S.tooltip.staff_list.sack):setSound() -- prevent two sound trigger
 
   -- "Arrow" to show title of doctors
   self.arrow = self:addPanel(12, 259, 397)
@@ -336,7 +336,8 @@ function UIStaffManagement:draw(canvas, x, y)
   self.portrait_back.visible = false
   -- If a staff member is selected, draw picture, skill etc
   if self.selected_staff then
-    local profile = self.staff_members[self.category][self.selected_staff].profile
+    local staff = self.staff_members[self.category][self.selected_staff]
+    local profile = staff.profile
     -- Draw the red rectangle TODO: Make a neater function in C?
     local red = canvas:mapRGB(221, 83, 0)
     local y_pos = self.selected_staff - (self.page - 1)*10
@@ -353,8 +354,10 @@ function UIStaffManagement:draw(canvas, x, y)
     profile:drawFace(canvas, x + 68, y + 377, self.face_parts)
 
     -- 10 % increase in salary or a bonus:
+    local max_salary = self.hospital.world.map.level_config.payroll.MaxSalary
+    local new_salary = math.min(math.floor(profile.wage * 1.1), max_salary)
     titles:draw(canvas, "$" .. math_floor(profile.wage*0.1), x + 377, y + 387, 45, 0)
-    titles:draw(canvas, "$" .. math_floor(profile.wage*0.1 + profile.wage), x + 377, y + 432, 45, 0)
+    titles:draw(canvas, "$" .. new_salary, x + 377, y + 432, 45, 0)
 
     -- Attention to detail
     local attention_bar_width = math_floor(profile.attention_to_detail * 40 + 0.5)
@@ -537,18 +540,25 @@ function UIStaffManagement:payBonus()
     staff:changeAttribute("happiness", 0.5)
     self.hospital:spendMoney(math_floor(staff.profile.wage*0.1), _S.transactions.personal_bonus)
     self.ui:playSound("cashreg.wav")
+    return
   end
+  self.ui:playSound("wrong2.wav")
 end
 
 function UIStaffManagement:increaseSalary()
   if self.selected_staff then
     local staff = self.staff_members[self.category][self.selected_staff]
-    staff:increaseWage(math_floor(staff.profile.wage*0.1))
+    if staff:increaseWage(math_floor(staff.profile.wage * 0.1)) then
+      self.ui:playSound("bonusal2.wav")
+      return
+    end
   end
+  self.ui:playSound("wrong2.wav")
 end
 
 function UIStaffManagement:fire()
   if self.selected_staff then
+    self.ui:playSound(self.default_button_sound)
     self.ui:addWindow(UIConfirmDialog(self.ui, false, _S.confirmation.sack_staff, --[[persistable:staff_management_confirm_sack]] function()
       local current_category = self.staff_members[self.category]
       current_category[self.selected_staff]:fire()
@@ -560,6 +570,8 @@ function UIStaffManagement:fire()
       -- Update the staff list
       self:updateStaffList(current_category[self.selected_staff])
     end)) -- End of confirmation dialog
+  else
+    self.ui:playSound("wrong2.wav")
   end
 end
 
@@ -569,6 +581,11 @@ function UIStaffManagement:close()
 end
 
 function UIStaffManagement:afterLoad(old, new)
-  UIFullscreen.afterLoad(self, old, new)
   self:registerKeyHandlers()
+
+  if old < 174 then
+    self:close()
+  end
+
+  UIFullscreen.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -67,9 +67,10 @@ function UIStaffManagement:UIStaffManagement(ui)
   -- Other buttons
   self:addPanel(0, 12, 86):makeButton(0, 0, 31, 74, 2, self.scrollUp):setTooltip(_S.tooltip.staff_list.prev_person)
   self:addPanel(0, 12, 274):makeButton(0, 0, 31, 74, 3, self.scrollDown):setTooltip(_S.tooltip.staff_list.next_person)
-  self:addPanel(0, 319, 372):makeButton(0, 0, 112, 39, 7, self.payBonus):setTooltip(_S.tooltip.staff_list.bonus):setSound() -- custom sound
-  self:addPanel(0, 319, 418):makeButton(0, 0, 112, 39, 8, self.increaseSalary):setTooltip(_S.tooltip.staff_list.pay_rise):setSound() -- custom sound
-  self:addPanel(0, 438, 372):makeButton(0, 0, 45, 85, 9, self.fire):setTooltip(_S.tooltip.staff_list.sack):setSound() -- prevent two sound trigger
+  -- Disable the default sounds on the the following three buttons as their sounds are implemented in the callback.
+  self:addPanel(0, 319, 372):makeButton(0, 0, 112, 39, 7, self.payBonus):setTooltip(_S.tooltip.staff_list.bonus):setSound()
+  self:addPanel(0, 319, 418):makeButton(0, 0, 112, 39, 8, self.increaseSalary):setTooltip(_S.tooltip.staff_list.pay_rise):setSound()
+  self:addPanel(0, 438, 372):makeButton(0, 0, 45, 85, 9, self.fire):setTooltip(_S.tooltip.staff_list.sack):setSound()
 
   -- "Arrow" to show title of doctors
   self.arrow = self:addPanel(12, 259, 397)

--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -583,7 +583,7 @@ end
 function UIStaffManagement:afterLoad(old, new)
   self:registerKeyHandlers()
 
-  if old < 174 then
+  if old < 175 then
     self:close()
   end
 

--- a/CorsixTH/Lua/dialogs/staff_rise.lua
+++ b/CorsixTH/Lua/dialogs/staff_rise.lua
@@ -182,6 +182,7 @@ function UIStaffRise:increaseSalary()
   self.staff.message_callback = nil
   self.staff:increaseWage(self.rise_amount)
   self.staff.quitting_in = nil
+  self.ui:playSound("bonusal2.wav")
   self:close()
 end
 

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -737,10 +737,18 @@ end
 --!param amount (number) This amount is added to the existing value for the attribute,
 --  and is then capped to be between 0 and 1.
 function Humanoid:changeAttribute(attribute, amount)
-  -- Receptionist is always 100% happy
-  if self.humanoid_class and self.humanoid_class == "Receptionist" and attribute == "happiness" then
-    self.attributes[attribute] = 1
-    return true
+  -- Handle some happiness special cases
+  if attribute == "happiness" and self.humanoid_class then
+    local max_salary = self.world.map.level_config.payroll.MaxSalary
+    if self.humanoid_class == "Receptionist" then
+      -- A receptionist is never unhappy
+      self.attributes[attribute] = 1
+      return true
+    elseif self.profile and self.profile.wage >= max_salary then
+      -- A maximum salaried staff member is never unhappy
+      self.attributes[attribute] = 1
+      return true
+    end
   end
 
   if self.attributes[attribute] then

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -188,7 +188,6 @@ function Staff:checkIfWaitedTooLong()
       if self.hospital.policies.grant_wage_increase then
         local amount = math.floor(math.max(self.profile.wage * 1.1, (self.profile:getFairWage(self.world) + self.profile.wage) / 2) - self.profile.wage)
         self.quitting_in = nil
-        self:setMood("pay_rise", "deactivate")
         self.hospital:removeMessage(self)
         self:increaseWage(amount)
         return
@@ -559,9 +558,19 @@ end
 -- Makes the staff member request a raise of 10%, or a wage exactly in the middle of their current and a fair one, whichever is more.
 function Staff:requestRaise()
   assert(self.hospital, "A staff member asked for a pay rise who doesn't belong to a hospital!")
+  local max_salary = self.world.map.level_config.payroll.MaxSalary
+  -- Never request a raise if already at max salary
+  if self.profile.wage >= max_salary then
+    self.timer_until_raise = nil
+    return
+  end
   -- Check whether there is already a request for raise.
   if not self:isMoodActive("pay_rise") then
     local amount = math.floor(math.max(self.profile.wage * 1.1, (self.profile:getFairWage() + self.profile.wage) / 2) - self.profile.wage)
+    -- Don't ask over the salary cap
+    if self.profile.wage + amount > max_salary then
+      amount = max_salary - self.profile.wage
+    end
     -- At least for now, staff are timid, and only ask for raises 1/5th of the time
     if math.random(1, 5) ~= 1 or amount <= 0 then
       self.timer_until_raise = nil
@@ -578,16 +587,24 @@ end
 -- any request raise dialogs.
 --!param amount (integer) The amount, in game dollars per month, to increase
 -- the salary by.
+--!return (bool) Whether the wage actually increased
 function Staff:increaseWage(amount)
-  self.profile.wage = self.profile.wage + amount
-  self.world.ui:playSound("cashreg.wav")
-  if self.profile.wage > 2000 then -- What cap here?
-    self.profile.wage = 2000
-  else -- If the cap has been reached this member of staff won't get unhappy
-       -- ever again...
-    self:changeAttribute("happiness", 0.99)
-    self:setMood("pay_rise", "deactivate")
+  -- Are we already paid the maximum?
+  local max_salary = self.world.map.level_config.payroll.MaxSalary
+  local wage_raised = true
+  if self.profile.wage >= max_salary then
+    wage_raised = false -- Already at max salary
+  elseif self.profile.wage + amount > max_salary then
+    -- Maximum salary hit. The staff member will never be unhappy again
+    self.profile.wage = max_salary
+  else
+    -- Apply new salary
+    self.profile.wage = self.profile.wage + amount
   end
+  -- Reset
+  self:setMood("pay_rise", "deactivate")
+  self:changeAttribute("happiness", 0.99)
+  return wage_raised
 end
 
 --! Sets dynamic info text before the dynamic info update

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -835,7 +835,7 @@ function Map:afterLoad(old, new)
     {Value = 0}, -- I_UNEXPECTED_SWELLING
     }
   end
-  if old < 174 then
+  if old < 175 then
     -- Set max salary value for existing saves
     self.level_config.payroll = {
       MaxSalary = 2000,

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -835,4 +835,10 @@ function Map:afterLoad(old, new)
     {Value = 0}, -- I_UNEXPECTED_SWELLING
     }
   end
+  if old < 174 then
+    -- Set max salary value for existing saves
+    self.level_config.payroll = {
+      MaxSalary = 2000,
+    }
+  end
 end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
- Maximum salary converted to configuration item (debate over if the max value should be changed is a separate thing imo)
- Staff will not request a raise if already at maximum salary (i.e. never, previously we just hoped and prayed)
- Salary raise now uses the correct sound
- Bonus and salary raise buttons in Staff Management no longer play "selectx" and dedicated sound together.
- Staff Management now shows the maximum salary, if a salary raise would hit that limit
- Clicking on salary raise button when at maximum salary now results in the "wrong2" sound
- Happiness is now fixed at 1 when at maximum salary
- Some rewording of inline comments
- Bugfix: Now properly deactivates salary rise and resets happiness if staff member hit max salary.

There may be a bit of redundancy in here still. I suppose I was trying to add safety nets that may not be needed.