### PR TITLE
Show languages as disabled when they aren't available

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/dropdown.lua
+++ b/CorsixTH/Lua/dialogs/resizables/dropdown.lua
@@ -58,7 +58,8 @@ function UIDropdown:UIDropdown(ui, parent_window, parent_button, items, callback
   for i, item in ipairs(items) do
   if item.tooltip and item.tooltip[1] then
     self:addBevelPanel(1, y + 1, width - 2, height - 2, parent_window.colour):setLabel(item.text, item.font)
-      :makeButton(-1, -1, width, height, nil, --[[persistable:dropdown_tooltip_callback]] function() self:selectItem(i) end)
+      :makeToggleButton(-1, -1, width, height, nil, --[[persistable:dropdown_tooltip_callback]] function() self:selectItem(i) end)
+      :enable(not item.disabled)
       :setTooltip(item.tooltip[1], item.tooltip[2] or math.floor(self.ui.app.config.width / 2 - 25),
         math.floor(self.ui.app.config.height / 4 - 130 + item.tooltip[3]) or 0)
         -- Magic numbers used to find a static position across different screen resolutions.

--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -237,12 +237,17 @@ function UIOptions:checkForAvailableLanguages()
   local langs, c = {}, 1
   for _, lang in pairs(app.strings.languages) do
     local font = app.strings:getFont(lang)
-    if app.gfx:hasLanguageFont(font) and app.strings.languages_english[lang] then
-      local eng_name = app.strings.languages_english[lang]
-      c = c + 1
+    local eng_name = app.strings.languages_english[lang]
+    c = c + 1
+    -- If freetype support and a unicode font setting are not present then
+    -- languages not supported by the builtin font are named in English and cannot be selected
+    if app.gfx:hasLanguageFont(font) then
       font = font and app.gfx:loadLanguageFont(font, app.gfx:loadSpriteTable("QData", "Font01V"))
-      langs[#langs + 1] = { text = lang, font = font,
+      langs[#langs + 1] = { text = lang, name = lang, font = font, disabled = false,
       tooltip = { _S.tooltip.options_window.language_dropdown_item:format(eng_name), nil, BTN_HEIGHT * c } }
+    else
+      langs[#langs + 1] = { text = eng_name, name = lang, font = self.builtin_font, disabled = true,
+      tooltip = { _S.tooltip.options_window.language_dropdown_no_font, nil, BTN_HEIGHT * c } }
     end
   end
   self.available_languages = langs
@@ -263,7 +268,7 @@ function UIOptions:dropdownLanguage(activate)
 end
 
 function UIOptions:selectLanguage(number)
-  local lang = self.app.strings.languages_english[self.available_languages[number]["text"]]
+  local lang = self.app.strings.languages_english[self.available_languages[number].name]
   local app = self.ui.app
   app.config.language = (lang)
   app:initLanguage()

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -454,6 +454,7 @@ tooltip.options_window = {
   language = "The language texts in the game will appear in",
   select_language = "Select the game language",
   language_dropdown_item = "Choose %s as language",
+  language_dropdown_no_font = "Select a font in the folders settings to enable this language",
   back = "Close the Settings window",
   scrollspeed = "Set the scroll speed between 1 (slowest) to 10 (fastest). The default is 2.",
   shift_scrollspeed = "Set the speed of scrolling while the shift key is pressed. 1 (slowest) to 10 (fastest). The default is 4.",

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -89,6 +89,7 @@ function Strings:init()
         if names[1] ~= "original_strings" then
           self.languages[#self.languages + 1] = names[1]
           -- Also save the second name for tooltips and internal purposes.
+          assert(names[2], filename .. " does not have an English name.")
           self.languages_english[names[1]] = names[2]
         end
         -- Associate every passed name with this file, case-independently


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Addresses #1915*

**Describe what the proposed change does**
- If the user can't switch to the unicode languages, show them in the language select list with their English name in a disabled button. The tooltip tells them to set a font.