### PR TITLE
Cleanup/"fix" the UseObjectAction

### DIFF
--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -227,7 +227,7 @@ function Machine:createHandymanActions(handyman)
 
   local repair_action = UseObjectAction(self):setProlongedUsage(false)
       :setAfterUse(repair_after_use)
-  repair_action.min_length = 20
+  repair_action.min_length = 20 -- Minimum number of frames needed for the action.
 
   if handyman_room and handyman_room ~= this_room then
     handyman:setNextAction(handyman_room:createLeaveAction())

--- a/CorsixTH/Lua/humanoid_actions/use_object.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_object.lua
@@ -442,12 +442,12 @@ local function action_use_object_start(action, humanoid)
   local flags = 0
   if not object.object_type.usage_animations[orient] then
     orient = orient_mirror[orient]
-    flags = flags + 1
+    flags = flags + DrawFlags.FlipHorizontal
   end
   local spec = object.object_type.orientations[object.direction]
   -- early_list_while_in_use (if defined) will take precedence over early_list
   if spec.early_list_while_in_use or (spec.early_list_while_in_use == nil and spec.early_list) then
-    flags = flags + 1024
+    flags = flags + DrawFlags.EarlyList
   end
 
   -- The handyman has his own place to be in

--- a/CorsixTH/Lua/humanoid_actions/use_object.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_object.lua
@@ -284,12 +284,15 @@ local function action_use_phase(action, humanoid, phase)
   setHumanoidTileSpeed(action, humanoid)
   humanoid.user_of = object
 
-  local length = anim_length * humanoid.world:getAnimLength(anim)
-  if action.min_length and phase == 0 and action.min_length > length then
-    -- A certain length is desired.
-    -- Even it out so that an integer number of animation sequences are done.
-    length = action.min_length + action.min_length % length
+  local frame_count = humanoid.world:getAnimLength(anim)
+  local action_anim_count = 1 -- Number of times to show 'in_use' animation for the action.
+  if action.min_length and phase == 0 then
+    -- 'action.min_length' is a frame count, convert to number of complete animations.
+    action_anim_count = math.floor((action.min_length + frame_count - 1) / frame_count)
   end
+  -- Take the smallest number of of animations that satisfies both the object and
+  -- the action minimum count.
+  local length = math.max(action_anim_count, anim_length) * frame_count
 
   -- A timer would be redundant in certain situations, so check it is needed
   if phase ~= 0 or is_list or length ~= 1 or not action.prolonged_usage or

--- a/CorsixTH/Lua/humanoid_actions/use_object.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_object.lua
@@ -191,7 +191,7 @@ local function action_use_phase(action, humanoid, phase)
   elseif phase == 5 then
     anim_table = action.anims.finish_use_5
   end
-  local is_list = false
+
   local anim = anim_table[humanoid.humanoid_class]
   if not anim then
     -- Handymen have their own number of animations.
@@ -212,6 +212,7 @@ local function action_use_phase(action, humanoid, phase)
     anim_length = anim.length
   end
 
+  local is_list = false
   if type(anim) == "table" and anim[1] ~= "morph" and #anim > 1 then
     -- If an animation list is provided rather than a single animation, then
     -- choose an animation from the list at random.


### PR DESCRIPTION
**Describe what the proposed change does**
- Adds comment, some lua docs, and a few empty lines for better readability.
- Replaces some `DrawFlags` magic constants.
- Fixes the logic for required minimal use (does not affect the only case that uses it, since the dna fixer has 1 frame (ie any number of frames is correct), and `20 % 10 == 0` so nothing is actually added).
  To understand how it's broken, the old code was:
  ``` diff
  - local length = anim_length * humanoid.world:getAnimLength(anim)
  - if action.min_length and phase == 0 and action.min_length > length then
  -   -- A certain length is desired.
  -   -- Even it out so that an integer number of animation sequences are done.
  -   length = action.min_length + action.min_length % length
  - end
   ```
  - `anim_length` is the number of animations defined with the object.
  - `length` is the number of frames for `anim_length` animations.
  - In the `in_use` phase, if the action requires more frames: Take the number of frames for the action + some fraction of it.
  - This is only an "integer number of animation sequences" if the `action.min_length` is that as well. In general however, such an implicit connection is undesired. It may break as soon as the animation is changed.
  - However, if the `action.min_length` has the property above, then why does it lengthen the sequence at all, given that `action.min_length > length` already holds?
