### PR TITLE
Replace original game download link Origin with EA

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You will need the following:
    - A Flatpak for Linux users is available on [Flathub](https://flathub.org/apps/details/com.corsixth.corsixth).
 - We use graphics, sound and other data from the original game so one of the following is required:
    - Original game CD from eBay etc. or your dusty bookshelf:smile:
-   - A download from [GOG.com](https://www.gog.com/game/theme_hospital) or [Origin](https://www.origin.com/en-gb/store/buy/theme-hospital-origin/pc-download/base-game/standard-edition)
+   - A download from [GOG.com](https://www.gog.com/game/theme_hospital) or [EA](https://www.ea.com/games/theme/theme-hospital)
 
  Head over to our [getting started](https://github.com/CorsixTH/CorsixTH/wiki/Getting-Started) page for more detail.
 


### PR DESCRIPTION
Addition for #2338

**Describe what the proposed change does**
- Update the download source of the original game in the readme file (Replace Origin by EA)