### PR TITLE
Don't clear patient_wait mood on seek_room interrupt

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -170,7 +170,6 @@ local function action_seek_room_no_diagnosis_room_found(action, humanoid)
 end
 
 local action_seek_room_interrupt = permanent"action_seek_room_interrupt"( function(action, humanoid)
-  humanoid:setMood("patient_wait", "deactivate")
   -- Just in case we are somehow started again:
   -- FIXME: This seems to be used for intermediate actions like peeing while the patient is waiting
   --        Unfortunately this means that if you finish the required room while the patient is peeing


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2496*

**Describe what the proposed change does**
- Removes the mood deactivate on interrupt of seek_room. The wait now clears once the seek_room wait is properly resolved or by acting on the fax. This line up with the mood's behaviour in TH.
