### PR TITLE
[RFC] Add simple interface for serialize

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -29,7 +29,7 @@ globals = { -- Globals
             "permanent", "print_table", "rangeMapLookup", "rnc",
             "strict_declare_global", "table_length", "unpermanent", "values",
             "serialize", "array_join", "shallow_clone", "staff_initials_cache",
-            "hasBit", "bitOr",
+            "hasBit", "bitOr", "inspect",
 
             -- Game classes
             "AIHospital", "AnimationManager", "AnimationEffect", "App", "Audio",

--- a/CorsixTH/Lua/utility.lua
+++ b/CorsixTH/Lua/utility.lua
@@ -404,6 +404,15 @@ function serialize(val, options, depth, pt_reflist)
   end
 end
 
+--! Simplified interface for serializing a value with option for depth
+-- See serialize for further explanation
+-- Output is dumped to the console
+--!param value A table or string to inspect
+--!param depth (num) Optional, defaults at 1
+function inspect(value, depth)
+  print(serialize(value, {detect_cycles = true, max_depth = depth or 1, pretty = true}))
+end
+
 -- Clones a table, but only the first level.
 function shallow_clone(tbl)
   if type(tbl) ~= "table" then return tbl end


### PR DESCRIPTION
I use this function for my own debugging purposes but may be helpful for others. It provides a simplified interface to use `serialize` rather than needing to juggle options every time.

I can close this PR if we don't want this functionality in utility.