### PR TITLE
Cleanup door-handling in walk action

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -252,15 +252,12 @@ end)
 
 navigateDoor = function(humanoid, x1, y1, dir)
   local action = humanoid:getCurrentAction()
-  local duration = 12
   local dx = x1
   local dy = y1
   if dir == "east" then
     dx = dx + 1
-    duration = 10
   elseif dir == "south" then
     dy = dy + 1
-    duration = 10
   end
   local swinging = false
   local door = humanoid.world:getObject(dx, dy, "door")
@@ -338,33 +335,35 @@ navigateDoor = function(humanoid, x1, y1, dir)
   humanoid:setTilePositionSpeed(dx, dy)
   humanoid.user_of = door
   door:setUser(humanoid)
-  local entering, leaving
-  if swinging then
-    entering = anims.entering_swing
-    leaving = anims.leaving_swing
-    duration = humanoid.world:getAnimLength(entering)
-  else
-    entering = anims.entering
-    leaving = anims.leaving
-  end
-  local direction = "in"
+  local entering = swinging and anims.entering_swing or anims.entering
+  local leaving = swinging and anims.leaving_swing or anims.leaving
+
+  local duration, direction
   if dir == "north" then
     humanoid:setAnimation(leaving, flag_list_bottom)
-    to_x, to_y = dx, dy - 1
     duration = humanoid.world:getAnimLength(leaving)
+    to_x, to_y = dx, dy - 1
+    direction = "in"
+
   elseif dir == "west" then
     humanoid:setAnimation(leaving, flag_list_bottom + flag_flip_h)
-    to_x, to_y = dx - 1, dy
     duration = humanoid.world:getAnimLength(leaving)
+    to_x, to_y = dx - 1, dy
+    direction = "in"
+
   elseif dir == "east" then
     humanoid:setAnimation(entering, flag_list_bottom)
+    duration = humanoid.world:getAnimLength(entering)
     to_x, to_y = dx, dy
     direction = "out"
+
   elseif dir == "south" then
     humanoid:setAnimation(entering, flag_list_bottom + flag_flip_h)
+    duration = humanoid.world:getAnimLength(entering)
     to_x, to_y = dx, dy
     direction = "out"
   end
+
   humanoid.last_move_direction = dir
   if swinging then
     door:swingDoors(direction, duration)


### PR DESCRIPTION
**Describe what the proposed change does**
- Code has a `duration` variable with some hard-coded values. Also, it is changed a few times, making it hard to understand what actually happens.
- Analysis showed it simply uses the door animation length in all cases.
- Simplified the code without changing functionality.

----
As the function is long, and there are 2 door types, 4 compass directions, leaving/entering case distinction and many humanoid types, some analysis was done first.

Added code to dump the available animations and their length on first creation of a humanoid:
``` diff
diff --git a/CorsixTH/Lua/entities/humanoid.lua b/CorsixTH/Lua/entities/humanoid.lua
index cf88ac8e..857ea297 100644
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -283,6 +283,8 @@ for anim in values(door_animations, "*.leaving_swing") do
   anim_mgr:setMarker(anim, 0, {0.1, 0}, 9, {0, -1})
 end
 
+local door_anim_dump = door_animations -- Door animations by humanoid class
+
 --!param ... Arguments for base class constructor.
 function Humanoid:Humanoid(...)
   self:Entity(...)
@@ -301,6 +303,20 @@ function Humanoid:Humanoid(...)
   self.build_callbacks  = {--[[set]]}
   self.remove_callbacks = {--[[set]]}
   self.staff_change_callbacks = {--[[set]]}
+
+  if door_anim_dump then
+    local names = {"entering", "leaving", "entering_swing", "leaving_swing"}
+    for _, name in ipairs(names) do
+      print()
+      for h_class, anims in pairs(door_anim_dump) do
+        if anims[name] then
+          print(h_class .. " - " .. name .. ": " .. TheApp.world:getAnimLength(anims[name]))
+        end
+      end
+    end
+  end
+  door_anim_dump = nil
+
 end
``` 

The above resulted in understanding:
- standard door entering has 10 frames for all
- standard door leaving has 12 frames for all
- swing door entering has 6 frames for all
- swing door leaving has 9 frames for most, 7 for nurse and 5 for doctor.

