### PR TITLE
Fix missing initial in staff names

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 184 -- Dynamically pair swing doors
+local SAVEGAME_VERSION = 185 -- Fix missing staff initial
 
 class "App"
 

--- a/CorsixTH/Lua/staff_profile.lua
+++ b/CorsixTH/Lua/staff_profile.lua
@@ -28,8 +28,6 @@ function StaffProfile:StaffProfile(world, humanoid_class, local_string)
   self.humanoid_class = humanoid_class
   self.name = "Initialised"
   self.initial = "UN"
-  -- 1009 is a prime number which avoids a modulo of 0 when we need
-  -- a positive number to randomly pick the initial letter
   self.name_seed = math.random(1, 1009)
   self.name_lang = self.world.app.config.language
   self.wage = 0


### PR DESCRIPTION
*Fixes #2554*

**Describe what the proposed change does**
- When the number used to pick a staff initial is 0, make it 1. Apply this to existing staff.