### PR TITLE
Remove destroyed patients from epidemics

### DIFF
--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -279,7 +279,7 @@ function Epidemic:checkPatientsForRemoval()
   for i = #self.infected_patients, 1, -1 do
     local infected_patient = self.infected_patients[i]
     if (not self.coverup_in_progress and infected_patient.going_home) or
-        infected_patient.dead then
+        infected_patient.dead or infected_patient.tile_x == nil then
       table.remove(self.infected_patients,i)
     end
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2256*

**Describe what the proposed change does**
- Removes patients from the infected list of epidemics if they are despawned. Prevents future_epidemics from being triggered with no active contagious patients and makes result fair.