### PR TITLE
Refactor drawable draw / hit_test / is_multiple_frame_animation methods

### DIFF
--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2688;
+return 2689;

--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2689;
+return 2688;

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1344,7 +1344,8 @@ void animation::depersist(lua_persist_reader* pReader) {
   do {
     // Read the chain
     if (!pReader->read_stack_object()) break;
-    next = reinterpret_cast<link_list*>(lua_touserdata(L, -1));
+
+    next = get_animation_base_from_userdata(L, -1);
     if (next) next->prev = this;
     lua_pop(L, 1);
 
@@ -1827,7 +1828,7 @@ void sprite_render_list::depersist(lua_persist_reader* pReader) {
     return;
   }
 
-  next = reinterpret_cast<link_list*>(lua_touserdata(L, -1));
+  next = get_animation_base_from_userdata(L, -1);
   if (next) {
     next->prev = this;
   }

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1285,7 +1285,7 @@ void animation::persist(lua_persist_writer* pWriter) const {
   // Write the drawable fields
   pWriter->write_uint(flags);
 
-  if (anim_kind  == animation_kind::normal) {
+  if (anim_kind == animation_kind::normal) {
     pWriter->write_uint(1);
   } else if (anim_kind == animation_kind::child) {
     pWriter->write_uint(2);
@@ -1656,8 +1656,7 @@ void animation_base::set_layer(int iLayer, int iId) {
   }
 }
 
-sprite_render_list::sprite_render_list() : animation_base() {
-}
+sprite_render_list::sprite_render_list() : animation_base() {}
 
 sprite_render_list::~sprite_render_list() { delete[] sprites; }
 

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1249,55 +1249,6 @@ bool animation::hit_test_morph(int iDestX, int iDestY, int iTestX, int iTestY) {
          morph_target->hit_test(iDestX, iDestY, iTestX, iTestY);
 }
 
-namespace {
-bool THAnimation_hit_test_child(drawable* pSelf, int iDestX, int iDestY,
-                                int iTestX, int iTestY) {
-  return reinterpret_cast<animation*>(pSelf)->hit_test_child(iDestX, iDestY,
-                                                             iTestX, iTestY);
-}
-
-void THAnimation_draw_child(drawable* pSelf, render_target* pCanvas, int iDestX,
-                            int iDestY) {
-  reinterpret_cast<animation*>(pSelf)->draw_child(pCanvas, iDestX, iDestY);
-}
-
-bool THAnimation_hit_test_morph(drawable* pSelf, int iDestX, int iDestY,
-                                int iTestX, int iTestY) {
-  return reinterpret_cast<animation*>(pSelf)->hit_test_morph(iDestX, iDestY,
-                                                             iTestX, iTestY);
-}
-
-void THAnimation_draw_morph(drawable* pSelf, render_target* pCanvas, int iDestX,
-                            int iDestY) {
-  reinterpret_cast<animation*>(pSelf)->draw_morph(pCanvas, iDestX, iDestY);
-}
-
-bool THAnimation_hit_test(drawable* pSelf, int iDestX, int iDestY, int iTestX,
-                          int iTestY) {
-  return reinterpret_cast<animation*>(pSelf)->hit_test(iDestX, iDestY, iTestX,
-                                                       iTestY);
-}
-
-void THAnimation_draw(drawable* pSelf, render_target* pCanvas, int iDestX,
-                      int iDestY) {
-  reinterpret_cast<animation*>(pSelf)->draw(pCanvas, iDestX, iDestY);
-}
-
-bool THAnimation_is_multiple_frame_animation(drawable* pSelf) {
-  animation* pAnimation = reinterpret_cast<animation*>(pSelf);
-  if (pAnimation) {
-    size_t firstFrame = pAnimation->get_animation_manager()->get_first_frame(
-        pAnimation->get_animation());
-    size_t nextFrame =
-        pAnimation->get_animation_manager()->get_next_frame(firstFrame);
-    return nextFrame != firstFrame;
-  } else {
-    return false;
-  }
-}
-
-}  // namespace
-
 animation_base::animation_base() : drawable() {
   x_relative_to_tile = 0;
   y_relative_to_tile = 0;
@@ -1315,10 +1266,8 @@ animation::animation()
       frame_index(0),
       speed({0, 0}),
       sound_to_play(0),
-      crop_column(0) {
-  draw_fn = THAnimation_draw;
-  hit_test_fn = THAnimation_hit_test;
-  is_multiple_frame_animation_fn = THAnimation_is_multiple_frame_animation;
+      crop_column(0),
+      anim_kind(animation_kind::normal) {
   patient_effect = animation_effect::none;
   patient_effect_offset = rand();
 }
@@ -1336,13 +1285,11 @@ void animation::persist(lua_persist_writer* pWriter) const {
   // Write the drawable fields
   pWriter->write_uint(flags);
 
-  if (draw_fn == THAnimation_draw && hit_test_fn == THAnimation_hit_test) {
+  if (anim_kind  == animation_kind::normal) {
     pWriter->write_uint(1);
-  } else if (draw_fn == THAnimation_draw_child &&
-             hit_test_fn == THAnimation_hit_test_child) {
+  } else if (anim_kind == animation_kind::child) {
     pWriter->write_uint(2);
-  } else if (draw_fn == THAnimation_draw_morph &&
-             hit_test_fn == THAnimation_hit_test_morph) {
+  } else if (anim_kind == animation_kind::morph) {
     // NB: Prior version of code used the number 3 here, and forgot
     // to persist the morph target.
     pWriter->write_uint(4);
@@ -1371,7 +1318,7 @@ void animation::persist(lua_persist_writer* pWriter) const {
   }
 
   // Write the unioned fields
-  if (draw_fn != THAnimation_draw_child) {
+  if (anim_kind != animation_kind::child) {
     pWriter->write_int(speed.dx);
     pWriter->write_int(speed.dy);
   } else {
@@ -1411,16 +1358,13 @@ void animation::depersist(lua_persist_reader* pReader) {
         // missing, so settle for a graphical bug rather than a segfault
         // by reverting to the normal function set.
       case 1:
-        draw_fn = THAnimation_draw;
-        hit_test_fn = THAnimation_hit_test;
+        set_animation_kind(animation_kind::normal);
         break;
       case 2:
-        draw_fn = THAnimation_draw_child;
-        hit_test_fn = THAnimation_hit_test_child;
+        set_animation_kind(animation_kind::child);
         break;
       case 4:
-        draw_fn = THAnimation_draw_morph;
-        hit_test_fn = THAnimation_hit_test_morph;
+        set_animation_kind(animation_kind::morph);
         pReader->read_stack_object();
         morph_target = reinterpret_cast<animation*>(lua_touserdata(L, -1));
         lua_pop(L, 1);
@@ -1450,7 +1394,7 @@ void animation::depersist(lua_persist_reader* pReader) {
     }
 
     // Read the unioned fields
-    if (draw_fn != THAnimation_draw_child) {
+    if (anim_kind != animation_kind::child) {
       if (!pReader->read_int(speed.dx)) break;
       if (!pReader->read_int(speed.dy)) break;
     } else {
@@ -1494,6 +1438,10 @@ void animation::set_patient_effect(animation_effect patient_effect) {
   this->patient_effect = patient_effect;
 }
 
+void animation::set_animation_kind(animation_kind anim_kind) {
+  this->anim_kind = anim_kind;
+}
+
 namespace {
 // Map of frame numbers to sounds to play.
 const std::map<size_t, int> frame_sound_replacements{
@@ -1516,7 +1464,7 @@ const std::map<size_t, int> frame_sound_replacements{
 
 void animation::tick() {
   frame_index = manager->get_next_frame(frame_index);
-  if (draw_fn != THAnimation_draw_child) {
+  if (anim_kind != animation_kind::child) {
     x_relative_to_tile += speed.dx;
     y_relative_to_tile += speed.dy;
   }
@@ -1569,12 +1517,10 @@ void animation_base::attach_to_tile(map_tile* pMapNode, int layer) {
 void animation::set_parent(animation* pParent) {
   remove_from_tile();
   if (pParent == nullptr) {
-    draw_fn = THAnimation_draw;
-    hit_test_fn = THAnimation_hit_test;
+    set_animation_kind(animation_kind::normal);
     speed = {0, 0};
   } else {
-    draw_fn = THAnimation_draw_child;
-    hit_test_fn = THAnimation_hit_test_child;
+    set_animation_kind(animation_kind::child);
     parent = pParent;
     next = parent->next;
     if (next) next->prev = this;
@@ -1589,8 +1535,7 @@ void animation::set_animation(animation_manager* pManager, size_t iAnimation) {
   frame_index = pManager->get_first_frame(iAnimation);
   if (morph_target) {
     morph_target = nullptr;
-    draw_fn = THAnimation_draw;
-    hit_test_fn = THAnimation_hit_test;
+    set_animation_kind(animation_kind::normal);
   }
 }
 
@@ -1654,8 +1599,7 @@ int GetAnimationDurationAndExtent(animation_manager* pManager, size_t iFrame,
 
 void animation::set_morph_target(animation* pMorphTarget, int iDurationFactor) {
   morph_target = pMorphTarget;
-  draw_fn = THAnimation_draw_morph;
-  hit_test_fn = THAnimation_hit_test_morph;
+  set_animation_kind(animation_kind::morph);
 
   /* Morphing is the process by which two animations are combined to give a
   single animation of one animation turning into another. At the moment,
@@ -1712,30 +1656,7 @@ void animation_base::set_layer(int iLayer, int iId) {
   }
 }
 
-namespace {
-
-bool THSpriteRenderList_hit_test(drawable* pSelf, int iDestX, int iDestY,
-                                 int iTestX, int iTestY) {
-  return reinterpret_cast<sprite_render_list*>(pSelf)->hit_test(iDestX, iDestY,
-                                                                iTestX, iTestY);
-}
-
-void THSpriteRenderList_draw(drawable* pSelf, render_target* pCanvas,
-                             int iDestX, int iDestY) {
-  reinterpret_cast<sprite_render_list*>(pSelf)->draw(pCanvas, iDestX, iDestY);
-}
-
-bool THSpriteRenderList_is_multiple_frame_animation(drawable* pSelf) {
-  return false;
-}
-
-}  // namespace
-
 sprite_render_list::sprite_render_list() : animation_base() {
-  draw_fn = THSpriteRenderList_draw;
-  hit_test_fn = THSpriteRenderList_hit_test;
-  is_multiple_frame_animation_fn =
-      THSpriteRenderList_is_multiple_frame_animation;
 }
 
 sprite_render_list::~sprite_render_list() { delete[] sprites; }

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1345,7 +1345,7 @@ void animation::depersist(lua_persist_reader* pReader) {
     // Read the chain
     if (!pReader->read_stack_object()) break;
 
-    next = get_animation_base_from_userdata(L, -1);
+    next = luaT_testuserdata<animation_base>(L, -1, false);
     if (next) next->prev = this;
     lua_pop(L, 1);
 
@@ -1828,7 +1828,7 @@ void sprite_render_list::depersist(lua_persist_reader* pReader) {
     return;
   }
 
-  next = get_animation_base_from_userdata(L, -1);
+  next = luaT_testuserdata<animation_base>(L, -1, false);
   if (next) {
     next->prev = this;
   }

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -706,7 +706,7 @@ class sprite_render_list : public animation_base {
 // class.
 template <>
 inline animation_base* luaT_testuserdata<animation_base>(lua_State* L, int idx,
-                                                  bool required) {
+                                                         bool required) {
   animation_base* p = luaT_testuserdata<animation>(L, idx, false);
   if (p == nullptr) {
     p = luaT_testuserdata<sprite_render_list>(L, idx, required);

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -702,10 +702,14 @@ class sprite_render_list : public animation_base {
   bool use_intermediate_buffer = false;
 };
 
-inline animation_base* get_animation_base_from_userdata(lua_State* L, int idx) {
+// Specialization of the 'luaT_testuserdata' template for the 'animation_base'
+// class.
+template <>
+inline animation_base* luaT_testuserdata<animation_base>(lua_State* L, int idx,
+                                                  bool required) {
   animation_base* p = luaT_testuserdata<animation>(L, idx, false);
   if (p == nullptr) {
-    p = luaT_testuserdata<sprite_render_list>(L, idx, false);
+    p = luaT_testuserdata<sprite_render_list>(L, idx, required);
   }
   return p;
 }

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -574,13 +574,13 @@ class animation : public animation_base {
 
   void draw_fn(render_target* pCanvas, int iDestX, int iDestY) {
     switch (anim_kind) {
-    case animation_kind::normal:
+      case animation_kind::normal:
         draw(pCanvas, iDestX, iDestY);
         return;
-    case animation_kind::child:
+      case animation_kind::child:
         draw_child(pCanvas, iDestX, iDestY);
         return;
-    case animation_kind::morph:
+      case animation_kind::morph:
         draw_morph(pCanvas, iDestX, iDestY);
         return;
     }
@@ -588,21 +588,20 @@ class animation : public animation_base {
 
   bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY) {
     switch (anim_kind) {
-    case animation_kind::normal:
+      case animation_kind::normal:
         return hit_test(iDestX, iDestY, iTestX, iTestY);
-    case animation_kind::child:
+      case animation_kind::child:
         return hit_test_child(iDestX, iDestY, iTestX, iTestY);
-    case animation_kind::morph:
+      case animation_kind::morph:
         return hit_test_morph(iDestX, iDestY, iTestX, iTestY);
     }
     return false;
   }
 
   bool is_multiple_frame_animation_fn() {
-    size_t firstFrame = get_animation_manager()->get_first_frame(
-        get_animation());
-    size_t nextFrame =
-        get_animation_manager()->get_next_frame(firstFrame);
+    size_t firstFrame =
+        get_animation_manager()->get_first_frame(get_animation());
+    size_t nextFrame = get_animation_manager()->get_next_frame(firstFrame);
     return nextFrame != firstFrame;
   }
 
@@ -677,9 +676,7 @@ class sprite_render_list : public animation_base {
     return hit_test(iDestX, iDestY, iTestX, iTestY);
   }
 
-  bool is_multiple_frame_animation_fn() {
-    return false;
-  }
+  bool is_multiple_frame_animation_fn() { return false; }
 
  private:
   struct sprite {

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -572,7 +572,7 @@ class animation : public animation_base {
   void draw_child(render_target* pCanvas, int iDestX, int iDestY);
   bool hit_test_child(int iDestX, int iDestY, int iTestX, int iTestY);
 
-  void draw_fn(render_target* pCanvas, int iDestX, int iDestY) {
+  void draw_fn(render_target* pCanvas, int iDestX, int iDestY) override {
     switch (anim_kind) {
       case animation_kind::normal:
         draw(pCanvas, iDestX, iDestY);
@@ -586,7 +586,7 @@ class animation : public animation_base {
     }
   }
 
-  bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY) {
+  bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY) override {
     switch (anim_kind) {
       case animation_kind::normal:
         return hit_test(iDestX, iDestY, iTestX, iTestY);
@@ -598,7 +598,7 @@ class animation : public animation_base {
     return false;
   }
 
-  bool is_multiple_frame_animation_fn() {
+  bool is_multiple_frame_animation_fn() override {
     size_t firstFrame =
         get_animation_manager()->get_first_frame(get_animation());
     size_t nextFrame = get_animation_manager()->get_next_frame(firstFrame);
@@ -668,15 +668,15 @@ class sprite_render_list : public animation_base {
   void persist(lua_persist_writer* pWriter) const;
   void depersist(lua_persist_reader* pReader);
 
-  void draw_fn(render_target* pCanvas, int iDestX, int iDestY) {
+  void draw_fn(render_target* pCanvas, int iDestX, int iDestY) override {
     draw(pCanvas, iDestX, iDestY);
   }
 
-  bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY) {
+  bool hit_test_fn(int iDestX, int iDestY, int iTestX, int iTestY) override {
     return hit_test(iDestX, iDestY, iTestX, iTestY);
   }
 
-  bool is_multiple_frame_animation_fn() { return false; }
+  bool is_multiple_frame_animation_fn() override { return false; }
 
  private:
   struct sprite {

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -30,6 +30,7 @@ SOFTWARE.
 #include "th.h"
 #include "th_gfx_common.h"
 #include "th_gfx_sdl.h"
+#include "th_lua.h"
 
 class lua_persist_reader;
 class lua_persist_writer;
@@ -700,5 +701,13 @@ class sprite_render_list : public animation_base {
   //! rendering quality when scaling.
   bool use_intermediate_buffer = false;
 };
+
+inline animation_base* get_animation_base_from_userdata(lua_State* L, int idx) {
+  animation_base* p = luaT_testuserdata<animation>(L, idx, false);
+  if (p == nullptr) {
+    p = luaT_testuserdata<sprite_render_list>(L, idx, false);
+  }
+  return p;
+}
 
 #endif  // CORSIX_TH_TH_GFX_H_

--- a/CorsixTH/Src/th_lua.h
+++ b/CorsixTH/Src/th_lua.h
@@ -367,10 +367,10 @@ T* luaT_testuserdata(lua_State* L, int idx, int mt_idx, bool required = true) {
 }
 
 template <class T>
-T* luaT_testuserdata(lua_State* L, int idx = 1) {
+T* luaT_testuserdata(lua_State* L, int idx = 1, bool required = true) {
   int iMetaIndex = luaT_environindex;
   if (idx > 1) iMetaIndex = luaT_upvalueindex(idx - 1);
-  return luaT_testuserdata<T>(L, idx, iMetaIndex);
+  return luaT_testuserdata<T>(L, idx, iMetaIndex, required);
 }
 
 template <class T, int mt>

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1042,7 +1042,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
       }
       drawable* pItem = static_cast<drawable*>(itrNode->oEarlyEntities.next);
       while (pItem) {
-        pItem->draw_fn(pItem, pCanvas, itrNode.x(), itrNode.y());
+        pItem->draw_fn(pCanvas, itrNode.x(), itrNode.y());
         pItem = static_cast<drawable*>(pItem->next);
       }
     }
@@ -1091,8 +1091,8 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
 
       drawable* pItem = static_cast<drawable*>(itrNode->entities.next);
       while (pItem) {
-        pItem->draw_fn(pItem, pCanvas, itrNode.x(), itrNode.y());
-        if (pItem->is_multiple_frame_animation_fn(pItem)) {
+        pItem->draw_fn(pCanvas, itrNode.x(), itrNode.y());
+        if (pItem->is_multiple_frame_animation_fn()) {
           bRedrawAnimations = true;
         }
         if (pItem->get_drawing_layer() == 1) {
@@ -1115,7 +1115,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
             formerIterator.get_previous_tile()->entities.next);
         while (pItem) {
           if (pItem->get_drawing_layer() == 9) {
-            pItem->draw_fn(pItem, pCanvas, formerIterator.x() - 64,
+            pItem->draw_fn(pCanvas, formerIterator.x() - 64,
                            formerIterator.y());
             bTileNeedsRedraw = true;
           }
@@ -1129,7 +1129,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
                     : nullptr;
         while (pItem) {
           if (pItem->get_drawing_layer() == 8) {
-            pItem->draw_fn(pItem, pCanvas, formerIterator.x(),
+            pItem->draw_fn(pCanvas, formerIterator.x(),
                            formerIterator.y());
           }
           pItem = static_cast<drawable*>(pItem->next);
@@ -1163,13 +1163,13 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
           pItem = static_cast<drawable*>(
               itrNode.get_previous_tile()->oEarlyEntities.next);
           for (; pItem; pItem = static_cast<drawable*>(pItem->next)) {
-            pItem->draw_fn(pItem, pCanvas, itrNode.x() - 64, itrNode.y());
+            pItem->draw_fn(pCanvas, itrNode.x() - 64, itrNode.y());
           }
 
           pItem = static_cast<drawable*>(
               itrNode.get_previous_tile()->entities.next);
           for (; pItem; pItem = static_cast<drawable*>(pItem->next)) {
-            pItem->draw_fn(pItem, pCanvas, itrNode.x() - 64, itrNode.y());
+            pItem->draw_fn(pCanvas, itrNode.x() - 64, itrNode.y());
           }
         }
       }
@@ -1245,7 +1245,7 @@ drawable* level_map::hit_test_drawables(link_list* pListStart, int iXs, int iYs,
   drawable* pList = static_cast<drawable*>(pListEnd);
 
   while (true) {
-    if (pList->hit_test_fn(pList, iXs, iYs, iTestX, iTestY)) return pList;
+    if (pList->hit_test_fn(iXs, iYs, iTestX, iTestY)) return pList;
 
     if (pList == pListStart) {
       return nullptr;

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1603,7 +1603,7 @@ void level_map::depersist(lua_persist_reader* pReader) {
     }
 
     if (!pReader->read_stack_object()) return;
-    pNode->entities.next = get_animation_base_from_userdata(L, -1);
+    pNode->entities.next = luaT_testuserdata<animation_base>(L, -1, false);
     if (pNode->entities.next) {
       if (pNode->entities.next->prev != nullptr) {
         std::fprintf(stderr, "Warning: THMap linked-lists are corrupted.\n");
@@ -1613,7 +1613,7 @@ void level_map::depersist(lua_persist_reader* pReader) {
     lua_pop(L, 1);
 
     if (!pReader->read_stack_object()) return;
-    pNode->oEarlyEntities.next = get_animation_base_from_userdata(L, -1);
+    pNode->oEarlyEntities.next = luaT_testuserdata<animation_base>(L, -1, false);
     if (pNode->oEarlyEntities.next) {
       if (pNode->oEarlyEntities.next->prev != nullptr) {
         std::fprintf(stderr, "Warning: THMap linked-lists are corrupted.\n");

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1603,7 +1603,7 @@ void level_map::depersist(lua_persist_reader* pReader) {
     }
 
     if (!pReader->read_stack_object()) return;
-    pNode->entities.next = static_cast<link_list*>(lua_touserdata(L, -1));
+    pNode->entities.next = get_animation_base_from_userdata(L, -1);
     if (pNode->entities.next) {
       if (pNode->entities.next->prev != nullptr) {
         std::fprintf(stderr, "Warning: THMap linked-lists are corrupted.\n");
@@ -1613,7 +1613,7 @@ void level_map::depersist(lua_persist_reader* pReader) {
     lua_pop(L, 1);
 
     if (!pReader->read_stack_object()) return;
-    pNode->oEarlyEntities.next = static_cast<link_list*>(lua_touserdata(L, -1));
+    pNode->oEarlyEntities.next = get_animation_base_from_userdata(L, -1);
     if (pNode->oEarlyEntities.next) {
       if (pNode->oEarlyEntities.next->prev != nullptr) {
         std::fprintf(stderr, "Warning: THMap linked-lists are corrupted.\n");

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1613,7 +1613,8 @@ void level_map::depersist(lua_persist_reader* pReader) {
     lua_pop(L, 1);
 
     if (!pReader->read_stack_object()) return;
-    pNode->oEarlyEntities.next = luaT_testuserdata<animation_base>(L, -1, false);
+    pNode->oEarlyEntities.next =
+        luaT_testuserdata<animation_base>(L, -1, false);
     if (pNode->oEarlyEntities.next) {
       if (pNode->oEarlyEntities.next->prev != nullptr) {
         std::fprintf(stderr, "Warning: THMap linked-lists are corrupted.\n");

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1129,8 +1129,7 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
                     : nullptr;
         while (pItem) {
           if (pItem->get_drawing_layer() == 8) {
-            pItem->draw_fn(pCanvas, formerIterator.x(),
-                           formerIterator.y());
+            pItem->draw_fn(pCanvas, formerIterator.x(), formerIterator.y());
           }
           pItem = static_cast<drawable*>(pItem->next);
         }


### PR DESCRIPTION
- Replaced the 'drawable' base class function pointers by abstract virtual methods.
- Implemented them in 'animation' and 'sprite_render_list'.
- Added an enumeration to 'animation' to track the kind of animation that is stored.

- Deleted all the functions of the removed function pointers.

**Describe what the proposed change does**
- Simplify extending to secondary marker support.