### PR TITLE
Add new criterion - year

### DIFF
--- a/CorsixTH/Lua/date.lua
+++ b/CorsixTH/Lua/date.lua
@@ -263,6 +263,13 @@ function Date:isSameDay(other)
   return self._year == other._year and self._month == other._month and self._day == other._day
 end
 
+--[[ Calculates the number of months played until a time an hour in the future. This is used in EndConditions
+!return (number) Integer of months since Jan 2000
+]]
+function Date:getProgressInMonths()
+  return self:plusHours(1):monthOfGame()
+end
+
 -- METAMETHODS
 
 local Date_mt = Date._metatable

--- a/CorsixTH/Lua/endconditions.lua
+++ b/CorsixTH/Lua/endconditions.lua
@@ -32,13 +32,15 @@ local local_criteria_variable = {
     -- New criteria
   {name = "staff_happiness",  icon = 16, icon_file = "MPointer", formats = 2, two_tooltips = true},
   {name = "patient_happiness",icon = 18, icon_file = "MPointer", formats = 2, two_tooltips = true},
+  {name = "months_played",    icon = 46, icon_file = "Font04V",  formats = 4, two_tooltips = true},
 }
 
 -- A table of functions for fetching criteria values that cannot be measured
---   directly from a hospital attribute of the same name.
+-- directly from a hospital attribute of the same name.
 local get_custom_criteria = {
   staff_happiness = function(hospital) return 100 * hospital:getAverageStaffAttribute("happiness", 0.5) end,
   patient_happiness = function(hospital) return 100 * hospital:getAveragePatientAttribute("happiness", 0.5) end,
+  months_played = function(hospital) return hospital.world.game_date:getProgressInMonths() end,
 }
 
 class "EndConditions"

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -872,6 +872,7 @@ information = {
     cheat = "Hope you didn't click the Lose Level button by accident!",
     staff_happiness = "Your average staff happiness fell below %d%.",
     patient_happiness = "Your average patient happiness fell below %d%.",
+    months_played = "You didn't meet the level goals within %d months.",
   },
   cheat_not_possible = "You cannot use that cheat on this level.",
 }
@@ -1089,10 +1090,14 @@ tooltip.status = {
   over = {
     staff_happiness = "Your average staff happiness should be over %d%. Currently it's %d%",
     patient_happiness = "Your average patient happiness should be over %d%. Currently it's %d%",
+    months_played = "You need to reach the end of %s %d. Currently it's %s %d",
+    years_played = "You need to reach the year %d. Currently it's the year %d",
   },
   under = {
     staff_happiness = "Your average staff happiness should not be less than %d%. Currently it's %d%",
     patient_happiness = "Your average patient happiness should not be less than %d%. Currently it's %d%",
+    months_played = "You need to win by the end of %s %d. Currently it's %s %d",
+    years_played = "You need to reach the year %d. Currently it's the year %d",
   }
 }
 --------------------------------  UNUSED  -----------------------------------


### PR DESCRIPTION

**Describe what the proposed change does**
- Add new endcondition criterion for the year. Is it clearer as complete years, without a decimal point for progress in the current year?  
The year needs 0.99 removed to work for the comparisons in checking win and lose. As with the internal values for year, it starts at 0 not 2000 and is only changed to this millennium for display.  
A requirement for over a certain year can be combined with others as a grace period, eg cure percentage must be over 60% after ten years
Examples for ending after 3 years.
#win_criteria[0].Criteria.MaxMin.Value.Group.Bound 9 1 3 1 0
#lose_criteria[0].Criteria.MaxMin.Value.Group.Bound 9 1 3 1 0


