### PR TITLE
Patch Lua Bitmap Makefiles

### DIFF
--- a/CorsixTH/Bitmap/example.spec
+++ b/CorsixTH/Bitmap/example.spec
@@ -1,0 +1,21 @@
+--[[ EXAMPLE SPEC FILE FOR MAKING SPRITESHEETS ]]
+-- Specify your sprites (BMP images) and output file locations
+-- It is recommended to leave palette and compression options at their default values
+local SPEC = {
+  sprites = { -- one bmp per line
+    "example1.bmp",
+    "example2.bmp",
+  },
+  -- Palette options
+  palette = "from bitmap",
+
+  -- Compression options
+  complex = true,
+  rnc = false,
+
+  -- Output filenames
+  output_tab = "example.tab",
+  output_dat = "example.dat",
+}
+
+return SPEC

--- a/CorsixTH/Bitmap/lib_spritesheet.lua
+++ b/CorsixTH/Bitmap/lib_spritesheet.lua
@@ -18,27 +18,30 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+-- This is a custom written spritesheet library for CorsixTH. It currently only supports
+-- complex encoding
+
 local io_open, assert, setmetatable, string_char, table_concat
     = io.open, assert, setmetatable, string.char, table.concat
 
-module "spritesheet"
+local Spr = {}
 local mt = {__index = _M}
 
-function open(filename_tab, filename_dat, is_complex)
+function Spr.open(filename_tab, filename_dat, is_complex)
   return setmetatable({
     tab = assert(io_open(filename_tab, "wb")),
     dat = assert(io_open(filename_dat, "wb")),
-    encode = is_complex and encodeComplex or encodeSimple,
+    encode = is_complex and Spr.encodeComplex or Spr.encodeSimple,
   }, mt)
 end
 
-function close(ss)
+function Spr.close(ss)
   ss.tab:close()
   ss.dat:close()
   return ss
 end
 
-function writeDummy(ss)
+function Spr.writeDummy(ss)
   ss.tab:write"\0\0\0\0\0\0"
   return ss
 end
@@ -55,18 +58,18 @@ local function uint4(value)
   return string_char(b0, b1, b2, value)
 end
 
-function write(ss, width, height, pixels)
+function Spr.write(ss, width, height, pixels)
   ss.tab:write(uint4(ss.dat:seek()))
   ss.tab:write(string_char(width, height))
   ss.dat:write(ss.encode(width, height, pixels))
   return ss
 end
 
-function encodeSimple(width, height, data)
+function Spr.encodeSimple(width, height, data)
   error "TODO"
 end
 
-function encodeComplex(width, height, data)
+function Spr.encodeComplex(width, height, data)
   local result = {}
   local run_start = 1
   local run_byte = false
