### PR TITLE
Draw the hospital balance one number at a time

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -174,8 +174,19 @@ end
 function UIBottomPanel:draw(canvas, x, y)
   Window.draw(self, canvas, x, y)
 
+  -- Draw balance with temporary offset in unicode languages
   x, y = x + self.x, y + self.y
-  self.money_font:draw(canvas, ("%7i"):format(self.ui.hospital.balance), x + 44, y + 9)
+  local offset_x, offset_y = 0, 0
+  if self.ui.app.gfx.language_font then
+    offset_x = 4
+    offset_y = 2
+  end
+  local balance = math.floor(self.ui.hospital.balance)
+  local i = 7 - tostring(balance):len() -- Indent balances under 100k
+  for digit in ("%7i"):format(balance):gmatch("[-0-9]") do
+    self.money_font:draw(canvas, digit, x + offset_x + 44 + i * 13, y + offset_y + 9)
+    i = i + 1
+  end
   local game_date = self.world:date()
   local month, day = game_date:monthOfYear(), game_date:dayOfMonth()
   self.date_font:draw(canvas, _S.date_format.daymonth:format(day, month), x + 140, y + 20, 60, 0)

--- a/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
@@ -191,8 +191,18 @@ function UITownMap:draw(canvas, x, y)
   local heating_costs = math.floor(((hospital.heating.radiator_heat *10)* radiators)* 7.5)
   self.info_font:draw(canvas, ("%8i"):format(heating_costs),  x + 100, y + 355)
 
-  -- draw money balance
-  self.money_font:draw(canvas, ("%7i"):format(hospital.balance), x + 49, y + 431)
+  -- Draw balance with temporary offset in unicode languages
+  local offset_x, offset_y = 0, 0
+  if self.ui.app.gfx.language_font then
+    offset_x = 4
+    offset_y = 2
+  end
+  local balance = math.floor(hospital.balance)
+  local i = 7 - tostring(balance):len() -- Indent balances under 100k
+  for digit in ("%7i"):format(balance):gmatch("[-0-9]") do
+    self.money_font:draw(canvas, digit, x + offset_x + 49 + i * 13, y + offset_y + 431)
+    i = i + 1
+  end
 
   -- radiator heat
   local rad_max_width = 60 -- Radiator indicator width

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -427,8 +427,6 @@ end
 function Graphics:loadFont(sprite_table, x_sep, y_sep, ...)
   -- Allow (multiple) arguments for loading a sprite table in place of the
   -- sprite_table argument.
-  -- TODO: Native number support for e.g. Korean languages. Current use of load_font is a stopgap solution for #1193 and should be eventually removed
-  local load_font = x_sep
   if type(sprite_table) == "string" then
     local arg = {sprite_table, x_sep, y_sep, ...}
     local n_pass_on_args = #arg
@@ -447,8 +445,7 @@ function Graphics:loadFont(sprite_table, x_sep, y_sep, ...)
   end
 
   local use_bitmap_font = true
-  -- Force bitmap font for the moneybar (Font05V)
-  if not sprite_table:isVisible(46) or load_font == "Font05V" then -- luacheck: ignore 542
+  if not sprite_table:isVisible(46) then -- luacheck: ignore 542
     -- The font doesn't contain an uppercase M, so (in all likelihood) is used
     -- for drawing special symbols rather than text, so the original bitmap
     -- font should be used.


### PR DESCRIPTION
*Fixes #1193*

**Describe what the proposed change does**
- Draw each digit of the balance in the boxes in the bottom panel and town map. Add a temporary offset for unicode languages for #2459 
<img width="216" alt="Screenshot 2024-03-15 at 16 59 42" src="https://github.com/CorsixTH/CorsixTH/assets/552285/b2496979-39b3-4526-83b3-e7758b8a4c9f">

The text is very faint, and I prefer the existing solution of using the builtin font in all languages, but this change is consistent with the rest of the UI.