### PR TITLE
Delay entity garbage collection

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -765,7 +765,7 @@ end
 -- feeling of warmth accordingly. Returns whether the calling function should proceed.
 function Humanoid:tickDay()
   -- No use doing anything if we're going home/fired (or dead)
-  if self.going_home or self.dead then
+  if self.going_home or self.dead or self.delete then
     return false
   end
 

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -548,6 +548,7 @@ end
 -- For example if thirst gets over a certain level (now: 0.7), the patient
 -- tries to find a drinks machine nearby.
 function Patient:tickDay()
+  if self.delete then return end -- Entity is marked for deletion
   -- First of all it may happen that this patient is tired of waiting and goes home.
   if self.waiting then
     self.waiting = self.waiting - 1

--- a/CorsixTH/Lua/entities/humanoids/vip.lua
+++ b/CorsixTH/Lua/entities/humanoids/vip.lua
@@ -92,6 +92,7 @@ end
 
 --[[--VIP while on premises--]]
 function Vip:tickDay()
+  if self.delete then return end -- Entity is marked for deletion
   -- for the vip
   if self.waiting then
     self.waiting = self.waiting - 1

--- a/CorsixTH/Lua/entity.lua
+++ b/CorsixTH/Lua/entity.lua
@@ -191,6 +191,7 @@ end
 -- of time in the game engine. Typically used to advance animations and similar
 -- recurring or long-duration tasks.
 function Entity:tick()
+  if self.delete then return end -- Entity is marked for deletion
   if self.num_animation_ticks then
     for _ = 1, self.num_animation_ticks do
       self:_tick()

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1023,6 +1023,16 @@ function World:onTick()
     end
     self.tick_timer = self.tick_rate
 
+    -- Remove entities marked for deletion
+    if self.entity_gc then
+      for i = #self.entities, 1, -1 do
+        if self.entities[i].delete then
+          table.remove(self.entities, i)
+        end
+      end
+      self.entity_gc = nil
+    end
+
     -- if an earthquake is supposed to be going on, call the earthquake function
     if self.next_earthquake.active then
       self:tickEarthquake()
@@ -1940,13 +1950,11 @@ function World:newEntity(class, animation)
   return entity
 end
 
+--! Mark an entity for deletion in the next tick
+--!param entity
 function World:destroyEntity(entity)
-  for i, e in ipairs(self.entities) do
-    if e == entity then
-      table.remove(self.entities, i)
-      break
-    end
-  end
+  entity.delete = true
+  self.entity_gc = true -- Garbage collection in onTick
   entity:onDestroy()
 end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #1467*

**Describe what the proposed change does**
- Mark entities for deletion where they were previously deleted, and delete them in the next tick
- Don't run tick functions for entities that have been marked for deletion. This may be optional, I had an error I can't recreate that made me think of this.
