### PR TITLE
Bump vcpkg and favour fluidsynth

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,0 +1,47 @@
+---
+name: Windows
+
+on:  # yamllint disable-line rule:trurhy
+  push:
+    branches-ignore:
+      - 'gh-pages'
+  pull_request:
+
+jobs:
+  Windows:
+    runs-on: windows-2022
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Restore vcpkg cache
+        uses: actions/cache@v3
+        with:
+          path: vcpkg
+          key: vcpkg-${{runner.os}}-${{hashFiles('CMake/VcpkgDeps.cmake','scripts/build_vcpkg_deps.ps1')}}
+
+      - name: Create Project 
+        run: cmake -G "Visual Studio 17 2022" -DUSE_VCPKG_DEPS=ON -DVCPKG_TARGET_TRIPLET=x64-windows-release -DENABLE_UNIT_TESTS=ON -Bbuild .
+
+      - name: Build
+        run: cmake --build build/ --config RelWithDebInfo
+
+      - name: Test
+        run: |
+          pushd build/CorsixTH
+          ctest --extra-verbose --build-config RelWithDebInfo --output-on-failure
+          popd
+
+      - name: Copy data files for archive
+        run: |
+          cp -R CorsixTH/Lua build/CorsixTH/RelWithDebInfo/Lua
+          cp -R CorsixTH/Bitmap build/CorsixTH/RelWithDebInfo/Bitmap
+          cp -R CorsixTH/Levels build/CorsixTH/RelWithDebInfo/Levels
+          cp -R CorsixTH/Campaigns build/CorsixTH/RelWithDebInfo/Campaigns
+          cp CorsixTH/CorsixTH.lua build/CorsixTH/RelWithDebInfo/
+
+      - name: Archive Release
+        uses: actions/upload-artifact@v3
+        with:
+          path: build/CorsixTH/RelWithDebInfo
+          name: CorsixTH

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -32,6 +32,10 @@ jobs:
           ctest --extra-verbose --build-config RelWithDebInfo --output-on-failure
           popd
 
+      - name: Download soundfont
+        run:
+          aria2c -d build/CorsixTH/RelWithDebInfo https://github.com/Jacalz/fluid-soundfont/raw/master/SF3/FluidR3.sf3
+
       - name: Copy data files for archive
         run: |
           cp -R CorsixTH/Lua build/CorsixTH/RelWithDebInfo/Lua

--- a/CMake/CopyVcpkgLua.cmake
+++ b/CMake/CopyVcpkgLua.cmake
@@ -29,7 +29,7 @@ add_custom_command(TARGET CorsixTH POST_BUILD
   $<TARGET_FILE_DIR:CorsixTH>/ssl.dll
 )
 
-if(${_VCPKG_TARGET_TRIPLET} STREQUAL "x64-windows")
+if(${_VCPKG_TARGET_TRIPLET} MATCHES "x64-windows.*")
   set(_OPENSSL_SUFFIX "-x64")
 else()
   set(_OPENSSL_SUFFIX "")

--- a/CMake/CopyVcpkgSdlMixerBackends.cmake
+++ b/CMake/CopyVcpkgSdlMixerBackends.cmake
@@ -1,5 +1,0 @@
-add_custom_command(TARGET CorsixTH POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy
-  "${VCPKG_INSTALLED_PATH}/$<$<CONFIG:Debug>:debug/>bin/modplug.dll"
-  $<TARGET_FILE_DIR:CorsixTH>
-)

--- a/CMake/VcpkgDeps.cmake
+++ b/CMake/VcpkgDeps.cmake
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-set(VCPKG_COMMIT_SHA "13d8ccd373c70f71a1e6d76edc7b31f79a4b2119")
+set(VCPKG_COMMIT_SHA "9f9ea97d514f4da611df58ee10bfcda394eace1e")
 
 # Setup the various paths we are using
 set(_VCPKG_SCRIPT_NAME "build_vcpkg_deps.ps1")

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -101,7 +101,6 @@ set_property(TARGET CorsixTH PROPERTY CXX_STANDARD_REQUIRED ON)
 # Add an extra step to copy built DLLs on MSVC
 if(USE_VCPKG_DEPS)
   include(CopyVcpkgLua)
