### PR TITLE
Add new criteria - staff and patient happiness

### DIFF
--- a/CorsixTH/Lua/endconditions.lua
+++ b/CorsixTH/Lua/endconditions.lua
@@ -29,11 +29,16 @@ local local_criteria_variable = {
   {name = "num_cured" ,       icon = 13, formats = 2},
   {name = "percentage_killed",icon = 14, formats = 2},
   {name = "value",            icon = 15, formats = 2}, -- Hospital value
+    -- New criteria
+  {name = "staff_happiness",  icon = 16, icon_file = "MPointer", formats = 2, two_tooltips = true},
+  {name = "patient_happiness",icon = 18, icon_file = "MPointer", formats = 2, two_tooltips = true},
 }
 
 -- A table of functions for fetching criteria values that cannot be measured
 --   directly from a hospital attribute of the same name.
 local get_custom_criteria = {
+  staff_happiness = function(hospital) return 100 * hospital:getAverageStaffAttribute("happiness", 0.5) end,
+  patient_happiness = function(hospital) return 100 * hospital:getAveragePatientAttribute("happiness", 0.5) end,
 }
 
 class "EndConditions"

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -790,6 +790,8 @@ information = {
     balance = "Your bank balance fell below %d.",
     percentage_killed = "You killed more than %d percent of the patients.",
     cheat = "This was your choice or did you select the wrong button? So you can't even cheat correctly, not that funny huh?",
+    staff_happiness = "Your average staff happiness fell below %d%.",
+    patient_happiness = "Your average patient happiness fell below %d%.",
   },
   cheat_not_possible = "Cannot use that cheat on this level. You even fail to cheat, not that funny huh?",
 }
@@ -969,6 +971,17 @@ hotkeys_file_err = {
 }
 
 transactions.remove_room = "Build: Remove destroyed room"
+
+tooltip.status = {
+  over = {
+    staff_happiness = "Your average staff happiness should be over %d%. Currently it's %d%",
+    patient_happiness = "Your average patient happiness should be over %d%. Currently it's %d%",
+  },
+  under = {
+    staff_happiness = "Your average staff happiness should not be less than %d%. Currently it's %d%",
+    patient_happiness = "Your average patient happiness should not be less than %d%. Currently it's %d%",
+  }
+}
 --------------------------------  UNUSED  -----------------------------------
 ------------------- (kept for backwards compatibility) ----------------------
 


### PR DESCRIPTION
**Describe what the proposed change does**
- Adds the end game criteria of average happiness for staff and patients. 

See it with this in example.level, or change the 30 to 60 for a quick lose.
```
 7 Average staff happiness (0-100)
 8 Average patient happiness (0-100)
 #win_criteria[0].Criteria.MaxMin.Value.Group.Bound 7 1 70 1 50
 #lose_criteria[0].Criteria.MaxMin.Value.Group.Bound 8 0 30 2 50
```
I'm writing a wiki page for this process of adding criteria.