### PR TITLE
Replace debug.getinfo with App:getFullPath

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_campaign.lua
+++ b/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_campaign.lua
@@ -18,8 +18,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
-local pathsep = package.config:sub(1, 1)
-
 --! Custom Campaign Window
 class "UICustomCampaign" (UIMenuList)
 
@@ -66,10 +64,7 @@ end
 function UICustomCampaign:UICustomCampaign(ui)
   self.label_font = TheApp.gfx:loadFont("QData", "Font01V")
 
-  local local_path = debug.getinfo(1, "S").source:sub(2, -61)
-  local dir = "Campaigns" .. pathsep
-  local path = local_path .. dir
-
+  local path = TheApp:getFullPath("Campaigns", true)
   local campaigns = createCampaignList(path)
 
   self:UIMenuList(ui, "menu", _S.custom_campaign_window.caption, campaigns, 10, details_width + 40)

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -21,7 +21,6 @@ SOFTWARE. --]]
 local TH = require("TH")
 
 local pathsep = package.config:sub(1, 1)
-local ourpath = debug.getinfo(1, "S").source:sub(2, -17)
 
 --! Layer for loading (and subsequently caching) graphical resources.
 --! The Graphics class handles loading and caching of graphics resources.
@@ -97,7 +96,7 @@ function Graphics:Graphics(app)
   if self.app.config.use_new_graphics then
     -- Check if the config specifies a place to look for graphics in.
     -- Otherwise check in the default "Graphics" folder.
-    graphics_folder = self.app.config.new_graphics_folder or ourpath .. "Graphics"
+    graphics_folder = self.app.config.new_graphics_folder or self.app:getFullPath("Graphics", true)
     if graphics_folder:sub(-1) ~= pathsep then
       graphics_folder = graphics_folder .. pathsep
     end

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -24,7 +24,6 @@ class "Map"
 ---@type Map
 local Map = _G["Map"]
 
-local pathsep = package.config:sub(1, 1)
 local math_floor, tostring, table_concat
     = math.floor, tostring, table.concat
 local thMap = require("TH").map
@@ -170,7 +169,7 @@ the original game levels are considered.
 has been loaded.
 ]]
 function Map:load(level, difficulty, level_name, map_file, level_intro, map_editor)
-  local objects
+  local objects, _
   if not difficulty then
     difficulty = "full"
   end
@@ -180,11 +179,9 @@ function Map:load(level, difficulty, level_name, map_file, level_intro, map_edit
       local f = assert(loadfile(filename))
       return f()
     end
-  local path = debug.getinfo(1, "S").source:sub(2, -12)
-  local result = file(path .. "Lua" .. pathsep .. "base_config.lua")
 
+  local result = file(self.app:getFullPath({"Lua", "base_config.lua"}))
   local base_config = result
-  local _
   if type(level) == "number" then
     local errors, data
     -- Playing the original campaign.
@@ -207,8 +204,8 @@ function Map:load(level, difficulty, level_name, map_file, level_intro, map_edit
     -- Check if we're using the demo files. If we are, that special config should be loaded.
     if self.app.using_demo_files then
       -- Try to load our own configuration file for the demo.
-      local p = debug.getinfo(1, "S").source:sub(2, -12) .. "Levels" .. pathsep .. "demo.level"
-      errors, result = self:loadMapConfig(p, base_config, true)
+      local demo_path = self.app:getFullPath({"Levels", "demo.level"})
+      errors, result = self:loadMapConfig(demo_path, base_config, true)
       if errors then
         print("Warning: Could not find the demo configuration, try reinstalling the game")
       end
@@ -221,8 +218,8 @@ function Map:load(level, difficulty, level_name, map_file, level_intro, map_edit
       -- Override with the specific configuration for this level
       _, result = self:loadMapConfig(difficulty .. level_no .. ".SAM", base_config)
       -- Finally load additional CorsixTH config per level
-      local p = debug.getinfo(1, "S").source:sub(2, -12) .. "Levels" .. pathsep .. "original" .. level_no .. ".level"
-      _, result = self:loadMapConfig(p, result, true)
+      local level_path = self.app:getFullPath({"Levels", "original" .. level_no .. ".level"})
+      _, result = self:loadMapConfig(level_path, result, true)
       self.level_config = result
     end
   elseif map_editor then

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -39,9 +39,8 @@ function Strings:init()
   -- Load (but do not execute) everything from the language directory
   -- Note that files are loaded with loadfile_envcall
   self.language_chunks = {}
-  local ourpath = debug.getinfo(1, "S").source:sub(2, -12)
   local pathsep = package.config:sub(1,1)
-  local path = ourpath .. "languages" .. pathsep
+  local path = self.app:getFullPath({"Lua", "languages"}, true)
   for file in lfs.dir(path) do
     if file:match("%.lua$") then
       local result, err = loadfile_envcall(path .. file)

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -201,10 +201,9 @@ end
 function UI:runDebugScript()
   -- luacheck: ignore 111 _ is set in debug code
   print("Executing Debug Script...")
-  local path_sep = package.config:sub(1, 1)
-  local lua_dir = debug.getinfo(1, "S").source:sub(2, -8)
+  local debug_script = self.app:getFullPath({"Lua", "debug_script.lua"})
   _ = TheApp.ui and TheApp.ui.debug_cursor_entity
-  local script = assert(loadfile(lua_dir .. path_sep .. "debug_script.lua"))
+  local script = assert(loadfile(debug_script))
   script()
   -- Clear _ after the script to prevent save corruption
   _ = nil


### PR DESCRIPTION
**Describe what the proposed change does**
- Uses a new function for making full paths. Not used in config_finder so that it can be used by the windows_config script.
