### PR TITLE
#2738 stop epidemic timer on epidemic successfully eradicated

### DIFF
--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -271,7 +271,7 @@ end
 --[[ Check for conditions that no any uncured infected patients
 left in hospital. If so then epidemic must end earlier than the
 length of the timer.]]
-function Epidemic:checkThereAreNoAnyInfectedPatientsLeft()
+function Epidemic:checkNoInfectedPatients()
   if self.result_determined then return end
 
   if (self:countInfectedPatients() == 0) then

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -262,12 +262,15 @@ function Epidemic:checkNoInfectedPlayerHasLeft()
         px and py and not self.hospital:isInHospital(px,py) then
       -- Patient escaped from the hospital, discovery is inevitable.
       self.result_determined = true
-      if not self.inspector then
-        self:spawnInspector()
-      end
       self:finishCoverUp()
       return
     end
+  end
+
+  local all_infected_cured = self:countInfectedPatients() == 0 
+  if all_infected_cured then
+    self:finishCoverUp()
+    return
   end
 end
 
@@ -410,6 +413,10 @@ end
 later (@see applyOutcome) ]]
 function Epidemic:finishCoverUp()
   self.result_determined = true
+
+  if not self.inspector then
+    self:spawnInspector()
+  end
 
   self.timer:close()
 

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -267,7 +267,7 @@ function Epidemic:checkNoInfectedPlayerHasLeft()
     end
   end
 
-  local all_infected_cured = self:countInfectedPatients() == 0 
+  local all_infected_cured = self:countInfectedPatients() == 0
   if all_infected_cured then
     self:finishCoverUp()
     return

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -277,7 +277,6 @@ function Epidemic:checkThereAreNoAnyInfectedPatientsLeft()
   local no_any_infected_patients_left = self:countInfectedPatients() == 0
   if no_any_infected_patients_left then
     self:finishCoverUp()
-    return
   end
 end
 

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -110,9 +110,9 @@ function Epidemic:tick()
   if self.coverup_in_progress then
     if not self.result_determined then
       self:checkNoInfectedPlayerHasLeft()
+      self:checkNoInfectedPatients()
       self:markedPatientsCallForVaccination()
       self:showAppropriateAdviceMessages()
-      self:checkThereAreNoAnyInfectedPatientsLeft()
     end
     self:tryAnnounceInspector()
   end
@@ -274,7 +274,7 @@ length of the timer.]]
 function Epidemic:checkNoInfectedPatients()
   if self.result_determined then return end
 
-  if (self:countInfectedPatients() == 0) then
+  if self:countInfectedPatients() == 0 then
     self:finishCoverUp()
   end
 end

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -268,6 +268,9 @@ function Epidemic:checkNoInfectedPlayerHasLeft()
   end
 end
 
+--[[ Check for conditions that no any uncured infected patients
+left in hospital. If so then epidemic must end earlier than the
+length of the timer.]]
 function Epidemic:checkThereAreNoAnyInfectedPatientsLeft()
   if self.result_determined then return end
 

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -274,8 +274,7 @@ length of the timer.]]
 function Epidemic:checkThereAreNoAnyInfectedPatientsLeft()
   if self.result_determined then return end
 
-  local no_any_infected_patients_left = self:countInfectedPatients() == 0
-  if no_any_infected_patients_left then
+  if (self:countInfectedPatients() == 0) then
     self:finishCoverUp()
   end
 end

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -112,6 +112,7 @@ function Epidemic:tick()
       self:checkNoInfectedPlayerHasLeft()
       self:markedPatientsCallForVaccination()
       self:showAppropriateAdviceMessages()
+      self:checkThereAreNoAnyInfectedPatientsLeft()
     end
     self:tryAnnounceInspector()
   end
@@ -248,9 +249,9 @@ function Epidemic:announceEndOfEpidemic()
   end
 end
 
---[[ Checks for conditions that could end the epidemic earlier than
- the length of the timer. If an infected patient leaves the
- hospital it's discovered instantly and will result in a fail.]]
+--[[ Check for conditions that one of the infected and not cured
+patient leaved the hospital. This discover epidemic to public instantly.
+So epidemic must end earlier than the length of the timer.]]
 function Epidemic:checkNoInfectedPlayerHasLeft()
   if self.result_determined then return end
 
@@ -261,14 +262,17 @@ function Epidemic:checkNoInfectedPlayerHasLeft()
     if infected_patient.going_home and not infected_patient.cured and
         px and py and not self.hospital:isInHospital(px,py) then
       -- Patient escaped from the hospital, discovery is inevitable.
-      self.result_determined = true
       self:finishCoverUp()
       return
     end
   end
+end
 
-  local all_infected_cured = self:countInfectedPatients() == 0
-  if all_infected_cured then
+function Epidemic:checkThereAreNoAnyInfectedPatientsLeft()
+  if self.result_determined then return end
+
+  local no_any_infected_patients_left = self:countInfectedPatients() == 0
+  if no_any_infected_patients_left then
     self:finishCoverUp()
     return
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2738, #1454*

**Describe what the proposed change does**
- Fixes bug when epidemic Timer doesn't stop when an epidemic is successfully eradicated.
-
