### PR TITLE
added tooltips to Hotkey Assignment screen

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/hotkey_assign.lua
+++ b/CorsixTH/Lua/dialogs/resizables/hotkey_assign.lua
@@ -311,7 +311,7 @@ function UIHotkeyAssign:UIHotkeyAssign(ui, mode)
   self.key_options = {{
       id = "global",
       title = _S.hotkey_window.panel_globalKeys,
-      tooltip = _S.hotkey_window.panel_globalKeys,
+      tooltip = _S.tooltip.hotkey_window.panel_globalKeys,
       sections = {{
           title = _S.hotkey_window.panel_globalKeys,
           keys = {
@@ -324,7 +324,7 @@ function UIHotkeyAssign:UIHotkeyAssign(ui, mode)
     {
       id = "ingame",
       title = _S.hotkey_window.panel_generalInGameKeys,
-      tooltip = _S.hotkey_window.panel_generalInGameKeys,
+      tooltip = _S.tooltip.hotkey_window.panel_generalInGameKeys,
       sections = {{
           title = _S.hotkey_window.panel_generalInGameKeys,
           keys = {
@@ -357,7 +357,7 @@ function UIHotkeyAssign:UIHotkeyAssign(ui, mode)
     {
       id = "scroll",
       title = _S.hotkey_window.panel_scrollKeys,
-      tooltip = _S.hotkey_window.panel_scrollKeys,
+      tooltip = _S.tooltip.hotkey_window.panel_scrollKeys,
       sections = {{
           title = _S.hotkey_window.panel_scrollKeys,
           keys = {
@@ -370,7 +370,7 @@ function UIHotkeyAssign:UIHotkeyAssign(ui, mode)
     {
       id = "zoom",
       title = _S.hotkey_window.panel_zoomKeys,
-      tooltip = _S.hotkey_window.panel_zoomKeys,
+      tooltip = _S.tooltip.hotkey_window.panel_zoomKeys,
       sections = {{
           title = _S.hotkey_window.panel_zoomKeys,
           keys = {
@@ -382,7 +382,7 @@ function UIHotkeyAssign:UIHotkeyAssign(ui, mode)
     {
       id = "toggle",
       title = _S.hotkey_window.panel_toggleKeys,
-      tooltip = _S.hotkey_window.panel_toggleKeys,
+      tooltip = _S.tooltip.hotkey_window.panel_toggleKeys,
       sections = {{
           title = _S.hotkey_window.panel_toggleKeys,
           keys = {
@@ -450,7 +450,7 @@ function UIHotkeyAssign:UIHotkeyAssign(ui, mode)
     table.insert(self.key_options, {
         id = "debug",
         title = _S.hotkey_window.panel_debugKeys,
-        tooltip = _S.hotkey_window.panel_debugKeys,
+        tooltip = _S.tooltip.hotkey_window.panel_debugKeys,
         sections = {{
             title = _S.hotkey_window.panel_debugKeys,
             keys = {

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -682,9 +682,15 @@ tooltip.hotkey_window = {
   button_accept = "Accept and save hotkey assignments",
   button_defaults = "Reset all hotkeys to the program's defaults",
   button_cancel = "Cancel the assignment and go back to the options menu",
-  caption_panels = "Open window to assign panel keys",
-  button_gameSpeedKeys = "Open window to set keys to control game speed",
-  button_recallPosKeys = "Open window to set keys to store and recall camera positions",
+  panel_globalKeys = "Assign global hotkeys",
+  panel_generalInGameKeys = "Assign general in-game hotkeys",
+  button_gameSpeedKeys = "Assign hotkeys to control the game speed",
+  panel_scrollKeys = "Assign hotkeys to scroll the screen",
+  panel_zoomKeys = "Assign hotkeys to zoom in and out",
+  panel_toggleKeys = "Assign hotkeys to toggle options",
+  caption_panels = "Assign hotkeys to open panels",
+  button_recallPosKeys = "Assign hotkeys to save and recall camera positions",
+  panel_debugKeys = "Assign hotkeys for debugging",
   button_back_02 = "Go back to the main hotkey window. Hotkeys changed in this window can be accepted there",
 }
 


### PR DESCRIPTION
*Fixes #2721*

- Adds missing tooltips to Hotkey Assignment screen (the keys are consistent with each corresponding button's label)
- Adjusted wording of existing tooltips on Hotkey Assignment screen
- Feel free to suggest any improvements to the values provided
