### PR TITLE
Fix custom campaign scrollbar

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_campaign.lua
+++ b/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/custom_campaign.lua
@@ -87,6 +87,10 @@ function UICustomCampaign:UICustomCampaign(ui)
     :setTooltip(_S.tooltip.custom_campaign_window.start_selected_campaign)
 end
 
+function UICustomCampaign:updateDescriptionOffset()
+  self.description_offset = self.details_scrollbar.value - 1
+end
+
 -- Overrides the function in the UIMenuList, choosing what should happen when the player
 -- clicks a choice in the list.
 function UICustomCampaign:buttonClicked(num)


### PR DESCRIPTION
**Describe what the proposed change does**
Add support for long custom campaign descriptions, requiring a scrollbar. I think this was intended in the PR that makes the custom campaign dialog, which added this function in the single scenario dialog I copied. https://github.com/CorsixTH/CorsixTH/pull/676/files#diff-7cb59940abdd2a76ef1e4a7ef1a43bed82b0381d550c30229453f02e6230bb04R99
I tested this by repeating a line in the ChrizmanTV campaign description.
