### PR TITLE
Use new strings for load map window

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/load_map.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/load_map.lua
@@ -28,7 +28,7 @@ function UILoadMap:UILoadMap(ui, mode)
   local path = ui.app.user_level_dir
   local treenode = FilteredFileTreeNode(path, ".map")
   treenode.label = "Maps"
-  self:UIFileBrowser(ui, mode, _S.load_game_window.caption:format(".map"), 295,
+  self:UIFileBrowser(ui, mode, _S.load_map_window.caption:format(".map"), 295,
       treenode, true, _S.load_game_window.load_button)
   -- The most probable preference of sorting is by date - what you played last
   -- is the thing you want to play soon again.

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -413,6 +413,11 @@ tooltip.save_map_window = {
   new_map = "Enter name for a map savegame",
 }
 
+load_map_window = {
+  caption = "Load Map (%1%)",
+  load_button = "Load",
+}
+
 menu_list_window = {
   name = "Name",
   save_date = "Modified",

--- a/CorsixTH/Lua/languages/russian.lua
+++ b/CorsixTH/Lua/languages/russian.lua
@@ -170,6 +170,10 @@ save_map_window = {
   save_button = "Сохранить",
   missing_filename = "Пожалуйста, введите название новой карты или выберите старое для перезаписи.",
 }
+load_map_window = {
+  caption = "Загрузить карту (%1%)",
+  load_button = "Загрузить",
+}
 
 hotkey_window = {
   right_mouse_scrolling = "Переключить клавишу мыши, которая отвечает за прокрутку карты",


### PR DESCRIPTION
* Fixes #2585 *

**Describe what the proposed change does**
- load_map.lua uses now `load_map_window` set of strings instead of `load_game_window`

