### PR TITLE
Fix campaign subfolders

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -614,6 +614,7 @@ function App:loadCampaign(campaign_file)
     self.ui:addWindow(UIInformation(self.ui, { _S.errors.could_not_load_campaign:format(errors) }))
     return
   end
+  campaign_info.folder = campaign_file:match("(.*" .. pathsep .. ")")
 
   level_info, errors = self:readLevelFile(campaign_info.levels[1], campaign_info.folder)
   if not level_info then

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -216,10 +216,10 @@ function UIFax:choice(choice_number)
       local campaign_info = self.ui.app.world.campaign_info
       for i, level in ipairs(campaign_info.levels) do
         if self.ui.app.world.map.level_filename == level then
-          local level_info, _ = self.ui.app:readLevelFile(campaign_info.levels[i + 1])
+          local level_info, _ = self.ui.app:readLevelFile(campaign_info.levels[i + 1], campaign_info.folder)
           if level_info then
             self.ui.app:loadLevel(level_info.path, nil, level_info.name,
-                level_info.map_file, level_info.briefing, nil, _S.errors.load_level_prefix, self.ui.app.world.campaign_info)
+                level_info.map_file, level_info.briefing, nil, _S.errors.load_level_prefix, campaign_info)
             if campaign_info.movie then
               local n = math.max(1, 12 - #campaign_info.levels + i)
               self.ui.app.moviePlayer:playAdvanceMovie(n)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
- Set the origin folder for a custom campaign. This is the last part of permitting campaigns to be in their own folder.