Actual dumped lengths for me:
``` text
Chewbacca Patient - entering: 10
Invisible Patient - entering: 10
Doctor - entering: 10
Standard Male Patient - entering: 10
Alternate Male Patient - entering: 10
Elvis Patient - entering: 10
Transparent Female Patient - entering: 10
Slack Male Patient - entering: 10
Handyman - entering: 10
Nurse - entering: 10
Transparent Male Patient - entering: 10
Alien Female Patient - entering: 10
Slack Female Patient - entering: 10
Standard Female Patient - entering: 10
Alien Male Patient - entering: 10

Chewbacca Patient - leaving: 12
Invisible Patient - leaving: 12
Doctor - leaving: 12
Standard Male Patient - leaving: 12
Alternate Male Patient - leaving: 12
Elvis Patient - leaving: 12
Transparent Female Patient - leaving: 12
Slack Male Patient - leaving: 12
Handyman - leaving: 12
Nurse - leaving: 12
Transparent Male Patient - leaving: 12
Alien Female Patient - leaving: 12
Slack Female Patient - leaving: 12
Standard Female Patient - leaving: 12
Alien Male Patient - leaving: 12

Doctor - entering_swing: 6
Standard Male Patient - entering_swing: 6
Handyman - entering_swing: 6
Nurse - entering_swing: 6
Alien Female Patient - entering_swing: 6
Slack Female Patient - entering_swing: 6
Standard Female Patient - entering_swing: 6
Alien Male Patient - entering_swing: 6

Doctor - leaving_swing: 5
Standard Male Patient - leaving_swing: 9
Handyman - leaving_swing: 9
Nurse - leaving_swing: 7
Alien Female Patient - leaving_swing: 9
Slack Female Patient - leaving_swing: 9
Standard Female Patient - leaving_swing: 9
Alien Male Patient - leaving_swing: 9
```

At the `duration` side this means that the meaning of `duration` gets changed as follows:
(appended comment to all occurrences of  `duration`)
``` diff
diff --git a/CorsixTH/Lua/humanoid_actions/walk.lua b/CorsixTH/Lua/humanoid_actions/walk.lua
index 8edbbe2a..12828fc5 100644
--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -252,15 +252,15 @@ end)
 
 navigateDoor = function(humanoid, x1, y1, dir)
   local action = humanoid:getCurrentAction()
-  local duration = 12
+  local duration = 12 -- Standard door, leaving
   local dx = x1
   local dy = y1
   if dir == "east" then
     dx = dx + 1
-    duration = 10
+    duration = 10 -- Standard door, entering
   elseif dir == "south" then
     dy = dy + 1
-    duration = 10
+    duration = 10 -- Standard door, entering
   end
   local swinging = false
   local door = humanoid.world:getObject(dx, dy, "door")
@@ -342,7 +342,7 @@ navigateDoor = function(humanoid, x1, y1, dir)
   if swinging then
     entering = anims.entering_swing
     leaving = anims.leaving_swing
-    duration = humanoid.world:getAnimLength(entering)
+    duration = humanoid.world:getAnimLength(entering) -- Use animation enter lengths for swings
   else
     entering = anims.entering
     leaving = anims.leaving
@@ -351,11 +351,11 @@ navigateDoor = function(humanoid, x1, y1, dir)
   if dir == "north" then
     humanoid:setAnimation(leaving, flag_list_bottom)
     to_x, to_y = dx, dy - 1
-    duration = humanoid.world:getAnimLength(leaving)
+    duration = humanoid.world:getAnimLength(leaving) -- Use animation leaving length for all doors
   elseif dir == "west" then
     humanoid:setAnimation(leaving, flag_list_bottom + flag_flip_h)
     to_x, to_y = dx - 1, dy
-    duration = humanoid.world:getAnimLength(leaving)
+    duration = humanoid.world:getAnimLength(leaving) -- Use animation leaving length for all doors
   elseif dir == "east" then
     humanoid:setAnimation(entering, flag_list_bottom)
     to_x, to_y = dx, dy
@@ -367,7 +367,7 @@ navigateDoor = function(humanoid, x1, y1, dir)
   end
   humanoid.last_move_direction = dir
   if swinging then
-    door:swingDoors(direction, duration)
+    door:swingDoors(direction, duration) -- Setup swing doors for their animation length
   end
 
   -- We want to notify the rooms on either side of the door that the humanoid
@@ -394,7 +394,7 @@ navigateDoor = function(humanoid, x1, y1, dir)
   end
 
   action.path_index = action.path_index + 1
-  humanoid:setTimer(duration, action_walk_tick_door)
+  humanoid:setTimer(duration, action_walk_tick_door) -- Wait until door is done, for all doors
 end
 
 local function action_walk_start(action, humanoid)
```
This analysis suggested that the `duration` value seemed the same as real animation lengths.

