### PR TITLE
Make VIP walk slow

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -29,7 +29,7 @@ local runDebugger = corsixth.require("run_debugger")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 206 -- Add support for new win and lose criteria
+local SAVEGAME_VERSION = 207 -- Make VIP move slower
 
 class "App"
 

--- a/CorsixTH/Lua/entities/humanoids/vip.lua
+++ b/CorsixTH/Lua/entities/humanoids/vip.lua
@@ -87,7 +87,7 @@ function Vip:Vip(...)
   -- sets the chance VIP visits each room, default is 50% or 1/2. For every 40 rooms in a hospital over 79 we increase n by 1 and chance is 1/n+1
   self.room_visit_chance = 1
   self.waiting = 0
-
+  self.slow_animation = true
 end
 
 --[[--VIP while on premises--]]
@@ -503,6 +503,9 @@ function Vip:afterLoad(old, new)
         end
       end
     end
+  end
+  if old < 207 then
+    self.slow_animation = true
   end
   Humanoid.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -111,6 +111,10 @@ local flag_flip_h = 1
 local navigateDoor
 
 local function action_walk_raw(humanoid, x1, y1, x2, y2, map, timer_fn)
+  -- The variables below must always make up factor*quantity = 8 or the
+  -- animation glitches
+  -- Factor must also be able to multiply by 2 to become an integer
+  -- Quantity must always be an integer
   local factor = 1
   local quantity = 8
   if humanoid.speed and humanoid.speed == "fast" then


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**Describe what the proposed change does**
- VIPs walk slowly, like in TH
- Inspectors walk at normal speed, so unaffected by this

I also found that the `self.speed` variable on `humanoid` is pretty useless to have the value as `slow`. But not planning to look at that.

This PR should be followed by a future one to suggest changing walk speed where patients and vips are off map from the spawn point.
