### PR TITLE
Epidemic refactoring. `coverup_in_progress` rename.

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 211 -- 'coverup_in_progress' renamed to 'coverup_selected'
+local SAVEGAME_VERSION = 212 -- 'coverup_in_progress' renamed to 'coverup_selected'
 
 class "App"
 

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 210 -- 'coverup_in_progress' renamed to 'coverup_selected'
+local SAVEGAME_VERSION = 211 -- 'coverup_in_progress' renamed to 'coverup_selected'
 
 class "App"
 

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 209 -- Add soda price to level config
+local SAVEGAME_VERSION = 210 -- 'coverup_in_progress' renamed to 'coverup_selected'
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/watch.lua
+++ b/CorsixTH/Lua/dialogs/watch.lua
@@ -94,11 +94,8 @@ function UIWatch:onCountdownEnd()
     self.ui.hospital:resolveEmergency()
   elseif self.count_type == "epidemic" then
     local epidemic = self.hospital.epidemic
-    if epidemic and not epidemic.inspector then
-      epidemic:spawnInspector()
-      if epidemic.vaccination_mode_active then
-        epidemic:toggleVaccinationMode()
-      end
+    if epidemic then
+      epidemic:coverUpTimeIsUp()
     end
   elseif self.count_type == "initial_opening" then
     self.hospital:open()

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -44,7 +44,8 @@ function Patient:Patient(...)
   self.vaccinated = false
   -- Has the patient been sent to the wrong room and needs redirecting
   self.needs_redirecting = false
-  self.attempted_to_infect= false
+  -- Is under attempt to be infected
+  self.attempted_to_infect = false
   -- Is the patient about to be vaccinated?
   self.vaccination_candidate = false
   -- Has the patient passed reception?
@@ -990,7 +991,7 @@ function Patient:updateDynamicInfo()
   end
   -- Set the centre line of dynamic info based on contagiousness, if appropriate
   local epidemic = self.hospital and self.hospital.epidemic
-  if epidemic and self.infected and epidemic.coverup_in_progress then
+  if epidemic and self.infected and epidemic.coverup_selected then
     if self.vaccinated then
       self:setDynamicInfo('text',
         {action_string, _S.dynamic_info.patient.actions.epidemic_vaccinated, info})
@@ -1059,6 +1060,18 @@ function Patient:updateMessage(choice)
   end
 end
 
+--[[ Show patient infected status ]]
+function Patient:setInfectedStatus()
+  self:setMood("epidemy4","activate")
+end
+
+--[[ Show patient as ready for vaccination status ]]
+function Patient:setToReadyForVaccinationStatus()
+  self:setMood("epidemy4","deactivate")
+  self:setMood("epidemy2","activate")
+  self.marked_for_vaccination = true
+end
+
 --[[ If the patient is not a vaccination candidate then
   give them the arrow icon and candidate status ]]
 function Patient:giveVaccinationCandidateStatus()
@@ -1067,13 +1080,31 @@ function Patient:giveVaccinationCandidateStatus()
   self.vaccination_candidate = true
 end
 
---[[Remove the vaccination candidate icon and status from the patient]]
+--[[ Remove the vaccination candidate icon and status from the patient ]]
 function Patient:removeVaccinationCandidateStatus()
   if not self.vaccinated then
     self:setMood("epidemy3","deactivate")
     self:setMood("epidemy2","activate")
     self.vaccination_candidate = false
   end
+end
+
+--[[ Show vaccinated status for vaccinated patient ]]
+function Patient:setVaccinatedStatus()
+  -- Disable either vaccination icon that may be present (edge case)
+  self:setMood("epidemy3", "deactivate")
+  self:setMood("epidemy2", "deactivate")
+  self:setMood("epidemy1", "activate")
+  self.marked_for_vaccination = false
+  self.vaccinated = true
+end
+
+--[[ Clear all epidemic status ]]
+function Patient:removeAnyEpidemicStatus()
+  self:setMood("epidemy1","deactivate")
+  self:setMood("epidemy2","deactivate")
+  self:setMood("epidemy3","deactivate")
+  self:setMood("epidemy4","deactivate")
 end
 
 function Patient:afterLoad(old, new)

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -1062,20 +1062,21 @@ end
 
 --[[ Show patient infected status ]]
 function Patient:setInfectedStatus()
