### PR TITLE
Safeguard cheat transfer

### DIFF
--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -839,7 +839,7 @@ function PlayerHospital:afterLoad(old, new)
   end
 
   -- Refresh the cheat system every load
-  local old_active_cheats = self.hosp_cheats.active_cheats
+  local old_active_cheats = self.hosp_cheats and self.hosp_cheats.active_cheats or {}
   self.hosp_cheats = Cheats(self)
   self.hosp_cheats.active_cheats = old_active_cheats
 


### PR DESCRIPTION
**Describe what the proposed change does**
- hosp_cheats may not exist in an old save. Make sure if we don't crash by safeguarding the check for transferring active cheats first.

Found by @Alberth289346 -- chances are this case could potentially affect newer saves than the one it was found in.
