### PR TITLE
Fix typo in lightness calculation

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -1217,7 +1217,7 @@ bool sprite_sheet::get_sprite_average_colour(size_t iSprite,
     double Y = 0.2126 * linR + 0.7152 * linG + 0.0722 * linB;
     // - Compute lightness L*.
     //   L* = 116 * Y ^ 1/3 - 16, range is from 0 to 100.
-    double L = std::min(100.0, std::max(0.0, 166 * std::cbrt(Y) - 16));
+    double L = std::min(100.0, std::max(0.0, 116 * std::cbrt(Y) - 16));
     uint8_t cIntensity = static_cast<uint8_t>(L / 100 * 255.0);
 
     // Grant higher score to pixels with high or low intensity (helps avoid


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2779*

*Reopens #2744*
**Describe what the proposed change does**
- A typo in the lightness calculation caused some fonts to be offset. However, it brings back the Pause text issue.

![image](https://github.com/user-attachments/assets/0cc63fba-7b31-42f7-a591-d3506c295dba)
![image](https://github.com/user-attachments/assets/564ca2c2-474e-45c2-a198-de816e7bdff9)
![image](https://github.com/user-attachments/assets/b60d0079-a335-4d0d-9c4e-41780e9adee1)

(I think there might just be something wrong with how we're colouring Pause elsewhere)