### PR TITLE
Add a warning to mapeditor when a map has no spawn path

### DIFF
--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -546,8 +546,15 @@ function UIMenuBar:makeMapeditorMenu(app)
   local menu = UIMenu()
   local hotkeys = app.hotkeys
 
+  local function mapeditorSave(ui)
+    local message = app.world:validateMap()
+    if message then
+      ui:addWindow(UIInformation(ui, {message}))
+    end
+    ui:addWindow(UISaveMap(ui))
+  end
   menu:appendItem(_S.menu_file.load:format(hotkey_value_label("ingame_loadMenu", hotkeys)), function() self.ui:addWindow(UILoadMap(self.ui, "map")) end)
-    :appendItem(_S.menu_file.save:format(hotkey_value_label("ingame_saveMenu", hotkeys)), function() self.ui:addWindow(UISaveMap(self.ui)) end)
+    :appendItem(_S.menu_file.save:format(hotkey_value_label("ingame_saveMenu", hotkeys)), function() mapeditorSave(self.ui) end)
     :appendItem(_S.menu_file.quit:format(hotkey_value_label("ingame_quitLevel", hotkeys)), function() self.ui:quit() end)
   self:addMenu(_S.menu.file, menu)
 

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -911,7 +911,10 @@ map_editor_window = {
     heliport_3 = "Heliport 3",
     heliport_4 = "Heliport 4",
     paste = "Paste area",
-  }
+  },
+  checks = {
+    spawn_points_and_path = "Warning: Patients cannot reach the hospital. They need 'road' tiles or 'outside' grey tiles at the edge of the map and a path of these tiles to the hospital entrance.",
+  },
 }
 
 hotkeys_file_err = {

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -172,7 +172,7 @@ function World:World(app)
     self.object_id_by_thob[object_type.thob] = object_type.id
   end
   self:makeAvailableStaff(0)
-  self:calculateSpawnTiles()
+  self.spawn_points = self:calculateSpawnTiles()
 
   -- Next Events dates
   -- emergencies
@@ -409,8 +409,9 @@ function World:getLocalPlayerHospital()
 end
 
 --! Identify the tiles on the map suitable for spawning `Humanoid`s from.
+--!return (table) 0-8 spawn points of the map.
 function World:calculateSpawnTiles()
-  self.spawn_points = {}
+  local spawn_points = {}
   local w, h = self.map.width, self.map.height
   local directions = {
     {direction = "north", origin = {1, 1}, step = { 1,  0}},
@@ -436,9 +437,10 @@ function World:calculateSpawnTiles()
     local num = math.min(8, #xs)
     for i = 1, num do
       local index = math.floor((i - 0.5) / num * #xs + 1)
-      self.spawn_points[#self.spawn_points + 1] = {x = xs[index], y = ys[index], direction = edge.direction}
+      spawn_points[#spawn_points + 1] = {x = xs[index], y = ys[index], direction = edge.direction}
     end
   end
+  return spawn_points
 end
 
 --! Function to determine whether a given disease is available for new patients.
@@ -2879,4 +2881,15 @@ function World:setCampaignData(campaign_data)
     self[key] = value
   end
   self:getLocalPlayerHospital():setCampaignData(campaign_data.hospital)
+end
+
+--! Perform validity tests on the map in world
+--!return (string) The message relating to the first failed check
+function World:validateMap()
+  local spawn_points = self:calculateSpawnTiles()
+  -- Do any passable tiles on the edge of the map have a path of
+  -- passable tiles to the hospital
+  if not spawn_points[1] then
+    return _S.map_editor_window.checks.spawn_points_and_path
+  end
 end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

Partially addresses #1378

**Describe what the proposed change does**
- Checks the map has a valid path from the hospital to the first spawn point.
Should the spawn points be niled after this?