### PR TITLE
Temporarily Bump Very Old Save

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2161,7 +2161,8 @@ function World:afterLoad(old, new)
     self.original_savegame_version = old
   end
   -- If the original save game version is considerably lower than the current, warn the player.
-  if new - 20 > self.original_savegame_version then
+  -- For 2024 release, bump cutoff from 20 to 25 pending new methods in PR2518
+  if new - 25 > self.original_savegame_version then
     self.ui:addWindow(UIInformation(self.ui, {_S.information.very_old_save}))
   end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
- Bump the very old save cutoff for next release while #2518 is to be finished for 2025's release; otherwise saves from 0.66 will complain as being unsupported.
