### PR TITLE
try to fix infinite loop when word wider than box Width

### DIFF
--- a/CorsixTH/Src/th_gfx_font.cpp
+++ b/CorsixTH/Src/th_gfx_font.cpp
@@ -500,10 +500,9 @@ text_layout freetype_font::draw_text_wrapped(render_target* pCanvas,
             next_utf8_codepoint(sLineBreakPosition, sMessageEnd);
             iHandledRows++;
           }
-          sMessage = sLineBreakPosition;
+          sMessage = sLineStart = sLineBreakPosition;
           // Skip leading white space on a line
           skip_utf8_whitespace(sMessage, sMessageEnd);
-          sLineStart = sMessage;
         } else {
           if (iHandledRows >= iSkipRows) {
             vLines.push_back(std::make_pair(sLineStart, sOldMessage));


### PR DESCRIPTION
https://discord.com/channels/731272375949328486/854282144101040179/1086963524338712576

how to reproduce the bug:
-  use some font and select some game language(maybe other than English) which uses freetypefont.
   my case - mingliu.ttc, Traditional Chinese.
- display a long word "a wwwwwwwwwwwwwwwwwwwwww..." in tips window of home screen.
  ("xxxx..." does not trigger the bug. Need to be "x xxxx...".)
- infinite loop; freeze;

thanks.
