### PR TITLE
Do not show cheats in map editor

### DIFF
--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -167,7 +167,7 @@ function GameUI:setupGlobalKeyHandlers()
     self:addKeyHandler(string.format("ingame_recallPosition_%d", i), self, self.recallMapPosition, i)
   end
 
-  if self.app.config.debug then
+  if self.app.config.debug and self.app.world.map.level_number ~= "MAP EDITOR" then
     self:addKeyHandler("ingame_showCheatWindow", self, self.showCheatsWindow)
   end
 end


### PR DESCRIPTION
* Fixes #2613 

**Describe what the proposed change does**
- Disables cheats menu bind in the map editor