### PR TITLE
Remove lpeg version check in docs build

### DIFF
--- a/LDocGen/c_tokenise.lua
+++ b/LDocGen/c_tokenise.lua
@@ -18,8 +18,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
-local lpeg = require "lpeg"
-need_lpeg_version(0, 9)
+local lpeg = require("lpeg")
 
 local C, P, R, S, V = lpeg.C, lpeg.P, lpeg.R, lpeg.S, lpeg.V
 local Carg, Cc, Cp, Ct = lpeg.Carg, lpeg.Cc, lpeg.Cp, lpeg.Ct

--- a/LDocGen/helpers.lua
+++ b/LDocGen/helpers.lua
@@ -25,16 +25,6 @@ if not rawget(_G, "loadstring") then
   loadstring = load
 end
 
-function need_lpeg_version(major, minor)
-  local v = require"lpeg".version()
-  local m, n = v:match"^(%d+)%.(%d+)"
-  m = tonumber(m)
-  n = tonumber(n)
-  if m < major or (m == major and n < minor) then
-    error(("LPEG version >= %d.%d is required (you have %s)"):format(major, minor, v))
-  end
-end
-
 local auto_tokens
 local auto_tokens_c = {
   [","]  = {"operator", ","},

--- a/LDocGen/lua_tokenise.lua
+++ b/LDocGen/lua_tokenise.lua
@@ -18,8 +18,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
-local L = require "lpeg"
-need_lpeg_version(0, 9)
+local L = require("lpeg")
 
 local C, P, R, S, V = L.C, L.P, L.R, L.S, L.V
 local Carg, Cc, Cp, Ct, Cg, Cb, Cmt = L.Carg, L.Cc, L.Cp, L.Ct, L.Cg, L.Cb, L.Cmt


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2412*

**Describe what the proposed change does**
- Remove the lpeg version check. Lpeg 0.9 is at least 14 years old.