### PR TITLE
RFC: Move sprite functions into virtual methods.

### DIFF
--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2684;
+return 2685;

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1451,8 +1451,9 @@ void animation::depersist(lua_persist_reader* pReader) {
         // 3 should be the morph set, but the actual morph target is
         // missing, so settle for a graphical bug rather than a segfault
         // by reverting to the normal function set.
+        [[fallthrough]];
       case 1:
-        break;
+        [[fallthrough]];  // Should be "break;" but not allowed.
       case 2:
         break;
       case 4:

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1740,11 +1740,13 @@ bool THSpriteRenderList_is_multiple_frame_animation(drawable* pSelf) {
 
 }  // namespace
 
-void sprite_render_list::draw_fn(render_target* pCanvas, int iDestX, int iDestY) {
+void sprite_render_list::draw_fn(render_target* pCanvas, int iDestX,
+                                 int iDestY) {
   THSpriteRenderList_draw(this, pCanvas, iDestX, iDestY);
 }
 
-bool sprite_render_list::hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY) {
+bool sprite_render_list::hit_test_fn(int iDestX, int iDestY, int iTestX,
+                                     int iTestY) {
   return THSpriteRenderList_hit_test(this, iDestX, iDestY, iTestX, iTestY);
 }
 
@@ -1752,8 +1754,7 @@ bool sprite_render_list::is_multiple_frame_animation_fn() {
   return THSpriteRenderList_is_multiple_frame_animation(this);
 }
 
-sprite_render_list::sprite_render_list() : animation_base() {
-}
+sprite_render_list::sprite_render_list() : animation_base() {}
 
 sprite_render_list::~sprite_render_list() { delete[] sprites; }
 

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1446,25 +1446,21 @@ void animation::depersist(lua_persist_reader* pReader) {
     int iFunctionSet;
     if (!pReader->read_uint(iFunctionSet)) break;
     set_function_set(iFunctionSet);
-    switch (iFunctionSet) {
-      case 3:
-        // 3 should be the morph set, but the actual morph target is
-        // missing, so settle for a graphical bug rather than a segfault
-        // by reverting to the normal function set.
-        [[fallthrough]];
-      case 1:
-        [[fallthrough]];  // Should be "break;" but not allowed.
-      case 2:
-        break;
-      case 4:
-        pReader->read_stack_object();
-        morph_target = reinterpret_cast<animation*>(lua_touserdata(L, -1));
-        lua_pop(L, 1);
-        break;
-      default:
-        pReader->set_error(lua_pushfstring(
-            L, "Unknown animation function set #%i", iFunctionSet));
-        return;
+
+    if (iFunctionSet >= 1 && iFunctionSet <= 3) {
+      // Do nothing.
+
+      // 3 should be the morph set, but the actual morph target is
+      // missing, so settle for a graphical bug rather than a segfault
+      // by reverting to the normal function set.
+    } else if (iFunctionSet == 4) {
+      pReader->read_stack_object();
+      morph_target = reinterpret_cast<animation*>(lua_touserdata(L, -1));
+      lua_pop(L, 1);
+    } else {
+      pReader->set_error(lua_pushfstring(
+          L, "Unknown animation function set #%i", iFunctionSet));
+      return;
     }
 
     // Read the simple fields

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -109,24 +109,22 @@ struct drawable : public link_list {
   /*!
       Can also "draw" the object to the speakers, i.e. play sounds.
   */
-  void (*draw_fn)(drawable* pSelf, render_target* pCanvas, int iDestX,
-                  int iDestY);
+  virtual void draw_fn(render_target* pCanvas, int iDestX, int iDestY) = 0;
 
   //! Perform a hit test against the object
   /*!
       Should return true if when the object is drawn at (iDestX, iDestY) on a
      canvas, the point (iTestX, iTestY) is within / on the object.
   */
-  bool (*hit_test_fn)(drawable* pSelf, int iDestX, int iDestY, int iTestX,
-                      int iTestY);
-
-  //! Drawing flags (zero or more list flags from #draw_flags).
-  uint32_t flags;
+  virtual bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY) = 0;
 
   /** Returns true if instance is a multiple frame animation.
       Should be overloaded in derived class.
   */
-  bool (*is_multiple_frame_animation_fn)(drawable* pSelf);
+  virtual bool is_multiple_frame_animation_fn() = 0;
+
+  //! Drawing flags (zero or more list flags from #draw_flags).
+  uint32_t flags;
 
   int get_drawing_layer() { return drawing_layer; }
   void set_drawing_layer(int layer) { drawing_layer = layer; }
@@ -583,6 +581,11 @@ class animation : public animation_base {
   void set_morph_target(animation* pMorphTarget, int iDurationFactor = 1);
   void set_frame(size_t iFrame);
 
+  virtual void draw_fn(render_target* pCanvas, int iDestX, int iDestY);
+  virtual bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY);
+  virtual bool is_multiple_frame_animation_fn();
+  void set_function_set(int value);
+
   void set_speed(int iX, int iY) { speed.dx = iX, speed.dy = iY; }
   void set_crop_column(int iColumn) { crop_column = iColumn; }
 
@@ -611,6 +614,7 @@ class animation : public animation_base {
   //! Number of game_ticks to offset animation by so they aren't all
   //! running in sync.
   size_t patient_effect_offset;
+  int function_set;
 };
 
 class sprite_render_list : public animation_base {
@@ -631,6 +635,10 @@ class sprite_render_list : public animation_base {
 
   void persist(lua_persist_writer* pWriter) const;
   void depersist(lua_persist_reader* pReader);
+
+  virtual void draw_fn(render_target* pCanvas, int iDestX, int iDestY);
+  virtual bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY);
+  virtual bool is_multiple_frame_animation_fn();
 
  private:
   struct sprite {

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -581,9 +581,9 @@ class animation : public animation_base {
   void set_morph_target(animation* pMorphTarget, int iDurationFactor = 1);
   void set_frame(size_t iFrame);
 
-  virtual void draw_fn(render_target* pCanvas, int iDestX, int iDestY);
-  virtual bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY);
-  virtual bool is_multiple_frame_animation_fn();
+  void draw_fn(render_target* pCanvas, int iDestX, int iDestY) override;
+  bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY) override;
+  bool is_multiple_frame_animation_fn() override;
   void set_function_set(int value);
 
   void set_speed(int iX, int iY) { speed.dx = iX, speed.dy = iY; }
@@ -636,9 +636,9 @@ class sprite_render_list : public animation_base {
   void persist(lua_persist_writer* pWriter) const;
   void depersist(lua_persist_reader* pReader);
 
-  virtual void draw_fn(render_target* pCanvas, int iDestX, int iDestY);
-  virtual bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY);
-  virtual bool is_multiple_frame_animation_fn();
+  void draw_fn(render_target* pCanvas, int iDestX, int iDestY) override;
+  bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY) override;
+  bool is_multiple_frame_animation_fn() override;
 
  private:
   struct sprite {

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1031,7 +1031,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
       }
       drawable* pItem = static_cast<drawable*>(itrNode->oEarlyEntities.next);
       while (pItem) {
-        pItem->draw_fn(pItem, pCanvas, itrNode.x(), itrNode.y());
+        pItem->draw_fn(pCanvas, itrNode.x(), itrNode.y());
         pItem = static_cast<drawable*>(pItem->next);
       }
     }
@@ -1080,8 +1080,8 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
 
       drawable* pItem = static_cast<drawable*>(itrNode->entities.next);
       while (pItem) {
-        pItem->draw_fn(pItem, pCanvas, itrNode.x(), itrNode.y());
-        if (pItem->is_multiple_frame_animation_fn(pItem)) {
+        pItem->draw_fn(pCanvas, itrNode.x(), itrNode.y());
+        if (pItem->is_multiple_frame_animation_fn()) {
           bRedrawAnimations = true;
         }
         if (pItem->get_drawing_layer() == 1) {
@@ -1104,7 +1104,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
             formerIterator.get_previous_tile()->entities.next);
         while (pItem) {
           if (pItem->get_drawing_layer() == 9) {
-            pItem->draw_fn(pItem, pCanvas, formerIterator.x() - 64,
+            pItem->draw_fn(pCanvas, formerIterator.x() - 64,
                            formerIterator.y());
             bTileNeedsRedraw = true;
           }
@@ -1118,7 +1118,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
                     : nullptr;
         while (pItem) {
           if (pItem->get_drawing_layer() == 8) {
-            pItem->draw_fn(pItem, pCanvas, formerIterator.x(),
+            pItem->draw_fn(pCanvas, formerIterator.x(),
                            formerIterator.y());
           }
           pItem = static_cast<drawable*>(pItem->next);
@@ -1152,13 +1152,13 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
           pItem = static_cast<drawable*>(
               itrNode.get_previous_tile()->oEarlyEntities.next);
           for (; pItem; pItem = static_cast<drawable*>(pItem->next)) {
-            pItem->draw_fn(pItem, pCanvas, itrNode.x() - 64, itrNode.y());
+            pItem->draw_fn(pCanvas, itrNode.x() - 64, itrNode.y());
           }
 
           pItem = static_cast<drawable*>(
               itrNode.get_previous_tile()->entities.next);
           for (; pItem; pItem = static_cast<drawable*>(pItem->next)) {
-            pItem->draw_fn(pItem, pCanvas, itrNode.x() - 64, itrNode.y());
+            pItem->draw_fn(pCanvas, itrNode.x() - 64, itrNode.y());
           }
         }
       }
@@ -1234,7 +1234,7 @@ drawable* level_map::hit_test_drawables(link_list* pListStart, int iXs, int iYs,
   drawable* pList = static_cast<drawable*>(pListEnd);
 
   while (true) {
-    if (pList->hit_test_fn(pList, iXs, iYs, iTestX, iTestY)) return pList;
+    if (pList->hit_test_fn(iXs, iYs, iTestX, iTestY)) return pList;
 
     if (pList == pListStart) {
       return nullptr;

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1118,8 +1118,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
                     : nullptr;
         while (pItem) {
           if (pItem->get_drawing_layer() == 8) {
-            pItem->draw_fn(pCanvas, formerIterator.x(),
-                           formerIterator.y());
+            pItem->draw_fn(pCanvas, formerIterator.x(), formerIterator.y());
           }
           pItem = static_cast<drawable*>(pItem->next);
         }


### PR DESCRIPTION
The `drawable` struct has
``` cpp
void (*draw_fn)(drawable* pSelf, render_target* pCanvas, int iDestX,  int iDestY);
bool (*hit_test_fn)(drawable* pSelf, int iDestX, int iDestY, int iTestX,  int iTestY);
bool (*is_multiple_frame_animation_fn)(drawable* pSelf);
```
which seemed like virtual methods to me so I hacked the code somewhat to see if it could fly.

For the very limited testing I have done it seems to work. A new game doesn't seem to have problems, a very old save crashes on load but iit does in `master` too, so probably too old.

As for the code change, I did a minimum change. More can be done (at the very least reformatting).

What do you think of such a change?
