### PR TITLE
Use tired values from level config for staff tiredness

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 186 -- Refactor staff happiness calculation
+local SAVEGAME_VERSION = 187 -- Add tired values to level config
 
 class "App"
 

--- a/CorsixTH/Lua/base_config.lua
+++ b/CorsixTH/Lua/base_config.lua
@@ -139,6 +139,12 @@ local configuration = {
     RschImproveCostPercent = 10,
     -- %-point increase in improve cost per improvement
     RschImproveIncrementPercent = 10,
+    -- Per mille point of attribute fatigue to be just tired (hospital policy "go to staffroom")
+    Tired = 600,
+    -- Per mille point of attribute fatigue to be very tired
+    VeryTired = 700,
+    -- Per mille point of attribute fatigue to be crack up (extremely) tired
+    CrackUpTired = 800,
   },
 
   towns = {

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -52,7 +52,7 @@ function Staff:tickDay()
 
   -- if you overwork your Dr's then there is a chance that they can go crazy
   -- when this happens, find him and get him to rest straight away
-  if self:getAttribute("fatigue") < 0.7 and self:isResting() then
+  if not self:isVeryTired() and self:isResting() then
     self:setMood("tired", "deactivate")
     self:changeAttribute("happiness", 0.006)
   end
@@ -352,9 +352,9 @@ function Staff:updateSpeed()
   elseif self.hospital and self.hospital.hosp_cheats:isCheatActive("no_rest_cheat") then
     level = 3 -- Cheat makes everyone speedy
   elseif self.humanoid_class ~= "Receptionist" then
-    if self:getAttribute("fatigue") >= 0.8 then
+    if self:isCrackUpTired() then
       level = level - 2
-    elseif self:getAttribute("fatigue") >= 0.7 then
+    elseif self:isVeryTired() then
       level = level - 1
     end
   end
@@ -374,7 +374,7 @@ end
 -- and go to the StaffRoom if it is.
 function Staff:checkIfNeedRest()
   -- Only when the staff member is very tired should the icon emerge. Unhappiness will also escalate
-  if self:getAttribute("fatigue") >= 0.7 then
+  if self:isVeryTired() then
     self:setMood("tired", "activate")
     self:changeAttribute("happiness", -0.0002)
   end
@@ -719,6 +719,18 @@ end
 ]]
 function Staff:tostring()
   return Humanoid.tostring(self)
+end
+
+--! Judge tiredness based on the level config (which has a default of 700)
+--!return (boolean) Is staff member very tired?
+function Staff:isVeryTired()
+  return self:getAttribute("fatigue") * 1000 >= self.world.map.level_config.gbv.VeryTired
+end
+
+--! Judge crack up tiredness based on the level config (which has a default of 800)
+--!return (boolean) Is staff member very tired?
+function Staff:isCrackUpTired()
+  return self:getAttribute("fatigue") * 1000 >= self.world.map.level_config.gbv.CrackUpTired
 end
 
 -- Dummy callback for savegame compatibility

--- a/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
@@ -42,7 +42,7 @@ function Doctor:tickDay()
 
   -- if you overwork your Dr's then there is a chance that they can go crazy
   -- when this happens, find him and get him to rest straight away
-  if self:getAttribute("fatigue") < 0.7 then
+  if not self:isVeryTired() then
     if self:isResting() then
       self:setCrazy(false)
     end

--- a/CorsixTH/Lua/entities/humanoids/vip.lua
+++ b/CorsixTH/Lua/entities/humanoids/vip.lua
@@ -265,7 +265,7 @@ function Vip:setVIPRating()
   if count_staff > 1 then
     -- Loop through staff tiredness, if any above verytired, break loop
     for _, staff in ipairs(self.hospital.staff) do
-      if staff:getAttribute("fatigue") >= 0.7 then
+      if staff:isVeryTired() then
         self.vip_rating = self.vip_rating + 2
         break
       end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -171,7 +171,6 @@ function Hospital:Hospital(world, avail_rooms, name)
   self.patients = {}
   self.debug_patients = {} -- right-click-commandable patients for testing
   self.disease_casebook = {}
-  self.policies = {}
   self.discovered_diseases = {} -- a list
 
   -- Create a cheats instance for each hospital. AIHospitals don't know how to cheat (we hope!)
@@ -187,12 +186,15 @@ function Hospital:Hospital(world, avail_rooms, name)
     }
   end
 
-  self.policies["staff_allowed_to_move"] = true
-  self.policies["send_home"] = 0.1
-  self.policies["guess_cure"] = 0.9
-  self.policies["stop_procedure"] = 1 -- Note that this is between 1 and 2 ( = 100% - 200%)
-  self.policies["goto_staffroom"] = 0.6
-  self.policies["grant_wage_increase"] = TheApp.config.grant_wage_increase
+  local gbv = level_config.gbv
+  self.policies = {
+    staff_allowed_to_move = true,
+    send_home = 0.1,
+    guess_cure = 0.9,
+    stop_procedure = 1, -- Note that this is between 1 and 2 ( = 100% - 200%)
+    goto_staffroom = gbv.Tired / 1000, -- Defaults to 0.6 on normal difficulty
+    grant_wage_increase = TheApp.config.grant_wage_increase,
+  }
 
   -- Semi-randomly select three insurance companies to use, only different by name right now.
   -- The companies in the first quarter of the list are more likely to be selected
@@ -219,7 +221,6 @@ function Hospital:Hospital(world, avail_rooms, name)
   -- Initialize diseases
   local diseases = TheApp.diseases
   local expertise = level_config.expertise
-  local gbv = level_config.gbv
   for _, disease in ipairs(diseases) do
     local disease_available = true
     local drug_effectiveness = 95

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -841,4 +841,10 @@ function Map:afterLoad(old, new)
       MaxSalary = 2000,
     }
   end
+  if old < 187 then
+    local gbv = self.level_config.gbv
+    gbv.Tired = gbv.Tired or 600
+    gbv.VeryTired = gbv.VeryTired or 700
+    gbv.CrackUpTired = gbv.CrackUpTired or 800
+  end
 end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2564*

**Describe what the proposed change does**
- Use Tired, VeryTired and CrackUpTired from level_config.gbv to judge staff tiredness. The defaults are the current magic numbers, from TH level config.
