### PR TITLE
Fix walls afterLoad 172

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 173 -- Make couches fully passable objects
+local SAVEGAME_VERSION = 174 -- Fix typo from afterLoad 172 (wall re-init)
 
 class "App"
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2769,8 +2769,9 @@ function World:afterLoad(old, new)
     self.wall_set_by_block_id = nil
     self.wall_dir_by_block_id = nil
   end
-  if old < 172 then
-    self.wall_types = self.app.wall_types
+  if old < 174 then
+    -- Originally 172, bumping afterLoad to correct a typo
+    self.wall_types = self.app.walls
     self:initWallTypes()
   end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2248*

**Describe what the proposed change does**
- Corrects `app.wall_types` to `app.walls` in 172 afterLoad and bumps that afterLoad to 174 as a safety net (No damage is done reloading walls anyway).
