### PR TITLE
Resize UIInformation

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 181 -- Pair swing doors instantly
+local SAVEGAME_VERSION = 182 -- Changes UIInformation padding
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/information.lua
+++ b/CorsixTH/Lua/dialogs/information.lua
@@ -57,10 +57,10 @@ function UIInformation:UIInformation(ui, text, use_built_in_font)
   -- Window size parameters
   self.text_width = 300
   self.spacing = {
-    l = 40,
-    r = 40,
-    t = 20,
-    b = 20,
+    l = 15,
+    r = 15,
+    t = 15,
+    b = 18 + 15, -- Size of close button + padding
   }
 
   self:onChangeLanguage()
@@ -89,19 +89,19 @@ function UIInformation:onChangeLanguage()
 
   for x = 4, self.width - 4, 4 do
     self:addPanel(12, x, 0)  -- Dialog top and bottom borders
-    self:addPanel(16, x, self.height-4)
+    self:addPanel(16, x, self.height - 4)
   end
   for y = 4, self.height - 4, 4 do
     self:addPanel(18, 0, y)  -- Dialog left and right borders
-    self:addPanel(14, self.width-4, y)
+    self:addPanel(14, self.width - 4, y)
   end
   self:addPanel(11, 0, 0)  -- Border top left corner
-  self:addPanel(17, 0, self.height-4)  -- Border bottom left corner
-  self:addPanel(13, self.width-4, 0)  -- Border top right corner
-  self:addPanel(15, self.width-4, self.height-4)  -- Border bottom right corner
+  self:addPanel(17, 0, self.height - 4)  -- Border bottom left corner
+  self:addPanel(13, self.width - 4, 0)  -- Border top right corner
+  self:addPanel(15, self.width - 4, self.height - 4)  -- Border bottom right corner
 
   -- Close button
-  self:addPanel(19, self.width - 30, self.height - 30):makeButton(0, 0, 18, 18, 20, self.close):setTooltip(_S.tooltip.information.close)
+  self:addPanel(19, self.width - 28, self.height - 28):makeButton(0, 0, 18, 18, 20, self.close):setTooltip(_S.tooltip.information.close)
 end
 
 function UIInformation:draw(canvas, x, y)
@@ -133,6 +133,16 @@ function UIInformation:close()
 end
 
 function UIInformation:afterLoad(old, new)
+  if old < 182 then
+    -- box resized to be more like the original
+    self.spacing = {
+    l = 15,
+    r = 15,
+    t = 15,
+    b = 33, -- includes space for close button (18px + 15px padding)
+    }
+    self:onChangeLanguage()
+  end
   Window.afterLoad(self, old, new)
   self:registerKeyHandlers()
 end


### PR DESCRIPTION

**Describe what the proposed change does**
- Makes UIInformation more uniform to the original game as our implementation has excessive width padding. Works without any impact on non-standard fonts/cjk. Note Chinese still has an oddity where it adds additional blank space to the right.
- Makes close button have a reserved zone on bottom to allow for better utilisation of the box width
- Reformats some of the code spacing (there's too many magic numbers going on currently for me to focus on improving that here)
- Before 
![image](https://github.com/CorsixTH/CorsixTH/assets/20030128/7f67eb3b-d90a-4e04-a120-a547e9fadac4)

- After 
![image](https://github.com/CorsixTH/CorsixTH/assets/20030128/9a2332fd-9ee8-4465-805c-de96d0d8df1b)


A future improvement would be to also utilise the empty space adjacent to the button with awareness for that button existing on wrap. Or, move the button outside the box to look like a little tab on the top right.