### PR TITLE
Delay destruction of intermediate textures.

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -30,6 +30,7 @@ SOFTWARE.
 #include <memory>
 #include <stack>
 #include <stdexcept>
+#include <vector>
 
 #include "persist_lua.h"
 #include "th.h"
@@ -374,6 +375,8 @@ class render_target {
 
   double draw_scale() const;
 
+  void destroy_intermediate_textures();
+
   SDL_Window* window;
   SDL_Renderer* renderer;
   scoped_target_texture* current_target = nullptr;
@@ -389,6 +392,10 @@ class render_target {
   int cursor_y;
 
   std::stack<SDL_Rect> clip_rects;  ///< Stack of requested clip rects.
+
+  // Intermediate textures used in the production of the current frame.
+  // These are destroyed after the frame is presented.
+  std::vector<SDL_Texture*> intermediate_textures;
 
   bool scale_bitmaps;  ///< Whether bitmaps should be scaled.
   bool supports_target_textures;


### PR DESCRIPTION
This is a possible fix for #2301. It may be that destroying the intermediate texture as soon as we issue a draw call for it is unsafe. This delays the destruction of the texture until the next frame is started.

*Maybe fixes #2301*

**Describe what the proposed change does**
- Collects textures that we are finished with on the render target into a vector.
- Destroys those textures when we begin the next frame, i.e. they should be done with at this point.