### PR TITLE
Encourage level restarts on very_old_saves

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1755,9 +1755,7 @@ function App:getReleaseString(savegame_version)
   local release = self:getReleaseData(savegame_version)
   local release_string = "v" .. release.major .. "." .. release.minor .. "." ..
       release.revision
-  if string.len(release.patch) > 0 then
-    release_string = release_string .. release.patch
-  end
+  release_string = release_string .. release.patch
   return release_string
 end
 
@@ -1773,9 +1771,10 @@ end
 --!return The step difference between release a and release b for release method
 --- or The raw savegame version difference for version method
 function App:compareVersions(version_a, version_b, method)
-  assert((type(version_a) == "table" or type(version_a) == "number") and
-      (type(version_b) == "table" or type(version_b) == "number"),
-      "Compare requires savegame version or the version table to function")
+  assert(type(version_a) == "table" or type(version_a) == "number",
+      "version_a requires savegame version or an entry from the version table to compare")
+  assert(type(version_b) == "table" or type(version_b) == "number",
+      "version_b requires savegame version or an entry from the version table to compare")
   assert(method == "release" or method == "version",
       "Not using a valid compare method")
 
@@ -1791,8 +1790,9 @@ function App:compareVersions(version_a, version_b, method)
           if step == 0 then step = 1 break end -- working from current development
           break
         end
-        step = (release.revision == 0 and string.len(release.patch) == 0)
-            and step - 1 or step
+        if release.revision == 0 and release.patch == "" then
+          step = step - 1
+        end
       end
       return step
     end

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1821,9 +1821,10 @@ function App:_checkOrFind(test_file, campaign_dir)
 end
 
 --! Restarts the current level (offers confirmation window first)
-function App:restart()
+--!param message (string) Optional message to the player
+function App:restart(message)
   assert(self.map, "Trying to restart while no map is loaded.")
