### PR TITLE
Stop mouse capture on initial TH Selection screen

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -169,7 +169,6 @@ function App:init()
   self.video:setBlueFilterActive(false)
   SDL.wm.setIconWin32()
 
-  self:setCaptureMouse()
   self.caption = "CorsixTH"
 
   -- Create gamelog file if missing
@@ -182,6 +181,7 @@ function App:init()
 
   -- Put up the loading screen
   if good_install_folder then
+    self:setCaptureMouse()
     self.video:startFrame()
     self.gfx:loadRaw("Load01V", 640, 480):draw(self.video,
       math.floor((self.config.width - 640) / 2), math.floor((self.config.height - 480) / 2))


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2711* only

**Describe what the proposed change does**
- Stop mouse capture if we need to choose the TH install directory, since TH cursor graphics isn't available.
