### PR TITLE
Spawn a patient on open

### DIFF
--- a/CorsixTH/Lua/dialogs/watch.lua
+++ b/CorsixTH/Lua/dialogs/watch.lua
@@ -101,7 +101,7 @@ function UIWatch:onCountdownEnd()
       end
     end
   elseif self.count_type == "initial_opening" then
-    self.ui.hospital.opened = true
+    self.hospital:open()
     self.ui:playSound("fanfare.wav")
   end
 end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2365,6 +2365,16 @@ function Hospital:getRandomBusyRoom()
   if #chosen_room.door.queue >= busy_threshold then return chosen_room end
 end
 
+--! Open the hospital
+function Hospital:open()
+  self.opened = true
+end
+
+--! Check if the hospital is ready to accept patients
+function Hospital:canAcceptPatients()
+  return self.opened and self:hasStaffedDesk()
+end
+
 ---- Stubs section - these functions have nothing to do here, are overridden in a derived class.
 
 --! Give advice to the user about the need to buy the first reception desk.

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -483,9 +483,15 @@ end
 
 --! Called at the end of each day.
 function PlayerHospital:onEndDay()
-  -- Advise the player.
-  if self:hasStaffedDesk() then
+  if self:canAcceptPatients() then
+    -- Are we providing advice today?
     self:dailyAdviceChecks()
+
+    -- If we haven't spawned our first patient yet for the player make it happen so
+    -- they don't wait too long
+    if self.num_visitors == 0 then
+      self.world:spawnPatient(self)
+    end
   end
 
   -- check if we still have to announce VIP visit


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

This aims to partially address the issue of #649 by forcing a patient to be given on open https://github.com/CorsixTH/CorsixTH/issues/649#issuecomment-1279949701 . It doesn't address the difference in wait of that issue but should at least make the first patient a little more consistent.

**Describe what the proposed change does**
- Moves hospital modification out of `UIWatch`
- Spawns a patient on open of hospital (providing you built a reception desk, of course!)
- Gives the `AIHospital` a function path to open for future use.

RFC needed because one oversight here is that some players will open their hospital as soon as they start, evading this change. Should another consideration be made for this instance (e.g. if open without desk, spawn patient once a desk gets made the first time).