-  self.ui:addWindow(UIConfirmDialog(self.ui, false, _S.confirmation.restart_level,
+  self.ui:addWindow(UIConfirmDialog(self.ui, true, message or _S.confirmation.restart_level,
     --[[persistable:app_confirm_restart]] function()
     self:worldExited()
     local campaign_info = self.world.campaign_info

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1762,17 +1762,11 @@ end
 --- method(version) reports the difference between two savegame versions
 --! if a match is detected as a development version it will target the release it was built upon, except for via version method.
 function App:compareVersions(version_a, version_b, method)
-  assert(type(version_a) ~= "string" and type(version_b) ~= "string",
+  assert((type(version_a) == "table" or type(version_a) == "number") and
+      (type(version_b) == "table" or type(version_b) == "number"),
       "Compare requires savegame version or the version table to function")
   assert(method == "release" or method == "version",
       "Not using a valid compare method")
-
-  if type(version_a) == "number" then
-    version_a = self:getVersion(version_a)
-  end
-  if type(version_b) == "number" then
-    version_b = self:getVersion(version_b)
-  end
 
   if method == "release" then
     local function countBackward(version_to_check)
@@ -1792,13 +1786,19 @@ function App:compareVersions(version_a, version_b, method)
       end
       return step
     end
+
+    if type(version_a) == "number" then version_a = self:getVersion(version_a) end
+    if type(version_b) == "number" then version_b = self:getVersion(version_b) end
     return countBackward(version_a.version) - countBackward(version_b.version)
   end
 
   if method == "version" then
-    return version_a.version - version_b.version
+    local a = version_a.version or version_a
+    local b = version_b.version or version_b
+    return a - b
   end
 end
+
 
 function App:save(filename)
   return SaveGameFile(filename)

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1695,26 +1695,26 @@ end
 --]]
 local version_table = {
   -- Format: major, minor, revision, patch (string), release date {YYYY, MM, DD}, savegame_version
-  {major = 0, minor = 0, revision = 8, patch = "", date = {2012, 01, 01}, version = 0}, -- Beta 8 or below
-  {major = 0, minor = 1, revision = 0, patch = "", date = {2012, 03, 24}, version = 51},
-  {major = 0, minor = 10, revision = 0, patch = "", date = {2012, 09, 24}, version = 53},
-  {major = 0, minor = 11, revision = 0, patch = "", date = {2012, 11, 17}, version = 54},
-  {major = 0, minor = 20, revision = 0, patch = "", date = {2013, 03, 24}, version = 66},
-  {major = 0, minor = 21, revision = 0, patch = "", date = {2013, 05, 24}, version = 72},
-  {major = 0, minor = 30, revision = 0, patch = "", date = {2013, 12, 24}, version = 78},
-  {major = 0, minor = 40, revision = 0, patch = "", date = {2014, 12, 22}, version = 91},
-  {major = 0, minor = 50, revision = 0, patch = "", date = {2015, 08, 31}, version = 105},
-  {major = 0, minor = 60, revision = 0, patch = "", date = {2016, 05, 30}, version = 111},
-  {major = 0, minor = 61, revision = 0, patch = "", date = {2017, 12, 21}, version = 122},
-  {major = 0, minor = 62, revision = 0, patch = "", date = {2018, 07, 21}, version = 127},
-  {major = 0, minor = 63, revision = 0, patch = "", date = {2019, 05, 24}, version = 134},
-  {major = 0, minor = 64, revision = 0, patch = "", date = {2020, 06, 16}, version = 138},
-  {major = 0, minor = 65, revision = 0, patch = "", date = {2021, 06, 19}, version = 156},
+  {major = 0, minor = 0, revision = 8, patch = "", version = 0}, -- Beta 8 or below
+  {major = 0, minor = 1, revision = 0, patch = "", version = 51},
+  {major = 0, minor = 10, revision = 0, patch = "", version = 53},
+  {major = 0, minor = 11, revision = 0, patch = "", version = 54},
+  {major = 0, minor = 20, revision = 0, patch = "", version = 66},
+  {major = 0, minor = 21, revision = 0, patch = "", version = 72},
+  {major = 0, minor = 30, revision = 0, patch = "", version = 78},
+  {major = 0, minor = 40, revision = 0, patch = "", version = 91},
+  {major = 0, minor = 50, revision = 0, patch = "", version = 105},
+  {major = 0, minor = 60, revision = 0, patch = "", version = 111},
+  {major = 0, minor = 61, revision = 0, patch = "", version = 122},
+  {major = 0, minor = 62, revision = 0, patch = "", version = 127},
+  {major = 0, minor = 63, revision = 0, patch = "", version = 134},
+  {major = 0, minor = 64, revision = 0, patch = "", version = 138},
+  {major = 0, minor = 65, revision = 0, patch = "", version = 156},
   -- There was also 0.65.1, not differentiated by version number
-  {major = 0, minor = 66, revision = 0, patch = "", date = {2022, 06, 26}, version = 170},
-  {major = 0, minor = 67, revision = 0, patch = "", date = {2023, 08, 12}, version = 180},
-  {major = 0, minor = 68, revision = 0, patch = "", date = {2024, 10, 13}, version = 194},
-  {major = 0, minor = 69, revision = 0, patch = "-beta-1", date = {2025, 06, 07}, version = 216}
+  {major = 0, minor = 66, revision = 0, patch = "", version = 170},
+  {major = 0, minor = 67, revision = 0, patch = "", version = 180},
+  {major = 0, minor = 68, revision = 0, patch = "", version = 194},
+  {major = 0, minor = 69, revision = 0, patch = "-beta-1", version = 216}
 }
 
 function App:getCurrentVersion()
@@ -1760,12 +1760,11 @@ end
 --!param method (string) What method to compare by
 --- method(release) reports the difference between the matching releases in steps, revisions are not counted.
 --- method(version) reports the difference between two savegame versions
---- method(age) reports the difference in days between the matching release dates
 --! if a match is detected as a development version it will target the release it was built upon, except for via version method.
 function App:compareVersions(version_a, version_b, method)
   assert(type(version_a) ~= "string" and type(version_b) ~= "string",
       "Compare requires savegame version or the version table to function")
-  assert(method == "age" or method == "release" or method == "version",
+  assert(method == "release" or method == "version",
       "Not using a valid compare method")
 
   if type(version_a) == "number" then
@@ -1798,13 +1797,6 @@ function App:compareVersions(version_a, version_b, method)
 
   if method == "version" then
     return version_a.version - version_b.version
-  end
-
-  if method == "age" then
-    local date_a, date_b = version_a.date, version_b.date
-    local unix_time_a = os.time({year=date_a[1], month=date_a[2], day=date_a[3]})
-    local unix_time_b = os.time({year=date_b[1], month=date_b[2], day=date_b[3]})
-    return math.floor(os.difftime(unix_time_a, unix_time_b) / (60 * 60 * 24))
   end
 end
 

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1694,7 +1694,7 @@ end
   Each patch note must begin with a '-'
 --]]
 local version_table = {
-  -- Format: major, minor, revision, patch (string), release date {YYYY, MM, DD}, savegame_version
+  -- Format: major, minor, revision, patch (string), savegame_version
   {major = 0, minor = 0, revision = 8, patch = "", version = 0}, -- Beta 8 or below
   {major = 0, minor = 1, revision = 0, patch = "", version = 51},
   {major = 0, minor = 10, revision = 0, patch = "", version = 53},
@@ -1717,6 +1717,7 @@ local version_table = {
   {major = 0, minor = 69, revision = 0, patch = "-beta-1", version = 216}
 }
 
+--! Retrieve the current savegame version as defined in the application.
 function App:getCurrentVersion()
   return self.savegame_version
 end
@@ -1730,7 +1731,7 @@ end
 function App:getVersion(savegame_version, concatenate)
   savegame_version = savegame_version or self:getCurrentVersion()
   local result
-  for i=#version_table, 1, -1 do
+  for i = #version_table, 1, -1 do
     local version = version_table[i]
     if version.version == savegame_version then
       result = version
@@ -1771,7 +1772,7 @@ function App:compareVersions(version_a, version_b, method)
   if method == "release" then
     local function countBackward(version_to_check)
       local step = 0
-      for i=#version_table, 1, -1 do
+      for i = #version_table, 1, -1 do
         local version = version_table[i]
         if version.version == version_to_check then
           break

--- a/CorsixTH/Lua/dialogs/resizables/main_menu.lua
+++ b/CorsixTH/Lua/dialogs/resizables/main_menu.lua
@@ -68,7 +68,8 @@ function UIMainMenu:UIMainMenu(ui)
   -- Work out the menu's height, giving extra space for the version information
   local line_height = 15
   local top_padding = 20
-  local num_lines = computeSize({TheApp:isUpdateCheckDisabledByConfig(), TheApp.config.debug, TheApp:getVersion()}) -- see UIMainMenu:draw for how these are used
+  local version = TheApp:getVersion(nil, true)
+  local num_lines = computeSize({TheApp:isUpdateCheckDisabledByConfig(), TheApp.config.debug, version}) -- see UIMainMenu:draw for how these are used
   local bottom_text_height = (line_height * num_lines)
   self.height = top_padding + ((menu_item_height + 10) * #menu_items) + bottom_text_height
 
@@ -81,7 +82,7 @@ function UIMainMenu:UIMainMenu(ui)
 
   -- The main menu also shows the version number of the player's copy of the game.
   self.label_font = TheApp.gfx:loadFontAndSpriteTable("QData", "Font01V", nil, nil, 0, 0, label_ttf_col)
-  self.version_number = TheApp:getVersion()
+  self.version_number = version
 
   -- individual buttons
   self.default_button_sound = "selectx.wav"

--- a/CorsixTH/Lua/dialogs/resizables/main_menu.lua
+++ b/CorsixTH/Lua/dialogs/resizables/main_menu.lua
@@ -68,8 +68,8 @@ function UIMainMenu:UIMainMenu(ui)
   -- Work out the menu's height, giving extra space for the version information
   local line_height = 15
   local top_padding = 20
-  local version = TheApp:getVersion(nil, true)
-  local num_lines = computeSize({TheApp:isUpdateCheckDisabledByConfig(), TheApp.config.debug, version}) -- see UIMainMenu:draw for how these are used
+  local release_string = TheApp:getReleaseString()
+  local num_lines = computeSize({TheApp:isUpdateCheckDisabledByConfig(), TheApp.config.debug, release_string}) -- see UIMainMenu:draw for how these are used
   local bottom_text_height = (line_height * num_lines)
   self.height = top_padding + ((menu_item_height + 10) * #menu_items) + bottom_text_height
 
@@ -82,7 +82,7 @@ function UIMainMenu:UIMainMenu(ui)
 
   -- The main menu also shows the version number of the player's copy of the game.
   self.label_font = TheApp.gfx:loadFontAndSpriteTable("QData", "Font01V", nil, nil, 0, 0, label_ttf_col)
-  self.version_number = version
+  self.release_string = release_string
 
   -- individual buttons
   self.default_button_sound = "selectx.wav"
@@ -127,7 +127,7 @@ function UIMainMenu:draw(canvas, x, y)
     self.label_font:draw(canvas, _S.main_menu.savegame_version .. TheApp.savegame_version, x + 5, ly, 190, 0, "right")
     ly = ly - 15
   end
-  self.label_font:draw(canvas, _S.main_menu.version .. self.version_number, x + 5, ly, 190, 0, "right")
+  self.label_font:draw(canvas, _S.main_menu.version .. self.release_string, x + 5, ly, 190, 0, "right")
 end
 
 function UIMainMenu:onTick()

--- a/CorsixTH/Lua/languages/czech.lua
+++ b/CorsixTH/Lua/languages/czech.lua
@@ -303,6 +303,8 @@ confirmation = {
   return_to_blueprint = "Jste si jisti, že se chcete vrátit do režimu Návrhu?",
   maximum_screen_size = "Velikost obrazovky, kterou jste zadali, je vyšší než 3000 x 2000. Na tato rozlišení lze přejít za předpokladu, že máte hardware schopný tuto hru udržet v hratelné rychlosti. Opravdu chcete pokračovat?",
   remove_destroyed_room = "Opravdu chcete odebrat místnost? Bude to stát $%d.",
+  very_old_save = "Od doby, kdy jste začali s touto hrou, jsme již mnohokrát program aktualizovali. Chcete teď restartovat úroveň, pro jistotu, že vše správně funguje?//" ..
+  "Vaše uložené rozehrané hry nebudou smazány, dokud je sami nepřepíšete novým uložením.",
 }
 adviser = {
   goals = {

--- a/CorsixTH/Lua/languages/dutch.lua
+++ b/CorsixTH/Lua/languages/dutch.lua
@@ -2582,6 +2582,7 @@ confirmation = {  --spaces on the end make the text fit properly in text windows
   maximum_screen_size = "De resolutie die je hebt ingevoerd is groter dan 3000x2000. Een hoge resolutie is mogelijk, mits je hardware goed genoeg is om een speelbare framerate te behalen. Weet je zeker dat je wilt doorgaan?",
   replace_machine_extra_info = "De nieuwe machine zal %d vermogen hebben (momenteel %d)",
   remove_destroyed_room = "Wil je de kamer voor $%d verwijderen?",
+  very_old_save = "Er zijn veel updates geweest sinds je met dit level bent begonnen. Om zeker te zijn dat alles werkt zoals het hoort, zou je nu opnieuw willen beginnen dit level?//Je opgeslagen spel blijft beschikbaar tenzij je het overschrijft.",
 }
 menu_display = {
   mcga_lo_res = "  LAGE RES  ",

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -799,13 +799,14 @@ confirmation = {
   replace_machine_extra_info = "The new machine will have %d strength (currently %d).",
   restart_mapeditor = "Are you sure you want to restart the map editor?",
   quit_mapeditor = "Are you sure you want to quit the map editor?",
+  very_old_save = "There have been a lot of updates to the game since you started. To be sure that all features work as intended would you like to restart this level now?//" ..
+  "Your old save won't be deleted unless you overwrite it.",
 }
 
 information = {
   custom_game = "Welcome to CorsixTH. Have fun with this custom map!",
   no_custom_game_in_demo = "Sorry, but in the demo version you can't play any custom maps.",
   cannot_restart = "Unfortunately this custom game was saved before the restart feature was implemented.",
-  very_old_save = "There have been a lot of updates to the game since you started this level. To be sure that all features work as intended please consider restarting it.",
   level_lost = {
     "Bummer! You failed the level. Better luck next time!",
     "The reason you lost:",
@@ -1039,6 +1040,7 @@ tooltip.status = {
 
 options_window.change_resolution = "Change resolution"
 tooltip.options_window.change_resolution = "Change the window resolution to the dimensions entered on the left"
+information.very_old_save = "There have been a lot of updates to the game since you started this level. To be sure that all features work as intended please consider restarting it."
 
 cheats_window.cheats = {
  toggle_infected = show_infected,

--- a/CorsixTH/Lua/languages/french.lua
+++ b/CorsixTH/Lua/languages/french.lua
@@ -1046,7 +1046,9 @@ confirmation = {
   abort_edit_room = "Vous êtes actuellement en train de construire ou d'éditer une pièce. Si tous les objets requis sont placés, elle sera validée, mais sinon elle sera détruite. Continuer ?",
   maximum_screen_size = "La taille de l'écran que vous avez entrée est supérieure à 3000 x 2000. Des plus hautes résolutions sont possibles, mais il faudra un meilleur matériel afin de maintenir un taux de trame jouable. Êtes-vous sûr de vouloir continuer?",
   remove_destroyed_room = "Souhaitez-vous supprimer la salle pour %d $ ?",
-  replace_machine_extra_info = "La nouvelle machine aura une puissance de %d (actuellement %d)."
+  replace_machine_extra_info = "La nouvelle machine aura une puissance de %d (actuellement %d).",
+  very_old_save = "Il y a eu de nombreuses mises à jour du jeu depuis que vous avez commencé. Pour être sûr que toutes les fonctionnalités fonctionnent comme prévu, voudriez-vous recommencer ce niveau maintenant ?//"..
+  "Votre ancienne sauvegarde ne sera pas supprimée à moins que vous ne l'écrasiez."
 }
 
 -- Information dialog

--- a/CorsixTH/Lua/languages/spanish.lua
+++ b/CorsixTH/Lua/languages/spanish.lua
@@ -1212,6 +1212,8 @@ confirmation = {
   music_warning = "Nota: Necesitas el archivo smpeg.dll o el equivalente para tu sistema operativo, de lo contrario no tendrás música en el juego. ¿Quieres continuar?",
   remove_destroyed_room = "¿Te gustaría eliminar la habitación por $%d?",
   replace_machine_extra_info = "La nueva máquina tendrá una resistencia de %d (actualmente es de %d).",
+  very_old_save = "Ha habido muchas actualizaciones en el juego desde que comenzaste. Para asegurarte de que todas las características funcionen como se espera, ¿te gustaría reiniciar este nivel ahora?//" ..
+  "Tu archivo de guardado anterior no se eliminará a menos que lo sobrescribas."
 }
 
 information = {

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -90,7 +90,7 @@ function World:World(app, free_build_mode)
   self.floating_dollars = {}
   self.game_log = {} -- saves list of useful debugging information
   self.savegame_version = app.savegame_version -- Savegame version number
-  self.release_version = app:getVersion(self.savegame_version) -- Savegame release version (e.g. 0.60), or Trunk
+  self.release_version = app:getVersion(self.savegame_version, true) -- Savegame release version (e.g. 0.60), or Trunk
   -- Also preserve this throughout future updates.
   self.original_savegame_version = app.savegame_version
 
@@ -2568,7 +2568,7 @@ function World:afterLoad(old, new)
   end
   -- If the original save game version is considerably lower than the current, ask
   -- the player if they want to restart the level.
-  if new - 20 > self.original_savegame_version then
+  if TheApp:compareVersions(new, old, "release") > 2 then
     TheApp:restart(_S.confirmation.very_old_save)
   end
   self.savegame_version = new

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -90,7 +90,7 @@ function World:World(app, free_build_mode)
   self.floating_dollars = {}
   self.game_log = {} -- saves list of useful debugging information
   self.savegame_version = app.savegame_version -- Savegame version number
-  self.release_version = app:getVersion(self.savegame_version, true) -- Savegame release version (e.g. 0.60), or Trunk
+  self.release_version = app:getReleaseString() -- Savegame release version (e.g. 0.60), or Trunk
   -- Also preserve this throughout future updates.
   self.original_savegame_version = app.savegame_version
 
@@ -2572,7 +2572,7 @@ function World:afterLoad(old, new)
     TheApp:restart(_S.confirmation.very_old_save)
   end
   self.savegame_version = new
-  self.release_version = TheApp:getVersion(new)
+  self.release_version = TheApp:getReleaseString(new)
   self:setSystemPause(false) -- Reset flag on load
 end
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2175,16 +2175,6 @@ end
 --!param old (integer) The old version of the save game.
 --!param new (integer) The current version of the save game format.
 function World:afterLoad(old, new)
-
-  if not self.original_savegame_version then
-    self.original_savegame_version = old
-  end
-  -- If the original save game version is considerably lower than the current, warn the player.
-  -- For 2024 release, bump cutoff from 20 to 25 pending new methods in PR2518
-  if new - 25 > self.original_savegame_version then
-    self.ui:addWindow(UIInformation(self.ui, {_S.information.very_old_save}))
-  end
-
   self:setUI(self.ui)
 
   -- insert global compatibility code here
@@ -2571,9 +2561,19 @@ function World:afterLoad(old, new)
   self:previousSpeed()
 
   self.earthquake:afterLoad(old, new)
+
+  -- Savegame version housekeeping
+  if not self.original_savegame_version then
+    self.original_savegame_version = old
+  end
+  -- If the original save game version is considerably lower than the current, ask
+  -- the player if they want to restart the level.
+  if new - 20 > self.original_savegame_version then
+    TheApp:restart(_S.confirmation.very_old_save)
+  end
   self.savegame_version = new
   self.release_version = TheApp:getVersion(new)
-  self.system_pause = false -- Reset flag on load
+  self:setSystemPause(false) -- Reset flag on load
 end
 
 function World:playLoadedEntitySounds()


### PR DESCRIPTION
Proposal to give the option to the user to restart their level for very old saves compared to just information.
This method might be too assertive on the player so it can be dropped if it's going to be too far.

**Describe what the proposed change does**
- Changes this UIInformation to a UIConfirmDIalog for old saves.
- Adapts `App:restart()` to take an optional message for the box

![image](https://github.com/CorsixTH/CorsixTH/assets/20030128/613cb662-91db-41ed-bdec-f2b6c0e17361)
