### PR TITLE
[WIP] Add parcel check for meandering

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1636,6 +1636,11 @@ function World:getPath(x, y, dest_x, dest_y)
   return self.pathfinder:findPath(x, y, dest_x, dest_y)
 end
 
+-- Find an tile for idling.
+-- !param x X coordinate of the queue position.
+-- !param y Y coordinate of the queue position.
+-- !param idx Number of standing persons in the queue before the person asking for an idle tile.
+-- !return Position of an idle tile if it exists.
 function World:getIdleTile(x, y, idx)
   local cache_idx = (y - 1) * self.map.width + x
   local cache = self.idle_cache[cache_idx]

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -116,7 +116,7 @@ function World:World(app)
 
   -- If set, do not create salary raise requests.
   self.debug_disable_salary_raise = self.free_build_mode
-  self.idle_cache = {}
+  self.idle_cache = {} -- Cached queue standing positions for all queues.
   -- List of which goal criterion means what, and what number the corresponding icon has.
   self.level_criteria = local_criteria_variable
   self.delayed_map_objects = {} -- Initial objects in the map for parcels without owner.

--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -940,9 +940,12 @@ int l_path_idle(lua_State* L) {
   pathfinder* pPathfinder = luaT_testuserdata<pathfinder>(L);
 
   bool found = pPathfinder->find_idle_tile(
-      nullptr, static_cast<int>(luaL_checkinteger(L, 2)) - 1,
-      static_cast<int>(luaL_checkinteger(L, 3)) - 1,
-      static_cast<int>(luaL_optinteger(L, 4, 0)));
+      nullptr,                                        // Default map.
+      static_cast<int>(luaL_checkinteger(L, 2)) - 1,  // X coordinate queue.
+      static_cast<int>(luaL_checkinteger(L, 3)) - 1,  // Y coordinate queue.
+      static_cast<int>(
+          luaL_optinteger(L, 4, 0)),  // Number of standing persons in queue.
+      static_cast<int>(luaL_optinteger(L, 5, -1)));  // Parcel number.
   if (!found) {
     return 0;
   }

--- a/CorsixTH/Src/th_pathfind.cpp
+++ b/CorsixTH/Src/th_pathfind.cpp
@@ -271,7 +271,7 @@ bool idle_tile_finder::try_node(path_node* pNode, map_tile_flags flags,
 }
 
 bool idle_tile_finder::find_idle_tile(const level_map* pMap, int iStartX,
-                                      int iStartY, int iN) {
+                                      int iStartY, int iN, int parcelId) {
   if (pMap == nullptr) {
     pMap = parent->default_map;
   }
@@ -290,9 +290,15 @@ bool idle_tile_finder::find_idle_tile(const level_map* pMap, int iStartX,
 
   while (true) {
     pNode->visited = true;
-    map_tile_flags flags = pMap->get_tile_unchecked(pNode->x, pNode->y)->flags;
 
-    if (!flags.do_not_idle && flags.passable && flags.hospital) {
+    // Check whether pNode is a feasible destination.
+    const map_tile* node_tile = pMap->get_tile_unchecked(pNode->x, pNode->y);
+    map_tile_flags flags = node_tile->flags;
+    bool correct_parcel = parcelId < 0 || parcelId == node_tile->iParcelId;
+    if (!flags.do_not_idle && flags.passable && flags.hospital &&
+        correct_parcel) {
+      // Try to avoid re-using a queue-ing position of a humanoid earlier in the
+      // queue.
       if (iN == 0) {
         parent->destination = pNode;
         return true;

--- a/CorsixTH/Src/th_pathfind.h
+++ b/CorsixTH/Src/th_pathfind.h
@@ -166,12 +166,22 @@ class idle_tile_finder : public abstract_pathfinder {
   bool try_node(path_node* pNode, map_tile_flags flags, path_node* pNeighbour,
                 travel_direction direction) override;
 
-  bool find_idle_tile(const level_map* pMap, int iStartX, int iStartY, int iN);
+  //| Find a tile for idling.
+  /*!
+      @param pMap Map to search.
+      @param iStartX X coordinate of the queue start position.
+      @param iStartY Y coordinate of the queue start position.
+      @param iN Number of persons standing in the queue before the humanoid.
+      @param parcelId Id of the parcel with valid destinations, use \c -1 for
+     any parcel.
+   */
+  bool find_idle_tile(const level_map* pMap, int iStartX, int iStartY, int iN,
+                      int parcelId);
 
   path_node* best_next_node;
   double best_distance;
-  int start_x;  ///< X coordinate of the start position.
-  int start_y;  ///< Y coordinate of the start position.
+  int start_x;  ///< X coordinate of the queue position.
+  int start_y;  ///< Y coordinate of the queue position.
 };
 
 class object_visitor : public abstract_pathfinder {
@@ -221,8 +231,9 @@ class pathfinder {
   }
 
   inline bool find_idle_tile(const level_map* pMap, int iStartX, int iStartY,
-                             int iN) {
-    return idle_tile_finder.find_idle_tile(pMap, iStartX, iStartY, iN);
+                             int iN, int parcelId) {
+    return idle_tile_finder.find_idle_tile(pMap, iStartX, iStartY, iN,
+                                           parcelId);
   }
 
   inline bool find_path_to_hospital(const level_map* pMap, int iStartX,


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2123 

**Describe what the proposed change does**
- Extend CPP idle tile finding to find tiles only in a provided parcel is requested
- Extend handyman meandering to use that functionality for finding idle tiles.

