### PR TITLE
Move idle ticks to follow app ticks

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1253,8 +1253,8 @@ function App:idle()
     self:resetIdle()
     return
   end
-  -- Have we been idle enough (~30s)
-  if self.idle_tick > 1000 then
+  -- Have we been idle enough (~30s, based on SDL tick rate of 18ms)
+  if self.idle_tick > 1680 then
     -- User is idle, play the demo gameplay movie
     self.moviePlayer:playDemoMovie()
     self:resetIdle()

--- a/CorsixTH/Lua/dialogs/resizables/main_menu.lua
+++ b/CorsixTH/Lua/dialogs/resizables/main_menu.lua
@@ -121,6 +121,9 @@ function UIMainMenu:draw(canvas, x, y)
     ly = ly - 15
   end
   self.label_font:draw(canvas, _S.main_menu.version .. self.version_number, x + 5, ly, 190, 0, "right")
+end
+
+function UIMainMenu:onTick()
   TheApp:idle()
 end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2690*

**Describe what the proposed change does**
- The idle tick counter for the demo movie used draw events. With `track_fps` these can happen very quickly
- Changed it so increment counter at `onTick()` events instead


WIP because I need to test cyco's tick changes again against the count. 0.67 loads the demo movie after 30s; 0.68.0 it's 37s. I'm expecting the tick changes again to affect the time.