### PR TITLE
Pair swing doors instantly

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 180 -- CorsixTH 0.67 release
+local SAVEGAME_VERSION = 181 -- Pair swing doors instantly
 
 class "App"
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2389*

**Describe what the proposed change does**
- Ward and Operating Theatre doors are paired within the same tick, when built or loaded from an old save.
