### PR TITLE
Transfer active cheats on refresh

### DIFF
--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -797,6 +797,10 @@ function PlayerHospital:afterLoad(old, new)
     self.adviser_data.reception_advice = self.adviser_data.reception_advice or self.receptionist_msg
   end
 
+  -- Refresh the cheat system every load
+  local old_active_cheats = self.hosp_cheats.active_cheats
   self.hosp_cheats = Cheats(self)
+  self.hosp_cheats.active_cheats = old_active_cheats
+
   Hospital.afterLoad(self, old, new)
 end


### PR DESCRIPTION
**Describe what the proposed change does**
- Prevents refresh of the cheats system from wiping out active toggle cheats.