+  self:removeAnyEpidemicStatus()
   self:setMood("epidemy4","activate")
+  self.vaccination_candidate = false
 end
 
 --[[ Show patient as ready for vaccination status ]]
 function Patient:setToReadyForVaccinationStatus()
-  self:setMood("epidemy4","deactivate")
+  self:removeAnyEpidemicStatus()
   self:setMood("epidemy2","activate")
   self.marked_for_vaccination = true
 end
 
---[[ If the patient is not a vaccination candidate then
-  give them the arrow icon and candidate status ]]
+--[[ Show patient selected vaccination candidate status ]]
 function Patient:giveVaccinationCandidateStatus()
-  self:setMood("epidemy2","deactivate")
+  self:removeAnyEpidemicStatus()
   self:setMood("epidemy3","activate")
   self.vaccination_candidate = true
 end
@@ -1083,7 +1084,7 @@ end
 --[[ Remove the vaccination candidate icon and status from the patient ]]
 function Patient:removeVaccinationCandidateStatus()
   if not self.vaccinated then
-    self:setMood("epidemy3","deactivate")
+    self:removeAnyEpidemicStatus()
     self:setMood("epidemy2","activate")
     self.vaccination_candidate = false
   end
@@ -1091,20 +1092,18 @@ end
 
 --[[ Show vaccinated status for vaccinated patient ]]
 function Patient:setVaccinatedStatus()
-  -- Disable either vaccination icon that may be present (edge case)
-  self:setMood("epidemy3", "deactivate")
-  self:setMood("epidemy2", "deactivate")
-  self:setMood("epidemy1", "activate")
+  self:removeAnyEpidemicStatus()
+  self:setMood("epidemy1","activate")
   self.marked_for_vaccination = false
   self.vaccinated = true
 end
 
 --[[ Clear all epidemic status ]]
 function Patient:removeAnyEpidemicStatus()
-  self:setMood("epidemy1","deactivate")
-  self:setMood("epidemy2","deactivate")
-  self:setMood("epidemy3","deactivate")
-  self:setMood("epidemy4","deactivate")
+  self:setMood("epidemy1","deactivate") -- vaccinated (step 4)
+  self:setMood("epidemy2","deactivate") -- marked (step 2)
+  self:setMood("epidemy3","deactivate") -- choosed by nurse (step 3)
+  self:setMood("epidemy4","deactivate") -- infected (step 1)
 end
 
 function Patient:afterLoad(old, new)

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -44,8 +44,10 @@ function Patient:Patient(...)
   self.vaccinated = false
   -- Has the patient been sent to the wrong room and needs redirecting
   self.needs_redirecting = false
-  -- Is under attempt to be infected
-  self.attempted_to_infect = false
+  -- Is under infection attempt
+  -- Indicates is currently some infected patient trying to infect this patient
+  -- Helps to prevent the situation when several infectors trying to infect the same victim
+  self.under_infection_attempt = false
   -- Is the patient about to be vaccinated?
   self.vaccination_candidate = false
   -- Has the patient passed reception?
@@ -1167,6 +1169,9 @@ function Patient:afterLoad(old, new)
     if self.humanoid_class == "Standard Female Patient" then
       self.on_ground_anim = 1764
     end
+  end
+  if old < 210 then
+    self.under_infection_attempt = self.attempted_to_infect
   end
   self:updateDynamicInfo()
   Humanoid.afterLoad(self, old, new)

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -1170,7 +1170,7 @@ function Patient:afterLoad(old, new)
       self.on_ground_anim = 1764
     end
   end
-  if old < 210 then
+  if old < 211 then
     self.under_infection_attempt = self.attempted_to_infect
   end
   self:updateDynamicInfo()

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -44,9 +44,8 @@ function Patient:Patient(...)
   self.vaccinated = false
   -- Has the patient been sent to the wrong room and needs redirecting
   self.needs_redirecting = false
-  -- Is under infection attempt
   -- Indicates is currently some infected patient trying to infect this patient
