### PR TITLE
Look for a bundled Noto CJK font

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 # CorsixTH Features and behaviour
 #   - WITH_AUDIO      : Activate sound (yes)
 #   - WITH_FREETYPE2  : Active support for non-Latin script alphabets (yes)
+#   - WITH_FONT       : Path of a font that will be used if the user does not set one (empty, Arial on macOS)
 #   - WITH_MOVIES     : Activate movies (requires with_audio, FFmpeg) (yes)
 #   - WITH_UPDATE_CHECK : Activates support to check for new version on launch (requires libcurl) (yes)
 #   - USE_SOURCE_DATADIRS : Use the source directory for loading resources. Incompatible with the install target (no)
@@ -90,6 +91,15 @@ endif()
 option(SEARCH_LOCAL_DATADIRS
   "Search resources in the working directory and the program directory where the executable stores."
   ${SEARCH_LOCAL_DATADIRS_DEFAULT})
+
+if(WITH_FREETYPE2)
+  if(APPLE)
+    set(WITH_FONT_DEFAULT "/Library/Fonts/Arial Unicode.ttf")
+  else()
+    set(WITH_FONT_DEFAULT "")
+  endif()
+  set(WITH_FONT ${WITH_FONT_DEFAULT} CACHE FILEPATH "Use this font if one is not set in the game settings")
+endif()
 
 # Dependency management
 if(UNIX AND CMAKE_COMPILER_IS_GNU)

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -67,6 +67,11 @@ else()
   set(CORSIX_TH_ARCH ${CMAKE_SYSTEM_PROCESSOR})
 endif()
 
+# Set default value of font file in compile_opts.font
+if(WITH_FONT)
+  set(CORSIX_TH_FONT ${WITH_FONT})
+endif()
+
 # Ensure config.h is picked up by cmake - moving this into subdir cmake files will
 # prevent it applying to the CorsixTH project
 set(CorsixTH_generated_src_dir ${CMAKE_BINARY_DIR}/CorsixTH/Src/)

--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2690;
+return 2691;

--- a/CorsixTH/Src/config.h.in
+++ b/CorsixTH/Src/config.h.in
@@ -105,4 +105,7 @@ using std::uint64_t;
 /** Report system architecture **/
 #cmakedefine CORSIX_TH_ARCH "@CORSIX_TH_ARCH@"
 
+/** Set default value of font file **/
+#cmakedefine CORSIX_TH_FONT "@CORSIX_TH_FONT@"
+
 #endif  // CORSIX_TH_CONFIG_H_

--- a/CorsixTH/Src/th_lua.cpp
+++ b/CorsixTH/Src/th_lua.cpp
@@ -280,6 +280,12 @@ int l_get_compile_options(lua_State* L) {
   lua_pushinteger(L, get_api_version());
   lua_setfield(L, -2, "api_version");
 
+#ifdef CORSIX_TH_FONT
+  // Set default value of font file
+  lua_pushliteral(L, CORSIX_TH_FONT);
+  lua_setfield(L, -2, "font");
+#endif
+
   return 1;
 }
 


### PR DESCRIPTION
**Describe what the proposed change does**
- Look for a bundled Noto CJK font, or a packager chosen bundled font path or a system font path. The official Noto project doesn't release a suitable single file, but there are some third party builds that do. [satbyy](https://github.com/satbyy/go-noto-universal/releases/tag/v7.0) has [GoNotoKurrent-Bold.ttf](https://github.com/satbyy/go-noto-universal/releases/download/v7.0/GoNotoKurrent-Bold.ttf), I chose this because the licence on this project is clearer.
Other font options include [KlokanTechNotoSansCJK-Regular.otf from klokantech](https://github.com/klokantech/klokantech-gl-fonts) or [GoNotoKurrent-Regular.ttf from satbyy](https://github.com/satbyy/go-noto-universal).
- The new priority is user setting > bundled font > system font. Linux users from before this change will have an old user setting by default that is probably worse than Noto for CJK.

Korean preview
![Screen 2023-09-04 at 20 56 39](https://github.com/CorsixTH/CorsixTH/assets/552285/0f333221-a23d-46a6-af45-def249159247)

Fixes #1901 fixes #823 fixes #1219