### PR TITLE
Add explore button to file and folder browsers to open folder in a file manager

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1928,6 +1928,25 @@ function App:gamelogHeader()
   return (gen_date .. compiled .. running)
 end
 
+--! Open the given string (URL or folder path) in the operating system. Requires io.popen.
+--!param path (string)
+function App:osOpen(path)
+  if not path or not io.popen then return end
+  local cmd
+  if self.os == "windows" then
+    cmd = 'start "" "'
+  elseif self.os == "macos" then
+    cmd = 'open "'
+  else
+    cmd = 'xdg-open "'
+  end
+  local handle = io.popen(cmd .. path .. '" 2>&1')
+  local output = handle:read('*a'):gsub('[\n\r]', ' ')
+  if output:len() > 0 then
+    self.ui:addWindow(UIInformation(self.ui, {output}))
+  end
+end
+
 -- Do not remove, for savegame compatibility < r1891
 local app_confirm_quit_stub = --[[persistable:app_confirm_quit]] function()
 end

--- a/CorsixTH/Lua/dialogs/resizables/directory_browser.lua
+++ b/CorsixTH/Lua/dialogs/resizables/directory_browser.lua
@@ -149,20 +149,24 @@ function UIDirectoryBrowser:UIDirectoryBrowser(ui, mode, instruction, treenode_c
 
   self.modal_class = mode == "menu" and "main menu" or "dir browser"
   self.resizable = false
-  self.exit_button = self:addBevelPanel(260, 400, 100, 18, self.col_bg)
+  local button_width, button_height, button_pos = 135, 30, self.height - 35
+  local indent = math.floor((self.width - (3 * button_width)) / 4)
+  self.exit_button = self:addBevelPanel(indent, button_pos, button_width, button_height, self.col_bg)
 
   if mode ~= nil then
     self.font = TheApp.gfx:loadFont("QData", "Font01V")
     self:setDefaultPosition(0.5, 0.25)
     self.on_top = true
     self.esc_closes = true
-    self.exit_button:setLabel(_S.install.cancel, self.font):makeButton(0, 0, 100, 18, nil, self.close)
+    self.exit_button:setLabel(_S.install.cancel, self.font)
+      :makeButton(0, 0, button_width, button_height, nil, self.close)
   else
     self.font = ui.app.gfx:loadBuiltinFont()
     self:setDefaultPosition(0.05, 0.5)
     self:addKeyHandler("global_cancel", self.exit)
     self:addKeyHandler("global_cancel_alt", self.exit)
-    self.exit_button:setLabel(_S.install.exit, self.font):makeButton(0, 0, 100, 18, nil, self.exit)
+    self.exit_button:setLabel(_S.install.exit, self.font)
+      :makeButton(0, 0, button_width, button_height, nil, self.exit)
   end
 
   -- Create the root item (or items, on Windows), and set it as the
@@ -185,7 +189,7 @@ function UIDirectoryBrowser:UIDirectoryBrowser(ui, mode, instruction, treenode_c
     end
   end
 
-  local control = TreeControl(root, 5, 55, 490, 340, self.col_bg, self.col_scrollbar)
+  local control = TreeControl(root, 5, 55, 490, 330, self.col_bg, self.col_scrollbar)
     :setSelectCallback(select_function)
 
   local ok_function = function()
@@ -193,10 +197,12 @@ function UIDirectoryBrowser:UIDirectoryBrowser(ui, mode, instruction, treenode_c
       select_function(control.selected_node)
     end
   end
-  self.ok_button = self:addBevelPanel(130, 400, 100, 18, self.col_bg)
-    :setLabel(_S.install.ok, self.font):makeButton(0, 0, 100, 18, nil, ok_function)
+  self.ok_button = self
+    :addBevelPanel(self.width - button_width - indent, button_pos, button_width, button_height, self.col_bg)
+    :setLabel(_S.install.ok, self.font):makeButton(0, 0, button_width, button_height, nil, ok_function)
 
   self:addWindow(control)
+  self.control = control
 end
 
 function UIDirectoryBrowser:exit()

--- a/CorsixTH/Lua/dialogs/resizables/folder_settings.lua
+++ b/CorsixTH/Lua/dialogs/resizables/folder_settings.lua
@@ -43,7 +43,7 @@ local col_caption = {
 }
 
 function UIFolder:UIFolder(ui, mode)
-  self:UIResizable(ui, 360, 240, col_bg)
+  self:UIResizable(ui, 400, 240, col_bg)
 
   local app = ui.app
   self.mode = mode
@@ -66,7 +66,8 @@ function UIFolder:UIFolder(ui, mode)
   self:addBevelPanel(20, 50, 130, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.folders_window.data_label):setTooltip(_S.tooltip.folders_window.data_location)
     .lowered = true
-  self:addBevelPanel(160, 50, 180, 20, col_bg)
+  self:addBevelPanel(160, 50, 20, 20, col_bg):setLabel("O"):makeButton(0, 0, 20, 20, nil, self.exploreTHInstallDir):setTooltip(_S.tooltip.folders_window.explore)
+  self:addBevelPanel(180, 50, 180, 20, col_bg)
     :setLabel(app.config.theme_hospital_install, built_in):setAutoClip(true)
     :makeButton(0, 0, 180, 20, nil, self.buttonBrowseForTHInstall):setTooltip(_S.tooltip.folders_window.browse_data:format(app.config.theme_hospital_install))
 
@@ -74,8 +75,11 @@ function UIFolder:UIFolder(ui, mode)
   self:addBevelPanel(20, 75, 130, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.folders_window.font_label):setTooltip(_S.tooltip.folders_window.font_location)
     .lowered = true
+  if app.config.unicode_font then
+    self:addBevelPanel(160, 75, 20, 20, col_bg):setLabel("O"):makeButton(0, 0, 20, 20, nil, self.exploreFontDir):setTooltip(_S.tooltip.folders_window.explore)
+  end
   local tooltip_font = app.config.unicode_font and _S.tooltip.folders_window.browse_font:format(app.config.unicode_font) or _S.tooltip.folders_window.no_font_specified
-  self:addBevelPanel(160, 75, 180, 20, col_bg)
+  self:addBevelPanel(180, 75, 180, 20, col_bg)
     :setLabel(app.config.unicode_font and app.config.unicode_font or tooltip_font, built_in):setAutoClip(true)
     :makeButton(0, 0, 180, 20, nil, self.buttonBrowseForFont):setTooltip(tooltip_font)
 
@@ -83,36 +87,67 @@ function UIFolder:UIFolder(ui, mode)
   self:addBevelPanel(20, 100, 130, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.folders_window.savegames_label):setTooltip(_S.tooltip.folders_window.savegames_location)
     .lowered = true
+  self:addBevelPanel(160, 100, 20, 20, col_bg):setLabel("O"):makeButton(0, 0, 20, 20, nil, self.exploreSavesDir):setTooltip(_S.tooltip.folders_window.explore)
   local tooltip_saves = app.config.savegames and _S.tooltip.folders_window.browse_saves:format(app.config.savegames) or _S.tooltip.folders_window.default
-  self.saves_panel = self:addBevelPanel(160, 100, 160, 20, col_bg)
+  self.saves_panel = self:addBevelPanel(180, 100, 180, 20, col_bg)
   self.saves_panel:setLabel(app.config.savegames and app.config.savegames or tooltip_saves , built_in):setAutoClip(true)
-    :makeButton(0, 0, 160, 20, nil, self.buttonBrowseForSavegames):setTooltip(tooltip_saves)
-  self:addBevelPanel(320, 100, 20, 20, col_bg):setLabel("X"):makeButton(0, 0, 20, 20, nil, self.resetSavegameDir):setTooltip(_S.tooltip.folders_window.reset_to_default)
+    :makeButton(0, 0, 180, 20, nil, self.buttonBrowseForSavegames):setTooltip(tooltip_saves)
+  self:addBevelPanel(360, 100, 20, 20, col_bg):setLabel("X"):makeButton(0, 0, 20, 20, nil, self.resetSavegameDir):setTooltip(_S.tooltip.folders_window.reset_to_default)
 
   -- location for screenshots
   self:addBevelPanel(20, 125, 130, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.folders_window.screenshots_label):setTooltip(_S.tooltip.folders_window.screenshots_location)
     .lowered = true
+  self:addBevelPanel(160, 125, 20, 20, col_bg):setLabel("O"):makeButton(0, 0, 20, 20, nil, self.exploreScreenshotsDir):setTooltip(_S.tooltip.folders_window.explore)
   local tooltip_screenshots = app.config.screenshots and _S.tooltip.folders_window.browse_screenshots:format(app.config.screenshots) or _S.tooltip.folders_window.default
-  self.screenshots_panel = self:addBevelPanel(160, 125, 160, 20, col_bg)
+  self.screenshots_panel = self:addBevelPanel(180, 125, 180, 20, col_bg)
   self.screenshots_panel:setLabel(app.config.screenshots and app.config.screenshots or tooltip_screenshots, built_in):setAutoClip(true)
-    :makeButton(0, 0, 160, 20, nil, self.buttonBrowseForScreenshots):setTooltip(tooltip_screenshots)
-  self:addBevelPanel(320, 125, 20, 20, col_bg):setLabel("X"):makeButton(0, 0, 20, 20, nil, self.resetScreenshotDir):setTooltip(_S.tooltip.folders_window.reset_to_default)
+    :makeButton(0, 0, 180, 20, nil, self.buttonBrowseForScreenshots):setTooltip(tooltip_screenshots)
+  self:addBevelPanel(360, 125, 20, 20, col_bg):setLabel("X"):makeButton(0, 0, 20, 20, nil, self.resetScreenshotDir):setTooltip(_S.tooltip.folders_window.reset_to_default)
 
  -- location for music files
   self:addBevelPanel(20, 150, 130, 20, col_shadow, col_bg, col_bg)
     :setLabel(_S.folders_window.music_label):setTooltip(_S.tooltip.folders_window.music_location)
     .lowered = true
+  if app.config.audio_music then
+    self:addBevelPanel(160, 150, 20, 20, col_bg):setLabel("O"):makeButton(0, 0, 20, 20, nil, self.exploreMusicDir):setTooltip(_S.tooltip.folders_window.explore)
+  end
   local tooltip_audio = app.config.audio_music and _S.tooltip.folders_window.browse_music:format(app.config.audio_music) or _S.tooltip.folders_window.not_specified
-  self.music_panel = self:addBevelPanel(160, 150, 180, 20, col_bg)
+  self.music_panel = self:addBevelPanel(180, 150, 180, 20, col_bg)
   self.music_panel:setLabel(app.config.audio_music and app.config.audio_music or tooltip_audio, built_in):setAutoClip(true)
-    :makeButton(0, 0, 160, 20, nil, self.buttonBrowseForAudio_music):setTooltip(tooltip_audio)
-  self:addBevelPanel(320, 150, 20, 20, col_bg):setLabel("X"):makeButton(0, 0, 20, 20, nil, self.resetmusicDir):setTooltip(_S.tooltip.folders_window.reset_to_default)
+    :makeButton(0, 0, 180, 20, nil, self.buttonBrowseForAudio_music):setTooltip(tooltip_audio)
+  self:addBevelPanel(360, 150, 20, 20, col_bg):setLabel("X"):makeButton(0, 0, 20, 20, nil, self.resetmusicDir):setTooltip(_S.tooltip.folders_window.reset_to_default)
 
   -- "Back" button
-  self:addBevelPanel(20, 180, 320, 40, col_bg):setLabel(_S.folders_window.back)
-    :makeButton(0, 0, 320, 40, nil, self.buttonBack):setTooltip(_S.tooltip.folders_window.back)
+  self:addBevelPanel(20, 180, 360, 40, col_bg):setLabel(_S.folders_window.back)
+    :makeButton(0, 0, 360, 40, nil, self.buttonBack):setTooltip(_S.tooltip.folders_window.back)
   self.built_in_font = built_in
+end
+
+function UIFolder:exploreTHInstallDir()
+  local app = TheApp
+  app:osOpen(TheApp.config.theme_hospital_install)
+end
+
+function UIFolder:exploreFontDir()
+  local app = self.app
+  -- Open the folder with the font file.
+  app:osOpen(app.config.unicode_font:match("(.*/)"))
+end
+
+function UIFolder:exploreSavesDir()
+  local app = self.app
+  app:osOpen(app.savegame_dir)
+end
+
+function UIFolder:exploreScreenshotsDir()
+  local app = self.app
+  app:osOpen(app.screenshot_dir)
+end
+
+function UIFolder:exploreMusicDir()
+  local app = self.app
+  app:osOpen(app.config.audio_music)
 end
 
 function UIFolder:resetSavegameDir()

--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -383,18 +383,6 @@ function UIOptions:buttonJukebox()
   end
 end
 
-function UIOptions:buttonBrowseForTHInstall()
-  local function callback(path)
-    local app = TheApp
-    app.config.theme_hospital_install = path
-    app:saveConfig()
-    debug.getregistry()._RESTART = true
-    app.running = false
-  end
-  local browser = UIDirectoryBrowser(self.ui, self.mode, _S.options_window.new_th_directory, "InstallDirTreeNode", callback)
-  self.ui:addWindow(browser)
-end
-
 function UIOptions:buttonAudioGlobal()
   local app = self.ui.app
   app.config.audio = not app.config.audio

--- a/CorsixTH/Lua/dialogs/resizables/update.lua
+++ b/CorsixTH/Lua/dialogs/resizables/update.lua
@@ -100,21 +100,9 @@ function UIUpdate:draw(canvas, x, y)
 end
 
 function UIUpdate:buttonDownload()
-
-  if self.app.os == "windows" then
-    os.execute("start " .. self.download_url)
-  elseif self.app.os == "macos" then
-    os.execute("open " .. self.download_url)
-  else
-    os.execute("xdg-open " .. self.download_url)
-  end
-
+  self.ui.app:osOpen(self.download_url)
 end
 
 function UIUpdate:buttonIgnore()
   self:close()
 end
-
-
-
-

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -534,6 +534,7 @@ tooltip.folders_window = {
   not_specified = "No folder location specified yet!",
   default = "Default location",
   reset_to_default = "Reset the directory to its default location",
+  explore = "Open this folder in your file manager",
   back  = "Close this menu and go back to the Settings Menu",
 }
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*May fix #369*

**Describe what the proposed change does**
-  Add an explore button to all relevant windows. Rather than add rename and delete buttons, this helps the user make those changes in their file manager. The window doesn't update with those changes.
- Add App.osOpen to open these paths, and urls from updates. This could be in utility.lua or App:init with math.random variants.
- The windows open command start [needs extra quotes.](https://superuser.com/questions/1656455/how-to-use-a-path-with-spaces-in-the-batch-file)
