### PR TITLE
Update for 0.68.0 RC2

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 192 -- CorsixTH 0.68.0~rc1
+local SAVEGAME_VERSION = 193 -- CorsixTH 0.68.0~rc2
 
 class "App"
 
@@ -1641,8 +1641,10 @@ function App:getVersion(version)
   -- Versioning format is major.minor.revision (required) Patch (optional)
   -- Old versions (<= 0.67) retain existing format
   -- All patch versions should be retained in this table (due to be replaced, see PR2518)
-  if ver > 192 then
+  if ver > 193 then
     return "Trunk"
+  elseif ver > 192 then
+    return "v0.68.0 RC 2"
   elseif ver > 191 then
     return "v0.68.0 RC 1"
   elseif ver > 180 then

--- a/CorsixTH/com.corsixth.corsixth.metainfo.xml
+++ b/CorsixTH/com.corsixth.corsixth.metainfo.xml
@@ -20,6 +20,22 @@
   </provides>
   <launchable type="desktop-id">com.corsixth.corsixth.desktop</launchable>
   <releases>
+    <release version="0.68.0~rc2" date="2024-09-25" type="development">
+      <description>
+        <p>Translations:</p>
+        <ul>
+          <li>Dutch translation has been updated</li>
+          <li>Ukranian translation has been updated</li>
+        </ul>
+        <p>Bug Fixes:</p>
+        <ul>
+          <li>Added a safeguard to prevent a crash of games previously using the
+              old cheat system</li>
+          <li>Patients waiting for a player decision no longer lose their mood icon
+              on vomit/pee</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.68.0~rc1" date="2024-09-14" type="development">
       <description>
         <p>New Features:</p>
@@ -29,13 +45,13 @@
         </ul>
         <p>Translations:</p>
         <ul>
-          <li>Ukranian translation added.</li>
+          <li>Ukranian translation added</li>
           <li>Brazilian-Portuguese translation has been updated</li>
         </ul>
         <p>Bug Fixes:</p>
         <ul>
-          <li>Tooltips for language menu now align with list items. Please note we are
-              aware of an issue where some languages don&apos;t show a tooltip.</li>
+          <li>Tooltips for language menu now align with list items. Please note we
+             are aware of an issue where some languages don&apos;t show a tooltip</li>
         </ul>
       </description>
     </release>

--- a/CorsixTH/corsix-th.6
+++ b/CorsixTH/corsix-th.6
@@ -95,4 +95,4 @@ Copyright CorsixTH contributors.
 CorsixTH is available under the MIT license.
 .Pp
 For the full license text see:
-.Lk https://raw.githubusercontent.com/CorsixTH/CorsixTH/v0.68.0-rc1/LICENSE.txt
+.Lk https://raw.githubusercontent.com/CorsixTH/CorsixTH/v0.68.0-rc2/LICENSE.txt

--- a/WindowsInstaller/Win32Script.nsi
+++ b/WindowsInstaller/Win32Script.nsi
@@ -24,7 +24,7 @@
 ;---------------------------------- Definitions for the game -----------------------------------
 
 !define PRODUCT_NAME "CorsixTH"
-!define PRODUCT_VERSION "0.68.0-rc1"
+!define PRODUCT_VERSION "0.68.0-rc2"
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
 !define PRODUCT_UNINST_ROOT_KEY "HKLM"
 !define PRODUCT_STARTMENU_REGVAL "NSIS:StartMenuDir"

--- a/changelog.txt
+++ b/changelog.txt
@@ -44,7 +44,7 @@ CorsixTH 0.68.0 - released September 2024
 
 # Translations
 * Ukranian translation added. Thanks @JurecStrongman
-* Dutch translation has been updated. Thanks @jetenergy
+* Dutch translation has been updated. Thanks @jetenergy and @Alberth289346
 * Italian translation has been updated. Thanks @SebastianoPistore & @Inkub0
 * Russian translation has been updated. Thanks @Matroftt
 * Spanish translation has been updated. Thanks @ShiroAka
@@ -65,6 +65,8 @@ CorsixTH 0.68.0 - released September 2024
 * Staff who have left the hospital can no longer ask for a raise
 * Fixed a bug where some staff may have no initial before surname
 * Patients can no longer litter outdoors
+* Patients waiting for a player decision no longer lose their mood icon on
+  vomit/pee
 * Fixed a bug where an unreachable reception desk could cause a crash
 * The Computer and Atom Analyser now make button sounds as originally intended
 * The mark for vaccination action now makes a sound as originally intended
@@ -79,7 +81,7 @@ CorsixTH 0.68.0 - released September 2024
 * Custom campaigns menu now will use a scrollbar for long campaign descriptions
 * Continue Game now properly targets files explicitly ending in the .sav format
 * Tooltips for language menu now align with list items. Please note we are aware
-  of an issue where some languages don't show a tooltip.
+  of an issue where some languages don't show a tooltip
 * Fixed an instance where information boxes could load pink from older
   savegames
 * Implemented a more permanent fix for the money bar being drawn incorrectly in


### PR DESCRIPTION
For next RC.

Note the bugfix change `Added a safeguard to prevent a crash of games previously using the old cheat system` isn't in the main changelog because on release it will be fall under the bugfix `Active cheats will now persist across saves` instead.
