### PR TITLE
Add adviser messages for patients waiting for a staffed gps office

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -2502,3 +2502,7 @@ end
 --! The UI parts of earthquake ticks
 function Hospital:tickEarthquake(stage)
 end
+
+--! Give advice that a patient is waiting for the player to build a GP's office
+function Hospital:adviseNoGPOffice()
+end

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -106,6 +106,8 @@ function PlayerHospital:dailyAdviceChecks()
   -- Reset advise flags at the end of the month.
   if day == 28 then
     self.adviser_data.temperature_advice = false
+    self.adviser_data.no_gp_office = false
+    self.adviser_data.no_doctor_no_gp_office = false
   end
 end
 
@@ -812,6 +814,23 @@ function PlayerHospital:tickEarthquake(stage)
     end
   else
     assert(false, "Unknown stage: " .. (stage or "nil"))
+  end
+end
+
+--! Give advice that a patient is waiting for the player to build a GP's office
+-- Called when a patient has passed reception and is waiting for a room to be built.
+-- Each piece of advice is only given once per month
+function PlayerHospital:adviseNoGPOffice()
+  if self:countStaffOfCategory("Doctor", 1) > 0 then -- Doctor without a room
+    if not self.adviser_data.no_gp_office then
+      self.world.ui.adviser:say(_A.warnings.no_gp_office)
+      self.adviser_data.no_gp_office = true
+    end
+  else -- No room or doctor
+    if not self.adviser_data.no_doctor_no_gp_office then
+      self.world.ui.adviser:say(_A.warnings.no_doctor_no_gp_office)
+      self.adviser_data.no_doctor_no_gp_office = true
+    end
   end
 end
 

--- a/CorsixTH/Lua/humanoid_actions/seek_room.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_room.lua
@@ -326,12 +326,13 @@ local function action_seek_room_start(action, humanoid)
           humanoid:setDynamicInfoText(_S.dynamic_info.patient.actions.awaiting_decision)
         end
       else
-        -- No more diagnosis rooms can be found
-        -- The GP's office is a special case. TODO: Make a custom message anyway?
         if action.room_type == "gp" then
+          -- The GP's office is a special case.
           humanoid:setMood("patient_wait", "activate")
           humanoid:setDynamicInfoText(_S.dynamic_info.patient.actions.no_gp_available)
+          humanoid.hospital:adviseNoGPOffice()
         else
+          -- No more diagnosis rooms can be found
           action_still_valid = action_seek_room_no_diagnosis_room_found(action, humanoid)
         end
       end

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -268,6 +268,8 @@ adviser = {
     high_prices = "Your charges for %s are high. This will make big profits in the short-term, but ultimately you'll start to drive people away.",
     fair_prices = "Your charges for %s seem fair and balanced.",
     patient_not_paying = "A patient left without paying for %s because it's too expensive!",
+    no_doctor_no_gp_office = "You should build a GP's Office and hire a doctor at some point!",
+    no_gp_office = "You haven't built a GP's Office where your doctors can diagnose the patients!",
   },
   cheats = {
     th_cheat = "Congratulations, you have unlocked cheats!",


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #1877*

**Describe what the proposed change does**
- Add advice telling the player to build a GPs office for a hired doctor, or build the room and hire the doc. The advice is only given once per month. The third case of an unstaffed room already has a message.

This is for the regular path, when the hospital has a reception but not rooms. It doesn't apply to patients who queued at a room since deleted.