### PR TITLE
Debug patients properly deregister on autopsy

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -509,9 +509,11 @@ function Patient:goHome(reason, disease_id)
 
   hosp:updatePercentages()
 
+  -- Debug patients must be removed from the debug list so they can despawn properly
   if self.is_debug then
     hosp:removeDebugPatient(self)
   end
+
   -- Remove any messages and/or callbacks related to the patient.
   self:unregisterCallbacks()
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1308,15 +1308,6 @@ function Hospital:spawnPatient()
   self.world:spawnPatient(self)
 end
 
-function Hospital:removeDebugPatient(patient)
-  for i, p in ipairs(self.debug_patients) do
-    if p == patient then
-      table.remove(self.debug_patients, i)
-      return
-    end
-  end
-end
-
 local debug_n
 function Hospital:getDebugPatient()
   if not debug_n or debug_n >= #self.debug_patients then
@@ -1730,9 +1721,17 @@ function Hospital:removeStaff(staff)
 end
 
 --! Remove a patient from the hospital.
+--  Also if a debug patient, they are also removed from the debug list.
 --!param patient (Patient) Patient to remove.
 function Hospital:removePatient(patient)
+  if patient.is_debug then self:removeDebugPatient(patient) end
   RemoveByValue(self.patients, patient)
+end
+
+--! Remove a debug patient from the debug list.
+--!param patient (Patient) Patient to remove
+function Hospital:removeDebugPatient(patient)
+  RemoveByValue(self.debug_patients, patient)
 end
 
 -- TODO: This should depend on difficulty and level


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2699*

**Describe what the proposed change does**
- Debug patients at autopsy are now properly removed from debug list on death (as well as room explosion)
- Intended to do more refactor, but debug patients must be deregistered out the debug list much earlier than from the hospital patient list
- A little doc
