### PR TITLE
Remove old commented out code

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/file_browser.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browser.lua
@@ -57,20 +57,9 @@ function FilteredFileTreeNode:createNewNode(path)
 end
 
 function FilteredFileTreeNode:getLabel()
-  -- The label was previously only the file name without extension or
-  -- folder hierarchy. TODO: Is there some reason to not show the extension?
   local label = self.label
   if not label then
     label = FileTreeNode.getLabel(self)
-    --[[if type(self.filter_by) == "table" then
-      for _, ext in ipairs(self.filter_by) do
-        if string.sub(label:lower(), -string.len(ext)) == ext then
-          label = string.sub(label:lower(), 0, -string.len(ext) - 1)
-        end
-      end
-    elseif string.sub(label:lower(), -string.len(self.filter_by)) == self.filter_by then
-      label = string.sub(label:lower(), 0, -string.len(self.filter_by) - 1)
-    end--]]
     self.label = label
   end
   return label

--- a/CorsixTH/Lua/entity.lua
+++ b/CorsixTH/Lua/entity.lua
@@ -277,13 +277,6 @@ function Entity:onDestroy()
   self:setMoodInfo()
   self:setTile(nil)
   self.world.dispatcher:dropFromQueue(self)
-  -- Debug aid to check that there are no hanging references after the entity
-  -- has been destroyed:
-  --[[
-  self.gc_dummy = newproxy(true) -- undocumented Lua library function
-  getmetatable(self.gc_dummy).__gc = function()
-    print("Entity " .. tostring(self) .. " has been garbage collected.")
-  end --]]
   if self.waiting_for_sound_effects_to_be_turned_on then
     TheApp.audio:entityNoLongerWaitingForSoundsToBeTurnedOn(self)
   end


### PR DESCRIPTION
**Describe what the proposed change does**
- The file browser comment was moved to other functions in that commit. https://github.com/CorsixTH/CorsixTH/blame/a45512ba654066520da123999fbdc382e0e248cc/CorsixTH/Lua/dialogs/resizables/file_browser.lua#L65
- The entity comment uses newproxy, which was deprecated in 5.1, removed in 5.2. https://github.com/CorsixTH/CorsixTH/blame/a45512ba654066520da123999fbdc382e0e248cc/CorsixTH/Lua/entity.lua#L280
