### PR TITLE
repatch 2135/2333

### DIFF
--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -497,6 +497,10 @@ end
 -- and dynamic info text
 --!param activate (bool) - true to activate, false or nil to deactivate
 function Room:_staffWaitToggle(activate)
+  if not self.staff_member and not self.staff_member_set then
+    return -- No staff in room
+  end
+
   local state = "deactivate"
   local dynamic_text = ""
 
@@ -551,6 +555,8 @@ function Room:tryAdvanceQueue()
   end
 end
 
+--! Handles the departure of a humanoid from the room
+--!param humanoid The subject entity
 function Room:onHumanoidLeave(humanoid)
   if self.staff_member == humanoid then
     self.staff_member = nil
@@ -561,7 +567,7 @@ function Room:onHumanoidLeave(humanoid)
     return
   end
   self.humanoids[humanoid] = nil
-  local staff_leaving = false
+  local staff_leaving = false -- used only for staff leaving immediately after a patient
 
   if class.is(humanoid, Patient) then
     -- Some staff member in the room might be waiting to get to the staffroom.

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -287,7 +287,7 @@ function World:initLevel(app, avail_rooms)
       end
     end
   end
-  if #self.available_diseases == 0 and not self.map.level_number == "MAP EDITOR" then
+  if #self.available_diseases == 0 and not self.map.level_number == "MAP EDITOR" then -- luacheck: ignore 582
     -- No diseases are needed if we're actually in the map editor!
     print("Warning: This level does not contain any diseases")
   end


### PR DESCRIPTION
*Fixes #2325 again*

**Describe what the proposed change does**
- Prevent crash where no staff member is in the room (due to staff member leaving; or a staff member is at `queue:front()`)

#2135 replaced the call of checking all humanoids for a wait toggle and applying the mood update as necessary. This meant that if no staff were present nothing needed to be done. The wait toggle change now expects a staff member present as its target and would fail if nobody was there. Unfortunately, `Room:tryAdvanceQueue` is used for a broad scope of things to get the queue moving -- this includes Handymen trying to enter when the door is reserved.

It is possible that the new patch needs to go in `Room:_checkWaitToggleValidTarget()` instead with its explanatory scope change.

It is also advisable to check https://github.com/CorsixTH/CorsixTH/issues/2325#issuecomment-1581228443 as there is definitely something going on at a wider scope here with a nurse failing to leave, but that really needs a new issue.