### PR TITLE
Add a timeout to the update checker

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1827,6 +1827,7 @@ function App:checkForUpdates()
   end
   local http = require("socket.http")
   local url = require("socket.url")
+  http.TIMEOUT = 2
 
   print("Checking for CorsixTH updates...")
   local update_body, status, _ = http.request(update_url)


### PR DESCRIPTION
**Describe what the proposed change does**
- If there's the false appearance of an internet connection (eg the phone cable is unplugged from the router), the app will hang for several seconds until it times out. This cuts that down to two seconds.