### PR TITLE
Make the tips window adapt to the space beside the main menu

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/tip_of_the_day.lua
+++ b/CorsixTH/Lua/dialogs/resizables/tip_of_the_day.lua
@@ -31,9 +31,13 @@ local col_bg = {
 }
 
 function UITipOfTheDay:UITipOfTheDay(ui)
-  self:UIResizable(ui, 380, 110, col_bg)
-
   local app = ui.app
+  -- If the application window is not wide enough,
+  --  the tips window is narrower and taller to fit beside the main menu
+  local width = math.min(380, math.floor(app.config.width / 2) - 150)
+  local height = width > 290 and 110 or 210
+  self:UIResizable(ui, width, height, col_bg)
+
   self.ui = ui
   self.resizable = false
   self:setDefaultPosition(-20, -20)
@@ -49,10 +53,18 @@ function UITipOfTheDay:UITipOfTheDay(ui)
   end
   self.tip_num = math.random(1, self.num_tips)
 
-  self:addBevelPanel(10, self.height - 30, self.width / 2 - 20, 20, col_bg):setLabel(_S.totd_window.previous)
-    :makeButton(0, 0, self.width / 2 - 20, 20, nil, self.buttonPrev):setTooltip(_S.tooltip.totd_window.previous)
-  self:addBevelPanel(self.width / 2 + 10, self.height - 30, self.width / 2 - 20, 20, col_bg):setLabel(_S.totd_window.next)
-    :makeButton(0, 0, self.width / 2 - 20, 20, nil, self.buttonNext):setTooltip(_S.tooltip.totd_window.next)
+  -- Previous button's y, next button's x, button width
+  local function add_nav_buttons(y1, x2, btn_width)
+    self:addBevelPanel(10, y1, btn_width, 20, col_bg):setLabel(_S.totd_window.previous)
+      :makeButton(0, 0, btn_width, 20, nil, self.buttonPrev):setTooltip(_S.tooltip.totd_window.previous)
+    self:addBevelPanel(x2, height - 30, btn_width, 20, col_bg):setLabel(_S.totd_window.next)
+      :makeButton(0, 0, btn_width, 20, nil, self.buttonNext):setTooltip(_S.tooltip.totd_window.next)
+  end
+  if width > 290 then -- The buttons are side by side
+    add_nav_buttons(height - 30, math.floor(width / 2) + 10, math.floor(width / 2) - 20)
+  else -- The buttons are stacked
+    add_nav_buttons(height - 55, 10, width - 20)
+  end
 end
 
 function UITipOfTheDay:draw(canvas, x, y)
@@ -77,4 +89,11 @@ function UITipOfTheDay:buttonNext()
   if self.tip_num > self.num_tips then
     self.tip_num = 1
   end
+end
+
+--! Called after the resolution of the game window changes
+function UITipOfTheDay:onChangeResolution()
+  self:close()
+  self.ui:addWindow(UITipOfTheDay(self.ui))
+  Window.onChangeResolution(self)
 end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2200*

**Describe what the proposed change does**
- The width of the tips window is narrower in small resolutions, with stacked previous/next buttons. As it doesn't overlap with the main menu, is this an acceptable place to close and reopen windows without caring about window order?
