### PR TITLE
Add Actions for Windows Installer

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -29,7 +29,6 @@ jobs:
     runs-on: windows-2022
     env:
       PRESET: ${{inputs.preset || 'win-x64-rel'}}
-      VCPKG_DEFAULT_TRIPLET: ${{inputs.preset == 'win-x86-rel' && 'x86-windows' || 'x64-windows-release'}}
       ANIMVIEW: ${{inputs.animview && 'ON' || 'OFF'}}
       NAME: CorsixTH${{inputs.animview && '_and_AnimView' || ''}}${{inputs.preset == 'win-x86-rel' && '_x86' || ''}}
     defaults:
@@ -64,10 +63,10 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: ${{env.PRESET}}
-          configurePresetAdditionalArgs: "['-DBUILD_ANIMVIEW=${{env.ANIMVIEW}}']"
-          buildPreset: ${{env.PRESET}}
-          buildPresetAdditionalArgs: "['--verbose', '--target install',
+          configurePresetAdditionalArgs: "['-DBUILD_ANIMVIEW=${{env.ANIMVIEW}}',
             '-DCMAKE_INSTALL_PREFIX=build/${{env.PRESET}}/CorsixTH/RelWithDebInfo/']"
+          buildPreset: ${{env.PRESET}}
+          buildPresetAdditionalArgs: "['--verbose', '--target install']"
           testPreset: ${{env.PRESET}}
 
       - name: Download soundfont
@@ -79,17 +78,15 @@ jobs:
       - name: Copy data files for archive
         if: inputs.PRESET != 'win-dev'
         run: |
-          cp -R CorsixTH/Lua build/${{env.PRESET}}/CorsixTH/RelWithDebInfo/Lua
-          cp -R CorsixTH/Bitmap build/${{env.PRESET}}/CorsixTH/RelWithDebInfo/Bitmap
-          cp -R CorsixTH/Levels build/${{env.PRESET}}/CorsixTH/RelWithDebInfo/Levels
-          cp -R CorsixTH/Campaigns build/${{env.PRESET}}/CorsixTH/RelWithDebInfo/Campaigns
-          cp CorsixTH/CorsixTH.lua build/${{env.PRESET}}/CorsixTH/RelWithDebInfo/
+          cp -r build/${{env.PRESET}}/. .
+          cp -Ru CorsixTH/RelWithDebInfo/CorsixTH/. CorsixTH/RelWithDebInfo/
+          rm -rf CorsixTH/RelWithDebInfo/CorsixTH/
           if [ "${{inputs.animview}}" == "true" ]; then
             mkdir -p artifact
-            mv build/${{env.PRESET}}/AnimView/RelWithDebInfo artifact/AnimView
-            mv build/${{env.PRESET}}/CorsixTH/RelWithDebInfo artifact/CorsixTH
+            mv AnimView/RelWithDebInfo artifact/AnimView
+            mv CorsixTH/RelWithDebInfo artifact/CorsixTH
           else
-            mv build/${{env.PRESET}}/CorsixTH/RelWithDebInfo artifact
+            mv CorsixTH/RelWithDebInfo artifact
           fi
           ls -R artifact
 

--- a/.github/workflows/WindowsInstaller.yml
+++ b/.github/workflows/WindowsInstaller.yml
@@ -1,0 +1,47 @@
+---
+name: Windows installer
+
+on:
+  workflow_dispatch:
+    inputs:
+      x86:
+        description: 'x86 run ID (url part)'
+        required: true
+        type: number
+      x64:
+        description: 'x64 run ID (url part)'
+        required: true
+        type: number
+
+jobs:
+  WindowsInstaller:
+    runs-on: ubuntu-24.04
+    name: Make and test Windows installer
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install NSIS
+        run: sudo apt-get install nsis
+      - name: Download x86 artifact
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{inputs.x86}}
+          path: WindowsInstaller
+          github-token: ${{github.token}}
+      - name: Download x64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{inputs.x64}}
+          path: WindowsInstaller
+          github-token: ${{github.token}}
+      - name: Create installer
+        run: |
+          cd WindowsInstaller
+          mv CorsixTH_x86 x86
+          mv CorsixTH x64
+          makensis -V4 -WX -- Win32Script.nsi
+          sha256sum CorsixTHInstaller.exe >> $GITHUB_STEP_SUMMARY
+      - name: Upload installer
+        uses: actions/upload-artifact@v4
+        with:
+          path: 'WindowsInstaller/CorsixTHInstaller.exe'
+          name: 'Windows installer'

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -298,6 +298,10 @@ if(NOT USE_SOURCE_DATADIRS)
     if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/mime")
       install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mime" "${CMAKE_CURRENT_BINARY_DIR}/socket" DESTINATION ${CORSIX_TH_DATADIR})
     endif()
+    # Include this module to search for compiler-provided system runtime
+    # libraries and add install rules for them.
+    set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION ".")
+    include(InstallRequiredSystemLibraries)
   else()
     install(TARGETS CorsixTH
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/WindowsInstaller/Win32Script.nsi
+++ b/WindowsInstaller/Win32Script.nsi
@@ -105,8 +105,8 @@ var ICONS_GROUP
 !insertmacro MUI_UNPAGE_INSTFILES
 
 ; Icons used by the installer and uninstaller
-UninstallIcon "..\CorsixTH\corsixTH.ico"
-Icon "..\CorsixTH\corsixTH.ico"
+UninstallIcon "..\CorsixTH\CorsixTH.ico"
+Icon "..\CorsixTH\CorsixTH.ico"
 
 
 ; ------------------------------- Languages supported by the installer ---------------------------


### PR DESCRIPTION
**Describe what the proposed change does**
- Builds a Windows installer from successful x64 and x86 Windows Actions runs, chosen by their run id from the url.
 example https://github.com/tobylane/CorsixTH/actions/runs/9158967469 is made of two runs from March.