### PR TITLE
Add confirmation window to map editor restart

### DIFF
--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -677,17 +677,10 @@ function UIMenuBar:makeMapeditorMenu(app)
   local menu = UIMenu()
   local hotkeys = app.hotkeys
 
-  local function mapeditorSave(ui)
-    local message = app.world:validateMap()
-    if message then
-      ui:addWindow(UIInformation(ui, {message}))
-    end
-    ui:addWindow(UISaveMap(ui))
-  end
   menu:appendItem(_S.menu_file.load:format(hotkey_value_label("ingame_loadMenu", hotkeys)), function() self.ui:addWindow(UILoadMap(self.ui, "map")) end)
-    :appendItem(_S.menu_file.save:format(hotkey_value_label("ingame_saveMenu", hotkeys)), function() mapeditorSave(self.ui) end)
-    :appendItem(_S.menu_file.restart:format(hotkey_value_label("ingame_restartLevel", hotkeys)), function() app:mapEdit() end)
-    :appendItem(_S.menu_file.quit:format(hotkey_value_label("ingame_quitLevel", hotkeys)), function() self.ui:quit() end)
+    :appendItem(_S.menu_file.save:format(hotkey_value_label("ingame_saveMenu", hotkeys)), function() self.ui:addWindow(UISaveMap(self.ui)) end)
+    :appendItem(_S.menu_file.restart:format(hotkey_value_label("ingame_restartLevel", hotkeys)), function() self.ui:restartMapEditor() end)
+    :appendItem(_S.menu_file.quit:format(hotkey_value_label("ingame_quitLevel", hotkeys)), function() self.ui:quit(true) end)
   self:addMenu(_S.menu.file, menu)
 
   menu = UIMenu()

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_map.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_map.lua
@@ -55,6 +55,11 @@ function UISaveMap:UISaveMap(ui)
     :setLabel(_S.save_map_window.new_map, nil, "left"):setTooltip(_S.tooltip.save_map_window.new_map)
     :makeTextbox(--[[persistable:save_map_new_map_textbox_confirm_callback]] function() self:confirmName() end,
     --[[persistable:save_map_new_map_textbox_abort_callback]] function() self:abortName() end)
+
+  local message = ui.app.world:validateMap()
+  if message then
+    ui:addWindow(UIInformation(ui, {message}))
+  end
 end
 
 --! Function called when textbox is aborted (e.g. by pressing escape)

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -1298,8 +1298,10 @@ end
 
 --! Offers a confirmation window to quit the game and return to main menu
 -- NB: overrides UI.quit, do NOT call it from here
-function GameUI:quit()
-  self:addWindow(UIConfirmDialog(self, false, _S.confirmation.quit, --[[persistable:gameui_confirm_quit]] function()
+--!param mapeditor (boolean) If the user is quitting the map editor
+function GameUI:quit(mapeditor)
+  local msg = mapeditor and _S.confirmation.quit_mapeditor or _S.confirmation.quit
+  self:addWindow(UIConfirmDialog(self, false, msg, --[[persistable:gameui_confirm_quit]] function()
     self.app:loadMainMenu()
   end))
 end
@@ -1310,4 +1312,9 @@ end
 
 function GameUI:showMenuBar()
   self.menu_bar:appear()
+end
+
+function GameUI:restartMapEditor()
+  self:addWindow(UIConfirmDialog(self, false, _S.confirmation.restart_mapeditor,
+    --[[persistable:app_hotkey_confirm_mapeditor_restart]] function() self.app:mapEdit() end))
 end

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -751,6 +751,8 @@ confirmation = {
   maximum_screen_size = "The screen size you have entered is greater than 3000 x 2000. Larger resolutions are possible but will require better hardware in order to maintain a playable frame rate. Are you sure you want to continue?",
   remove_destroyed_room = "Would you like to remove the room for $%d?",
   replace_machine_extra_info = "The new machine will have %d strength (currently %d).",
+  restart_mapeditor = "Are you sure you want to restart the map editor?",
+  quit_mapeditor = "Are you sure you want to quit the map editor?",
 }
 
 information = {


### PR DESCRIPTION
**Describe what the proposed change does**
- Add confirm window to the restart map editor menu option
- Add mapeditor specific message to quit confirm window
- Move map editor save function to GameUI (used in a future PR).
