### PR TITLE
Change reroute behaviour on trimmed paths

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -116,7 +116,7 @@ local function action_seek_reception_start(action, humanoid)
       humanoid:setNextAction(QueueAction(x, y, best_desk.queue):setMustHappen(action.must_happen)
           :setFaceDirection(face_x, face_y))
     else
-      local walk = WalkAction(x, y):setMustHappen(action.must_happen)
+      local walk = WalkAction(x, y, true):setMustHappen(action.must_happen)
       humanoid:queueAction(walk, 0)
 
       trimQueuingTail(humanoid, walk.path_x, walk.path_y)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2501*

**Describe what the proposed change does**
- Adds a new parameter to the `Walk` action where a trimmed path issued
- Instead of attempting a reroute inside the Walk, the action is finished instead
- In the case of `SeekReception`, that action calls a new `Walk` with an updated path.


@Alberth289346 and I discussed this one, and both agree currently there may not be a very nice way to do this, but as it's a regression of #1852 introduced in 0.67 it may be worth considering a fix for now. A better long term solution is recoding how walk is handled as a whole.