### PR TITLE
Fixed the typos mentioned in Issue 2784

### DIFF
--- a/CorsixTH/Lua/dialogs/resizable.lua
+++ b/CorsixTH/Lua/dialogs/resizable.lua
@@ -158,8 +158,8 @@ function UIResizable:hitTestCorners(x, y)
 end
 
 --[[ Initiate resizing of the resizable window.
-!param x The X position of the cursor in window co-ordinatees.
-!param y The Y position of the cursor in window co-ordinatees.
+!param x The X position of the cursor in window coordinates.
+!param y The Y position of the cursor in window coordinates.
 !param mode Either one of "ul", "ur", "ll" or "lr" to denote in which direction to resize. (upper/lower + left/right)
 ]]
 function UIResizable:beginResize(x, y, mode)

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -383,7 +383,7 @@ function Patient:falling(player_init)
     self:queueAction(FallingAction(), 1)
     self:queueAction(OnGroundAction(), 2)
     self:queueAction(GetUpAction(), 3)
-    -- show the patient is annoyed, if possbile
+    -- show the patient is annoyed, if possible
     if math.random(1, 5) == 3 and self.shake_fist_anim then
       self:queueAction(ShakeFistAction(), 4)
       self:interruptAndRequeueAction(current, 5)

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -551,7 +551,7 @@ function Epidemic:spawnInspector()
 end
 
 --[[ Private function to check if a inspector already spawned.
-@return (boolean) true if spawned alredy, false if not]]
+@return (boolean) true if spawned already, false if not]]
 function Epidemic:_inspectorSpawned()
   return self.inspector ~= nil
 end

--- a/CorsixTH/Lua/objects/doors/swing_door_right.lua
+++ b/CorsixTH/Lua/objects/doors/swing_door_right.lua
@@ -47,10 +47,10 @@ end
 
 --! Links the master to the slave swing door. This allows the slave to mimic the
 --! master in interactions
---!param x (num) Co-ordinate
---!param y (num) Co-ordinate
+--!param x (num) Coordinate
+--!param y (num) Coordinate
 function SwingDoor:pairDoors(x, y)
-  -- Because we don't know the build order of each door we must accomodate for this
+  -- Because we don't know the build order of each door we must accommodate for this
   if self.is_master then -- The master will check for an adjacent slave
     local slave_type = "swing_door_left"
     self.slave = self.world:getObject(x - 1, y, slave_type) or

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -37,8 +37,8 @@ end
 --! Initialises primary components of the room.
 -- Additionally, if there is already a room, e.g. it is being moved,
 -- we can just reinit it by calling this, not make a new one.
---!param x (co-ordinate) starting tile
---!param y (co-ordinate) starting tile
+--!param x (coordinate) starting tile
+--!param y (coordinate) starting tile
 --!param w (num) width of room
 --!param h (num) height of room
 --!param door (object) primary door for room

