### PR TITLE
Clean edit_room afterload

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1555,11 +1555,9 @@ function UIEditRoom:placeObject()
 end
 
 function UIEditRoom:afterLoad(old, new)
-  if old < 171 then
-    self.wall_types = TheApp.walls
-    self:initWallTypes()
-  end
   if old < 172 then
+    -- reverts change in 171 where walls were moved into edit_room, its original
+    -- afterload was removed due to crashes
     self.wall_types = nil
     self.wall_id_by_block_id = nil
     self.wall_set_by_block_id = nil


### PR DESCRIPTION
*Fixes #*

**Describe what the proposed change does**
- Stops crash from 171 afterload by removing it
- Adds a comment on 172 afterload to explain context
