### PR TITLE
Skip invisible path head of initial walk

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -200,13 +200,14 @@ end
 -- hospital if they already belong to one. For player hospitals, patients who
 -- are not debug or emergency patients are made to seek a reception desk.
 --!param hospital (Hospital): hospital to assign to patient
-function Patient:setHospital(hospital)
+--!param trim_path_head If set, trim an invisible part of the path to the hospital.
+function Patient:setHospital(hospital, trim_path_head)
   if self.hospital then
     self.hospital:removePatient(self)
   end
   Humanoid.setHospital(self, hospital)
   if hospital.is_in_world and not self.is_debug and not self.is_emergency then
-    self:setNextAction(SeekReceptionAction())
+    self:setNextAction(SeekReceptionAction(trim_path_head))
   end
   hospital:addPatient(self)
 end

--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -89,7 +89,7 @@ local function isTileOnScreen(tile_top_x, tile_top_y, tile_size, scr_size)
   if tile_top_y + tile_size[2] < 0 then return false end
   if tile_top_y >= scr_size[2] then return false end
   if tile_top_x + tile_size[1] / 2 < 0 then return false end
-  return not (tile_top_x - tile_size[1] / 2 >= scr_size[1])
+  return tile_top_x - tile_size[1] / 2 < scr_size[1]
 end
 
 --! Remove some tiles from the start of the path with tiles that are not

--- a/CorsixTH/Lua/humanoid_actions/spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/spawn.lua
@@ -74,6 +74,9 @@ end)
 local function action_spawn_start(action, humanoid)
   assert(action.mode == "spawn" or action.mode == "despawn", "spawn action given invalid mode: " .. action.mode)
   local x, y = action.point.x, action.point.y
+
+  -- For despawning, insert a walk to the despawning position if the humanoid is
+  -- not there.
   if action.mode == "despawn" and (humanoid.tile_x ~= x or humanoid.tile_y ~= y) then
     humanoid:queueAction(WalkAction(action.point.x, action.point.y):setMustHappen(action.must_happen), 0)
     return
@@ -94,13 +97,13 @@ local function action_spawn_start(action, humanoid)
   assert(offset_x > 0 and offset_y > 0, "Spawning needs to be done from an adjacent tile.")
   local anim, flag, speed_x, speed_y, duration
   if walk_dir == "east" then
-    anim, flag, speed_x, speed_y, duration = anims.walk_east , 0,  4,  2, 10*offset_x
+    anim, flag, speed_x, speed_y, duration = anims.walk_east , 0,  4,  2, 10 * offset_x
   elseif walk_dir == "west" then
-    anim, flag, speed_x, speed_y, duration = anims.walk_north, 1, -4, -2, 10*offset_x
+    anim, flag, speed_x, speed_y, duration = anims.walk_north, 1, -4, -2, 10 * offset_x
   elseif walk_dir == "south" then
-    anim, flag, speed_x, speed_y, duration = anims.walk_east , 1, -4,  2, 10*offset_y
+    anim, flag, speed_x, speed_y, duration = anims.walk_east , 1, -4,  2, 10 * offset_y
   else--if walk_dir == "north" then
-    anim, flag, speed_x, speed_y, duration = anims.walk_north, 0,  4, -2, 10*offset_y
+    anim, flag, speed_x, speed_y, duration = anims.walk_north, 0,  4, -2, 10 * offset_y
   end
   humanoid.last_move_direction = walk_dir
   humanoid:setAnimation(anim, flag)

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -513,7 +513,7 @@ function World:spawnPatient(hospital)
   local patient = self:newEntity("Patient", 2)
   patient:setDisease(disease)
   patient:setNextAction(SpawnAction("spawn", spawn_point))
-  patient:setHospital(hospital)
+  patient:setHospital(hospital, true)
   return patient
 end
 
@@ -541,7 +541,7 @@ function World:spawnVIP(name)
   vip:setHospital(hospital)
   vip:updateDynamicInfo()
   hospital:onSpawnVIP()
-  vip:queueAction(SeekReceptionAction())
+  vip:queueAction(SeekReceptionAction(true))
 end
 
 --! Perform actions to simulate an active earthquake.


### PR DESCRIPTION
A step towards getting the first patient quicker (issue #649 ) in the hospital.

As discussed by @mugmuggy at https://github.com/CorsixTH/CorsixTH/issues/649#issuecomment-356282253 original game spawns closer to the hospital. This patch does that.

Patch is more readable when viewing commits rather than the entire branch.

The impact of this patch seems small judging by a first test-run, so the problem is also in the patient spawning process.

Addresses #649