### PR TITLE
Move the emergency announcement and advice to the first patient spawn

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -179,8 +179,6 @@ function UIFax:choice(choice_number)
   if choice == "accept_emergency" then
     self.ui.app.world:newObject("helicopter", "north")
     self.ui:addWindow(UIWatch(self.ui, "emergency"))
-    self.ui:playAnnouncement(self.ui.hospital.emergency.disease.emergency_sound, AnnouncementPriority.Critical)
-    self.ui.adviser:say(_A.information.emergency)
   elseif choice == "refuse_emergency" then
     self.ui.app.world:nextEmergency()
   -- VIP may choose to visit anyway if he is refused too often

--- a/CorsixTH/Lua/objects/helicopter.lua
+++ b/CorsixTH/Lua/objects/helicopter.lua
@@ -18,6 +18,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+corsixth.require("announcer")
+local AnnouncementPriority = _G["AnnouncementPriority"]
+
 local object = {}
 object.id = "helicopter"
 object.thob = 63
@@ -55,12 +58,15 @@ end
 
 function Helicopter:tick()
   local phase = self.phase
+  local ui = TheApp.ui
   if phase == 0 then
     self.th:makeVisible()
     self:setSpeed(0, 10)
+    ui:playAnnouncement(ui.hospital.emergency.disease.emergency_sound, AnnouncementPriority.Critical)
   elseif phase == 60 then
     self:setSpeed(0, 0)
     self.spawned_patients = 0
+    ui.adviser:say(_A.information.emergency)
   elseif phase == 85 then
     if self.spawned_patients < self.hospital.emergency.victims then
       self:spawnPatient()


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2419*

**Describe what the proposed change does**
- Move the announcement and advisor message from when the fax is accepted to when the first patient spawns. I looked at a few videos on youtube and this is about the right time, sometimes it appears to be around when the second or third patient spawns.
