### PR TITLE
Fix background music error message

### DIFF
--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -588,7 +588,7 @@ function Audio:playBackgroundTrack(index)
 
         if music_data == nil then
           error("Could not load music file \'" .. (info.filename_music or info.filename) .. "\'" ..
-              (e and (" (" .. e .. ")" or "")))
+              (e and " (" .. e .. ")" or ""))
         else
           info.music = music_data
           -- Do we still want it to play?


### PR DESCRIPTION
**Describe what the proposed change does**
- Concatenate the error message for unplayable music correctly. I had the error when playing formats not supported by my sdl2_mixer build.