### PR TITLE
Fix dynamic info on wakecheat

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -332,9 +332,9 @@ end
 -- so amounts here should be appropriately small comma values.
 function Staff:tire(amount)
   -- The no rest cheat overrides tiring effects
-  if self.hospital.hosp_cheats:isCheatActive("no_rest_cheat") then return end
-
-  self:changeAttribute("fatigue", amount)
+  if not self.hospital.hosp_cheats:isCheatActive("no_rest_cheat") then
+    self:changeAttribute("fatigue", amount)
+  end
   self:updateDynamicInfo()
 end
 


### PR DESCRIPTION
*Fixes #2319*

<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
- Quick fix to resolve no dynamic info updates to staff during nosleep cheat for 0.67. Need to later on look at points raised in https://github.com/CorsixTH/CorsixTH/issues/2319#issuecomment-1513297717
