### PR TITLE
Fix tick_rate remapping

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2486,6 +2486,7 @@ function World:afterLoad(old, new)
   if old < 208 then -- Adjust game speed and tick rates
     local old_tick_rates
     if old < 183 then
+      -- Save is using tick rates before 0.68.0 (PR2494)
       old_tick_rates = {
         ["Pause"]              = {0, 1},
         ["Slowest"]            = {1, 9},
@@ -2493,8 +2494,10 @@ function World:afterLoad(old, new)
         ["Normal"]             = {1, 3},
         ["Max speed"]          = {1, 1},
         ["And then some more"] = {3, 1},
+        ["Speed Up"]           = {8, 1},
       }
     else
+      -- Save is using tick rates introduced during development post 0.68.0 (PR2688)
       old_tick_rates = {
         ["Pause"]              = {0, 1},
         ["Slowest"]            = {1, 28},
@@ -2509,11 +2512,18 @@ function World:afterLoad(old, new)
     for name, rate in pairs(old_tick_rates) do
       if rate[1] == self.hours_per_tick and rate[2] == self.tick_rate then
         found_speed = true
-        self:setSpeed(name)
+        -- Do not call setSpeed as the values below are mapped to old tick rates.
+        -- Instead, update manually.
+        self.hours_per_tick = tick_rates[name][1]
+        self.tick_rate = tick_rates[name][2]
+        -- There is also no need to run it afterward either
         break
       end
     end
+    -- No conversion available; reset instead
     if not found_speed then
+      self.hours_per_tick = tick_rates["Pause"][1]
+      self.tick_rate = tick_rates["Pause"][2]
       self:setSpeed("Normal")
     end
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2788*

**Describe what the proposed change does**
- Attempting to update speed normally from a change in the tick rate table causes `self.prev_speed` to be set to `nil`
- Instead, tick rates are directly assigned for this afterload only
- Failsafe also altered, so the game is briefly set to pause rates, then normal speed is reapplied.
- the `Speed up` tick rate is also now entered for the original `old_tick_rates` table.

In both cases these changes will retain the `self.prev_speed` value.

Only downside is if the game was paused; in the failsafe method it will unpause. But that should be addressed separately e.g. as part of #2254 patches.