### PR TITLE
Add foundation code for using window active status

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -67,6 +67,7 @@ function App:App()
   self.savegame_version = SAVEGAME_VERSION
   self.check_for_updates = true
   self.idle_tick = 0
+  self.window_active_status = false -- whether window is in focus, set after App:init
 end
 
 --! Starts a Lua DBGp client & connects it to a DBGp server.
@@ -1241,8 +1242,8 @@ end
 function App:idle()
   if not self.config.play_demo then return end
   -- Check if we are in a proper 'idle' state and solely on the main menu
-  if not self.ui:getWindow(UIMainMenu) or self.ui:getWindow(UIUpdate)
-      or self.ui:getWindow(UIConfirmDialog) then
+  if not self.ui:getWindowActiveStatus() or not self.ui:getWindow(UIMainMenu) or
+      self.ui:getWindow(UIUpdate) or self.ui:getWindow(UIConfirmDialog) then
     self:resetIdle()
     return
   end

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -528,11 +528,13 @@ local UpdateCursorPosition = TH.cursor.setPosition
 
 local highlight_x, highlight_y
 
---! Called when the mouse enters or leaves the game window.
+--! Called when focus changes on game window.
+--!param gain (number) 1 for in-focus, 0 for out-of-focus
 function GameUI:onWindowActive(gain)
   if gain == 0 then
     self.tick_scroll_amount_mouse = false
   end
+  UI.onWindowActive(self, gain)
 end
 
 -- TODO: try to remove duplication with UI:onMouseMove

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -934,8 +934,22 @@ end
 
 local UpdateCursorPosition = TH.cursor.setPosition
 
---! Called when the mouse enters or leaves the game window.
+--! Called when focus changes on game window.
+--!param gain (number) 1 for in-focus, 0 for out-of-focus
 function UI:onWindowActive(gain)
+  self:setWindowActiveStatus(gain == 1)
+end
+
+--! Stores the game window active status
+--!param state (boolean) true for in-focus, false for out-of-focus
+function UI:setWindowActiveStatus(state)
+  self.app.window_active_status = state
+end
+
+--! Gets the game window active status
+--!return true for in-focus, false for out-of-focus
+function UI:getWindowActiveStatus()
+  return self.app.window_active_status
 end
 
 --! Window has been resized by the user


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**Describe what the proposed change does**
- Adds some groundwork functionality to tackle #2370 
- Being idle on main menu when game window is no longer is in focus will no longer trigger the demo movie
