### PR TITLE
FIX Crash seek_reception.lua:47: attempt to perform arithmetic on a boolean value (local 'this_score')

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -81,7 +81,7 @@ local function action_seek_reception_start(action, humanoid)
       local y = desk.tile_y + orientation.use_position[2]
 
       local distance_from_desk = humanoid.world:getPathDistance(humanoid.tile_x, humanoid.tile_y, x, y)
-      if distance_from_desk ~= false then
+      if distance_from_desk then
         local this_score = distance_from_desk + desk:getUsageScore()
         if not score or this_score < score then
           -- It is better, or the first one!

--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -65,6 +65,7 @@ local function action_seek_reception_start(action, humanoid)
   local world = humanoid.world
   local best_desk
   local score
+  local best_distance_from_desk
 
   assert(humanoid.hospital, "humanoid must be associated with a hospital to seek reception")
 
@@ -78,13 +79,16 @@ local function action_seek_reception_start(action, humanoid)
       local orientation = desk.object_type.orientations[desk.direction]
       local x = desk.tile_x + orientation.use_position[1]
       local y = desk.tile_y + orientation.use_position[2]
-      local this_score = humanoid.world:getPathDistance(humanoid.tile_x, humanoid.tile_y, x, y)
 
-      this_score = this_score + desk:getUsageScore()
-      if not score or this_score < score then
-        -- It is better, or the first one!
-        score = this_score
-        best_desk = desk
+      local distance_from_desk = humanoid.world:getPathDistance(humanoid.tile_x, humanoid.tile_y, x, y)
+      if distance_from_desk ~= false then
+        local this_score = distance_from_desk + desk:getUsageScore()
+        if not score or this_score < score then
+          -- It is better, or the first one!
+          score = this_score
+          best_desk = desk
+          best_distance_from_desk = distance_from_desk
+        end
       end
     end
   end
@@ -93,7 +97,7 @@ local function action_seek_reception_start(action, humanoid)
     local orientation = best_desk.object_type.orientations[best_desk.direction]
     local x = best_desk.tile_x + orientation.use_position[1]
     local y = best_desk.tile_y + orientation.use_position[2]
-    local dist = humanoid.world:getPathDistance(humanoid.tile_x, humanoid.tile_y, x, y)
+
     -- TODO: Make 'else' method work for all humanoids
     if class.is(humanoid, Vip) or class.is(humanoid, Inspector) then
       humanoid:updateDynamicInfo(_S.dynamic_info.patient.actions.on_my_way_to
@@ -107,7 +111,7 @@ local function action_seek_reception_start(action, humanoid)
 
     -- We don't want patients which have just spawned to be joining the queue
     -- immediately, so walk them closer to the desk before joining the queue
-    if can_join_queue_at(humanoid, humanoid.tile_x, humanoid.tile_y, dist) then
+    if can_join_queue_at(humanoid, humanoid.tile_x, humanoid.tile_y, best_distance_from_desk) then
       local face_x, face_y = best_desk:getSecondaryUsageTile()
       humanoid:setNextAction(QueueAction(x, y, best_desk.queue):setMustHappen(action.must_happen)
           :setFaceDirection(face_x, face_y))


### PR DESCRIPTION
*Fixes #1232*

**Describe what the proposed change does**

Refactor a bit the method `action_seek_reception_start` in `seek_reception.lua` :
- Add a guard to call of `getPathDistance` for boolean return value
- Remove one call to `getPathDistance` and reuse the already computed distance

I've also checked that the rest of the codebase is handling this case.
