### PR TITLE
Changelog 0.68.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 CorsixTH 0.68.0 - released xxxx 2024
 -------------------------------------------------------------------------------
 # New Features/Enhancements
-* In game movies now play for users using TH Data directly from a .ISO file
+* In-game movies now play for users using TH Data directly from a .ISO file
 * Custom campaign creators can now optionally use the original level advance
   movie when progressing through the campaign
 * The Map Editor has received some love including new features, fixes, and
@@ -37,8 +37,8 @@ CorsixTH 0.68.0 - released xxxx 2024
 * The information dialog box is now more closely aligned with the original game
 * The tip of the day window should no longer be obscured in the main menu
 * The load/save windows now have better labelling
-* Unavailable languages are shown as disabled until you select a unicode font
-* Support is added to auto detect a Theme Hospital install via GOG Galaxy
+* Unavailable languages are shown as disabled until you select a Unicode font
+* Support is added to auto-detect a Theme Hospital install via GOG Galaxy
 
 # Translations
 * Dutch translation has been updated. Thanks @jetenergy
@@ -64,7 +64,7 @@ CorsixTH 0.68.0 - released xxxx 2024
 * Fixed a bug where an unreachable reception desk could cause a crash
 * The Computer and Atom Analyser now make button sounds as originally intended
 * The mark for vaccination action now makes a sound as originally intended
-* Fixes a rare bug where edges of map tiles for parcels could cause unintended
+* Fixed a rare bug where edges of map tiles for parcels could cause unintended
   behaviour when purchasing plots
 * Active cheats will now persist across saves
 * Audio settings have better safeguards against no audio enabled/no background
@@ -73,12 +73,12 @@ CorsixTH 0.68.0 - released xxxx 2024
 * Config values using brackets (such as a custom music directory) will now work
   properly
 * Custom campaigns menu now will use a scrollbar for long campaign descriptions
-* Continue game now properly targets files explicitly ending in the .sav format
-* Fixes an instance where information boxes could load pink from older
+* Continue Game now properly targets files explicitly ending in the .sav format
+* Fixed an instance where information boxes could load pink from older
   savegames
 * Implemented a more permanent fix for the money bar being drawn incorrectly in
   some CJK and Cyrllic languages
-* Fixes a crash on exit that could occur in some systems
+* Fixed a crash on exit that could occur in some systems
 * Mouse panning behaviour has been made more responsive and accurate
 
 # Packager Notes

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,96 @@
 -------------------------------------------------------------------------------
+CorsixTH 0.68.0 - released xxxx 2024
+-------------------------------------------------------------------------------
+# New Features/Enhancements
+* In game movies now play for users using TH Data directly from a .ISO file
+* Custom campaign creators can now optionally use the original level advance
+  movie when progressing through the campaign
+* The Map Editor has received some love including new features, fixes, and
+  jukebox controls
+* You can now control the Jukebox from the Main Menu by going to
+  Options > Jukebox
+* External (non-TH) XMI files are now supported by the Jukebox
+* The adviser now tells you the cost of replacing your machine if you cannot
+  currently afford it
+* More cheats!
+* [Experimental] Right mouse panning can now be used instead of using the
+  middle mouse button. Enable it in the configuration file
+* [Experimental] We’re closer to fully implementing falling actions! Get a
+  sneak peek and get the chance to push people over by enabling it in the
+  configuration file/debug menu
+
+# Changes
+* The demo movie will no longer play and cause jumpscares at the main menu if
+  the CorsixTH window is not in focus 
+* Game speeds are now more closely aligned with the original game
+* Improvements to handling of win/lose conditions, and the progress report
+* Staff tiredness levels are now taken from the level config file based on
+  difficulty level of the main campaign
+* You can no longer win a level if you still have outstanding loans
+* Emergencies will now be announced once patients actually begin arriving
+  instead of at the start
+* Errors with music playback will now attempt to provide more helpful
+  information in the console
+* Level briefings now show before the in-game tutorial
+* The first patient of a level will now arrive faster after opening the
+  hospital
+* The information dialog box is now more closely aligned with the original game
+* The tip of the day window should no longer be obscured in the main menu
+* The load/save windows now have better labelling
+* Unavailable languages are shown as disabled until you select a unicode font
+* Support is added to auto detect a Theme Hospital install via GOG Galaxy
+
+# Translations
+* Dutch translation has been updated. Thanks @jetenergy
+* Italian translation has been updated. Thanks @SebastianoPistore & @Inkub0
+* Russian translation has been updated. Thanks @Matroftt
+* Spanish translation has been updated. Thanks @ShiroAka
+* French translation has been updated. Thanks @nMustaki & @Sanndow
+* Some unused language strings have been cleaned up
+* Custom campaign and level creators can now optionally add translated strings
+  for campaign description, level briefing, and winning text
+
+# Bug Fixes
+* Swing (double) doors will no longer crash your game if you built rooms that
+  used them while paused
+* Fixed a bug for NVIDIA users who didn’t like graphical corruption when
+  playing fullscreen at non-native resolutions
+* Games should no longer crash irrecoverably because you have a 4k monitor :) 
+* The game will now exit to the main menu cleanly if a problem occurred trying
+  to load a new level or map
+* Staff who have left the hospital can no longer ask for a raise
+* Fixed a bug where some staff may have no initial before surname
+* Patients can no longer litter outdoors
+* Fixed a bug where an unreachable reception desk could cause a crash
+* The Computer and Atom Analyser now make button sounds as originally intended
+* The mark for vaccination action now makes a sound as originally intended
+* Fixes a rare bug where edges of map tiles for parcels could cause unintended
+  behaviour when purchasing plots
+* Active cheats will now persist across saves
+* Audio settings have better safeguards against no audio enabled/no background
+  music
+* Movies will no longer attempt to play audio when global audio is off
+* Config values using brackets (such as a custom music directory) will now work
+  properly
+* Custom campaigns menu now will use a scrollbar for long campaign descriptions
+* Continue game now properly targets files explicitly ending in the .sav format
+* Fixes an instance where information boxes could load pink from older
+  savegames
+* Implemented a more permanent fix for the money bar being drawn incorrectly in
+  some CJK and Cyrllic languages
+* Fixes a crash on exit that could occur in some systems
+* Mouse panning behaviour has been made more responsive and accurate
+
+# Packager Notes
+* Minimum CMake version is now bumped to 3.14
+* CMake presets are now available for some common build scenarios
+* Dependencies can now be obtained automatically using vcpkg on Linux and
+  MacOS. If using Windows, please note that the CMake options have changed
+* If update checks are enabled you now require libcurl at build and run time
+  (update checks can be disabled using the WITH_UPDATE_CHECK CMake option).
+  Luasec and luasocket are no longer used
+
+-------------------------------------------------------------------------------
 Version 0.67 - released August 2023
 -------------------------------------------------------------------------------
 # New Features/Enhancements


### PR DESCRIPTION
Adds changelog ready for next release.

NB: As we're now planning to use the revision number more strictly, we should probably also start adding the .0

The following text below is intended to go on the release post at the top of the changelog:

**This version comes with two experimental features you can help us with by giving feedback on! These will be off by default.**