### PR TITLE
soda price can now configurable in the level file

### DIFF
--- a/CorsixTH/Levels/example.level
+++ b/CorsixTH/Levels/example.level
@@ -41,6 +41,9 @@ InterestRate is defined as centiprocent to allow for two decimals precision, i.e
 300 means 3 %
 #town.StartCash.InterestRate 100000 300
 
+Soda price at drinks machines
+#gbv.SodaPrice 20
+
 -------------------- Disease Configuration -------------------------
 
 When a drug is researched, what effectiveness does it have

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 208 -- Game tick speed adjustment
+local SAVEGAME_VERSION = 209 -- Add soda price to level config
 
 class "App"
 

--- a/CorsixTH/Lua/base_config.lua
+++ b/CorsixTH/Lua/base_config.lua
@@ -145,6 +145,8 @@ local configuration = {
     VeryTired = 700,
     -- Per mille point of attribute fatigue to be crack up (extremely) tired
     CrackUpTired = 800,
+    -- How much soda costs at a drinks machine
+    SodaPrice              = 20,
   },
 
   towns = {

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1417,10 +1417,11 @@ function Hospital:receiveMoneyForTreatment(patient)
   end
 end
 
---! Sell a soda to a patient.
+--! Sell a soda to a patient for the price in the level config (default $20).
 --!param patient (patient) The patient buying the soda.
 function Hospital:sellSodaToPatient(patient)
-  self:receiveMoneyForProduct(patient, 20, _S.transactions.drinks)
+  local soda_price = self.world.map.level_config.gbv.SodaPrice
+  self:receiveMoneyForProduct(patient, soda_price, _S.transactions.drinks)
   self.sodas_sold = self.sodas_sold + 1
 end
 

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -847,4 +847,7 @@ function Map:afterLoad(old, new)
     gbv.VeryTired = gbv.VeryTired or 700
     gbv.CrackUpTired = gbv.CrackUpTired or 800
   end
+  if old < 209 then
+    self.level_config.gbv.SodaPrice = 20
+  end
 end


### PR DESCRIPTION
**Describe what the proposed change does**
Allows soda price to be configurable in the level file in order to expand level creation capabilities.