### PR TITLE
Add descriptive audio error messages

### DIFF
--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -737,6 +737,7 @@ errors = {
     demo_in_full = "Sorry, you can't open a demo savegame with the full game files loaded. Please update your TH Data folder setting.",
     full_in_demo = "Sorry, you can't open a full game save with the demo files loaded. Please update your TH Data folder setting.",
   },
+  music = "There are playback issues with one or more files in your music directory. Problematic files will be disabled in the jukebox. See the console window for more information.",
 }
 
 warnings = {


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2520*

**Describe what the proposed change does**
- Change some SDL Mixer error messages to more helpful text, "Required soundfont is not found, please download one. A suitable soundfont is linked from the CorsixTH wiki." and the below message for known errors, and a catch all for anything else.
- Skip the playlist item and uncheck its box.

<img width="383" alt="Screenshot 2024-04-12 at 17 26 26" src="https://github.com/CorsixTH/CorsixTH/assets/552285/430f1147-302c-4cab-b864-fa4ac26cebaa">
