### PR TITLE
Rename canPeePukeOrFall

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -158,7 +158,7 @@ function Patient:setDiagnosed()
   self:updateDynamicInfo()
 end
 
--- Modifies the diagnosis progress of a patient.
+--! Modifies the diagnosis progress of a patient.
 -- incrementValue can be either positive or negative.
 function Patient:modifyDiagnosisProgress(incrementValue)
   self.diagnosis_progress = math.min(self.hospital.policies["stop_procedure"],
@@ -171,7 +171,7 @@ function Patient:modifyDiagnosisProgress(incrementValue)
   self:updateDynamicInfo()
 end
 
--- Updates the patients diagnostic progress based on the doctors skill
+--! Updates the patients diagnostic progress based on the doctors skill
 -- called when they are done using a diagnosis room
 function Patient:completeDiagnosticStep(room)
   -- Base: depending on difficulty of disease as set in sam file
@@ -204,7 +204,7 @@ function Patient:completeDiagnosticStep(room)
   self:modifyDiagnosisProgress(diagnosis_base + (diagnosis_bonus * multiplier))
 end
 
--- Sets the hospital for the patient - additionally removing them from a
+--! Sets the hospital for the patient - additionally removing them from a
 -- hospital if they already belong to one. For player hospitals, patients who
 -- are not debug or emergency patients are made to seek a reception desk.
 --!param hospital (Hospital): hospital to assign to patient
@@ -352,6 +352,10 @@ end
 -- Actions we can interrupt for in the canPeePukeOrFall function
 local good_actions = {walk=true, idle=true, seek_room=true, queue=true}
 
+--! Test whether the current tile of the patient is useful for inserting an
+-- action that needs a fully empty tile in the hospital.
+--!param current Current action.
+--!return Whether the tile can be used for inserting an action.
 function Patient:canPeePukeOrFall(current)
   if not good_actions[current.name] then return false end
   if self.going_home then return false end

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -354,10 +354,10 @@ local good_actions = {walk=true, idle=true, seek_room=true, queue=true}
 
 --! Test whether the current tile of the patient is useful for inserting an
 -- action that needs a fully empty tile in the hospital.
---!param current Current action.
+--!param cur_action Current action of the patient.
 --!return Whether the tile can be used for inserting an action.
-function Patient:canPeePukeOrFall(current)
-  if not good_actions[current.name] then return false end
+function Patient:canPeePukeOrFall(cur_action)
+  if not good_actions[cur_action.name] then return false end
   if self.going_home then return false end
 
   local th = self.world.map.th

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -349,14 +349,14 @@ function Patient:die()
   self:setDynamicInfoText(_S.dynamic_info.patient.actions.dying)
 end
 
--- Actions we can interrupt for in the canPeePukeOrFall function
+-- Actions we can interrupt when at a fully empty tile.
 local good_actions = {walk=true, idle=true, seek_room=true, queue=true}
 
 --! Test whether the current tile of the patient is useful for inserting an
 -- action that needs a fully empty tile in the hospital.
 --!param cur_action Current action of the patient.
 --!return Whether the tile can be used for inserting an action.
-function Patient:canPeePukeOrFall(cur_action)
+function Patient:atFullyEmptyTile(cur_action)
   if not good_actions[cur_action.name] then return false end
   if self.going_home then return false end
 
@@ -373,7 +373,7 @@ end
 function Patient:falling(player_init)
   local current = self:getCurrentAction()
   current.keep_reserved = true
-  if self.falling_anim and self:canPeePukeOrFall(current) and self.has_fallen == 1 then
+  if self.falling_anim and self:atFullyEmptyTile(current) and self.has_fallen == 1 then
     self.has_fallen = 2
     self:queueAction(FallingAction(), 1)
     self:queueAction(OnGroundAction(), 2)
@@ -405,7 +405,7 @@ end
 function Patient:vomit()
   local current = self:getCurrentAction()
   --Only vomit under these conditions. Maybe I should add a vomit for patients in queues too?
-  if self:canPeePukeOrFall(current) and self.has_vomitted == 0 then
+  if self:atFullyEmptyTile(current) and self.has_vomitted == 0 then
     self:queueAction(VomitAction(), 1)
     self:interruptAndRequeueAction(current, 2)
     self.has_vomitted = self.has_vomitted + 1
@@ -418,7 +418,7 @@ end
 function Patient:pee()
   local current = self:getCurrentAction()
   --Only pee under these conditions. As with vomit, should they also pee if in a queue?
-  if self:canPeePukeOrFall(current) then
+  if self:atFullyEmptyTile(current) then
     self:queueAction(PeeAction(), 1)
     self:interruptAndRequeueAction(current, 2)
     self:setMood("poo", "deactivate")


### PR DESCRIPTION
*Fixes a sub-optimal function name.

**Describe what the proposed change does**
- Functionally it does nothing.
- It renames the `Patient:canPeePukeOrFall` method to `Patient:atFullyEmptyTile`
- It add some lua docs and converts some comment to lua docs.
