### PR TITLE
Add demo gameplay movie

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/main_menu.lua
+++ b/CorsixTH/Lua/dialogs/resizables/main_menu.lua
@@ -96,6 +96,12 @@ function UIMainMenu:draw(canvas, x, y)
     ly = ly - 15
   end
   self.label_font:draw(canvas, _S.main_menu.version .. self.version_number, x + 5, ly, 190, 0, "right")
+  TheApp:idle()
+end
+
+function UIMainMenu:onMouseMove(x, y, dx, dy)
+  TheApp:resetIdle()
+  UIResizable.onMouseMove(self, x, y, dx, dy)
 end
 
 function UIMainMenu:buttonNewGame()

--- a/CorsixTH/Lua/movie_player.lua
+++ b/CorsixTH/Lua/movie_player.lua
@@ -96,12 +96,14 @@ function MoviePlayer:MoviePlayer(app, audio, video)
   self.lose_movies = {}
   self.advance_movies = {}
   self.intro_movie = nil
+  self.demo_movie = nil
   self.win_movie = nil
   self.can_skip = true
   self.wait_for_stop = false
   self.wait_for_over = false
 end
 
+--! Initialises the different movies used in the game
 function MoviePlayer:init()
   self.moviePlayer = TH.moviePlayer()
   self.moviePlayer:setRenderer(self.video)
@@ -126,25 +128,38 @@ function MoviePlayer:init()
     end
   end
 
-  --find intro
+  --find intro and demo movies
   movies = self.app.fs:listFiles("Intro")
   if movies then
     for _, movie in pairs(movies) do
       if movie:upper():match(pathsep .. "INTRO%.SM4$") then
         self.intro_movie = movie
+      elseif movie:upper():match(pathsep .. "ATTRACT.SMK$") then
+        self.demo_movie = movie
       end
     end
   end
 end
 
+--! Plays the opening movie from TH
+--!param callback_after_movie (function) What to do once movie ends
 function MoviePlayer:playIntro(callback_after_movie)
   self:playMovie(self.intro_movie, false, true, callback_after_movie)
 end
 
+--! Plays the demo gameplay footage movie from TH
+function MoviePlayer:playDemoMovie()
+  self:playMovie(self.demo_movie, false, true)
+end
+
+--! Plays the movie for winning the game
 function MoviePlayer:playWinMovie()
   self:playMovie(self.win_movie, true, true)
 end
 
+--! Plays the level advance movie, which is going to the next level on the game board
+--! This is for the original campaign only.
+--!param level (number) What level we're going to.
 function MoviePlayer:playAdvanceMovie(level)
   local filename = self.advance_movies[level]
 
@@ -165,6 +180,7 @@ function MoviePlayer:playAdvanceMovie(level)
   self:playMovie(filename, true, false)
 end
 
+--! Plays one of the lose scenario movies at random
 function MoviePlayer:playLoseMovie()
   if #self.lose_movies > 0 then
     local filename = self.lose_movies[math.random(#self.lose_movies)]
@@ -172,6 +188,12 @@ function MoviePlayer:playLoseMovie()
   end
 end
 
+--! Function used to tell the Movie Player to play something.
+--!param filename (string) Location of the movie file
+--!param wait_for_stop (boolean) If true, movie will not dismiss automatically
+--! (requires a mouse/key press)
+--!param can_skip (boolean) If true, the player can end movie prematurely
+--!param callback (function) What to do after the movie ends
 function MoviePlayer:playMovie(filename, wait_for_stop, can_skip, callback)
   local success, warning
 
@@ -255,6 +277,7 @@ function MoviePlayer:deallocatePictureBuffer()
   self.moviePlayer:deallocatePictureBuffer()
 end
 
+--! Handles when the movie ends
 function MoviePlayer:onMovieOver()
   if self.moviePlayer == nil then return end
 
@@ -264,6 +287,7 @@ function MoviePlayer:onMovieOver()
   end
 end
 
+--! Handles ending the movie prematurely (user input)
 function MoviePlayer:stop()
   if self.moviePlayer == nil then return end
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ There are some areas of the game still missing, and while we work to get them in
 - Rats (but rat holes are present) and the special rat level
 - Win level video/letter
 - Newspaper headlines on lose level
-- Demo gameplay video
 - The original graphics do not have a complete set for Pregnancy, Alien DNA, and female Fractured Bones patients -- these may cause anomalies if you enable regular spawning in settings
 - Patients have an astounding ability to always remain upright (can't fall over in earthquakes)
 - Some objects in the game may glitch with walls


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**Describe what the proposed change does**
- Adds `ATTRACT.SMK` video to game when idling in main menu
- Idle currently ~30s
- A slightly placeholder too for when we're able to replace with our own movies (e.g. wolter's one as discussed on Discord/Matrix)
