### PR TITLE
Adjust mood icons

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 209 -- Add soda price to level config
+local SAVEGAME_VERSION = 210 -- Renamed humanoid moods
 
 class "App"
 

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -104,8 +104,8 @@ end
 local function pee_anim(name, peeAnim)
   pee_animations[name] = peeAnim
 end
-local function moods(name, iconNo, prio, alwaysOn)
-  mood_icons[name] = {icon = iconNo, priority = prio, on_hover = alwaysOn}
+local function moods(name, iconNo, prio, onHover)
+  mood_icons[name] = {icon = iconNo, priority = prio, on_hover = onHover}
 end
 
 --   | Walk animations           |
@@ -235,35 +235,38 @@ pee_anim("Invisible Patient",          4208)
 pee_anim("Transparent Female Patient", 4852)
 pee_anim("Transparent Male Patient",   4848)
 
+-- Some icons should only appear when the player hovers over the humanoid
+-- Higher priority is more important.
 --   | Available Moods |
---   | Name            |Icon|Priority|Show Always| Notes
+--   | Name            |Icon|Priority|On Hover| Notes
 -----+-----------------+----+--------+-----------+
-moods("reflexion",      4020,       5)            -- Some icons should only appear when the player
-moods("cantfind",       4050,       3)            -- hover over the humanoid
-moods("idea1",          2464,      10)            -- Higher priority is more important.
+moods("reflexion",      4020,       5)
+moods("cantfind",       4050,       3)
+moods("idea1",          2464,      10)
 moods("idea2",          2466,      11)
 moods("idea3",          4044,      12)
 moods("staff_wait",     4054,      20)
 moods("tired",          3990,      30)
 moods("pay_rise",       4576,      40)
 moods("thirsty",        3986,       4)
-moods("cold",           3994,       0,       true) -- These have no priority since
-moods("hot",            3988,       0,       true) -- they will be shown when hovering
-moods("queue",          4568,      70)             -- no matter what other priorities.
+moods("cold",           3994,       0,   true) -- These have no priority since
+moods("hot",            3988,       0,   true) -- they will be shown when hovering
+                                               -- no matter what other priorities.
+moods("queue",          4568,      70)
 moods("poo",            3996,       5)
 moods("sad_money",      4018,      55)
-moods("patient_wait",   5006,      40)
+moods("patient_wait",   5006,      39)
 moods("epidemy1",       4566,      55)
 moods("epidemy2",       4570,      55)
 moods("epidemy3",       4572,      55)
 moods("epidemy4",       4574,      55)
-moods("sad1",           3992,      40)
-moods("sad2",           4000,      41)
-moods("sad3",           4002,      42)
-moods("sad4",           4004,      43)
-moods("sad5",           4006,      44)
-moods("sad6",           4008,      45)
-moods("sad7",           4578,      46)
+moods("sad1",           3992,      39)          -- unused?
+moods("sad2",           4578,      40)
+moods("dying1",         4000,      41)
+moods("dying2",         4002,      42)
+moods("dying3",         4004,      43)
+moods("dying4",         4006,      44)
+moods("dying5",         4008,      45)
 moods("dead",           4046,      60)
 moods("cured",          4048,      60)
 moods("emergency",      3914,      50)
@@ -340,6 +343,19 @@ function Humanoid:afterLoad(old, new)
   end
   if old < 134 and new >= 134 then
     self.staff_change_callbacks = {}
+  end
+  if old < 210 then
+    -- We renamed the old sad7 to sad2; and sad2 - sad6 to dying1 - dying5.
+    -- Make sure we adjust sad2 and sad7 to the new mood names
+    -- Other dying ones aren't an issue
+    if self:isMoodActive("sad2") then
+      self:setMood("sad2", "deactivate")
+      self:setMood("dying1", "activate")
+    end
+    if self:isMoodActive("sad7") then
+      self:setMood("sad7", "deactivate")
+      self:setMood("sad2", "activate")
+    end
   end
 
   for _, action in pairs(self.action_queue) do

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -582,9 +582,9 @@ function Patient:tickDay()
 
   -- if patients are getting unhappy, then maybe we should see this!
   if self:getAttribute("happiness") < 0.3 then
-    self:setMood("sad7", "activate")
+    self:setMood("sad2", "activate")
   else
-    self:setMood("sad7", "deactivate")
+    self:setMood("sad2", "deactivate")
   end
   -- Now call the parent function - it checks
   -- if we're outside the hospital or on our way home.
@@ -601,38 +601,38 @@ function Patient:tickDay()
   -- TODO clean up this block, nonmagical numbers
   local health = self:getAttribute("health")
   if health >= 0.18 and health < 0.22 then
-    self:setMood("sad2", "activate")
+    self:setMood("dying1", "activate")
     self:changeAttribute("happiness", -0.0002) -- waiting too long will make you sad
     -- There is a 1/3 chance that the patient will get fed up and leave.
     -- This is potentially run 10 ((0.22-0.18)/0.004) times, hence the 1/30 chance.
     -- If patient is already in the cure room, let the treatment happen.
     if not self:_checkIfCureRoom(self:getRoom()) and math.random(1,30) == 1 then
       self:setDynamicInfoText(_S.dynamic_info.patient.actions.fed_up)
-      self:setMood("sad2", "deactivate")
+      self:setMood("dying1", "deactivate")
       self:goHome("kicked")
     end
   elseif health >= 0.14 and health < 0.18 then
-    self:setMood("sad2", "deactivate")
-    self:setMood("sad3", "activate")
+    self:setMood("dying1", "deactivate")
+    self:setMood("dying2", "activate")
   -- now wishes they had gone to that other hospital
   elseif health >= 0.10 and health < 0.14 then
-    self:setMood("sad3", "deactivate")
-    self:setMood("sad4", "activate")
+    self:setMood("dying2", "deactivate")
+    self:setMood("dying3", "activate")
   -- starts to take a turn for the worse and is slipping away
   elseif health >= 0.06 and health < 0.10 then
-    self:setMood("sad4", "deactivate")
-    self:setMood("sad5", "activate")
+    self:setMood("dying3", "deactivate")
+    self:setMood("dying4", "activate")
   -- fading fast
   elseif health >= 0.01 and health < 0.06 then
-    self:setMood("sad5", "deactivate")
-    self:setMood("sad6", "activate")
+    self:setMood("dying4", "deactivate")
+    self:setMood("dying5", "activate")
   -- it's not looking good
   elseif health > 0.00 and health < 0.01 then
     self.attributes["health"] = 0.0
   -- is there time to say a prayer
   elseif health == 0.0 then
     if not self:getRoom() and not self:getCurrentAction().is_leaving then
-      self:setMood("sad6", "deactivate")
+      self:setMood("dying5", "deactivate")
       self:die()
     end
     -- Patient died, will die when they leave the room, will be cured, or is leaving


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2770*

**Describe what the proposed change does**
- Renames `sad7` to `sad2`
- Renames `sad2 - sad6` to `dying1 - dying5`
- Adjusts priority of  new `sad2` to be before `dying` moods
- Adjusts patient wait mood priority to coincide
- Restructures comments
- Updates affected humanoids with old `sad2` and `sad7`. The other sad ones won't matter, as the mood priority order will trump them anyway as they die more / cure / die.

@ARGAMX -- I have a suspicion this PR currently might have changed behaviour of the patient wait icon. However, sad2 is still trumping patient_wait as before so I think I've just imagined it.
If possible, I can adjust it if the original has a specified behaviour so wait has priority over regular sadness.
