### PR TITLE
Fix empty action queue dialogue crash

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -629,7 +629,7 @@ function Humanoid:_handleEmptyActionQueue()
   self.world:gameLog("Last action: " .. self.previous_action.name)
   self.world:gameLog(debug.traceback())
 
-  ui:addWindow(UIConfirmDialog(ui, true, {_S.errors.dialog_empty_queue},
+  ui:addWindow(UIConfirmDialog(ui, true, _S.errors.dialog_empty_queue,
     --[[persistable:humanoid_leave_hospital]] function()
       self.world:gameLog("The humanoid was told to leave the hospital...")
       if class.is(self, Staff) then


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**Describe what the proposed change does**
- Using curly braces in #2088 caused the "empty action queue!" dialogue message to never show up in 0.66 due to us sending `sizeOf` a table rather than a string to graphics.lua - `font_proxy_mt`
- PR addresses this and removes the curly braces.
- Potential future improvement is allowing `sizeOf` to accept a table of strings.
