### PR TITLE
FIX Level advance is possible while owing a loan #2027

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1463,16 +1463,24 @@ function World:checkWinningConditions(player_no)
     end
     if goal.win_value then
       local max_min = goal.max_min_win == 1 and 1 or -1
-      -- Special case for balance, subtract any loans!
+
       if goal.name == "balance" then
+        -- Special case for balance, subtract any loans!
         current_value = current_value - hospital.loan
       end
+
       -- Is this goal not fulfilled yet?
       if (current_value - goal.win_value) * max_min <= 0 then
         result.state = "nothing"
       end
     end
   end
+
+  -- Special case for loans: you cannot run from them !
+  if hospital.loan > 0 and result.state == "win" then
+    result.state = "nothing"
+  end
+
   return result
 end
 


### PR DESCRIPTION
*Fixes #2027*

Fix issue #2027 by ensuring loans are payed before winning is possible

**Describe what the proposed change does**
- If the players has loans and the state is "win", force it to "nothing"

Disclaimer:
I cannot compile yet on my computer, so I couldn't test

PS: I remember when the project was started, and it's great to see it's still moving on :-)