### PR TITLE
Remove duplicate call to open the win fax

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -452,7 +452,6 @@ end
 function UIAnnualReport:close()
   if TheApp.world:getLocalPlayerHospital().game_won then
     TheApp.video:setBlueFilterActive(false)
-    TheApp.world.ui.bottom_panel:openLastMessage()
   end
   self:updateAwards()
   Window.close(self)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #1675*

**Describe what the proposed change does**
https://github.com/search?q=repo%3ACorsixTH%2FCorsixTH+bottom_panel%3Aopenlastmessage&type=code

There are two calls to open the same win fax, this removes one of them.
