### PR TITLE
Permit brackets in config values

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -945,13 +945,8 @@ function App:saveConfig()
           -- replace the line, if needed
           handled_ids[identifier] = true
           if value ~= tostring(self.config[identifier]) then
-            local new_value = self.config[identifier]
-            if type(new_value) == "string" then
-              new_value = string.format("[[%s]]", new_value)
-            else
-              new_value = tostring(new_value)
-            end
-            lines[#lines] = string.format("%s = %s", identifier, new_value)
+            lines[#lines] = string.format("%s = %s", identifier,
+                serialize(self.config[identifier], { long_bracket_level_start = 1 } ))
           end
         end
       end

--- a/CorsixTH/Lua/utility.lua
+++ b/CorsixTH/Lua/utility.lua
@@ -311,8 +311,8 @@ function array_join(array, separator)
   return result
 end
 
-local function serialize_string(val)
-  local level = 0
+local function serialize_string(val, options)
+  local level = options and options.long_bracket_level_start or 0
   while string.find(val, ']' .. string.rep('=', level) .. ']') do
     level = level + 1
   end
@@ -391,12 +391,14 @@ end
 --!param options Option settings, table, 'detect_cycles' field boolean that
 --  ends recursion on a cycle, and 'max_depth' integer that ends recursion at the
 --  specified depth. By default initialized with "{detect_cycles = True}"
+--  'long_bracket_level_start' field integer that sets the starting long bracket level for escaping strings.
+--  If not set, level zero is used.
 --!param depth Recursion depth, should be omitted.
 --!param pt_reflist Seen nodes, should be omitted.
 --!return The seralized output.
 function serialize(val, options, depth, pt_reflist)
   if type(val) == "string" then
-    return serialize_string(val)
+    return serialize_string(val, options)
   elseif type(val) == "table" then
     return serialize_table(val, options, depth, pt_reflist)
   else


### PR DESCRIPTION
**Describe what the proposed change does**
- A config value with brackets will be saved, but can't be loaded. This looks for [] and uses [=[ ]=] to contain the whole value. eg A music folder ending [2023], or player name with [].
