### PR TITLE
Reduce machine strength chance on repair tuned to match TH

### DIFF
--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -289,14 +289,19 @@ end
 
 function Machine:machineRepaired(room)
   room.needs_repair = nil
-  local str = self.strength
-  if self.times_used/str > 0.55 then
-    self.strength = str - 1
+
+  local current_strength = self.strength
+  local used_out_rate = self.times_used / current_strength
+
+  // calculate chance of strength reducing
+  local should_reduce_strength = math.random() < used_out_rate
+  if should_reduce_strength then
+    self.strength = current_strength - 1
   end
+
   self.times_used = 0
   self:setRepairing(nil)
   setSmoke(self, false)
-
   local taskIndex = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "repairing")
   self.hospital:removeHandymanTask(taskIndex, "repairing")
 end

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -293,7 +293,7 @@ function Machine:machineRepaired(room)
   local current_strength = self.strength
   local used_out_rate = self.times_used / current_strength
 
-  // calculate chance of strength reducing
+  -- calculate chance of strength reducing
   local should_reduce_strength = math.random() < used_out_rate
   if should_reduce_strength then
     self.strength = current_strength - 1


### PR DESCRIPTION
Reduce machine strength chance on repair tuned to more match TH

*Fixes #*

**Describe what the proposed change does**

I have discovered, that CTH reduce machine strength chance is not matches the TH reduce machine strength chance.

I have checked CTH code and discovered that, 
`if (machine.times_used / machine.strength > 0.55) then`
reduce strength must happen.

So no any reducing will happen in cases like 
`strength = 8 and times_used = 4`.
But it is typical condition when handyman comes to fix automatically.

But in TH you can get reduce even if `strength = 12 and times_used = 1`, which gives `times_used / strength = 0.08`

At the same time, in TH you can get no reduce for case
'`strength = 8 and times_used = 6`'. For which CTH will give 100% reduce.

So CTH formula does not mimic the original behaviour.

I conducted an investigation, made more than 50 repairs in the original TH and summarized the results in a table.

The obtained results are more consistent with the next formula:
`if (self.times_used / current_strength) > math.random() then`
reduce strength must happen.

This formula will give low chance reducing for
`'strength = 12 and times_used = 1`' cases,
and high chance for
'`strength = 8 and times_used = 6`' cases.

For cases like
`strength = 8 and times_used = 4`
chance will be 50%.

This is not the fact that original TH use that formula. 
It's just assumption based on experiment results.
("Black-box" analysis approach)