### PR TITLE
[RFC] Adjust meandering when assigned to a parcel

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/meander.lua
+++ b/CorsixTH/Lua/humanoid_actions/meander.lua
@@ -68,6 +68,20 @@ local function meander_action_start(action, humanoid)
   local x, y = humanoid.world.pathfinder:findIdleTile(humanoid.tile_x,
       humanoid.tile_y, math.random(1, 24))
 
+  -- If the staff member is confined to one parcel, make sure they don't try to leave
+  if humanoid.parcelNr then
+    local th = TheApp.map.th
+    local current_plot = th:getCellFlags(humanoid.tile_x, humanoid.tile_y).parcelId
+    local target_plot = th:getCellFlags(x, y).parcelId
+    -- As long as they're in the right parcel, prevent them wandering outside of it
+    if (current_plot == humanoid.parcelNr and target_plot ~= humanoid.parcelNr) then
+      humanoid:queueAction(IdleAction():setCount(math.random(5, 40)))
+      humanoid:queueAction(MeanderAction())
+      humanoid:finishAction()
+      return
+    end
+  end
+
   if x == humanoid.tile_x and y == humanoid.tile_y then
     -- Nowhere to walk to - go idle instead, or go onto the next action
     if #humanoid.action_queue == 1 then


### PR DESCRIPTION
*Fixes #2123*

I noticed during my own play that a handyman assigned to a single plot that doesn't have much corridor space will often wander off to other parts of the hospital. The reasons for this are discussed in #2123, and this PR hopes to fix it.

**Prevent handyment from wandering into other plots when assigned to a single plot**
- This change only adjusts the behaviour of the meander action, so it doesn't stop a handyman from visiting another when they need to go to a Staff Room, and it also doesn't break if the player moves the handyman around manually.
- If the handyman is not inside their assigned plot when the check is completed, the outcome is unaffected. This means a handyman in the wrong parcel will go to the correct one only when attending to a job (or finds their way back randomly or by player action). 
- In an ideal situation the pathfinder would take the assigned parcel number as input, so we wouldn't need to reject the response from it. That makes this PR more of a patchy workaround than a pure fix.

I copied the IdleAction counter behaviour from elsewhere in the meander.lua class, I'm open to adjusting that if the values need changing.