### PR TITLE
Add debug to linux-dev

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,8 @@
         "USE_SOURCE_DATADIRS": "ON",
         "ENABLE_UNIT_TESTS": "ON",
         "BUILD_ANIMVIEW": "ON",
-        "BUILD_TOOLS": "ON"
+        "BUILD_TOOLS": "ON",
+	"CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {


### PR DESCRIPTION
Debug symbols are important to development

I merged just a moment too early