### PR TITLE
Patients may only litter indoors

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -883,6 +883,7 @@ function Patient:setTile(x, y)
     if self.litter_countdown == 0 then
       if x and not self:getRoom() and not self.world:getObjects(x, y) and
           self.world.map.th:getCellFlags(x, y).buildable and
+          self.hospital:isInHospital(x, y) and
           (not self.world:findObjectNear(self, "bin", 8) or math.random() < 0.05) then
         -- Drop some litter!
         local trash = math.random(1, 4)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #1563 *

**Describe what the proposed change does**
- Check the patient is in the players hospital before they litter.