-  include(CopyVcpkgSdlMixerBackends)
 endif()
 
 ## Finding libraries

--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2683;
+return 2684;

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1448,7 +1448,8 @@ function App:findSoundFont()
 
   local possible_locations = {
     self.config.soundfont or false,
-    data_dir .. "FluidR3_GM.sf2", -- shipped
+    data_dir .. "FluidR3_GM.sf2",
+    data_dir .. "FluidR3.sf3",
     "/usr/share/soundfonts/default.sf2", -- default linux
     "/usr/share/sounds/sf2/FluidR3_GM.sf2", -- debian based
     "/usr/share/soundfonts/FluidR3_GM.sf2" -- archlinux and others

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1443,6 +1443,26 @@ function App:checkInstallFolder()
   return true, #corrupt ~= 0 and corrupt or nil
 end
 
+function App:findSoundFont()
+  local data_dir = debug.getinfo(1, "S").source:sub(2, -12)
+
+  local possible_locations = {
+    self.config.soundfont or false,
+    data_dir .. "FluidR3_GM.sf2", -- shipped
+    "/usr/share/soundfonts/default.sf2", -- default linux
+    "/usr/share/sounds/sf2/FluidR3_GM.sf2", -- debian based
+    "/usr/share/soundfonts/FluidR3_GM.sf2" -- archlinux and others
+  }
+
+  for _, sf_path in ipairs(possible_locations) do
+    if sf_path and lfs.attributes(sf_path) then
+      return sf_path
+    end
+  end
+
+  return nil
+end
+
 --! Get the directory containing the bitmap files.
 --!return Name of the directory containing the bitmap files, ending with a
 --        directory path separator.

--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -504,14 +504,8 @@ end
 --! If nil is returned music might either be playing or completely stopped.
 function Audio:pauseBackgroundTrack()
   assert(self.background_music, "Trying to pause music while music is stopped")
-  -- TODO: There is a bug in SDL for Windows that makes all sound, not just music stop
-  -- when pausing. For the time being, stop the music instead to prevent this.
-  self:stopBackgroundTrack()
-  return false
-  -------------------------------------------------
-  -- Real pause logic
-  -------------------------------------------------
-  --[[local status
+
+  local status
   if self.background_paused then
     self.background_paused = nil
     status = SDL.audio.resumeMusic()
@@ -541,7 +535,7 @@ function Audio:pauseBackgroundTrack()
     end
   end
   self:notifyJukebox()
-  return self.background_paused--]]
+  return self.background_paused
 end
 
 --! Stops playing background music for the time being.

--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -164,8 +164,11 @@ function Audio:init()
     self.has_bg_music = true
   end
 
-  local status, err = SDL.audio.init(self.app.config.audio_frequency,
-    self.app.config.audio_channels, self.app.config.audio_buffer_size)
+  local status, err = SDL.audio.init(
+    self.app.config.audio_frequency,
+    self.app.config.audio_channels,
+    self.app.config.audio_buffer_size,
+    self.app:findSoundFont())
   if status then
     -- NB: Playback will not start if play_music is set to false
     self:playRandomBackgroundTrack()

--- a/CorsixTH/Src/sdl_audio.cpp
+++ b/CorsixTH/Src/sdl_audio.cpp
@@ -60,6 +60,14 @@ void audio_music_over_callback() {
 
 int l_init(lua_State* L) {
   constexpr int chunk_size = 2048;
+  size_t soundfont_path_len;
+  const char* sound_font = luaL_optlstring(L, 4, nullptr, &soundfont_path_len);
+
+  // soundfont must be set before Mix_OpenAudio the first time or else
+  // fluidsynth is not loaded
+  if (sound_font != nullptr) {
+    Mix_SetSoundFonts(sound_font);
+  }
 
   int err = Mix_OpenAudio(
       static_cast<int>(luaL_optinteger(L, 1, MIX_DEFAULT_FREQUENCY)),

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -35,7 +35,7 @@ Copyright (C) 2011-2012 Sérgio "Get_It" Ribeiro
 Copyright (C) 2011 Sergei Larionov
 Copyright (C) 2011 Alexey Pinyagin
 Copyright (C) 2011-2019 Giordano "Viandante" Celeghin
-Copyright (C) 2012-2022 Stephen "TheCycoONE" Baker
+Copyright (C) 2012-2023 Stephen "TheCycoONE" Baker
 Copyright (C) 2012 Alex Ghiran
 Copyright (C) 2012-2013,2021 Luis "driverpt" Duarte
 Copyright (C) 2012-2013 Ryan Hugh Dean
@@ -425,7 +425,197 @@ licence.
 -------------------------------------------------------------------------------
 
 Uses the SDL 2 and SDL_mixer 2 libraries, which are available from
-http://www.libsdl.org/ under the GNU LGPL 2.1 license.
+http://www.libsdl.org/ under the following terms (zlib license).
+
+
+Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
+  
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+  
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required. 
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+-------------------------------------------------------------------------------
+
+Uses FluidSynth, which is available from https://www.fluidsynth.org/ under the
+GNU LGPL 2.1 license.
+
+-------------------------------------------------------------------------------
+
+Uses mpg123, which is available from http://mpg123.de/ under the GNU LGPL 2.1
+license.
+
+-------------------------------------------------------------------------------
+
+Uses LAME, which is available from https://lame.sourceforge.io/ under the GNU
+LGPL 2.1
+
+-------------------------------------------------------------------------------
+
+Uses libvorbis, which is available https://xiph.org/vorbis/ from under the
+following terms:
+
+Copyright (c) 2002-2020 Xiph.org Foundation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.org Foundation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------
+
+Uses libFLAC, which is available from https://xiph.org/flac/ under the
+following terms:
+
+Copyright (C) 2000-2009  Josh Coalson
+Copyright (C) 2011-2022  Xiph.Org Foundation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.Org Foundation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------
+
+Uses libopus and opusfile, which is available from https://opus-codec.org
+following terms:
+
+Copyright 2001-2011 Xiph.Org, Skype Limited, Octasic,
+                    Jean-Marc Valin, Timothy B. Terriberry,
+                    CSIRO, Gregory Maxwell, Mark Borgerding,
+                    Erik de Castro Lopo
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of Internet Society, IETF or IETF Trust, nor the
+names of specific contributors, may be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Opus is subject to the royalty-free patent licenses which are
+specified at:
+
+Xiph.Org Foundation:
+https://datatracker.ietf.org/ipr/1524/
+
+Microsoft Corporation:
+https://datatracker.ietf.org/ipr/1914/
+
+Broadcom Corporation:
+https://datatracker.ietf.org/ipr/1526/
+
+-------------------------------------------------------------------------------
+
+Uses libmodplug which is available from https://github.com/Konstanty/libmodplug
+under the following terms:
+
+ModPlug-XMMS and libmodplug are now in the public domain.
+
+-------------------------------------------------------------------------------
+
+Uses Brotli which is available from https://github.com/google/brotli under the
+following terms:
+
+Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+Uses OpenSSL which is available from https://www.openssl.org under the
+Apache License 2.0 
 
 -------------------------------------------------------------------------------
 
@@ -885,3 +1075,180 @@ RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
 FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
 SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGES.
+
+-------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ cache:
   - vcpkg -> CMake/VcpkgDeps.cmake, scripts/build_vcpkg_deps.ps1
 configuration: Release
 before_build:
-  - cmd: cmake -G "Visual Studio 16 2019" -DUSE_VCPKG_DEPS=ON -DENABLE_UNIT_TESTS=ON .
+  - cmd: cmake -G "Visual Studio 16 2019" -DUSE_VCPKG_DEPS=ON -DVCPKG_TARGET_TRIPLET=x64-windows-release -DENABLE_UNIT_TESTS=ON .
 build:
   project: CorsixTH_Top_Level.sln
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ test_script:
   - cd ..
 
 after_build:
+- curl -L -o %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/FluidR3.sf3 https://github.com/Jacalz/fluid-soundfont/raw/master/SF3/FluidR3.sf3
 - cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Lua %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/Lua
 - cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Bitmap %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/Bitmap
 - cp -R %APPVEYOR_BUILD_FOLDER%/CorsixTH/Levels %APPVEYOR_BUILD_FOLDER%/CorsixTH/Release/Levels

--- a/scripts/build_vcpkg_deps.ps1
+++ b/scripts/build_vcpkg_deps.ps1
@@ -34,7 +34,7 @@ Param(
 ################
 
 $anim_view_libs = "wxwidgets"
-$corsixth_libs = "ffmpeg[core,avcodec,avformat,swresample,swscale]", "freetype", "lua[tools]", "luafilesystem", "lpeg", "sdl2", "sdl2-mixer[libmodplug,fluidsynth,libflac,mpg123]", "luasocket", "luasec", "catch2"
+$corsixth_libs = "ffmpeg[core,avcodec,avformat,swresample,swscale]", "freetype", "lua[tools]", "luafilesystem", "lpeg", "sdl2", "fluidsynth[sndfile]", "sdl2-mixer[libmodplug,fluidsynth,libflac,mpg123,opusfile]", "luasocket", "luasec", "catch2"
 
 $vcpkg_git_url = "https://github.com/CorsixTH/vcpkg"
 

--- a/scripts/build_vcpkg_deps.ps1
+++ b/scripts/build_vcpkg_deps.ps1
@@ -101,7 +101,7 @@ function run_script {
 
     # mpg123 on x64-windows requires x86-windows yasm-tool.
     # https://github.com/microsoft/vcpkg/issues/15890
-    if ($VcpkgTriplet -eq "x64-windows") {
+    if ($VcpkgTriplet -like "x64-windows*") {
         $yasm_tool_install = ".\vcpkg install yasm-tool:x86-windows"
         run_command -command $yasm_tool_install
     }

--- a/scripts/build_vcpkg_deps.ps1
+++ b/scripts/build_vcpkg_deps.ps1
@@ -34,7 +34,7 @@ Param(
 ################
 
 $anim_view_libs = "wxwidgets"
-$corsixth_libs = "ffmpeg[core,avcodec,avformat,swresample,swscale]", "freetype", "lua[tools]", "luafilesystem", "lpeg", "sdl2", "sdl2-mixer[libmodplug,nativemidi]", "luasocket", "luasec", "catch2"
+$corsixth_libs = "ffmpeg[core,avcodec,avformat,swresample,swscale]", "freetype", "lua[tools]", "luafilesystem", "lpeg", "sdl2", "sdl2-mixer[libmodplug,fluidsynth,libflac,mpg123]", "luasocket", "luasec", "catch2"
 
 $vcpkg_git_url = "https://github.com/CorsixTH/vcpkg"
 


### PR DESCRIPTION
vcpkg dependencies are bumped. The new set is listed below.

SDL2_Mixer has some vcpkg changes. native_midi is no longer an option when installing through vcpkg. This is a packaging change, not a code change upstream. Manually adding the dependency dlls for sdl2_mixer is also no longer required, they are pulled in properly on build now.

Since fluidsynth is now the preferred midi engine for CorsixTH and it only works if a soundfont is loaded, some initialization code to find soundfonts has been added. It is expected that we will be able to ship one with the installer for the next release version.

To give us more options in case of problems with appveyor a windows github action pipeline was added.

vcpkg packages:

brotli 1.0.9#5
bzip2 1.0.8#4
catch2 3.3.2
dirent 1.23.2#2
ffmpeg 5.1.2#6
fluidsynth 2.3.2#2
freetype 2.12.1#3
gettext 0.21.1
glib 2.76.1#1
libffi 3.4.4#1
libflac 1.4.2
libiconv 1.17#1
libmodplug 0.8.9.0#10
libogg 1.3.5#1
libpng 1.6.39#1
libsndfile 1.2.0
libvorbis 1.3.7#2
lpeg 1.0.2#4
lua 5.4.4#7
luafilesystem 1.8.0#4
luasec 1.3.1
luasocket 3.1.0
mp3lame 3.10
mpg123 1.31.3
openssl 3.1.0#3
opus 1.4
opusfile 0.12+20221121#1
pcre2 10.40#1
pkgconf 1.8.0#5
sdl2-mixer 2.6.3#1
sdl2 2.26.5
yasm-tool-helper 2020-03-11#1
yasm-tool 2021-12-14
yasm 1.3.0#5
zlib 1.2.13