### PR TITLE
Add OK to Filebrowser

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
@@ -63,6 +63,14 @@ function UISaveGame:abortName()
   self.new_savegame_textbox.panel:setLabel(_S.save_game_window.new_save_game)
 end
 
+--! Updates the textbox to selected file
+--!param label (string) Selected file name
+function UISaveGame:updateTextbox(label)
+  local name = string.gsub(label, "%.sav$", "")
+  self.new_savegame_textbox.text = name
+  self.new_savegame_textbox.panel:setLabel(name)
+end
+
 --! Function called when textbox is confirmed (e.g. by pressing enter)
 function UISaveGame:confirmName()
   local filename = self.new_savegame_textbox.text

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_map.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_map.lua
@@ -63,6 +63,14 @@ function UISaveMap:abortName()
   self.new_map_textbox.panel:setLabel(_S.save_map_window.new_map)
 end
 
+--! Updates the textbox to selected file
+--!param label (string) Selected file name
+function UISaveMap:updateTextbox(label)
+  local name = string.gsub(label, "%.map$", "")
+  self.new_map_textbox.text = name
+  self.new_map_textbox.panel:setLabel(name)
+end
+
 --! Function called when textbox is confirmed (e.g. by pressing enter)
 function UISaveMap:confirmName()
   local filename = self.new_map_textbox.text

--- a/CorsixTH/Lua/dialogs/tree_ctrl.lua
+++ b/CorsixTH/Lua/dialogs/tree_ctrl.lua
@@ -599,8 +599,21 @@ function TreeControl:onMouseDown(button, x, y)
   return redraw
 end
 
+--! Function to handle (final) selection by user that needs to feed back data to
+--! another dialog.
+--!param callback (function) Code to execute on trigger
+--!return self
 function TreeControl:setSelectCallback(callback)
   self.select_callback = callback
+  return self
+end
+
+--! Function for where an action in the file tree needs to feed back data to another
+--! dialog. Its specific usage should be noted in the parent element
+--!param callback (function) Code to execute on trigger
+--!return self
+function TreeControl:setValueChangeCallback(callback)
+  self.val_change_callback = callback
   return self
 end
 
@@ -622,6 +635,9 @@ function TreeControl:onMouseUp(button, x, y)
       redraw = true
     else
       self.selected_node = node
+      if self.val_change_callback then
+        self.val_change_callback(node, node:getLabel())
+      end
       node:select()
       redraw = true
     end

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -399,12 +399,14 @@ tooltip.save_map_window = {
 menu_list_window = {
   name = "Name",
   save_date = "Modified",
+  ok = "OK",
   back = "Back",
 }
 
 tooltip.menu_list_window = {
   name = "Click here to sort the list by name",
   save_date = "Click here to sort the list by last modification date",
+  ok = "Confirm choice",
   back = "Close this window",
 }
 

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -408,7 +408,10 @@ bool level_map::load_from_th_file(const uint8_t* pData, size_t iDataLength,
     return false;
   }
 
-  player_count = pData[0] % max_player_count;
+  player_count = pData[0];
+  if (player_count < 1) player_count = 1;
+  if (player_count > max_player_count) player_count = max_player_count;
+
   for (int i = 0; i < player_count; ++i) {
     read_tile_index(pData + camera_offset + (i * 2), initial_camera_x[i],
                     initial_camera_y[i]);


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #1913*
*Fixes #568*
*Fixes #2118*

**Describe what the proposed change does**
- Adds OK button to file browsers, allowing single click of item, then pressing OK to perform the same as a double-click action
- Saving a game will also add the selected save to the textbox when an item is single clicked. OK works same as above

Removed all the `origin` stuff now from this. Just got to work on making the code better before ready.
