### PR TITLE
Bump vcpkg for fluidsynth seek fix

### DIFF
--- a/CMake/VcpkgDeps.cmake
+++ b/CMake/VcpkgDeps.cmake
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-set(VCPKG_COMMIT_SHA "9f9ea97d514f4da611df58ee10bfcda394eace1e")
+set(VCPKG_COMMIT_SHA "5c469d5ff83c428afac0030002063efb6f80fe52")
 
 # Setup the various paths we are using
 set(_VCPKG_SCRIPT_NAME "build_vcpkg_deps.ps1")


### PR DESCRIPTION
Uses a patched version of sdl2-mixer that adds proper seek and start/stop to fluidsynth
