### PR TITLE
Remove unused original_path string

### DIFF
--- a/CorsixTH/Lua/languages/brazilian_portuguese.lua
+++ b/CorsixTH/Lua/languages/brazilian_portuguese.lua
@@ -506,7 +506,6 @@ tooltip.folders_window = {
   not_specified = "Pasta näo especificada!",
   default = "Localizaçäo padräo",
   reset_to_default = "Volta a atribuir a pasta a sua localizaçäo padräo",
- -- original_path = "The currently chosen directory of the original Theme Hospital installation", -- where is this used, I have left if for the time being?
   back  = "Fechar este menu e voltar para o menu de Configuraçöes",
 }
 

--- a/CorsixTH/Lua/languages/danish.lua
+++ b/CorsixTH/Lua/languages/danish.lua
@@ -257,7 +257,6 @@ tooltip.options_window = {
   height = "Indtast den önskede skærmhöjde",
   change_resolution = "Skift skærmstörrelsen til dimmensionerne indtastet til höjre",
   language = "Vælg %s som sprog",
-  original_path = "Theme Hospitals mappe",
   browse = "Gennemse et andet sted for installation af Theme Hospital. %1%",
   back = "Luk indstillingsvinduet",
 }

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -534,7 +534,6 @@ tooltip.folders_window = {
   not_specified = "No folder location specified yet!",
   default = "Default location",
   reset_to_default = "Reset the directory to its default location",
- -- original_path = "The currently chosen directory of the original Theme Hospital installation", -- where is this used, I have left if for the time being?
   back  = "Close this menu and go back to the Settings Menu",
 }
 

--- a/CorsixTH/Lua/languages/finnish.lua
+++ b/CorsixTH/Lua/languages/finnish.lua
@@ -301,7 +301,6 @@ tooltip = {
     height              = "Syötä peli-ikkunan haluttu korkeus",
     change_resolution   = "Muuta ikkunan resoluutio vasemmalla annettujen arvojen mukaiseksi",
     language            = "Valitse kieleksi %s",
-    original_path       = "Käytössä oleva Theme Hospital -pelin asennushakemisto",
     browse              = "Selaa hakemistoja valitaksesi uuden Theme Hospital -pelin asennushakemiston",
     back                = "Sulje tämä ikkuna",
   },

--- a/CorsixTH/Lua/languages/hungarian.lua
+++ b/CorsixTH/Lua/languages/hungarian.lua
@@ -241,7 +241,6 @@ tooltip.options_window = {
   height = "Add meg a kívánt magasságot",
   change_resolution = "Az ablak felbontásának alkalmazása a bal oldalon lévő adatok szerint",
   language = "%s nyelv kiválasztása",
-  original_path = "Az eredeti Theme Hospital telepítés jelenlegi elérési útvonala",
   browse = "Másik elérési útvonal kiválasztása a Theme Hospital fájljaihoz",
   back = "Beállítások ablak bezárása",
 }

--- a/CorsixTH/Lua/languages/iberic_portuguese.lua
+++ b/CorsixTH/Lua/languages/iberic_portuguese.lua
@@ -336,7 +336,6 @@ tooltip = {
 
   options_window = {
     fullscreen_button = "Clica para modo de tela cheia",
-    original_path = "A directoria da instalaçao original de Theme Hospital",
     browse = "Procura outra localizaçao da instalaçao original. %1%",
     change_resolution = "Altera a resoluçao da janela para as dimensoes colocadas à esquerda",
     height = "Coloca a altura desejada.",

--- a/CorsixTH/Lua/languages/italian.lua
+++ b/CorsixTH/Lua/languages/italian.lua
@@ -421,7 +421,6 @@ tooltip.folders_window = {
   not_specified = "Non è stata ancora specificata nessuna posizione per la cartella!",
   default = "Posizione di default",
   reset_to_default = "Ripristina la cartella alla sua posizione di default",
- -- original_path = "The currently chosen directory of the original Theme Hospital installation", -- where is this used, I have left if for the time being?
   back  = "Chiudi questo menù e torna al menù delle impostazioni",
 }
 

--- a/CorsixTH/Lua/languages/polish.lua
+++ b/CorsixTH/Lua/languages/polish.lua
@@ -609,7 +609,6 @@ tooltip = {
     language = "Język, w którym wyświetlone zostaną teksty gry",
     select_language = "Wybierz język gry",
     language_dropdown_item = "Wybierz %s jako język gry",
-    original_path = "Aktualnie wybrany katalog z zainstalowaną grą Theme Hospital",
     browse = "Zmień ścieżkę zainstalowanej gry Theme Hospital (obecna lokalizacja: %1%)",
     browse_font = "Zmień ścieżkę dla innego pliku z czcionką (obecna lokalizacja: %1%)",
     no_font_specified = "Lokalizacja czcionki nie została jeszcze wybrana!",

--- a/CorsixTH/Lua/languages/russian.lua
+++ b/CorsixTH/Lua/languages/russian.lua
@@ -114,7 +114,6 @@ options_window = {
   width = "Ширина",
   change_resolution = "Изменить разрешение",
   back = "Назад",
-  original_path = "Папка с установленной оригинальной игрой Theme Hospital",
   browse = "Выбрать папку",
   folder = "ПАПКИ",
   option_off = "Выкл",

--- a/CorsixTH/Lua/languages/simplified_chinese.lua
+++ b/CorsixTH/Lua/languages/simplified_chinese.lua
@@ -3473,7 +3473,6 @@ tooltip.folders_window = {
   not_specified = "没有指定文件夹位置！",
   default = "默认位置",
   reset_to_default = "重置到默认文件夹",
- -- original_path = "The currently chosen directory of the original Theme Hospital installation", -- where is this used, I have left if for the time being?
   back = "关闭此菜单，并返回设置菜单",
 }
 

--- a/CorsixTH/Lua/languages/spanish.lua
+++ b/CorsixTH/Lua/languages/spanish.lua
@@ -1036,7 +1036,6 @@ tooltip.folders_window = {
   not_specified = "¡No se ha especificado una carpeta!",
   default = "Ubicación predeterminada",
   reset_to_default = "Vuelve a asignar la carpeta a su ubicación predeterminada.",
- -- original_path = "Carpeta actual con la instalación del Theme Hospital original", -- where is this used, I have left if for the time being?
   back  = "Cerrar este menú y volver al menú de Opciones.",
 }
 

--- a/CorsixTH/Lua/languages/traditional_chinese.lua
+++ b/CorsixTH/Lua/languages/traditional_chinese.lua
@@ -3203,7 +3203,6 @@ tooltip.folders_window = {
   not_specified = "沒有指定資料夾位置！",
   default = "預設位置",
   reset_to_default = "重置到預設資料夾",
- -- original_path = "The currently chosen directory of the original Theme Hospital installation", -- where is this used, I have left if for the time being?
   back = "關閉此選單，並返回設定選單",
 }
 


### PR DESCRIPTION
**Describe what the proposed change does**
- The folder options dialog uses the data_location string, not original_path. Remove original_path from all languages.
