### PR TITLE
Appveyor on previous vs2022

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '{build}'
-image: Visual Studio 2022
+image: Previous Visual Studio 2022
 pull_requests:
   do_not_increment_build_number: true
 environment:


### PR DESCRIPTION
Temporarily roll back build to compensate for broken CMake
**There is no need to merge this (probably)**. I'm just making sure Appveyor is still building OK.