### PR TITLE
Add interpeter path for portable linux installs

### DIFF
--- a/CorsixTH/Src/main.cpp
+++ b/CorsixTH/Src/main.cpp
@@ -84,11 +84,12 @@ std::string search_script_file(lua_State* L) {
 
 #ifdef CORSIX_TH_SEARCH_LOCAL_DATADIRS
   // 2. Find CorsixTH.lua in working dir and program dir
-  static constexpr std::array<const char*, 4> asSearchDirs{
+  static constexpr std::array<const char*, 5> asSearchDirs{
       "./",
       "CorsixTH/",
       "Contents/Resources/",
       "../Resources/",
+      "../share/corsix-th/",
   };
   std::string strProgramDir = "";
   {


### PR DESCRIPTION
*Fixes #*

**Describe what the proposed change does**
- Add standard interpreter path when setting a custom install directory and standard `/usr` prefix for Linux

This is needed while working on building for AppImage.