-  -- Helps to prevent the situation when several infectors trying to infect the same victim
+  -- Prevents the situation when several infectors trying to infect the same victim
   self.under_infection_attempt = false
   -- Is the patient about to be vaccinated?
   self.vaccination_candidate = false

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -1172,6 +1172,7 @@ function Patient:afterLoad(old, new)
   end
   if old < 211 then
     self.under_infection_attempt = self.attempted_to_infect
+    self.attempted_to_infect = nil
   end
   self:updateDynamicInfo()
   Humanoid.afterLoad(self, old, new)

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -33,6 +33,7 @@ function Epidemic:Epidemic(hospital, contagious_patient)
   self.hospital = hospital
   self.world = self.hospital.world
 
+  -- Epidemic participants
   self.infected_patients = {}
 
   -- The contagious disease the epidemic is based around
@@ -57,7 +58,7 @@ function Epidemic:Epidemic(hospital, contagious_patient)
   self.cover_up_result_fax = {}
 
   -- Set if the user choses the cover up option instead of declaring
-  self.coverup_in_progress = false
+  self.coverup_selected = false
 
   --Cover up timer and amount of intervals the timer has
   self.timer = nil
@@ -70,7 +71,7 @@ function Epidemic:Epidemic(hospital, contagious_patient)
   -- For Cheat - Show the contagious icon even before the epidemic is revealed?
   self.cheat_always_show_mood = false
 
-  -- Number of times an infect patient has successfully infected another
+  -- Number of times an infected patients has successfully infected another
   self.total_infections = 0
   -- Number of times any infected patient has tried to infected another - successful or not
   self.attempted_infections = 0
@@ -113,8 +114,8 @@ function Epidemic:addContagiousPatient(patient)
   patient.infected = true
   patient:updateDynamicInfo()
   self.infected_patients[#self.infected_patients + 1] = patient
-  if self.coverup_in_progress or self.cheat_always_show_mood then
-    patient:setMood("epidemy4","activate")
+  if self.coverup_selected or self.cheat_always_show_mood then
+    patient:setInfectedStatus()
   end
 end
 
@@ -125,44 +126,42 @@ function Epidemic:infectOtherPatients()
   --[[ Can an infected patient infect another patient - taking into account
   spread factor as defined in the configuration. Patients must be both in the
   corridors or in the same room - don't infect through walls.
-  @param patient (Patient) already infected patient
-  @param other (Patient) target to possibly infect
+  @param infector (Patient) already infected patient who want to infect
+  @param victim (Patient) target to possibly infect
   @return true if patient can infect other, false otherwise (boolean) ]]
-  local function canInfectOther(patient, other)
-    -- Patient is not infectious.
-    if patient.cured or patient.vaccinated then return false end
+  local function canInfectOther(infector, victim)
+    -- Check is patient-Infector is not infectious.
+    if infector.cured or infector.vaccinated then return false end
 
     -- Don't allow infection outside the hospital grounds
     -- Also check both patients to prevent infecting through outer walls
-    local ppx, ppy = patient.tile_x, patient.tile_y
+    local ppx, ppy = infector.tile_x, infector.tile_y
     if ppx and ppy and not self.hospital:isInHospital(ppx, ppy) then return false end
-    local opx, opy = other.tile_x, other.tile_y
+    local opx, opy = victim.tile_x, victim.tile_y
     if opx and opy and not self.hospital:isInHospital(opx, opy) then return false end
 
-    -- 'other' is already infected or is going home.
-    if other.infected or other.cured or other.vaccinated then return false end
-    if other.is_emergency then return false end -- Don't interact with emergencies.
+    -- 'victim' is already infected or is going home.
+    if victim.infected or victim.cured or victim.vaccinated then return false end
+    -- Don't infect victim if it alredy under another attempt to be infected
+    if victim.attempted_to_infect then return false end
+    -- Don't infect emergencies.
+    if victim.is_emergency then return false end
 
-    -- If the other patient has a different disease OR the other patient's
+    -- If the victim patient has a different disease OR the victim patient's
     -- disease cannot be changed.
-    if patient.disease ~= other.disease and
-        (not other.disease.contagious or other.diagnosed) then return false end
-
-    if other.attempted_to_infect then return false end
+    if infector.disease ~= victim.disease and
+        (not victim.disease.contagious or victim.diagnosed) then return false end
 
     -- Only infect if both are in the same room.
-    return patient:getRoom() == other:getRoom()
+    return infector:getRoom() == victim:getRoom()
   end
 
-  local function infect_other(infected_patient, patient)
-    if infected_patient.disease == patient.disease then
-      self:addContagiousPatient(patient)
-      self.total_infections = self.total_infections + 1
-    else
-      patient:changeDisease(infected_patient.disease)
-      self:addContagiousPatient(patient)
-      self.total_infections = self.total_infections + 1
+  local function infect_other(infector, victim)
+    if infector.disease ~= victim.disease then
+      victim:changeDisease(infector.disease)
     end
+    self:addContagiousPatient(victim)
+    self.total_infections = self.total_infections + 1
   end
 
   -- Scale the chance of spreading the disease infecting spread_factor%
@@ -177,16 +176,16 @@ function Epidemic:infectOtherPatients()
   -- and making any patient they can infect contagious too.
   local entity_map = self.world.entity_map
   if entity_map then
-    for _, infected_patient in ipairs(self.infected_patients) do
+    for _, infector in ipairs(self.infected_patients) do
       local adjacent_patients =
-      entity_map:getPatientsInAdjacentSquares(infected_patient.tile_x, infected_patient.tile_y)
-      for _, patient in ipairs(adjacent_patients) do
-        if canInfectOther(infected_patient, patient) then
-          patient.attempted_to_infect = true
+      entity_map:getPatientsInAdjacentSquares(infector.tile_x, infector.tile_y)
+      for _, potential_victim in ipairs(adjacent_patients) do
+        if canInfectOther(infector, potential_victim) then
+          potential_victim.attempted_to_infect = true
           self.attempted_infections = self.attempted_infections + 1
           if (self.total_infections / self.attempted_infections) <
               (self.spread_factor / spread_scale_factor) then
-            infect_other(infected_patient, patient)
+            infect_other(infector, potential_victim)
           end
         end
       end
@@ -275,7 +274,7 @@ otherwise a player may never win the epidemic in such a case.]]
 function Epidemic:checkPatientsForRemoval()
   for i = #self.infected_patients, 1, -1 do
     local infected_patient = self.infected_patients[i]
