### PR TITLE
Use static mt builds for release on windows

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -69,11 +69,11 @@ jobs:
 
           sudo luarocks --lua-version 5.4 install luafilesystem
 
-      - name: Install CMake 3.14
+      - name: Install CMake 3.15
         if: matrix.cmake
         run: |
-          # Install CMake version 3.14, the oldest CorsixTH-supported version, which does not support Lua 5.4
-          curl -L https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.sh -o cmake.sh
+          # Install CMake version 3.15, the oldest CorsixTH-supported version, which does not support Lua 5.4
+          curl -L https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh -o cmake.sh
           sudo bash cmake.sh --prefix=/usr/local/ --exclude-subdir --skip-license
           cmake --version
       - name: Create CorsixTH${{ matrix.animview }} makefiles with ${{ matrix.lua }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'a1212c93cabaa9c5c36c1ffdb4bddd59fdf31e43'
+          vcpkgGitCommitId: '94a50e8c1357d423840e22451e122f56d62b5c20'
 
       - name: Run CMake dev configure
         if: inputs.PRESET == 'win-dev'
@@ -91,6 +91,7 @@ jobs:
           else
             mv build/${{env.PRESET}}/CorsixTH/RelWithDebInfo artifact
           fi
+          rm artifact/*.lib
           ls -R artifact
 
       - name: Upload build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 #   - BUILD_ANIMVIEW : Generate AnimView build files (no)
 #   - BUILD_TOOLS : Generate cli tools
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 # Define our options
 option(BUILD_CORSIXTH "Builds the main game" ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,8 +46,9 @@
       "architecture": "x64",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "VCPKG_TARGET_TRIPLET": "x64-windows-release",
-        "ENABLE_UNIT_TESTS": "ON"
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static-release",
+        "ENABLE_UNIT_TESTS": "ON",
+        "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded"
       }
     },
     {
@@ -57,8 +58,9 @@
       "architecture": "Win32",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "VCPKG_TARGET_TRIPLET": "x86-windows",
-        "ENABLE_UNIT_TESTS": "ON"
+        "VCPKG_TARGET_TRIPLET": "x86-windows-static",
+        "ENABLE_UNIT_TESTS": "ON",
+        "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded"
       }
     }
   ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,6 +62,18 @@
         "ENABLE_UNIT_TESTS": "ON",
         "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded"
       }
+    },
+    {
+      "name": "win-x64-rel-md",
+      "binaryDir": "${sourceDir}/build/win-x64-rel-md",
+      "generator": "Visual Studio 17 2022",
+      "architecture": "x64",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-windows-release",
+        "ENABLE_UNIT_TESTS": "ON",
+        "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreadedDLL"
+      }
     }
   ],
   "buildPresets": [

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -101,13 +101,6 @@ set_property(TARGET CorsixTH PROPERTY CXX_STANDARD_REQUIRED ON)
 
 ## Finding libraries
 
-# Workaround for vcpkg/fluidsynth bug: glib2 libraries are added without an
-# absolute path.
-if(MSVC AND VCPKG_TARGET_TRIPLET)
-  target_link_directories(CorsixTH PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/")
-endif()
-
-
 # Find SDL
 if(VCPKG_TARGET_TRIPLET)
   find_package(SDL2 CONFIG REQUIRED)
@@ -168,6 +161,12 @@ target_link_libraries(CorsixTH PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 # Find SDL_mixer
 if(CORSIX_TH_USE_SDL_MIXER)
   if(VCPKG_TARGET_TRIPLET)
+    # Workaround for static linking bug
+    if(MSVC)
+      find_package(FluidSynth CONFIG REQUIRED)
+      target_link_libraries(CorsixTH PRIVATE FluidSynth::libfluidsynth)
+    endif()
+
     find_package(SDL2_mixer CONFIG REQUIRED)
     target_link_libraries(
       CorsixTH

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(CorsixTH_lib STATIC ${CorsixTH_generated_src_dir})
 
 target_include_directories(CorsixTH_lib PUBLIC ${CorsixTH_generated_src_dir})
 
+
 target_link_libraries(CorsixTH_lib PRIVATE RncLib)
 if(SEARCH_LOCAL_DATADIRS)
   target_link_libraries(CorsixTH_lib PRIVATE WhereamiLib)
@@ -99,6 +100,13 @@ set_property(TARGET CorsixTH PROPERTY CXX_EXTENSIONS OFF)
 set_property(TARGET CorsixTH PROPERTY CXX_STANDARD_REQUIRED ON)
 
 ## Finding libraries
+
+# Workaround for vcpkg/fluidsynth bug: glib2 libraries are added without an
+# absolute path.
+if(MSVC AND VCPKG_TARGET_TRIPLET)
+  target_link_directories(CorsixTH PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/")
+endif()
+
 
 # Find SDL
 if(VCPKG_TARGET_TRIPLET)

--- a/CorsixTH/Src/sdl_audio.cpp
+++ b/CorsixTH/Src/sdl_audio.cpp
@@ -32,9 +32,6 @@ SOFTWARE.
 #include <cstring>
 
 #include "xmi2mid.h"
-#ifdef _MSC_VER
-#pragma comment(lib, "SDL2_mixer")
-#endif
 
 class music {
  public:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   - cd %APPVEYOR_BUILD_FOLDER%
 
 before_build:
-  - cmd: cmake --preset win-x64-rel -B .
+  - cmd: cmake --preset win-x64-rel-md -B .
 build:
   project: CorsixTH_Top_Level.sln
   verbosity: minimal

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "a1212c93cabaa9c5c36c1ffdb4bddd59fdf31e43",
+    "baseline": "94a50e8c1357d423840e22451e122f56d62b5c20",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
Removes the need for shipping the runtime

![Screenshot_20240615_233000](https://github.com/CorsixTH/CorsixTH/assets/823433/74312d31-9985-48e6-9c72-5234eb5cb5c3)

