### PR TITLE
Ensure handymen wait for patients to leave

### DIFF
--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -237,7 +237,8 @@ function Machine:createHandymanActions(handyman)
   end
 
   local meander_loop_callback = --[[persistable:handyman_meander_repair_loop_callback]] function()
-    if not self.user then
+    -- Wait until the machine is not in use and not about to be used
+    if not self.user and (not self:getRoom():getPatient() or self:getRoom():getPatient().isLeaving) then
       -- The machine is ready to be repaired.
       -- The following statement will finish the meander action in the handyman's
       -- action queue.

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -239,7 +239,7 @@ function Machine:createHandymanActions(handyman)
   local meander_loop_callback = --[[persistable:handyman_meander_repair_loop_callback]] function()
     -- Wait until the machine is not in use and not about to be used
     local patient = self:getRoom():getPatient()
-    if not self.user and (not patient or patient.isLeaving) then
+    if not self.user and (not patient or patient.isLeaving()) then
       -- The machine is ready to be repaired.
       -- The following statement will finish the meander action in the handyman's
       -- action queue.

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -238,7 +238,8 @@ function Machine:createHandymanActions(handyman)
 
   local meander_loop_callback = --[[persistable:handyman_meander_repair_loop_callback]] function()
     -- Wait until the machine is not in use and not about to be used
-    if not self.user and (not self:getRoom():getPatient() or self:getRoom():getPatient().isLeaving) then
+    local patient = self:getRoom():getPatient()
+    if not self.user and (not patient or patient.isLeaving) then
       -- The machine is ready to be repaired.
       -- The following statement will finish the meander action in the handyman's
       -- action queue.

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -239,7 +239,7 @@ function Machine:createHandymanActions(handyman)
   local meander_loop_callback = --[[persistable:handyman_meander_repair_loop_callback]] function()
     -- Wait until the machine is not in use and not about to be used
     local patient = self:getRoom():getPatient()
-    if not self.user and (not patient or patient.isLeaving()) then
+    if not self.user and (not patient or patient:isLeaving()) then
       -- The machine is ready to be repaired.
       -- The following statement will finish the meander action in the handyman's
       -- action queue.


### PR DESCRIPTION
*Fixes #70 *

**Describe what the proposed change does**
- Handymen waiting to repair a machine will now meander in the room if a patient is in the same room. This fixes the bug where the machine is repaired while it is in use.

This is the same behaviour that the original game has.