### PR TITLE
Advice player of new machine cost

### DIFF
--- a/CorsixTH/Lua/dialogs/machine_dialog.lua
+++ b/CorsixTH/Lua/dialogs/machine_dialog.lua
@@ -108,7 +108,8 @@ function UIMachine:replaceMachine()
   local cost = hosp.research.research_progress[machine.object_type].cost
   if hosp.balance < cost then
     -- give visual warning that player doesn't have enough $ to buy
-    self.ui.adviser:say(_A.warnings.cannot_afford_2, false, true)
+    local advice = _A.warnings.cannot_afford_machine:format(cost, machine.object_type.name)
+    self.ui.adviser:say(advice, false, true)
     self.ui:playSound("wrong2.wav")
     return
   end

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -238,6 +238,7 @@ adviser = {
     another_desk = "You'll need to build another desk for that new receptionist.",
     cannot_afford = "You don't have enough money in the bank to hire that person!", -- I can't see anything like this in the original strings
     cannot_afford_2 = "You don't have enough money in the bank to make that purchase!",
+    cannot_afford_machine = "You need at least $%1% in the bank to afford a new %2%!",
     falling_1 = "Hey! That is not funny, watch where you click that mouse; someone could get hurt!",
     falling_2 = "Stop messing about, how would you like it?",
     falling_3 = "Ouch, that had to hurt, someone call a Doctor!",

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -331,10 +331,11 @@ function Strings:setupAdviserMessage(messages)
     --build_advice
     --cheats
   }
+  -- Passes adviser message through string.format process
   local formatFunc
-  formatFunc = function(format_self, arg)
+  formatFunc = function(format_self, ...)
     -- After 'format', it is not useful to have indexing magic anymore.
-    return { text = format_self.text:format(arg), priority = format_self.priority }
+    return { text = format_self.text:format(...), priority = format_self.priority }
   end
   local indexFunc
   indexFunc = function(index_self, field)


### PR DESCRIPTION
*Fixes #2318*

**Describe what the proposed change does**
- Tell the player the cost of replacing their machine via the adviser if they can't afford it.
- Also adds ability for adviser to be given multiple arguments for string.format

Using the more flexible `%[1-9]%` argument format so translators can rephrase the string if needed.