### PR TITLE
Freeze patient's treatment cost when agreeing to pay

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -296,7 +296,7 @@ function Patient:treatDisease()
   end
 end
 
---! Sets a pernament price of treatment for this patient instance,
+--! Sets a permanent price of treatment for this patient instance,
 --! so changing price in casebook wont affect any longer
 function Patient:setTreatmentPrice(disease_id)
   local hosp = self.hospital

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -276,7 +276,6 @@ function Patient:treatDisease()
   local hospital = self.hospital
 
   hospital:receiveMoneyForTreatment(self)
-  self.pay_amount = 0
 
   -- Remove visual effects of disease.
   self.th:setPatientEffect(AnimationEffect.None)

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -275,7 +275,7 @@ end
 function Patient:treatDisease()
   local hospital = self.hospital
 
-  hospital:receiveMoneyForTreatment(self, self.pay_amount)
+  hospital:receiveMoneyForTreatment(self)
   self.pay_amount = 0
 
   -- Remove visual effects of disease.

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -300,7 +300,6 @@ end
 --! so changing price in casebook wont affect any longer
 function Patient:setTreatmentPrice(disease_id)
   local hosp = self.hospital
-  local casebook = self.hospital.disease_casebook[disease_id]
   self.pay_amount = hosp:getTreatmentPrice(disease_id)
 end
 

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -276,6 +276,7 @@ function Patient:treatDisease()
   local hospital = self.hospital
 
   hospital:receiveMoneyForTreatment(self, self.pay_amount)
+  self.pay_amount = 0
 
   -- Remove visual effects of disease.
   self.th:setPatientEffect(AnimationEffect.None)
@@ -296,22 +297,18 @@ function Patient:treatDisease()
   end
 end
 
---! Sets a permanent price of treatment for this patient instance,
---! so changing price in casebook wont affect any longer
-function Patient:setTreatmentPrice(disease_id)
-  local hosp = self.hospital
-  self.pay_amount = hosp:getTreatmentPrice(disease_id)
-end
-
 --! Returns true if patient agrees to pay for the given treatment.
 --!param disease_id (string): The id of the disease to test
 function Patient:agreesToPay(disease_id)
+  local hosp = self.hospital
   local casebook = self.hospital.disease_casebook[disease_id]
   local price_distortion = self:getPriceDistortion(casebook)
   local is_over_priced = price_distortion > self.hospital.over_priced_threshold
-  self:setTreatmentPrice(disease_id)
 
-  return not (is_over_priced and math.random(1, 5) == 1)
+  local agreesToPay = not (is_over_priced and math.random(1, 5) == 1)
+  if agreesToPay then self.pay_amount = hosp:getTreatmentPrice(disease_id) end
+
+  return agreesToPay
 end
 
 --! Either the patient is cured, or he/she dies.

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -36,6 +36,7 @@ function Patient:Patient(...)
   self.action_string = ""
   self.cured = false
   self.infected = false
+  self.pay_amount = 0
   -- To distinguish between actually being dead and having a nil hospital
   self.dead = false
   -- Is the patient reserved for a particular nurse when being vaccinated

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -301,14 +301,14 @@ end
 --!param disease_id (string): The id of the disease to test
 function Patient:agreesToPay(disease_id)
   local hosp = self.hospital
-  local casebook = self.hospital.disease_casebook[disease_id]
+  local casebook = hosp.disease_casebook[disease_id]
   local price_distortion = self:getPriceDistortion(casebook)
-  local is_over_priced = price_distortion > self.hospital.over_priced_threshold
+  local is_over_priced = price_distortion > hosp.over_priced_threshold
 
-  local agreesToPay = not (is_over_priced and math.random(1, 5) == 1)
-  if agreesToPay then self.pay_amount = hosp:getTreatmentPrice(disease_id) end
+  if is_over_priced and math.random(1, 5) == 1 then return false end
+  self.pay_amount = hosp:getTreatmentPrice(disease_id)
 
-  return agreesToPay
+  return true
 end
 
 --! Either the patient is cured, or he/she dies.

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -274,7 +274,7 @@ end
 function Patient:treatDisease()
   local hospital = self.hospital
 
-  hospital:receiveMoneyForTreatment(self)
+  hospital:receiveMoneyForTreatment(self, self.pay_amount)
 
   -- Remove visual effects of disease.
   self.th:setPatientEffect(AnimationEffect.None)
