### PR TITLE
Fix some problems with mouse panning

### DIFF
--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -557,8 +557,8 @@ function GameUI:onMouseMove(x, y, dx, dy)
     self.current_momentum.x = self.current_momentum.x - dx/zoom
     self.current_momentum.y = self.current_momentum.y - dy/zoom
 
-    local momentum_x_int = math.floor(self.current_momentum.x + 0.5)
-    local momentum_y_int = math.floor(self.current_momentum.y + 0.5)
+    local momentum_x_int = math.round(self.current_momentum.x)
+    local momentum_y_int = math.round(self.current_momentum.y)
 
     -- Stop zooming when the middle mouse button is pressed
     self.current_momentum.z = 0

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -554,11 +554,19 @@ function GameUI:onMouseMove(x, y, dx, dy)
 
   if self:_isMouseScrollButtonDown() then
     local zoom = self.zoom_factor
-    self.current_momentum.x = -dx/zoom
-    self.current_momentum.y = -dy/zoom
+    self.current_momentum.x = self.current_momentum.x - dx/zoom
+    self.current_momentum.y = self.current_momentum.y - dy/zoom
+
+    local momentum_x_int = math.floor(self.current_momentum.x + 0.5)
+    local momentum_y_int = math.floor(self.current_momentum.y + 0.5)
+
     -- Stop zooming when the middle mouse button is pressed
     self.current_momentum.z = 0
-    self:scrollMap(self.current_momentum.x, self.current_momentum.y)
+    self:scrollMap(momentum_x_int, momentum_y_int)
+
+    self.current_momentum.x = self.current_momentum.x - momentum_x_int
+    self.current_momentum.y = self.current_momentum.y - momentum_y_int
+
     repaint = true
   end
 


### PR DESCRIPTION
This fixes [bug #2498](https://github.com/CorsixTH/CorsixTH/issues/2498)

The problems shown in [bug #2498](https://github.com/CorsixTH/CorsixTH/issues/2498) of are due to these codes:

* In `GameUI:onMouseMove` the following code is run when panning with the mouse:
https://github.com/CorsixTH/CorsixTH/blob/3899df33db2917ad6b336c0027d111ff76b183fe/CorsixTH/Lua/game_ui.lua#L555-L563

* The previous code calls the function `GameUI:scrollMap`:
https://github.com/CorsixTH/CorsixTH/blob/3899df33db2917ad6b336c0027d111ff76b183fe/CorsixTH/Lua/game_ui.lua#L934-L943

The problems are caused by the floor operation in `GameUI:scrollMap`:
```lua
self.screen_offset_x = floor(dx + 0.5) 
self.screen_offset_y = floor(dy + 0.5)
```

Since it seens that `screen_offset_x` and `screen_offset_y` have to be integers, to solve this problem the decimal part of `self.current_momentum.x`  and `self.current_momentum.y` discarded by the floor operation should be somehow preserved for later. This pull request changes `GameUI:scrollMap` to do that.

With this change the resulting behaviour can be seen in the following example:

https://github.com/CorsixTH/CorsixTH/assets/86369321/f4f8dd51-f7d0-4eb8-9b0e-dade57beda45

Now, the panning follows exactly the cursor and is responsive even with a very high zoom.