-    if (not self.coverup_in_progress and infected_patient.going_home) or
+    if (not self.coverup_selected and infected_patient.going_home) or
         infected_patient.dead or infected_patient.tile_x == nil then
       table.remove(self.infected_patients,i)
     end
@@ -287,6 +286,17 @@ end
 (@see UIWatch:UIWatch) ]]
 function Epidemic:toggleVaccinationMode()
   self.vaccination_mode_active = not self.vaccination_mode_active
+  self:_updateVaccinationCursor()
+end
+
+--[[ Turn off vaccination cursor mode ]]
+function Epidemic:turnOffVaccinationMode()
+  self.vaccination_mode_active = false
+  self:_updateVaccinationCursor()
+end
+
+--[[ Update how the cursor interacts with the hospital. ]]
+function Epidemic:_updateVaccinationCursor()
   local cursor = self.vaccination_mode_active and "epidemic_hover" or "default"
   self.world.ui:setCursor(self.world.ui.app.gfx:loadMainCursor(cursor))
 end
@@ -298,9 +308,7 @@ end
 function Epidemic:markForVaccination(patient)
   if patient.infected and not patient.vaccinated and
       not patient.marked_for_vaccination then
-    patient.marked_for_vaccination = true
-    patient:setMood("epidemy4","deactivate")
-    patient:setMood("epidemy2","activate")
+    patient:setToReadyForVaccinationStatus()
     patient.hospital:playSound("vaccin.wav")
   end
 end
@@ -378,10 +386,7 @@ function Epidemic:clearAllInfectedPatients()
     infected_patient:removeVaccinationCandidateStatus()
     self.world.dispatcher:dropFromQueue(infected_patient)
     infected_patient.vaccinated = true