@@ -295,12 +295,21 @@ function Patient:treatDisease()
   end
 end
 
+--! Sets a pernament price of treatment for this patient instance,
+--! so changing price in casebook wont affect any longer
+function Patient:setTreatmentPrice(disease_id)
+  local hosp = self.hospital
+  local casebook = self.hospital.disease_casebook[disease_id]
+  self.pay_amount = hosp:getTreatmentPrice(disease_id)
+end
+
 --! Returns true if patient agrees to pay for the given treatment.
 --!param disease_id (string): The id of the disease to test
 function Patient:agreesToPay(disease_id)
   local casebook = self.hospital.disease_casebook[disease_id]
   local price_distortion = self:getPriceDistortion(casebook)
   local is_over_priced = price_distortion > self.hospital.over_priced_threshold
+  self:setTreatmentPrice(disease_id)
 
   return not (is_over_priced and math.random(1, 5) == 1)
 end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1412,6 +1412,7 @@ function Hospital:receiveMoneyForTreatment(patient)
     end
     casebook.money_earned = casebook.money_earned + amount
     patient.world:newFloatingDollarSign(patient, amount)
+    patient.pay_amount = 0
   end
 end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1399,7 +1399,7 @@ function Hospital:receiveMoneyForTreatment(patient, pay_amount)
     else
       reason = _S.transactions.cure_colon .. " " .. casebook.disease.name
     end
-    local amount = pay_amount or 0
+    local amount = pay_amount or self:getTreatmentPrice(disease_id)
 
     -- 25% of the payments now go through insurance
     if patient.insurance_company then

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1388,7 +1388,7 @@ end
 
 !param patient (Patient) The patient that just got treated.
 ]]
-function Hospital:receiveMoneyForTreatment(patient, pay_amount)
+function Hospital:receiveMoneyForTreatment(patientt)
   if not self.world.free_build_mode then
     local disease_id = patient:getTreatmentDiseaseId()
     if disease_id == nil then return end
@@ -1399,7 +1399,7 @@ function Hospital:receiveMoneyForTreatment(patient, pay_amount)
     else
       reason = _S.transactions.cure_colon .. " " .. casebook.disease.name
     end
-    local amount = pay_amount or self:getTreatmentPrice(disease_id)
+    local amount = patient.pay_amount or self:getTreatmentPrice(disease_id)
 
     -- 25% of the payments now go through insurance
     if patient.insurance_company then

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1399,7 +1399,8 @@ function Hospital:receiveMoneyForTreatment(patient)
     else
       reason = _S.transactions.cure_colon .. " " .. casebook.disease.name
     end
-    local amount = patient.pay_amount or self:getTreatmentPrice(disease_id)
+    local amount = patient.pay_amount or 0
+    amount = amount > 0 and amount or self:getTreatmentPrice(disease_id)
 
     -- 25% of the payments now go through insurance
     if patient.insurance_company then

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1388,7 +1388,7 @@ end
 
 !param patient (Patient) The patient that just got treated.
 ]]
-function Hospital:receiveMoneyForTreatment(patientt)
+function Hospital:receiveMoneyForTreatment(patient)
   if not self.world.free_build_mode then
     local disease_id = patient:getTreatmentDiseaseId()
     if disease_id == nil then return end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1388,7 +1388,7 @@ end
 
 !param patient (Patient) The patient that just got treated.
 ]]
-function Hospital:receiveMoneyForTreatment(patient)
+function Hospital:receiveMoneyForTreatment(patient, pay_amount)
   if not self.world.free_build_mode then
     local disease_id = patient:getTreatmentDiseaseId()
     if disease_id == nil then return end
@@ -1399,7 +1399,7 @@ function Hospital:receiveMoneyForTreatment(patient)
     else
       reason = _S.transactions.cure_colon .. " " .. casebook.disease.name
     end
-    local amount = self:getTreatmentPrice(disease_id)
+    local amount = pay_amount or 0
 
     -- 25% of the payments now go through insurance
     if patient.insurance_company then


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

* Fixes #2631 

**Describe what the proposed change does**
- Creates new variable `pay_amount` which stores the amount of treatment cost
- hospital:receiveMoneyForTreatment() now checks pay_amount variable instead of price in casebook