@@ -131,3 +134,5 @@ function encodeComplex(width, height, data)
   flush_run(#data + 1)
   return table_concat(result)
 end
+
+return Spr

--- a/CorsixTH/Bitmap/mkfont.lua
+++ b/CorsixTH/Bitmap/mkfont.lua
@@ -18,78 +18,88 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
-if select('#', ...) < 3 then
-  print("Usage: lua mkfont.lua <bitmap-file> <cell-width> <cell-height> "..
-        "<space-width>")
-  print("Converts a bitmap which contains multiple glyphs (arranged in a "..
-        "grid) into a sprite sheet (.tab and .dat) and a palette (.pal).")
-  return
-end
+-- Creates a dat, tab and palette file from a single BMP image of multiple glyphs
+-- to be used for a font spritesheet
+-- bitmap_name: the target BMP image
+-- cell_width: width per character glyph
+-- cell_height: height per character glyph
+-- space_width: spacing betweeen glyphs
+-- Output goes to the same location of the BMP image
 
-package.path = (debug.getinfo(1, "S").source:match("@(.*[" .. package.config
-               :sub(1, 1) .. "])") or "") .. "lib_" .. package.config:sub(5, 5)
-               .. ".lua" .. package.config:sub(3, 3) .. package.path
-require("bmp")
-require("spritesheet")
+function makeFont(bitmap_name, cell_width, cell_height, space_width)
+  if not (bitmap_name or cell_width or cell_height or space_width) then
+    print("Usage: lua mkfont.lua <bitmap-file> <cell-width> <cell-height> "..
+          "<space-width>")
+    print("Converts a bitmap which contains multiple glyphs (arranged in a "..
+          "grid) into a sprite sheet (.tab and .dat) and a palette (.pal).")
+    return
+  end
 
-local bitmap_name, cell_width, cell_height, space_width = ...
-cell_width = assert(tonumber(cell_width), "cell width must be a number")
-cell_height = assert(tonumber(cell_height), "cell height must be a number")
-space_width = tonumber(space_width) or cell_width
+  package.path = (debug.getinfo(1, "S").source:match("@(.*[" .. package.config
+                 :sub(1, 1) .. "])") or "") .. "lib_" .. package.config:sub(5, 5)
+                 .. ".lua" .. package.config:sub(3, 3) .. package.path
+  local bmp = require("lib_bmp")
+  local spritesheet = require("lib_spritesheet")
 
-local bitmap = assert(bmp.open(bitmap_name))
-local ncells_x = bitmap.width / cell_width
-assert(ncells_x % 1 == 0, "Bitmap width must be a multiple of the cell width")
-local ncells_y = bitmap.height / cell_height
-assert(ncells_y % 1 == 0, "Bitmap height must be a multiple of the cell height")
+  local bitmap_name, cell_width, cell_height, space_width = bitmap_name, cell_width, cell_height, space_width
+  cell_width = assert(tonumber(cell_width), "cell width must be a number")
+  cell_height = assert(tonumber(cell_height), "cell height must be a number")
+  space_width = tonumber(space_width) or cell_width
 
-local filename_base = bitmap_name:match"^(.*%.)[^.]*$"
-local ss = spritesheet.open(filename_base .. "tab", filename_base .. "dat", true)
+  local bitmap = assert(bmp.open(bitmap_name))
+  local ncells_x = bitmap.width / cell_width
+  assert(ncells_x % 1 == 0, "Bitmap width must be a multiple of the cell width")
+  local ncells_y = bitmap.height / cell_height
+  assert(ncells_y % 1 == 0, "Bitmap height must be a multiple of the cell height")
 
-local pal = assert(io.open(filename_base .. "pal", "wb"))
-pal:write(bitmap.palette)
-pal:close()
+  local filename_base = bitmap_name:match"^(.*%.)[^.]*$"
+  local ss = spritesheet.open(filename_base .. "tab", filename_base .. "dat", true)
 
-ss:writeDummy()
-for y = 0, ncells_y - 1 do
-  for x = 0, ncells_x - 1 do
-    if x == 0 and y == 0 then
-      ss:write(space_width, 1, bitmap:getSubPixels(0, 0, space_width, 1))
-    else
-      local x, y = x * cell_width, y * cell_height
-      local w, h = cell_width, cell_height
-      while h > 1 do
-        local is_empty = true
-        for d = 0, w - 1 do
-          if bitmap:getPixel(x + d, y + h - 1) ~= "\255" then
-            is_empty = false
-          end
-        end
-        if is_empty then
-          h = h - 1
-        else
-          break
-        end
-      end
-      while w > 1 do
-        local is_empty = true
-        for d = 0, h - 1 do
-          if bitmap:getPixel(x + w - 1, y + d) ~= "\255" then
-            is_empty = false
-          end
-        end
-        if is_empty then
-          w = w - 1
-        else
-          break
-        end
-      end
-      if w == 1 and h == 1 and bitmap:getPixel(x, y) == "\255" then
-        ss:writeDummy()
+  local pal = assert(io.open(filename_base .. "pal", "wb"))
+  pal:write(bitmap.palette)
+  pal:close()
+
+  spritesheet.writeDummy(ss)
+  for y = 0, ncells_y - 1 do
+    for x = 0, ncells_x - 1 do
+      if x == 0 and y == 0 then
+        spritesheet.write(ss, space_width, 1, bmp.getSubPixels(bitmap, 0, 0, space_width, 1))
       else
-        ss:write(w, cell_height, bitmap:getSubPixels(x, y, w, cell_height))
+        local x, y = x * cell_width, y * cell_height
+        local w, h = cell_width, cell_height
+        while h > 1 do
+          local is_empty = true
+          for d = 0, w - 1 do
+            if bmp.getPixel(bitmap, x + d, y + h - 1) ~= "\255" then
+              is_empty = false
+            end
+          end
+          if is_empty then
+            h = h - 1
+          else
+            break
+          end
+        end
+        while w > 1 do
+          local is_empty = true
+          for d = 0, h - 1 do
+            if bmp.getPixel(bitmap, x + w - 1, y + d) ~= "\255" then
+              is_empty = false
+            end
+          end
+          if is_empty then
+            w = w - 1
+          else
+            break
+          end
+        end
+        if w == 1 and h == 1 and bmp.getPixel(bitmap, x, y) == "\255" then
+          spritesheet.writeDummy(ss)
+        else
+          spritesheet.write(ss, w, cell_height, bmp.getSubPixels(bitmap, x, y, w, cell_height))
+        end
       end
     end
   end
+  spritesheet.close(ss)
 end
-ss:close()

--- a/CorsixTH/Bitmap/mkraw.lua
+++ b/CorsixTH/Bitmap/mkraw.lua
@@ -18,34 +18,41 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
-if not ... then
-  print "Usage: lua mkraw.lua <bitmap-file>"
-  print "Converts a bitmap into a raw .dat file and a .pal file"
-  return
-end
+-- Creates a dat and palette file from a single BMP image to be used in Graphics:loadRaw(...)
+-- file: the target BMP image
+-- Output goes to the same location of the BMP image
+function makeRaw(file)
+  if not file then
+    print "Usage: lua mkraw.lua <bitmap-file>"
+    print "Converts a bitmap into a raw .dat file and a .pal file"
+    return
+  end
 
-package.path = (debug.getinfo(1, "S").source:match("@(.*[" .. package.config
-               :sub(1, 1) .. "])") or "") .. "lib_" .. package.config:sub(5, 5)
-               .. ".lua" .. package.config:sub(3, 3) .. package.path
-require("bmp")
+  package.path = (debug.getinfo(1, "S").source:match("@(.*[" .. package.config
+                 :sub(1, 1) .. "])") or "") .. "lib_" .. package.config:sub(5, 5)
+                 .. ".lua" .. package.config:sub(3, 3) .. package.path
+  local bmp = require("lib_bmp")
 
-local filename = ...
-if not filename:match("%.bmp$") then
-  print("Error: Extension must must be .bmp")
-  return
-end
-local filename_base = filename:match"^(.*%.)[^.]*$"
-local dat, pal = filename_base .."dat", filename_base .. "pal"
-local bitmap = assert(bmp.open(filename))
-dat = assert(io.open(dat, "wb"))
-pal = assert(io.open(pal, "wb"))
+  local filename = file
+  if not filename:match("%.bmp$") then
+    print("Error: Extension must must be .bmp")
+    return
+  end
+  local filename_base = filename:match"^(.*%.)[^.]*$"
+  local dat, pal = filename_base .."dat", filename_base .. "pal"
+  local bitmap = assert(bmp.open(filename))
+  dat = assert(io.open(dat, "wb"))
+  pal = assert(io.open(pal, "wb"))
 
--- palette
-pal:write(bitmap.palette)
+  -- palette
+  pal:write(bitmap.palette)
+  pal:close()
 
--- image data
-dat:write(assert(bitmap:getPixels()))
+  -- image data
+  dat:write(assert(bmp.getPixels(bitmap)))
+  dat:close()
 
-if bitmap.pal_size ~= 256 then
-  print("Warning: palette size is " .. bitmap.pal_size .. ". Currently only palettes of size 256 will work in CorsixTH.")
+  if bitmap.pal_size ~= 256 then
+    print("Warning: palette size is " .. bitmap.pal_size .. ". Currently only palettes of size 256 will work in CorsixTH.")
+  end
 end

--- a/CorsixTH/Bitmap/mksheet.lua
+++ b/CorsixTH/Bitmap/mksheet.lua
@@ -18,65 +18,74 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
-if not ... then
-  print "Usage: lua mksheet.lua <spec-file>"
-  print "Converts a number of bitmaps into a sprite sheet using the given spec"
-  return
-end
+-- Creates a dat and tab file from a given specification file to combine multiple BMP
+-- images into a single spritesheet for use with Graphics:loadSpriteTable
+-- file: the spec to instruct what the spritesheet will contain. See example.spec
+-- for a template
 
-package.path = (debug.getinfo(1, "S").source:match("@(.*[" .. package.config
-               :sub(1, 1) .. "])") or "") .. "lib_" .. package.config:sub(5, 5)
-               .. ".lua" .. package.config:sub(3, 3) .. package.path
-require("bmp")
-require("spritesheet")
-
-local specfile = ...
-specfile = assert(loadfile(specfile))
-local spec = {}
-setfenv(specfile, spec)()
-
-assert(type(spec.sprites) == "table", "spec is missing sprite list")
-local required_fields = {
-  palette = {
-    ["from bitmap"] = true,
-  },
-  complex = {
-    [true] = true,
-    -- [false] = true, -- Not yet supported
-  },
-  rnc = {
-    -- [true] = true, -- Not yet supported
-    [false] = true,
-  },
-  output_tab = true,
-  output_dat = true,
-}
-for field, options in pairs(required_fields) do
-  assert(spec[field] ~= nil, "spec is missing '" .. field .. "' field")
-  if options ~= true then
-    assert(options[spec[field]], "spec field '" .. field .. "' is invalid")
+-- FIXME: BMP images and the output files must be located at the same directory of the
+-- program used to execute this. Ideally, they should all be in the location of the
+-- .spec file
+function makeSheet(file)
+  if not file then
+    print "Usage: lua mksheet.lua <spec-file>"
+    print "Converts a number of bitmaps into a sprite sheet using the given spec"
+    return
   end
-end
 
-local ss = spritesheet.open(spec.output_tab, spec.output_dat, spec.complex)
+  package.path = (debug.getinfo(1, "S").source:match("@(.*[" .. package.config
+                 :sub(1, 1) .. "])") or "") .. "lib_" .. package.config:sub(5, 5)
+                 .. ".lua" .. package.config:sub(3, 3) .. package.path
+  local bmp = require("lib_bmp")
+  local spritesheet = require("lib_spritesheet")
 
-for i = 0, table.maxn(spec.sprites) do
-  local filename = spec.sprites[i]
-  if not filename then
-    ss:writeDummy()
-  else
-    local function err(msg, ...)
-      error("Error processing " .. filename .. ":\n" .. msg:format(...))
+  local specfile = file
+  specfile = assert(dofile(specfile))
+  local spec = specfile
+
+  assert(type(spec.sprites) == "table", "spec is missing sprite list")
+  local required_fields = {
+    palette = {
+      ["from bitmap"] = true,
+    },
+    complex = {
+      [true] = true,
+      -- [false] = true, -- Not yet supported
+    },
+    rnc = {
+      -- [true] = true, -- Not yet supported
+      [false] = true,
+    },
+    output_tab = true,
+    output_dat = true,
+  }
+  for field, options in pairs(required_fields) do
+    assert(spec[field] ~= nil, "spec is missing '" .. field .. "' field")
+    if options ~= true then
+      assert(options[spec[field]], "spec field '" .. field .. "' is invalid")
     end
-    local bitmap, e = bmp.open(filename)
-    if not bitmap then
-      err(e)
-    end
-    local width, height = bitmap.width, bitmap.height
-    if width > 0xFF or height > 0xFF then
-      err "Image too big (maximum size is 255x255)"
-    end
-    ss:write(width, height, bitmap:getPixels())
   end
+
+  local ss = spritesheet.open(spec.output_tab, spec.output_dat, spec.complex)
+
+  for i = 0, #spec.sprites do
+    local filename = spec.sprites[i]
+    if not filename then
+      spritesheet.writeDummy(ss)
+    else
+      local function err(msg, ...)
+        error("Error processing " .. filename .. ":\n" .. msg:format(...))
+      end
+      local bitmap, e = bmp.open(filename)
+      if not bitmap then
+        err(e)
+      end
+      local width, height = bitmap.width, bitmap.height
+      if width > 0xFF or height > 0xFF then
+        err "Image too big (maximum size is 255x255)"
+      end
+      spritesheet.write(ss, width, height, bmp.getPixels(bitmap))
+    end
+  end
+  spritesheet.close(ss)
 end
-ss:close()


### PR DESCRIPTION
Work should bring these scripts up to Lua 5.4 compatibility while retaining Lua 5.1/JIT compatibility (not tested)

-- Removes `setfenv` call and rewrites spec file to work without it
-- Removes `module`, replaced with `require`
-- Fixes bug in `makeRaw` where bitmap files were not closed after execution

I've not attempted to completely untangle the methods Corsix used for these files so likely a lot of odd design choices still exist (and ones that fail our coding conventions) but I can confirm these mkfiles are running from CorsixTH.exe via debug script.

[**mkboostrap.lua**](https://github.com/CorsixTH/CorsixTH/blob/835bb9aad6d751749ff88e9449797547bf6424da/CorsixTH/Bitmap/mkbootstrap.lua) in Bitmap folder may need addressing with these changes, but I don't want to look at that one myself (if someone wanted to repatch it if needed they can add a commit.

I'd recommend turning off whitespace changes.