-    infected_patient:setMood("epidemy1","deactivate")
-    infected_patient:setMood("epidemy2","deactivate")
-    infected_patient:setMood("epidemy3","deactivate")
-    infected_patient:setMood("epidemy4","deactivate")
+    infected_patient:removeAnyEpidemicStatus()
   end
 end
 
@@ -394,11 +399,11 @@ function Epidemic:startCoverUp()
   self.world.ui:addWindow(self.timer)
   -- last chance clean up as entities might have ticked and changed state
   self:checkPatientsForRemoval()
-  self.coverup_in_progress = true
+  self.coverup_selected = true
   --Set the mood icon for all infected patients
   for _, infected_patient in ipairs(self.infected_patients) do
     infected_patient:updateDynamicInfo()
-    infected_patient:setMood("epidemy4","activate")
+    infected_patient:setInfectedStatus()
   end
 end
 
@@ -411,9 +416,7 @@ function Epidemic:finishCoverUp()
   self.timer:close()
 
   -- Turn vaccination mode off if enabled
-  if self.vaccination_mode_active then
-    self:toggleVaccinationMode()
-  end
+  self:turnOffVaccinationMode()
 end
 
 --[[ Inspector had arrived at reception desk. Check if
@@ -423,6 +426,11 @@ function Epidemic:handleInspectorArrival()
   self:determineFaxAndFines(still_infected)
   self:clearAllInfectedPatients()
   self:applyOutcome()
+end
+
+--[[ Epidemic timer time is up ]]
+function Epidemic:coverUpTimeIsUp()
+  self:finishCoverUp()
 end
 
 --[[ Calculates the contents of the fax and the appropriate fines based on the
@@ -559,7 +567,7 @@ end
 --[[ Private function to check if a cover up is in progress
 @return (boolean) true if cover up in progress, false if not]]
 function Epidemic:_isCoverUpActive()
-  return self.coverup_in_progress and not self:_inspectorSpawned()
+  return self.coverup_selected and not self:_inspectorSpawned()
 end
 
 --[[ Is the patient "still" either idle queuing or sitting on a bench
@@ -711,7 +719,7 @@ function Epidemic:hasNoInfectedPatients()
 end
 
 function Epidemic:tryAnnounceInspector()
-  if not self.coverup_in_progress then return end
+  if not self.coverup_selected then return end
   if not self:_inspectorSpawned() then return end
 
   local inspector = self.inspector
@@ -727,9 +735,7 @@ function Epidemic:cancelEpidemic()
   -- Remove init epidemic fax
   self.world.ui.bottom_panel:removeMessage(self)
   -- Turn vaccination mode off if enabled
-  if self.vaccination_mode_active then
-    self:toggleVaccinationMode()
-  end
+  self:turnOffVaccinationMode()
   -- Remove epidemic timer
   if self.timer ~= nil then
     self.timer:close()
@@ -746,5 +752,8 @@ end
 function Epidemic:afterLoad(old, new)
   if old < 106 then
     self.level_config = nil
+  end
+  if old < 210 then
+    self.coverup_selected = self.coverup_in_progress
   end
 end

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -753,7 +753,7 @@ function Epidemic:afterLoad(old, new)
   if old < 106 then
     self.level_config = nil
   end
-  if old < 210 then
+  if old < 211 then
     self.coverup_selected = self.coverup_in_progress
   end
 end

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -755,5 +755,6 @@ function Epidemic:afterLoad(old, new)
   end
   if old < 211 then
     self.coverup_selected = self.coverup_in_progress
+    self.coverup_in_progress = nil
   end
 end

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -753,7 +753,7 @@ function Epidemic:afterLoad(old, new)
   if old < 106 then
     self.level_config = nil
   end
-  if old < 211 then
+  if old < 212 then
     self.coverup_selected = self.coverup_in_progress
     self.coverup_in_progress = nil
   end

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -143,7 +143,7 @@ function Epidemic:infectOtherPatients()
     -- 'victim' is already infected or is going home.
     if victim.infected or victim.cured or victim.vaccinated then return false end
     -- Don't infect victim if it alredy under another attempt to be infected
-    if victim.attempted_to_infect then return false end
+    if victim.under_infection_attempt then return false end
     -- Don't infect emergencies.
     if victim.is_emergency then return false end
 
@@ -181,7 +181,7 @@ function Epidemic:infectOtherPatients()
       entity_map:getPatientsInAdjacentSquares(infector.tile_x, infector.tile_y)
       for _, potential_victim in ipairs(adjacent_patients) do
         if canInfectOther(infector, potential_victim) then
-          potential_victim.attempted_to_infect = true
+          potential_victim.under_infection_attempt = true
           self.attempted_infections = self.attempted_infections + 1
           if (self.total_infections / self.attempted_infections) <
               (self.spread_factor / spread_scale_factor) then

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -460,7 +460,7 @@ function GameUI:onCursorWorldPositionChange()
       local cursor = self.default_cursor
       if self.app.world.user_actions_allowed then
         --- If the patient is infected show the infected cursor
-        if epidemic and epidemic.coverup_in_progress and
+        if epidemic and epidemic.coverup_selected and
           entity and entity.infected and not epidemic.timer.closed then
           cursor = infected_cursor
           -- In vaccination mode display epidemic hover cursor for all entities

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -686,11 +686,11 @@ function Hospital:afterLoad(old, new)
   end
 
   -- Update other objects in the hospital (added in version 106).
-  if self.epidemic then self.epidemic.afterLoad(old, new) end
+  if self.epidemic then self.epidemic:afterLoad(old, new) end
   for _, future_epidemic in ipairs(self.future_epidemics_pool) do
-    future_epidemic.afterLoad(old, new)
+    future_epidemic:afterLoad(old, new)
   end
-  self.research.afterLoad(old, new)
+  self.research:afterLoad(old, new)
 end
 
 --! Count the number of patients in the hospital.
@@ -1302,11 +1302,11 @@ function Hospital:addToEpidemic(patient)
   local epidemic = self.epidemic
   -- Don't add a new contagious patient if the player is trying to cover up
   -- an existing epidemic - not really fair
-  if epidemic and not epidemic.coverup_in_progress and
+  if epidemic and not epidemic.coverup_selected and
       (patient.disease == epidemic.disease) then
     epidemic:addContagiousPatient(patient)
   elseif self.future_epidemics_pool and
-      not (epidemic and epidemic.coverup_in_progress) then
+      not (epidemic and epidemic.coverup_selected) then
     local added = false
     for _, future_epidemic in ipairs(self.future_epidemics_pool) do
       if future_epidemic.disease == patient.disease then

--- a/CorsixTH/Lua/humanoid_actions/vaccinate.lua
+++ b/CorsixTH/Lua/humanoid_actions/vaccinate.lua
@@ -92,16 +92,11 @@ local function vaccinate(action, nurse)
     if is_in_adjacent_square(nurse, patient) then
       CallsDispatcher.queueCallCheckpointAction(nurse)
       nurse:queueAction(AnswerCallAction())
-      -- Disable either vaccination icon that may be present (edge case)
-      patient:setMood("epidemy2", "deactivate")
-      patient:setMood("epidemy3", "deactivate")
-      patient:setMood("epidemy1", "activate")
-      patient.vaccinated = true
+      patient:setVaccinatedStatus()
       patient.hospital:spendMoney(action.vaccination_fee, _S.transactions.vaccination)
       patient:updateDynamicInfo()
     else
-      patient:setMood("epidemy3", "deactivate")
-      patient:setMood("epidemy2", "activate")
+      patient:removeVaccinationCandidateStatus()
       -- Drop it they may not even be the vacc candidate anymore
       CallsDispatcher.queueCallCheckpointAction(nurse)
       nurse:queueAction(AnswerCallAction())


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**Describe what the proposed change does**
- `coverup_in_progress` renamed to `coverup_selected` as this flag indicates the fact that the coverup was ever started for this epidemic
- `patient:setMood` calls moved from `epidemic.lua` and `vaccinate.lua` to `patient.lua`
- due to `hospital.lua` improper `afterLoad` call, afterLoad was always crash for savegames with `SAVEGAME_VERSION` less than `106`
- `SAVEGAME_VERSION` bump
