### PR TITLE
Fix #2181 Store palette 255 transparency

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 175 -- Max salary improvements
+local SAVEGAME_VERSION = 176 -- Palette fix
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -51,13 +51,12 @@ function UIAnnualReport:UIAnnualReport(ui, world)
   self.rep_amount = 0
 
   if not pcall(function()
-    local palette   = gfx:loadPalette("QData", "Award02V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+    local palette = gfx:loadPalette("QData", "Award02V.pal", true)
 
     -- Right now the statistics are first
     --self.background = gfx:loadRaw("Fame01V", 640, 480)
     self.award_background = gfx:loadRaw("Award01V", 640, 480)
-    self.stat_background = gfx:loadRaw("Award02V", 640, 480)
+    self.stat_background = gfx:loadRaw("Award02V", 640, 480, "QData", "QData", "Award02V.pal", true)
     self.background = self.stat_background
 
     self.stat_font = gfx:loadFont("QData", "Font45V", false, palette)
@@ -636,4 +635,21 @@ function UIAnnualReport:drawStatisticsScreen(canvas, x, y)
     font:draw(canvas, string.format("%.0f", self.value_sort[index_v2].value), x + 240 + col_x,
         y + row_y + row_no_y * 2 + row_dy * (index_v2 - 1), 70, 0, "right")
   end
+end
+
+function UIAnnualReport:afterLoad(old, new)
+  if old < 176 then
+    local gfx = TheApp.gfx
+
+    local palette = gfx:loadPalette("QData", "Award02V.pal", true)
+    self.award_background = gfx:loadRaw("Award01V", 640, 480)
+    self.stat_background = gfx:loadRaw("Award02V", 640, 480, "QData", "QData", "Award02V.pal", true)
+    self.background = self.stat_background
+    self.stat_font = gfx:loadFont("QData", "Font45V", false, palette)
+    self.write_font = gfx:loadFont("QData", "Font47V", false, palette)
+    self.stone_font = gfx:loadFont("QData", "Font46V", false, palette)
+    self.panel_sprites = gfx:loadSpriteTable("QData", "Award03V", true, palette)
+  end
+
+  UIFullscreen.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/dialogs/fullscreen/bank_manager.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/bank_manager.lua
@@ -29,16 +29,14 @@ function UIBankManager:UIBankManager(ui)
   local gfx = ui.app.gfx
   self.world = ui.app.world
   if not pcall(function()
-    self.background = gfx:loadRaw("Bank01V", 640, 480)
-    self.stat_background = gfx:loadRaw("Stat01V", 640, 480)
-    local palette = gfx:loadPalette("QData", "Bank01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+    self.background = gfx:loadRaw("Bank01V", 640, 480, "QData", "QData", "Bank01V.pal", true)
+    self.stat_background = gfx:loadRaw("Stat01V", 640, 480, "QData", "QData", "Stat01V.pal", true)
+    local palette = gfx:loadPalette("QData", "Bank01V.pal", true)
     self.panel_sprites = gfx:loadSpriteTable("QData", "Bank02V", true, palette)
     self.font = gfx:loadFont("QData", "Font36V", false, palette)
 
     -- The statistics font
-    palette = gfx:loadPalette("QData", "Stat01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+    palette = gfx:loadPalette("QData", "Stat01V.pal", true)
     self.stat_font = gfx:loadFont("QData", "Font37V", false, palette)
   end) then
     ui:addWindow(UIInformation(ui, {_S.errors.dialog_missing_graphics}))
@@ -120,6 +118,17 @@ function UIBankManager:afterLoad(old, new)
     self.smiles = self:addPanel(12, 303, 199)
     self.eyesblink = self:addPanel(7, 298, 173)
     self.browslift = self:addPanel(9, 296, 165)
+  end
+  if old < 176 then
+    local gfx = TheApp.gfx
+    self.background = gfx:loadRaw("Bank01V", 640, 480, "QData", "QData", "Bank01V.pal", true)
+    self.stat_background = gfx:loadRaw("Stat01V", 640, 480, "QData", "QData", "Stat01V.pal", true)
+    local palette = gfx:loadPalette("QData", "Bank01V.pal", true)
+    self.panel_sprites = gfx:loadSpriteTable("QData", "Bank02V", true, palette)
+    self.font = gfx:loadFont("QData", "Font36V", false, palette)
+
+    palette = gfx:loadPalette("QData", "Stat01V.pal", true)
+    self.stat_font = gfx:loadFont("QData", "Font37V", false, palette)
   end
   UIFullscreen.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/dialogs/fullscreen/drug_casebook.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/drug_casebook.lua
@@ -28,9 +28,8 @@ function UICasebook:UICasebook(ui, disease_selection)
   self:UIFullscreen(ui)
   local gfx = ui.app.gfx
   if not pcall(function()
-    self.background = gfx:loadRaw("DrugN01V", 640, 480)
-    local palette = gfx:loadPalette("QData", "DrugN01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+    self.background = gfx:loadRaw("DrugN01V", 640, 480, "QData", "QData", "DrugN01V.pal", true)
+    local palette = gfx:loadPalette("QData", "DrugN01V.pal", true)
     self.panel_sprites = gfx:loadSpriteTable("QData", "DrugN02V", true, palette)
     self.title_font = gfx:loadFont("QData", "Font25V", false, palette)
     self.selected_title_font = gfx:loadFont("QData", "Font26V", false, palette)
@@ -395,6 +394,16 @@ function UICasebook:onTick()
 end
 
 function UICasebook:afterLoad(old, new)
+  if old < 176 then
+    local gfx = TheApp.gfx
+    self.background = gfx:loadRaw("DrugN01V", 640, 480, "QData", "QData", "DrugN01V.pal", true)
+    local palette = gfx:loadPalette("QData", "DrugN01V.pal", true)
+    self.panel_sprites = gfx:loadSpriteTable("QData", "DrugN02V", true, palette)
+    self.title_font = gfx:loadFont("QData", "Font25V", false, palette)
+    self.selected_title_font = gfx:loadFont("QData", "Font26V", false, palette)
+    self.drug_font = gfx:loadFont("QData", "Font24V", false, palette)
+  end
+
   UIFullscreen.afterLoad(self, old, new)
   self:registerKeyHandlers()
 end

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -30,9 +30,8 @@ local UIFax = _G["UIFax"]
 function UIFax:UIFax(ui, icon)
   self:UIFullscreen(ui)
   local gfx = ui.app.gfx
-  self.background = gfx:loadRaw("Fax01V", 640, 480)
-  local palette = gfx:loadPalette("QData", "Fax01V.pal")
-  palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+  self.background = gfx:loadRaw("Fax01V", 640, 480, "QData", "QData", "Fax01V.pal", true)
+  local palette = gfx:loadPalette("QData", "Fax01V.pal", true)
   self.panel_sprites = gfx:loadSpriteTable("QData", "Fax02V", true, palette)
   self.fax_font = gfx:loadFont("QData", "Font51V", false, palette)
   self.icon = icon
@@ -287,6 +286,13 @@ function UIFax:close()
 end
 
 function UIFax:afterLoad(old, new)
+  if old < 176 then
+    local gfx = TheApp.gfx
+    self.background = gfx:loadRaw("Fax01V", 640, 480, "QData", "QData", "Fax01V.pal", true)
+    local palette = gfx:loadPalette("QData", "Fax01V.pal", true)
+    self.panel_sprites = gfx:loadSpriteTable("QData", "Fax02V", true, palette)
+    self.fax_font = gfx:loadFont("QData", "Font51V", false, palette)
+  end
   UIFullscreen.afterLoad(self, old, new)
   if old < 59 then
     -- self.choice_buttons added, changes to disabled buttons.

--- a/CorsixTH/Lua/dialogs/fullscreen/graphs.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/graphs.lua
@@ -43,9 +43,8 @@ function UIGraphs:UIGraphs(ui)
   self:UIFullscreen(ui)
   local gfx = ui.app.gfx
   if not pcall(function()
-    self.background = gfx:loadRaw("Graph01V", 640, 480)
-    local palette = gfx:loadPalette("QData", "Graph01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+    self.background = gfx:loadRaw("Graph01V", 640, 480, "QData", "QData", "Graph01V.pal", true)
+    local palette = gfx:loadPalette("QData", "Graph01V.pal", true)
     self.panel_sprites = gfx:loadSpriteTable("QData", "Graph02V", true, palette)
     self.white_font = gfx:loadFont("QData", "Font01V", false, palette)
     self.black_font = gfx:loadFont("QData", "Font00V", false, palette)
@@ -443,6 +442,15 @@ function UIGraphs:close()
 end
 
 function UIGraphs:afterLoad(old, new)
+  if old < 176 then
+    local gfx = TheApp.gfx
+
+    self.background = gfx:loadRaw("Graph01V", 640, 480, "QData", "QData", "Graph01V.pal", true)
+    local palette = gfx:loadPalette("QData", "Graph01V.pal", true)
+    self.panel_sprites = gfx:loadSpriteTable("QData", "Graph02V", true, palette)
+    self.white_font = gfx:loadFont("QData", "Font01V", false, palette)
+    self.black_font = gfx:loadFont("QData", "Font00V", false, palette)
+  end
   UIFullscreen.afterLoad(self, old, new)
   if old < 117 then
     self:close()

--- a/CorsixTH/Lua/dialogs/fullscreen/hospital_policy.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/hospital_policy.lua
@@ -28,9 +28,8 @@ function UIPolicy:UIPolicy(ui)
   self:UIFullscreen(ui)
   local gfx = ui.app.gfx
   if not pcall(function()
-    self.background = gfx:loadRaw("Pol01V", 640, 480)
-    local palette = gfx:loadPalette("QData", "Pol01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+    self.background = gfx:loadRaw("Pol01V", 640, 480, "QData", "QData", "Pol01V.pal", true)
+    local palette = gfx:loadPalette("QData", "Pol01V.pal", true)
     self.panel_sprites = gfx:loadSpriteTable("QData", "Pol02V", true, palette)
     self.label_font = gfx:loadFont("QData", "Font74V", false, palette)
     self.text_font = gfx:loadFont("QData", "Font105V", false, palette)
@@ -225,10 +224,19 @@ function UIPolicy:close()
 end
 
 function UIPolicy:afterLoad(old, new)
-  UIFullscreen.afterLoad(self, old, new)
-
   if old < 116 then -- Ensure panelHit tests the sliders in the right order.
     self.sliders_z = {self.sliders["send_home"], self.sliders["guess_cure"],
         self.sliders["stop_procedure"], self.sliders["goto_staffroom"]}
   end
+  if old < 176 then
+    local gfx = TheApp.gfx
+
+    self.background = gfx:loadRaw("Pol01V", 640, 480, "QData", "QData", "Pol01V.pal", true)
+    local palette = gfx:loadPalette("QData", "Pol01V.pal", true)
+    self.panel_sprites = gfx:loadSpriteTable("QData", "Pol02V", true, palette)
+    self.label_font = gfx:loadFont("QData", "Font74V", false, palette)
+    self.text_font = gfx:loadFont("QData", "Font105V", false, palette)
+  end
+
+  UIFullscreen.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
@@ -32,11 +32,10 @@ function UIProgressReport:UIProgressReport(ui)
   local gfx   = ui.app.gfx
 
   if not pcall(function()
-    local palette   = gfx:loadPalette("QData", "Rep01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+    local palette = gfx:loadPalette("QData", "Rep01V.pal", true)
 
-    self.background = gfx:loadRaw("Rep01V", 640, 480)
-    self.red_font  = gfx:loadFont("QData", "Font101V", false, palette)
+    self.background = gfx:loadRaw("Rep01V", 640, 480, "QData", "QData", "Rep01V.pal", true)
+    self.red_font = gfx:loadFont("QData", "Font101V", false, palette)
     self.normal_font = gfx:loadFont("QData", "Font100V", false, palette)
     self.small_font = gfx:loadFont("QData", "Font106V")
     self.panel_sprites = gfx:loadSpriteTable("QData", "Rep02V", true, palette)
@@ -231,4 +230,19 @@ function UIProgressReport:draw(canvas, x, y)
   self.small_font:draw(canvas, _S.progress_report.win_criteria:upper(), x + 263, y + 172)
   self.small_font:draw(canvas, _S.progress_report.percentage_pop:upper() .. " " ..
       (hospital.population * 100) .. "%", x + 450, y + 65)
+end
+
+function UIProgressReport:afterLoad(old, new)
+  if old < 176 then
+    local gfx = TheApp.gfx
+
+    local palette = gfx:loadPalette("QData", "Rep01V.pal", true)
+    self.background = gfx:loadRaw("Rep01V", 640, 480, "QData", "QData", "Rep01V.pal", true)
+    self.red_font = gfx:loadFont("QData", "Font101V", false, palette)
+    self.normal_font = gfx:loadFont("QData", "Font100V", false, palette)
+    self.small_font = gfx:loadFont("QData", "Font106V")
+    self.panel_sprites = gfx:loadSpriteTable("QData", "Rep02V", true, palette)
+  end
+
+  UIFullscreen.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/dialogs/fullscreen/research_policy.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/research_policy.lua
@@ -40,9 +40,8 @@ local col_bg = {
 function UIResearch:UIResearch(ui)
   self:UIFullscreen(ui)
   local gfx = ui.app.gfx
-  self.background = gfx:loadRaw("Res01V", 640, 480)
-  local palette = gfx:loadPalette("QData", "Res01V.pal")
-  palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+  self.background = gfx:loadRaw("Res01V", 640, 480, "QData", "QData", "Res01V.pal", true)
+  local palette = gfx:loadPalette("QData", "Res01V.pal", true)
   self.panel_sprites = gfx:loadSpriteTable("QData", "Res02V", true, palette)
   self.label_font = gfx:loadFont("QData", "Font43V", false, palette)
   self.number_font  = gfx:loadFont("QData", "Font43V", false, palette)
@@ -240,5 +239,13 @@ function UIResearch:afterLoad(old, new)
         more = self.buttons[2 * i + 1],
       }
     end
+  end
+  if old < 176 then
+    local gfx = TheApp.gfx
+    self.background = gfx:loadRaw("Res01V", 640, 480, "QData", "QData", "Res01V.pal", true)
+    local palette = gfx:loadPalette("QData", "Res01V.pal", true)
+    self.panel_sprites = gfx:loadSpriteTable("QData", "Res02V", true, palette)
+    self.label_font = gfx:loadFont("QData", "Font43V", false, palette)
+    self.number_font  = gfx:loadFont("QData", "Font43V", false, palette)
   end
 end

--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -30,9 +30,8 @@ function UIStaffManagement:UIStaffManagement(ui)
   self:UIFullscreen(ui)
   local gfx = ui.app.gfx
   if not pcall(function()
-    self.background = gfx:loadRaw("Staff01V", 640, 480)
-    local palette = gfx:loadPalette("QData", "Staff01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+    self.background = gfx:loadRaw("Staff01V", 640, 480, "QData", "QData", "Staff01V.pal", true)
+    local palette = gfx:loadPalette("QData", "Staff01V.pal", true)
     self.panel_sprites = gfx:loadSpriteTable("QData", "Staff02V", true, palette)
     self.title_font = gfx:loadFont("QData", "Font01V", false, palette)
     self.face_parts = ui.app.gfx:loadRaw("Face01V", 65, 1350, nil, "Data", "MPalette.dat")
@@ -586,6 +585,13 @@ function UIStaffManagement:afterLoad(old, new)
 
   if old < 175 then
     self:close()
+  end
+  if old < 176 then
+    local gfx = TheApp.gfx
+    self.background = gfx:loadRaw("Staff01V", 640, 480, "QData", "QData", "Staff01V.pal", true)
+    local palette = gfx:loadPalette("QData", "Staff01V.pal", true)
+    self.panel_sprites = gfx:loadSpriteTable("QData", "Staff02V", true, palette)
+    self.title_font = gfx:loadFont("QData", "Font01V", false, palette)
   end
 
   UIFullscreen.afterLoad(self, old, new)

--- a/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
@@ -34,10 +34,9 @@ function UITownMap:UITownMap(ui)
   self.app = app
 
   if not pcall(function()
-    local palette   = gfx:loadPalette("QData", "Town01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+    local palette = gfx:loadPalette("QData", "Town01V.pal", true)
 
-    self.background = gfx:loadRaw("Town01V", 640, 480)
+    self.background = gfx:loadRaw("Town01V", 640, 480, "QData", "QData", "Town01V.pal", true)
     self.info_font  = gfx:loadFont("QData", "Font34V", false, palette)
     self.city_font = gfx:loadFont("QData", "Font31V", false, palette)
     self.money_font = gfx:loadFont("QData", "Font05V")
@@ -344,4 +343,17 @@ function UITownMap:bankStats()
   dlg:showStatistics()
   self.ui:addWindow(dlg)
   self.ui:getWindow(UIBottomPanel):updateButtonStates()
+end
+
+function UITownMap:afterLoad(old, new)
+  if old < 176 then
+    local gfx = TheApp.gfx
+    local palette = gfx:loadPalette("QData", "Town01V.pal", true)
+    self.background = gfx:loadRaw("Town01V", 640, 480, "QData", "QData", "Town01V.pal", true)
+    self.info_font = gfx:loadFont("QData", "Font34V", false, palette)
+    self.city_font = gfx:loadFont("QData", "Font31V", false, palette)
+    self.panel_sprites = gfx:loadSpriteTable("QData", "Town02V", true, palette)
+  end
+
+  UIFullscreen.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_game.lua
@@ -75,7 +75,7 @@ function UICustomGame:UICustomGame(ui)
 
   -- Now add the free build button beside the list.
   if not pcall(function()
-    local palette = ui.app.gfx:loadPalette("QData", "DrugN01V.pal")
+    local palette = ui.app.gfx:loadPalette("QData", "DrugN01V.pal", true)
     self.panel_sprites = ui.app.gfx:loadSpriteTable("QData", "DrugN02V", true, palette)
     self.border_sprites = ui.app.gfx:loadSpriteTable("Bitmap", "aux_ui", true)
   end) then

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -149,8 +149,7 @@ function UI:UI(app, minimal)
   if minimal then
     self.tooltip_font = app.gfx:loadBuiltinFont()
   else
-    local palette = app.gfx:loadPalette("QData", "PREF01V.PAL")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
+    local palette = app.gfx:loadPalette("QData", "PREF01V.PAL", true)
     self.tooltip_font = app.gfx:loadFont("QData", "Font00V", false, palette)
   end
   self.tooltip = nil
@@ -195,47 +194,6 @@ function UI:UI(app, minimal)
 
   self:setCursor(self.default_cursor)
 
-  -- to avoid a bug which causes open fullscreen windows to display incorrectly, load
-  -- the sprite sheet associated with all fullscreen windows so they are correctly cached.
-  -- Darrell: Only do this if we have a valid data directory otherwise we won't be able to
-  -- display the directory browser to even find the data directory.
-  -- Edvin: Also, the demo does not contain any of the dialogs.
-  if self.app.good_install_folder and not self.app.using_demo_files then
-    local gfx = self.app.gfx
-    local palette
-    -- load drug casebook sprite table
-    palette = gfx:loadPalette("QData", "DrugN01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
-    gfx:loadSpriteTable("QData", "DrugN02V", true, palette)
-    -- load fax sprite table
-    palette = gfx:loadPalette("QData", "Fax01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
-    gfx:loadSpriteTable("QData", "Fax02V", true, palette)
-    -- load town map sprite table
-    palette = gfx:loadPalette("QData", "Town01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
-    gfx:loadSpriteTable("QData", "Town02V", true, palette)
-    -- load hospital policy sprite table
-    palette = gfx:loadPalette("QData", "Pol01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
-    gfx:loadSpriteTable("QData", "Pol02V", true, palette)
-    -- load bank manager sprite table
-    palette = gfx:loadPalette("QData", "Bank01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
-    gfx:loadSpriteTable("QData", "Bank02V", true, palette)
-    -- load research screen sprite table
-    palette = gfx:loadPalette("QData", "Res01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
-    gfx:loadSpriteTable("QData", "Res02V", true, palette)
-    -- load progress report sprite table
-    palette = gfx:loadPalette("QData", "Rep01V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
-    gfx:loadSpriteTable("QData", "Rep02V", true, palette)
-    -- load annual report sprite table
-    palette = gfx:loadPalette("QData", "Award02V.pal")
-    palette:setEntry(255, 0xFF, 0x00, 0xFF) -- Make index 255 transparent
-    gfx:loadSpriteTable("QData", "Award03V", true, palette)
-  end
 
   self:setupGlobalKeyHandlers()
 end
@@ -1119,6 +1077,17 @@ function UI:afterLoad(old, new)
   self.key_handlers = {}
   if old < 5 then
     self.editing_allowed = true
+  end
+  if old < 176 then
+    if self.app.good_install_folder and not self.app.using_demo_files then
+      local gfx = self.app.gfx
+      gfx.cache.raw = {}
+      gfx.cache.tabled = {}
+      gfx.cache.palette = {}
+      gfx.cache.palette_greyscale_ghost = {}
+      gfx.cache.language_fonts = {}
+      gfx.builtin_font = nil
+    end
   end
   self:setupGlobalKeyHandlers()
 


### PR DESCRIPTION
Use a flag to mark if the 255 entry in a palette is transparent. Store that flag so it will be applied again on load.

This removes the bug that required sprite sheets to be all fetched on load as well.

RFC because I'm not confident in the afterLoad change made in ui.lua - I suspect I'll have to move those into the individual dialogs that use them instead.