----
To check, I added debug code to the function:
``` diff
diff --git a/CorsixTH/Lua/humanoid_actions/walk.lua b/CorsixTH/Lua/humanoid_actions/walk.lua
index 8edbbe2a..a7ed8910 100644
--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -250,6 +250,8 @@ local action_walk_tick_door = permanent"action_walk_tick_door"( function(humanoi
   return action_walk_tick(humanoid)
 end)
 
+local seen_doors = {}
+
 navigateDoor = function(humanoid, x1, y1, dir)
   local action = humanoid:getCurrentAction()
   local duration = 12
@@ -348,20 +350,28 @@ navigateDoor = function(humanoid, x1, y1, dir)
     leaving = anims.leaving
   end
   local direction = "in"
+  local used_anim
   if dir == "north" then
     humanoid:setAnimation(leaving, flag_list_bottom)
+    used_anim = leaving
     to_x, to_y = dx, dy - 1
     duration = humanoid.world:getAnimLength(leaving)
+
   elseif dir == "west" then
     humanoid:setAnimation(leaving, flag_list_bottom + flag_flip_h)
+    used_anim = leaving
     to_x, to_y = dx - 1, dy
     duration = humanoid.world:getAnimLength(leaving)
+
   elseif dir == "east" then
     humanoid:setAnimation(entering, flag_list_bottom)
+    used_anim = entering
     to_x, to_y = dx, dy
     direction = "out"
+
   elseif dir == "south" then
     humanoid:setAnimation(entering, flag_list_bottom + flag_flip_h)
+    used_anim = entering
     to_x, to_y = dx, dy
     direction = "out"
   end
@@ -393,8 +403,26 @@ navigateDoor = function(humanoid, x1, y1, dir)
     humanoid.in_room = room
   end
 
+  local dump_humanoids = {
+    ["Handyman"] = true,
+    ["Standard Female Patient"] = true,
+    ["Nurse"] = true,
+    ["Doctor"] = true,
+  }
+
   action.path_index = action.path_index + 1
   humanoid:setTimer(duration, action_walk_tick_door)
+  if dump_humanoids[humanoid.humanoid_class] then
+    local door_type = swinging and "swing" or "normal"
+    local entry = humanoid.humanoid_class .. "-" .. dir .. "-" .. direction .. "-" .. door_type
+    if not seen_doors[entry] then
+      local anim_length = humanoid.world:getAnimLength(used_anim)
+      local text = (duration == anim_length) and "same" or "DIFFERENT"
+      text = text .. " length = " .. anim_length .. ", duration = " .. duration
+      print(entry .. " ##### " .. text)
+      seen_doors[entry] = text
+    end
+  end
 end
 
 local function action_walk_start(action, humanoid)
```
This produces one line of text for each case whether the `duration` value is the same as the animation length, for:
- One of the humanoids in `dump_humanoids`
- For n/w/e/s
- For in/out
- For standard/swing doors

After sorting the produces lines, it gave
``` text
Doctor-east-out-normal ##### same length = 10, duration = 10
Doctor-north-in-normal ##### same length = 12, duration = 12
Doctor-south-out-normal ##### same length = 10, duration = 10
Doctor-west-in-normal ##### same length = 12, duration = 12

Handyman-east-out-normal ##### same length = 10, duration = 10
Handyman-east-out-swing ##### same length = 6, duration = 6
Handyman-west-in-normal ##### same length = 12, duration = 12
Handyman-west-in-swing ##### same length = 9, duration = 9
Handyman-north-in-normal ##### same length = 12, duration = 12
Handyman-south-out-normal ##### same length = 10, duration = 10

Nurse-east-out-swing ##### same length = 6, duration = 6
Nurse-north-in-swing ##### same length = 7, duration = 7
Nurse-south-out-swing ##### same length = 6, duration = 6
Nurse-west-in-swing ##### same length = 7, duration = 7

Nurse-east-out-normal ##### same length = 10, duration = 10
Nurse-west-in-normal ##### same length = 12, duration = 12

Standard Female Patient-east-out-normal ##### same length = 10, duration = 10
Standard Female Patient-north-in-normal ##### same length = 12, duration = 12
Standard Female Patient-south-out-normal ##### same length = 10, duration = 10
Standard Female Patient-west-in-normal ##### same length = 12, duration = 12

Standard Female Patient-east-out-swing ##### same length = 6, duration = 6
Standard Female Patient-north-in-swing ##### same length = 9, duration = 9
Standard Female Patient-south-out-swing ##### same length = 6, duration = 6
Standard Female Patient-west-in-swing ##### same length = 9, duration = 9
```
As the level didn't have an operating theatre, I couldn't test the Doctor swing-door animations, but as swing doors lengths are always derived from the animation, I see no difference for it wrt to Nurse case.

----
All results state that the computed `duration` is also the real length of the used animation.
Code can be simplified thus.