### PR TITLE
Fix casebook label for alien dna

### DIFF
--- a/CorsixTH/Lua/staff_profile.lua
+++ b/CorsixTH/Lua/staff_profile.lua
@@ -266,6 +266,7 @@ function StaffProfile.translateStaffClass(staff_class)
     Doctor       = _S.staff_title.doctor,
     Surgeon      = _S.staff_title.surgeon,
     Psychiatrist = _S.staff_title.psychiatrist,
+    Researcher   = _S.staff_title.researcher,
   }
   return staffclass_to_string[staff_class]
 end


### PR DESCRIPTION
**Describe what the proposed change does**
On a level with Alien DNA, eg L12, this lets the drug casebook tell the player they need a researcher.