### PR TITLE
Show level briefing before the tutorial instead of after

### DIFF
--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -1094,13 +1094,14 @@ tutorial_phases = {
         -- the real game uses three.
         local texts = TheApp.using_demo_files and {
           {_S.introduction_texts["level15"]},
-          {_S.introduction_texts["demo"]},
         } or {
           {_S.introduction_texts["level15"]},
           {_S.introduction_texts["level16"]},
           {_S.introduction_texts["level17"]},
-          {_S.introduction_texts["level1"]},
         }
+        if TheApp.world.map.level_number ~= 1 then
+          table.insert(texts, _S.introduction_texts["level1"])
+        end
         TheApp.ui:addWindow(UIInformation(TheApp.ui, texts))
         TheApp.ui:addWindow(UIWatch(TheApp.ui, "initial_opening"))
       end,

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -996,6 +996,8 @@ local outside_temperatures = {
    4.75 / 50, -- December
 }
 
+local start_date = Date()
+
 --! World ticks are translated to game ticks (or hours) depending on the
 -- current speed of the game. There are 50 hours in a TH day.
 function World:onTick()
@@ -1017,8 +1019,10 @@ function World:onTick()
         print("Error while autosaving game: " .. err)
       end
     end
-    if self.game_date == Date() and not self.ui.start_tutorial then
-      self.ui:addWindow(UIWatch(self.ui, "initial_opening"))
+    if self.game_date == start_date then
+      if not self.ui.start_tutorial then
+        self.ui:addWindow(UIWatch(self.ui, "initial_opening"))
+      end
       self.ui:showBriefing()
     end
     self.tick_timer = self.tick_rate


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2001*

**Describe what the proposed change does**
- Always show the level briefing on day 1
- Don't show the final message of the tutorial when playing level 1, as it is the level briefing already shown