### PR TITLE
Fix spawn contagious patient cheat

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1190,6 +1190,10 @@ function Hospital:spawnContagiousPatient()
       patient:setDisease(disease)
       --Move the first patient closer (FOR TESTING ONLY)
       local x,y = self:getHeliportSpawnPosition()
+      if not x then
+        local spawn_point = self.world.spawn_points[math.random(1, #self.world.spawn_points)]
+        x, y = spawn_point.x, spawn_point.y
+      end
       patient:setTile(x,y)
       patient:setHospital(self)
       self:addToEpidemic(patient)


### PR DESCRIPTION
**Describe what the proposed change does**
- If there is no helipad (eg level 2), the patient created by the 'Soawn Contagious Patient' cheat is spawned on a random regular spawn tile.