### PR TITLE
Fix Font Picker's back button

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/choose_font.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/choose_font.lua
@@ -57,6 +57,6 @@ end
 function UIChooseFont:close()
   UIResizable.close(self)
   if self.mode == "menu" then
-    self.ui:addWindow(UIOptions(self.ui, self.mode))
+    self.ui:addWindow(UIFolder(self.ui, self.mode))
   end
 end


### PR DESCRIPTION
**Describe what the proposed change does**
- Back button went too far in reverse.
- Now properly exits to Folder Settings menu when pressing back

Also fixes the other part of #2118 