### PR TITLE
Account for draw scale in canvas size.

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -689,13 +689,13 @@ void render_target::pop_clip_rect() {
 int render_target::get_width() const {
   int w;
   SDL_RenderGetLogicalSize(renderer, &w, nullptr);
-  return std::ceil(w / draw_scale());
+  return static_cast<int>(std::ceil(w / draw_scale()));
 }
 
 int render_target::get_height() const {
   int h;
   SDL_RenderGetLogicalSize(renderer, nullptr, &h);
-  return std::ceil(h / draw_scale());
+  return static_cast<int>(std::ceil(h / draw_scale()));
 }
 
 void render_target::start_nonoverlapping_draws() {

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -689,13 +689,13 @@ void render_target::pop_clip_rect() {
 int render_target::get_width() const {
   int w;
   SDL_RenderGetLogicalSize(renderer, &w, nullptr);
-  return w;
+  return std::ceil(w / draw_scale());
 }
 
 int render_target::get_height() const {
   int h;
   SDL_RenderGetLogicalSize(renderer, nullptr, &h);
-  return h;
+  return std::ceil(h / draw_scale());
 }
 
 void render_target::start_nonoverlapping_draws() {


### PR DESCRIPTION
When a draw scale is set, the caller is not supposed to need to account for the draw scale. This scales the width and height returned accordingly.

*Fixes #2304*