### PR TITLE
Linux dev preset for cmake

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,6 +2,16 @@
   "version": 3,
   "configurePresets": [
     {
+      "name": "linux-dev",
+      "binaryDir": "${sourceDir}/build/dev",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "USE_SOURCE_DATADIRS": "ON",
+        "ENABLE_UNIT_TESTS": "ON",
+        "BUILD_ANIMVIEW": "ON"
+      }
+    },
+    {
       "name": "win-dev",
       "binaryDir": "${sourceDir}/build/dev",
       "generator": "Visual Studio 17 2022",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,7 +8,8 @@
       "cacheVariables": {
         "USE_SOURCE_DATADIRS": "ON",
         "ENABLE_UNIT_TESTS": "ON",
-        "BUILD_ANIMVIEW": "ON"
+        "BUILD_ANIMVIEW": "ON",
+        "BUILD_TOOLS": "ON"
       }
     },
     {
@@ -19,7 +20,8 @@
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "USE_SOURCE_DATADIRS": "ON",
         "ENABLE_UNIT_TESTS": "ON",
-        "BUILD_ANIMVIEW": "ON"
+        "BUILD_ANIMVIEW": "ON",
+        "BUILD_TOOLS": "ON"
       }
     },
     {


### PR DESCRIPTION
An opinionated linux dev preset for CMake

Enables unit tests and all optional components. Uses ninja as the make too.