### PR TITLE
Change gamelog render to yaml in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -110,7 +110,7 @@ body:
         Information about the configuration file can be found [here](https://github.com/CorsixTH/CorsixTH/wiki/Configuration-File).
         You can find gamelog.txt at the same location as the config file."
       placeholder: Paste gamelog.txt output here
-      render: bash
+      render: yaml
 # Extra Info
   - type: textarea
     id: extra


### PR DESCRIPTION
For issue templates we put the gamelog text in `bash`. However, the way we render gamelog data is more legible in yaml.

Bash:
```bash
Warning: Trying to remove nonexistent staff callback (function: 0000015E54720E90) from humanoid (table: 0000015E52626FE0).
Warning: Trying to resolve door deadlock at (29, 50)
Error in timer handler: 
Lua\entities\humanoid.lua:472: assertion failed!
stack traceback:
	[C]: in function 'assert'
	Lua\entities\humanoid.lua:472: in method 'startAction'
	Lua\entities\humanoid.lua:577: in method 'finishAction'
	Lua\humanoid_actions\use_screen.lua:48: in local 'timer_function'
	Lua\entity.lua:216: in method 'tick'
	Lua\world.lua:1074: in method 'onTick'
	Lua\app.lua:1202: in function <Lua\app.lua:1199>
	(...tail calls...)
	Lua\app.lua:1102: in function <Lua\app.lua:1097>
```

yaml
```yaml
Warning: Trying to remove nonexistent staff callback (function: 0000015E54720E90) from humanoid (table: 0000015E52626FE0).
Warning: Trying to resolve door deadlock at (29, 50)
Error in timer handler: 
Lua\entities\humanoid.lua:472: assertion failed!
stack traceback:
        [C]: in function 'assert'
        Lua\entities\humanoid.lua:472: in method 'startAction'
        Lua\entities\humanoid.lua:577: in method 'finishAction'
        Lua\humanoid_actions\use_screen.lua:48: in local 'timer_function'
        Lua\entity.lua:216: in method 'tick'
        Lua\world.lua:1074: in method 'onTick'
        Lua\app.lua:1202: in function <Lua\app.lua:1199>
        (...tail calls...)
        Lua\app.lua:1102: in function <Lua\app.lua:1097>
```