### PR TITLE
Fix: patient going home without despawn action

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -594,9 +594,9 @@ end
 
 --! Handle an empty action queue in some way instead of crashing.
 function Humanoid:_handleEmptyActionQueue()
-  -- if this is a patient that is going home, an empty
-  -- action queue is not a problem
+  -- if this is a patient that is going home, add a despawn action so that they leave
   if class.is(self, Patient) and self.going_home then
+    self:despawn()
     return
   end
 


### PR DESCRIPTION
Fixes a bug where a patient could be going home (`self.going_home`) but not have any action. 

The previous handling of an empty action queue treated this as ok, but it can cause a crash. This hapenned to me in the attached save game. If you open it, the crash will happen on the next patient to use the decontamination shower (there's no doctor in there, so you  will need to wait a minute or just move one to the room).

[crash shower.zip](https://github.com/CorsixTH/CorsixTH/files/10961267/crash.shower.zip)
