### PR TITLE
Fix developer language

### DIFF
--- a/CorsixTH/Lua/languages/developer.lua
+++ b/CorsixTH/Lua/languages/developer.lua
@@ -22,7 +22,7 @@ SOFTWARE. --]]
 -- following line. This language causes every translatable string to be
 -- displayed as the name of the string.
 
---Language("Developer")
+--Language("Developer", "Developer", "dev")
 
 Inherit("english")
 


### PR DESCRIPTION
Allows the language choice now to show in the language selection menu when you comment out line 25.

Have made sure "dev" does not conflict with any ISO standards for existing languages.