### PR TITLE
Fix shutdown order

### DIFF
--- a/CorsixTH/Src/sdl_core.cpp
+++ b/CorsixTH/Src/sdl_core.cpp
@@ -140,7 +140,8 @@ int l_mainloop(lua_State* L) {
       SDL_AddTimer(usertick_period_ms, timer_frame_callback, nullptr);
   SDL_Event e;
 
-  while (SDL_WaitEvent(&e) != 0) {
+  int wait_error = 0;
+  while ((wait_error = SDL_WaitEvent(&e)) != 0) {
     bool do_frame = false;
     bool do_timer = false;
     do {
@@ -294,6 +295,10 @@ int l_mainloop(lua_State* L) {
 
     // No events pending - a good time to do a bit of garbage collection
     lua_gc(L, LUA_GCSTEP, 2);
+  }
+
+  if (wait_error != 0) {
+    std::fprintf(stderr, "%s\n", SDL_GetError());
   }
 
 leave_loop:

--- a/CorsixTH/SrcUnshared/main.cpp
+++ b/CorsixTH/SrcUnshared/main.cpp
@@ -49,12 +49,12 @@ struct types_equal<T1, T1> {
 };
 
 static void cleanup(lua_State* L) {
+  lua_close(L);
 #ifdef CORSIX_TH_USE_SDL_MIXER
   while (Mix_QuerySpec(nullptr, nullptr, nullptr)) {
     Mix_CloseAudio();
   }
 #endif
-  lua_close(L);
   SDL_Quit();
 }
 


### PR DESCRIPTION
Also show error message if SDL_WaitEvent fails.

If SDL_Mixer is used by any destructor owned by lua, e.g. the movie player then it needs to still be available when lua is closed.

