### PR TITLE
The continue button/switch only loads filenames ending with .sav

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -361,7 +361,7 @@ function App:init()
         self.command_line.load = file
       else
         self.command_line.load = "Autosaves" .. pathsep ..
-            FileTreeNode(self.savegame_dir .. "Autosaves"):getMostRecentlyModifiedChildFile(".sav").label
+            FileTreeNode(self.savegame_dir .. "Autosaves"):getMostRecentlyModifiedChildFile(".%.sav$").label
       end
     end
     -- If a savegame was specified, load it

--- a/CorsixTH/Lua/dialogs/resizables/main_menu.lua
+++ b/CorsixTH/Lua/dialogs/resizables/main_menu.lua
@@ -153,7 +153,7 @@ function UIMainMenu:buttonCustomGame()
 end
 
 function UIMainMenu:buttonContinueGame()
-  local most_recent_saved_game = FileTreeNode(self.ui.app.savegame_dir):getMostRecentlyModifiedChildFile(".sav")
+  local most_recent_saved_game = FileTreeNode(self.ui.app.savegame_dir):getMostRecentlyModifiedChildFile(".%.sav$")
   if most_recent_saved_game then
     local path = most_recent_saved_game.path
     local app = self.ui.app


### PR DESCRIPTION
*Fixes #2408*

**Describe what the proposed change does**
- Previously, any file with \*sav in it could be loaded
- Now, only files ending in .sav will be loaded. The filename must match - wildcard, literal period, "sav" at the end.