### PR TITLE
Dynamically Pair Swing Doors

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 183 -- Adjust game speeds
+local SAVEGAME_VERSION = 184 -- Dynamically pair swing doors
 
 class "App"
 


### PR DESCRIPTION
*Fixes #2476*

**Describe what the proposed change does**
- Re-uses Edvin's entrance door function to pair doors in Swing Door to allow both doors to be built in either order.

~~This removes Toby's assertion from #2436 currently and it needs to be put back in in a good place.~~ now put back