### PR TITLE
Set minimum possible machine strength after repair to 2

### DIFF
--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -290,6 +290,7 @@ end
 function Machine:machineRepaired(room)
   room.needs_repair = nil
   self:reduceStrengthOnRepair(room)
+  self.times_used = 0
   self:setRepairing(nil)
   setSmoke(self, false)
   local taskIndex = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "repairing")
@@ -297,7 +298,6 @@ function Machine:machineRepaired(room)
 end
 
 --! Calculates if machine strength should be reduced as a result of repair
--- Also resets 'times_used' value
 --!param room (object) machine room
 function Machine:reduceStrengthOnRepair(room)
   local minimum_possible_strength = 2
@@ -311,8 +311,6 @@ function Machine:reduceStrengthOnRepair(room)
   if should_reduce_strength then
     self.strength = current_strength - 1
   end
-
-  self.times_used = 0
 end
 
 --! Tells the machine to start showing the icon that it needs repair.

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -289,6 +289,19 @@ end
 
 function Machine:machineRepaired(room)
   room.needs_repair = nil
+  self:reduceStrengthOnRepair(room)
+  self:setRepairing(nil)
+  setSmoke(self, false)
+  local taskIndex = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "repairing")
+  self.hospital:removeHandymanTask(taskIndex, "repairing")
+end
+
+--! Calculates if machine strength should be reduced as a result of repair
+-- Also resets 'times_used' value
+--!param room (object) machine room
+function Machine:reduceStrengthOnRepair(room)
+  local minimum_possible_strength = 2
+  if self.strength <= minimum_possible_strength then return end
 
   local current_strength = self.strength
   local used_out_rate = self.times_used / current_strength
@@ -300,10 +313,6 @@ function Machine:machineRepaired(room)
   end
 
   self.times_used = 0
-  self:setRepairing(nil)
-  setSmoke(self, false)
-  local taskIndex = self.hospital:getIndexOfTask(self.tile_x, self.tile_y, "repairing")
-  self.hospital:removeHandymanTask(taskIndex, "repairing")
 end
 
 --! Tells the machine to start showing the icon that it needs repair.


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**Describe what the proposed change does**
-
- ... as a result of Discord discussion...
- We noticed that in the vanilla TH machines have a minimum possible value for the strength, which we did not follow in CTX. This value 2. This PR fixes that for CTX.
-
