### PR TITLE
Add more music file extensions

### DIFF
--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -100,8 +100,11 @@ function Audio:init()
     - Uses titles from MIDI.TXT if found, else the filename.
   --]]
   local midi_txt -- File name of midi.txt file, if any.
-  local waveform = { MP3=true, OGG=true, WAV=true, AIFF=true, VOC=true, FLAC=true }
-  local instructional = { MID=true, MOD=true, XM=true, XMI=true }
+  local waveform = list_to_set({"OGG", "OPUS", "FLAC", "WV", "WAV", "WAVE",
+      "MPG", "MPEG", "MP3", "MAD", "AIFF", "AIFC", "AIF"})
+  local instructional = list_to_set({"MID", "MIDI", "KAR", "669", "AMF", "AMS", "DBM",
+      "DSM", "FAR", "GDM", "IT", "MED", "MDL", "MOD", "MOL", "MTM", "NST", "OKT", "PTM",
+      "S3M", "STM", "ULT", "UMX", "WOW", "XM"})
 
   local _f, _s, _v
   if music_dir then


### PR DESCRIPTION
**Describe what the proposed change does**
Expand the list of music file extensions that will be accepted for the jukebox. Sourced from the list https://github.com/libsdl-org/SDL_mixer/blob/release-2.8.x/src/music.c#L680 and https://github.com/libsdl-org/SDL_mixer/blob/release-2.8.x/src/music.c#L561 which ends with the comment that everything else gets given to modplug/xmp. GME is excluded as debian and vcpkg don't include it.
Sample music files
https://getsamplefiles.com/sample-audio-files
https://www.stanislavs.org/OldPages/mody_collection/
https://www.mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/Samples.html only uncompressed

