### PR TITLE
Improve debug patient handling

### DIFF
--- a/CorsixTH/Lua/dialogs/patient.lua
+++ b/CorsixTH/Lua/dialogs/patient.lua
@@ -270,35 +270,33 @@ function UIPatient:onTick()
   return Window.onTick(self)
 end
 
+--! Go through the buttons in the patient dialog to check whether they should be visible
 function UIPatient:updateInformation()
   local patient = self.patient
-  if patient.diagnosed then
-    self.disease_button.enabled = true
-    self.disease_button.visible = true
-    self.disease_blanker.visible = false
-  else
-    self.disease_button.enabled = false
-    self.disease_button.visible = false
-    self.disease_blanker.visible = true
-  end
-  if patient.going_home then
-    self.home_button.enabled = false
-    self.home_button.visible = false
-    self.home_blanker.visible = true
-  else
-    self.home_button.enabled = true
-    self.home_button.visible = true
-    self.home_blanker.visible = false
-  end
-  if patient.is_debug or patient.diagnosis_progress == 0 or patient.diagnosed or patient.going_home then
-    self.guess_button.enabled = false
-    self.guess_button.visible = false
-    self.guess_blanker.visible = true
-  else
-    self.guess_button.enabled = true
-    self.guess_button.visible = true
-    self.guess_blanker.visible = false
-  end
+  -- Show casebook?
+  -- Debug patients can exist before a disease is discovered (i.e. no casebook entry)
+  -- so make sure we guard against this.
+  local diag = patient.diagnosed
+  local disc = patient.hospital.disease_casebook[patient.disease.id].discovered
+  local show_dis_btn = diag and disc
+  self.disease_button.enabled = show_dis_btn
+  self.disease_button.visible = show_dis_btn
+  self.disease_blanker.visible = not show_dis_btn
+
+  -- Show go home?
+  local show_home_btn = not patient.going_home
+  self.home_button.enabled = show_home_btn
+  self.home_button.visible = show_home_btn
+  self.home_blanker.visible = not show_home_btn
+
+  -- Show guess cure?
+  local show_guess_btn = not (patient.is_debug or
+      patient.diagnosis_progress == 0 or
+      patient.diagnosed or
+      patient.going_home)
+  self.guess_button.enabled = show_guess_btn
+  self.guess_button.visible = show_guess_btn
+  self.guess_blanker.visible = not show_guess_btn
 end
 
 function UIPatient:viewQueue()

--- a/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/make_debug_patient.lua
+++ b/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/make_debug_patient.lua
@@ -25,12 +25,15 @@ local UIMakeDebugPatient = _G["UIMakeDebugPatient"]
 
 function UIMakeDebugPatient:UIMakeDebugPatient(ui)
   local items = {}
-  for _, disease in ipairs(ui.app.diseases) do
-    if disease.visuals_id or disease.non_visuals_id == 1 then
+  local hosp = TheApp.world:getLocalPlayerHospital()
+  -- Debug patient can be made from any disease available to the level
+  for _, dis in pairs(hosp.disease_casebook) do
+    local disease = dis.disease
+    if not disease.pseudo then
       items[#items + 1] = {
         name = disease.name,
         disease = disease,
-        tooltop = disease.name,
+        tooltip = _S.tooltip.debug_patient_window.item:format(disease.name),
       }
     end
   end

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -784,6 +784,10 @@ debug_patient_window = {
   caption = "Debug Patient",
 }
 
+tooltip.debug_patient_window = {
+  item = "Create a debug patient with %s",
+}
+
 cheats_window = {
   caption = "Cheats",
   warning = "Warning: You will not get any bonus points at the end of the level if you cheat!",


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
- Now makes up the debug patient options using all diseases available to the level. This prevents crashing of the game where a debug patient's disease is not known to the level.
- Hides the casebook icon in patient dialog, if a debug patient with a disease not yet discovered exists
- Tidying up in `UIPatient:updateInformation()`
- Fixes the tooltip for the debug patient window.
