### PR TITLE
Add localised text to level and campaign descriptions and winning text

### DIFF
--- a/CorsixTH/Campaigns/example.campaign
+++ b/CorsixTH/Campaigns/example.campaign
@@ -3,6 +3,13 @@ name = "Example campaign"
 description = "This is an example campaign where you get the chance to play " ..
   "through some of the levels shipped with CorsixTH. Happy gaming!"
 
+description_table = {
+  en = "This is an example campaign where you get the chance to play " ..
+    "through some of the levels shipped with CorsixTH. Happy gaming!",
+  fr = "Ceci est un exemple de campagne où vous avez la chance de jouer " ..
+    "à certains des niveaux fournis avec CorsixTH. Bon jeu !",
+}
+
 levels = {
   "finisham.level",
   "avatar.level",
@@ -10,4 +17,6 @@ levels = {
   "st.peter's.level",
 }
 
-winning_text = "Congratulations! You have successfully completed all the levels."
+winning_text_table = {}
+winning_text_table.en = "Congratulations! You have successfully completed all the levels."
+winning_text_table.fr = "Toutes nos félicitations! Vous avez terminé avec succès tous les niveaux."

--- a/CorsixTH/Levels/example.level
+++ b/CorsixTH/Levels/example.level
@@ -27,10 +27,14 @@ By default there are no diseases and only some basic rooms are available.
 
 Everything within citation marks will be the briefing/debriefing.
 Two new lines creates a new paragraph, but additional new lines in a row are discarded.
-%LevelBriefing = "This is an example map that shows aspiring map makers
+%LevelBriefingTable.en = "This is an example map that shows aspiring map makers
  what can be done when making new fantastic creations!"
+%LevelBriefingTable.fr = "Ceci est un exemple de carte qui montre les futurs créateurs de cartes
+  que peut-on faire en réalisant de nouvelles créations fantastiques !"
 
-%LevelDebriefing = "Congratulations! You played through the example map. Time to do your own?"
+%LevelDebriefingTable.en = "Congratulations! You played through the example map. Time to do your own?"
+%LevelDebriefingTable.fr = "Toutes nos félicitations! Vous avez joué à travers l'exemple de carte.
+  Il est temps de faire le vôtre ?"
 
 Town properties
 InterestRate is defined as centiprocent to allow for two decimals precision, i.e.

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -594,6 +594,12 @@ function App:loadCampaign(campaign_file)
     return
   end
 
+  -- Use localised description and winning text, if available
+  campaign_info.description = self.strings:getLocalisedText(campaign_info.description,
+      campaign_info.description_table)
+  campaign_info.winning_text = self.strings:getLocalisedText(campaign_info.winning_text,
+      campaign_info.winning_text_table)
+
   if self:loadLevel(campaign_info.levels[1], nil, level_info.name,
       level_info.map_file, level_info.briefing, nil, _S.errors.load_level_prefix) then
     -- The new world needs to know which campaign to continue on.

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -644,8 +644,18 @@ function App:readLevelFile(level)
     end
     level_info.deprecated_variable_used = true
   end
-  level_info.briefing = contents:match("%LevelBriefing ?= ?\"(.-)\"")
-  level_info.end_praise = contents:match("%LevelDebriefing ?= ?\"(.-)\"")
+
+  -- Pick a localised set of briefings, if available
+  local lang_code = self.strings:getLangCode()
+  local local_briefing = contents:match("%LevelBriefingTable%." .. lang_code .. " ?= ?\"(.-)\"")
+  local en_briefing = contents:match("%LevelBriefingTable%.en ?= ?\"(.-)\"")
+  local standard_briefing = contents:match("%LevelBriefing ?= ?\"(.-)\"")
+  level_info.briefing = local_briefing or en_briefing or standard_briefing
+
+  local local_end_praise = contents:match("%LevelDebriefingTable%." .. lang_code .. " ?= ?\"(.-)\"")
+  local en_end_praise = contents:match("%LevelDebriefingTable%.en ?= ?\"(.-)\"")
+  local standard_end_praise = contents:match("%LevelDebriefing ?= ?\"(.-)\"")
+  level_info.end_praise = local_end_praise or en_end_praise or standard_end_praise
   return level_info
 end
 

--- a/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_campaign.lua
+++ b/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_campaign.lua
@@ -50,7 +50,8 @@ local function createCampaignList(path)
             tooltip = _S.tooltip.custom_campaign_window.choose_campaign,
             no_levels = #campaign_info.levels,
             path = file,
-            description = campaign_info.description,
+            description = TheApp.strings:getLocalisedText(campaign_info.description,
+               campaign_info.description_table)
           }
         else
           print("Warning: Loaded campaign that had no levels specified")

--- a/CorsixTH/Lua/languages/korean.lua
+++ b/CorsixTH/Lua/languages/korean.lua
@@ -19,7 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
-Language("한국어", "Korean", "kor", "ko")
+Language("한국어", "Korean", "ko", "kor")
 Inherit("English")
 Encoding(utf8)
 

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -293,9 +293,21 @@ function Strings:getLanguageNames(language)
   return chunk and self.chunk_to_names[chunk]
 end
 
-function Strings:getLangCode(langage)
+function Strings:getLangCode(language)
   local lang = language or self.app.config.language
   return self.language_to_lang_code[lang:lower()]
+end
+
+--! Use local language text where possible.
+--!param string (string) The default, likely English, text
+--!param table (table) A table of translated text in language code fields
+--!return (string) The text in the current language if available, or in English, or the default string.
+function Strings:getLocalisedText(string, table)
+  if string and not table then return string
+  elseif table[self:getLangCode()] then return table[self:getLangCode()]
+  elseif table.en then return table.en
+  else return string
+  end
 end
 
 function Strings:_loadPrivate(language, env, ...)

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -63,6 +63,7 @@ function Strings:init()
   self.language_to_chunk = {}
   self.chunk_to_font = {}
   self.chunk_to_names = {}
+  self.language_to_lang_code = {}
   for chunk, filename in pairs(self.language_chunks) do
     -- To allow the file to set global variables without causing an error, it
     -- is given an infinite table as an environment. Reading a non-existent
@@ -95,6 +96,7 @@ function Strings:init()
         -- Associate every passed name with this file, case-independently
         for _, name in pairs(names) do
           self.language_to_chunk[name:lower()] = chunk
+          self.language_to_lang_code[name:lower()] = names[3]
         end
         self.chunk_to_names[chunk] = names
         error(good_error_marker)
@@ -289,6 +291,11 @@ end
 function Strings:getLanguageNames(language)
   local chunk = self.language_to_chunk[language:lower()]
   return chunk and self.chunk_to_names[chunk]
+end
+
+function Strings:getLangCode(langage)
+  local lang = language or self.app.config.language
+  return self.language_to_lang_code[lang:lower()]
 end
 
 function Strings:_loadPrivate(language, env, ...)


### PR DESCRIPTION
**Describe what the proposed change does**
- Collect language codes for languages, two letters long for all but Chinese.
- Use localised strings in the level files for the briefing and debriefing (single scenario description and end of level winning text), and in campaign files for description and winning text.
- Add French translations to the example level and campaign in differing ways.