--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -1709,8 +1709,8 @@ local --[[persistable:window_drag_position_representation]] function getNicestPo
 end
 
 --[[ Initiate dragging of the window.
-!param x The X position of the cursor in window co-ordinatees.
-!param y The Y position of the cursor in window co-ordinatees.
+!param x The X position of the cursor in window coordinates.
+!param y The Y position of the cursor in window coordinates.
 ]]
 function Window:beginDrag(x, y)
   if not self.width or not self.height or not self.ui or

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -589,7 +589,7 @@ const char* render_target::get_renderer_details() const {
 const char* render_target::get_last_error() { return SDL_GetError(); }
 
 bool render_target::start_frame() {
-  // Destroy any intermediate texures used last frame.
+  // Destroy any intermediate textures used last frame.
   destroy_intermediate_textures();
 
   fill_black();

--- a/CorsixTH/com.corsixth.corsixth.metainfo.xml
+++ b/CorsixTH/com.corsixth.corsixth.metainfo.xml
@@ -130,7 +130,7 @@
           <li>Fixed an instance where information boxes could load pink from
               older savegames</li>
           <li>Implemented a more permanent fix for the money bar being drawn
-              incorrectly in some CJK and Cyrllic languages</li>
+              incorrectly in some CJK and Cyrillic languages</li>
           <li>Fixed a crash on exit that could occur in some systems</li>
           <li>Mouse panning behaviour has been made more responsive and
               accurate</li>
@@ -142,7 +142,7 @@
         <p>Translations:</p>
         <ul>
           <li>Dutch translation has been updated</li>
-          <li>Ukranian translation has been updated</li>
+          <li>Ukrainian translation has been updated</li>
           <li>Russian translation has been updated</li>
         </ul>
         <p>Bug Fixes:</p>
@@ -163,7 +163,7 @@
         </ul>
         <p>Translations:</p>
         <ul>
-          <li>Ukranian translation added</li>
+          <li>Ukrainian translation added</li>
           <li>Brazilian-Portuguese translation has been updated</li>
         </ul>
         <p>Bug Fixes:</p>
@@ -266,7 +266,7 @@
         <li>Fixed an instance where information boxes could load pink from older
             savegames</li>
         <li>Implemented a more permanent fix for the money bar being drawn
-            incorrectly in some CJK and Cyrllic languages</li>
+            incorrectly in some CJK and Cyrillic languages</li>
         <li>Fixed a crash on exit that could occur in some systems</li>
         <li>Mouse panning behaviour has been made more responsive and accurate</li>
       </ul>

--- a/changelog.txt
+++ b/changelog.txt
@@ -43,7 +43,7 @@ CorsixTH 0.68.0 - released October 2024
 * Support is added to auto-detect a Theme Hospital install via GOG Galaxy
 
 # Translations
-* Ukranian translation added. Thanks @JurecStrongman
+* Ukrainian translation added. Thanks @JurecStrongman
 * Dutch translation has been updated. Thanks @jetenergy and @Alberth289346
 * Italian translation has been updated. Thanks @SebastianoPistore & @Inkub0
 * Russian translation has been updated. Thanks @Matroftt
@@ -85,7 +85,7 @@ CorsixTH 0.68.0 - released October 2024
 * Fixed an instance where information boxes could load pink from older
   savegames
 * Implemented a more permanent fix for the money bar being drawn incorrectly in
-  some CJK and Cyrllic languages
+  some CJK and Cyrillic languages
 * Fixed a crash on exit that could occur in some systems
 * Mouse panning behaviour has been made more responsive and accurate
 


### PR DESCRIPTION
*Fixes #2784*

**This Pull Request is to fix the typos mentioned in Issue 2784:**

- CorsixTH/com.corsixth.corsixth.metainfo.xml:133: Cyrllic ==> Cyrillic
- CorsixTH/com.corsixth.corsixth.metainfo.xml:145: Ukranian ==> Ukrainian
- CorsixTH/com.corsixth.corsixth.metainfo.xml:166: Ukranian ==> Ukrainian
- CorsixTH/com.corsixth.corsixth.metainfo.xml:269: Cyrllic ==> Cyrillic
- CorsixTH/Lua/epidemic.lua:554: alredy ==> already
- CorsixTH/Lua/room.lua:40: co-ordinate ==> coordinate
- CorsixTH/Lua/room.lua:41: co-ordinate ==> coordinate
- CorsixTH/Lua/objects/doors/swing_door_right.lua:50: Co-ordinate ==> Coordinate
- CorsixTH/Lua/objects/doors/swing_door_right.lua:51: Co-ordinate ==> Coordinate
- CorsixTH/Lua/objects/doors/swing_door_right.lua:53: accomodate ==> accommodate
- CorsixTH/Lua/entities/humanoids/patient.lua:386: possbile ==> possible, possibly
- CorsixTH/Src/th_gfx_sdl.cpp:592: texures ==> textures

**Note: The following typos have not been fixed, as they are deemed correct since the context of the typo is in French:**
- CorsixTH/Levels/example.level:32: exemple ==> example
- CorsixTH/Campaigns/example.campaign:9: exemple ==> example