### PR TITLE
Use date and time in log filenames

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -435,6 +435,9 @@ function App:initUserDirectories()
   self.user_campaign_dir = self.config.campaigns or
       conf_path:match("^(.-)[^" .. pathsep .. "]*$") .. "Campaigns"
   self.user_campaign_dir = setUserDir(self.user_campaign_dir, "User Campaigns")
+  self.user_log_dir = self.config.logs or
+      conf_path:match("^(.-)[^" .. pathsep .. "]*$") .. "Logs"
+  self.user_log_dir = setUserDir(self.user_log_dir, "Gamelogs")
 end
 
 --! Tries to initialize the savegame directory, returns true on success and

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -179,7 +179,7 @@ function App:init()
   self:setCaptureMouse()
   self.caption = "CorsixTH"
 
-  -- Create gamelog file if missing
+  -- Create gamelog file.
   self:initGamelogFile()
 
   -- Prereq 2: Load and initialise the graphics subsystem
@@ -389,21 +389,10 @@ function App:init()
   return true
 end
 
---! Works out the intended location of the gamelog file.
---!return full path gamelog should exist at
-function App:getGamelogPath()
-  local config_path = self.command_line["config-file"] or ""
-  config_path = config_path:match("^(.-)[^" .. pathsep .. "]*$")
-  return config_path .. "gamelog.txt"
-end
-
---! Checks and creates the gamelog file if it does not exist.
+--! Create the gamelog, using the launch time in the filename, and write the system information.
 function App:initGamelogFile()
-  local gamelog_path = self:getGamelogPath()
-  local gamelog = io.open(gamelog_path, "r")
-  if gamelog then gamelog:close() return end
-
-  local fi = self:writeToFileOrTmp(gamelog_path)
+  self.gamelog_path = self.user_log_dir .. os.date("%y-%m-%d--%H-%M-%S--gamelog.txt", os.time(os.date("!*t")))
+  local fi = self:writeToFileOrTmp(self.gamelog_path)
   local sysinfo = self:gamelogHeader()
   fi:write(sysinfo)
   fi:close()
@@ -1958,8 +1947,6 @@ end
 --! Generate information about user's system and the program
 --!return System and program info as a string
 function App:gamelogHeader()
-  local gen_date = os.date("%Y-%m-%d %H:%M:%S")
-  gen_date = string.format("Gamelog generated on %s\n", gen_date)
   local compile_opts = TH.GetCompileOptions()
   local comp_details = {}
   for key, value in pairs(compile_opts) do
@@ -1971,7 +1958,7 @@ function App:gamelogHeader()
   local running = string.format("%s run with api version: %s, game version: %s, savegame version: %s\n",
       compile_opts.jit or _VERSION, tostring(corsixth.require("api_version")),
       self:getVersion(), tostring(SAVEGAME_VERSION))
-  return (gen_date .. compiled .. running)
+  return (compiled .. running)
 end
 
 -- Do not remove, for savegame compatibility < r1891

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2088,7 +2088,7 @@ end
 --! Dump the contents of the game log into a file.
 -- This is automatically done on each error.
 function World:dumpGameLog()
-  local gamelog_path = TheApp:getGamelogPath()
+  local gamelog_path = TheApp.gamelog_path
   local fi = self.app:writeToFileOrTmp(gamelog_path)
   -- Start the gamelog file with the system information
   local sysinfo = TheApp:gamelogHeader()


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2665*

**Describe what the proposed change does**
- The gamelog is written to a file, in a new logs subfolder, named for the current date, time. At this point, older logs are deleted.

Flaws
- No UI yet
