### PR TITLE
Remove Serious Radiation epidemics

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 210 -- Renamed humanoid moods
+local SAVEGAME_VERSION = 211 -- Remove serious radiation epidemics
 
 class "App"
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1250,19 +1250,28 @@ function Hospital:manageEpidemics()
   end
 end
 
---[[ For Cheat - Cancel ongoing and future epidemics. ]]
-function Hospital:cancelEpidemics()
+--! Cancel ongoing and future epidemics.
+--!param disease (table) Optional, if specified only epidemics of a certain disease
+-- will be cancelled.
+function Hospital:cancelEpidemics(disease)
+  local function cancelEpidemic(epidemic)
+    if disease and disease ~= epidemic.disease then return false end
+    epidemic:cancelEpidemic()
+    return true
+  end
   -- Cancel ongoing epidemic
   if self.epidemic ~= nil then
-    self.epidemic:cancelEpidemic()
+    cancelEpidemic(self.epidemic)
     self.epidemic = nil
   end
   -- Cancel not revealed epidemics
   if self.future_epidemics_pool then
-    for i, future_epidemic in ipairs(self.future_epidemics_pool) do
-      future_epidemic:cancelEpidemic()
+    local future_epidemics = self.future_epidemics_pool
+    for i=#future_epidemics, 1, -1 do
+      if cancelEpidemic(future_epidemics[i]) then
+        table.remove(self.future_epidemics_pool, i)
+      end
     end
-    self.future_epidemics_pool = {}
   end
 end
 

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1261,8 +1261,7 @@ function Hospital:cancelEpidemics(disease)
   end
   -- Cancel ongoing epidemic
   if self.epidemic ~= nil then
-    cancelEpidemic(self.epidemic)
-    self.epidemic = nil
+    if cancelEpidemic(self.epidemic) then self.epidemic = nil end
   end
   -- Cancel not revealed epidemics
   if self.future_epidemics_pool then

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -862,7 +862,7 @@ function PlayerHospital:afterLoad(old, new)
     if self.epidemic and self.epidemic.disease == serious_radiation then
       -- Tell the player somehow we ended the epidemic, EPI0008 is most fitting
       self.world.ui:playAnnouncement("EPID008.wav", AnnouncementPriority.Critical)
-      self.world:gameLog("Notice: Removing active epidemic for Serious Radiation. See issue 2760.")
+      self.world:gameLog("Notice: Removing active epidemic for Serious Radiation as it may crash the game due to a bug.")
     end
     self:cancelEpidemics(serious_radiation)
   end

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -856,6 +856,16 @@ function PlayerHospital:afterLoad(old, new)
   if old < 159 then
     self.adviser_data.reception_advice = self.adviser_data.reception_advice or self.receptionist_msg
   end
+  if old < 211 then
+    -- Serious Radiation epidemics could exist in old saves and cause a crash
+    local serious_radiation = TheApp.diseases["serious_radiation"]
+    if self.epidemic and self.epidemic.disease == serious_radiation then
+      -- Tell the player somehow we ended the epidemic, EPI0008 is most fitting
+      self.world.ui:playAnnouncement("EPID008.wav", AnnouncementPriority.Critical)
+      self.world:gameLog("Notice: Removing active epidemic for Serious Radiation. See issue 2760.")
+    end
+    self:cancelEpidemics(serious_radiation)
+  end
 
   -- Refresh the cheat system every load
   local old_active_cheats = self.hosp_cheats and self.hosp_cheats.active_cheats or {}


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2760*

**Describe what the proposed change does**
- Checks the active epidemic and future epidemic pool for any Serious Radiation epidemics and removes them

While writing this I realise borrowing and revising the `cancelEpidemics` code may have been overkill; and possible that a simple copy of code into the afterload may have been wiser and cleaner...
