### PR TITLE
Add an option to use the advance level movie in custom campaigns

### DIFF
--- a/CorsixTH/Campaigns/example.campaign
+++ b/CorsixTH/Campaigns/example.campaign
@@ -10,6 +10,8 @@ description_table = {
     "à certains des niveaux fournis avec CorsixTH. Bon jeu !",
 }
 
+movie = true
+
 levels = {
   "finisham.level",
   "avatar.level",

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -605,6 +605,12 @@ function App:loadCampaign(campaign_file)
     -- The new world needs to know which campaign to continue on.
     self.world.campaign_info = campaign_info
   end
+
+  -- Play the level advance movie from a position where this campaign will end at 12
+  if campaign_info.movie then
+    local n = math.max(1, 12 - #campaign_info.levels)
+    self.moviePlayer:playAdvanceMovie(n)
+  end
 end
 
 --! Reads the given file name as a Lua chunk from the Campaigns folder in the CorsixTH install directory.

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -212,13 +212,18 @@ function UIFax:choice(choice_number)
         self.ui.app.moviePlayer:playAdvanceMovie(next_level)
       end
     else
-      for i, level in ipairs(self.ui.app.world.campaign_info.levels) do
+      local campaign_info = self.ui.app.world.campaign_info
+      for i, level in ipairs(campaign_info.levels) do
         if self.ui.app.world.map.level_number == level then
-          local next_level = self.ui.app.world.campaign_info.levels[i + 1]
+          local next_level = campaign_info.levels[i + 1]
           local level_info, _ = self.ui.app:readLevelFile(next_level)
           if level_info then
             self.ui.app:loadLevel(next_level, nil, level_info.name,
                 level_info.map_file, level_info.briefing, nil, _S.errors.load_level_prefix)
+            if campaign_info.movie then
+              local n = math.max(1, 12 - #campaign_info.levels + i)
+              self.ui.app.moviePlayer:playAdvanceMovie(n)
+            end
             break
           end
         end


### PR DESCRIPTION
**Describe what the proposed change does**
- Add the option 'movie' to custom campaigns. This plays the board game advance level movie, with the correct level number for that campaign (the movie doesn't play if there are more than 12 levels).
- Add this option to the example campaign.
