### PR TITLE
Add support for AddressSanitizer, drop VLD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,27 @@
 # Cmake File for CorsixTH
 # OPTIONS AVAILABLE:
 # Any of the following: (default)
+
+# CorsixTH Features and behaviour
 #   - WITH_AUDIO      : Activate sound (yes)
 #   - WITH_FREETYPE2  : Active support for non-Latin script alphabets (yes)
 #   - WITH_MOVIES     : Activate movies (requires with_audio, FFmpeg) (yes)
-#   - WITH_LUAJIT     : Use LuaJIT instead of Lua (must specify library path) (no)
 #   - WITH_UPDATE_CHECK : Activates support to check for new version on launch (requires libcurl) (yes)
 #   - USE_SOURCE_DATADIRS : Use the source directory for loading resources. Incompatible with the install target (no)
 #   - SEARCH_LOCAL_DATADIRS : Search resources in the working directory and the
 #       program directory where the executable stores. Makes the executable
 #       portable (yes for Apple)
 
-#   - WITH_VLD        : Build with Visual Leak Detector (requires Visual Studio) (no)
+# Dependency resolution
+#   - WITH_LUAJIT     : Use LuaJIT instead of Lua (must specify library path) (no)
 #   - USE_PRECOMPILED_DEPS : Use precompiled dependencies on *nix (no)
 #   - WITH_LUAROCKS : Install required luarocks in the macOS app (requires luarocks)
 
+# Tests and debug options
 #   - ENABLE_UNIT_TESTS : Enable Unit Testing Target (requires Catch2) (no)
+#   - ENABLE_ASAN : Build with AddressSanitizer enabled (no)
+
+# Additional build targets
 #   - BUILD_ANIMVIEW : Generate AnimView build files (no)
 #   - BUILD_TOOLS : Generate cli tools
 
@@ -32,6 +38,7 @@ option(USE_SOURCE_DATADIRS "Use the source directory for loading resources. Inco
 option(ENABLE_UNIT_TESTS "Enables Unit Testing Targets" OFF)
 option(BUILD_ANIMVIEW "Build the animation viewer as part of the build process" OFF)
 option(BUILD_TOOLS "Build additional CLI tools (rnc_decode)" OFF)
+option(ENABLE_ASAN "Build with AddressSanitizer enabled" OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
 
@@ -60,6 +67,11 @@ if(MINGW)
   set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
 endif()
 
+if(ENABLE_ASAN)
+  add_compile_options(-fsanitize=address)
+  add_link_options(-fsanitize=address)
+endif()
+
 include(CheckIncludeFiles)
 
 set(CORSIX_TH_DONE_TOP_LEVEL_CMAKE ON)
@@ -74,9 +86,6 @@ option(SEARCH_LOCAL_DATADIRS
   "Search resources in the working directory and the program directory where the executable stores."
   ${SEARCH_LOCAL_DATADIRS_DEFAULT})
 
-if(MSVC)
-  option(WITH_VLD "Build with Visual Leak Detector for Visual Studio" OFF)
-endif()
 # Dependency management
 if(UNIX AND CMAKE_COMPILER_IS_GNU)
   option(USE_PRECOMPILED_DEPS "Use Precompiled Dependencies" OFF) # Make *nix systems opt in
@@ -125,18 +134,6 @@ if(VCPKG_TARGET_TRIPLET AND NOT WITH_LUAROCKS)
   set(CORSIX_TH_LINK_LUA_MODULES ON)
 else()
   set(CORSIX_TH_LINK_LUA_MODULES OFF)
-endif()
-
-if(MSVC)
-  if(WITH_VLD)
-    set(CORSIX_TH_USE_VLD ON)
-    message("Note: Visual Leak Detector is enabled")
-  else()
-    set(CORSIX_TH_USE_VLD OFF)
-    message("Note: Visual Leak Detector is disabled (default)")
-  endif()
-else()
-  set(CORSIX_TH_USE_VLD OFF)
 endif()
 
 # Get precompiled dependencies before running the various find modules

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 # Tests and debug options
 #   - ENABLE_UNIT_TESTS : Enable Unit Testing Target (requires Catch2) (no)
-#   - ENABLE_ASAN : Build with AddressSanitizer enabled (no)
+#   - ENABLE_SANITIZERS : Build with AddressSanitizer (ASan) and UndefinedBehaviorSanitizer (UBSan) enabled (no)
 
 # Additional build targets
 #   - BUILD_ANIMVIEW : Generate AnimView build files (no)
@@ -38,7 +38,7 @@ option(USE_SOURCE_DATADIRS "Use the source directory for loading resources. Inco
 option(ENABLE_UNIT_TESTS "Enables Unit Testing Targets" OFF)
 option(BUILD_ANIMVIEW "Build the animation viewer as part of the build process" OFF)
 option(BUILD_TOOLS "Build additional CLI tools (rnc_decode)" OFF)
-option(ENABLE_ASAN "Build with AddressSanitizer enabled" OFF)
+option(ENABLE_SANITIZERS "Build with ASan and UBSan enabled" OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
 
@@ -67,9 +67,9 @@ if(MINGW)
   set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
 endif()
 
-if(ENABLE_ASAN)
-  add_compile_options(-fsanitize=address)
-  add_link_options(-fsanitize=address)
+if(ENABLE_SANITIZERS)
+  add_compile_options(-fsanitize=address,undefined)
+  add_link_options(-fsanitize=address,undefined)
 endif()
 
 include(CheckIncludeFiles)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,8 +68,13 @@ if(MINGW)
 endif()
 
 if(ENABLE_SANITIZERS)
-  add_compile_options(-fsanitize=address,undefined)
-  add_link_options(-fsanitize=address,undefined)
+  if(MSVC)
+    # https://learn.microsoft.com/en-us/cpp/build/reference/fsanitize?view=msvc-170
+    add_compile_options(/fsanitize=address)
+  else()
+    add_compile_options(-fsanitize=address,undefined)
+    add_link_options(-fsanitize=address,undefined)
+  endif()
 endif()
 
 include(CheckIncludeFiles)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,7 +8,7 @@
       "cacheVariables": {
         "USE_SOURCE_DATADIRS": "ON",
         "ENABLE_UNIT_TESTS": "ON",
-        "ENABLE_ASAN": "ON",
+        "ENABLE_SANITIZERS": "ON",
         "BUILD_ANIMVIEW": "ON",
         "BUILD_TOOLS": "ON",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
@@ -23,7 +23,7 @@
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "USE_SOURCE_DATADIRS": "ON",
         "ENABLE_UNIT_TESTS": "ON",
-        "ENABLE_ASAN": "ON",
+        "ENABLE_SANITIZERS": "ON",
         "BUILD_ANIMVIEW": "ON",
         "BUILD_TOOLS": "ON",
 	"CMAKE_BUILD_TYPE": "Debug"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,6 +8,7 @@
       "cacheVariables": {
         "USE_SOURCE_DATADIRS": "ON",
         "ENABLE_UNIT_TESTS": "ON",
+        "ENABLE_ASAN": "ON",
         "BUILD_ANIMVIEW": "ON",
         "BUILD_TOOLS": "ON",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
@@ -22,6 +23,7 @@
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "USE_SOURCE_DATADIRS": "ON",
         "ENABLE_UNIT_TESTS": "ON",
+        "ENABLE_ASAN": "ON",
         "BUILD_ANIMVIEW": "ON",
         "BUILD_TOOLS": "ON",
 	"CMAKE_BUILD_TYPE": "Debug"

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -245,17 +245,6 @@ else()
   message("Lua modules are not linked and will be loaded at runtime")
 endif()
 
-if(MSVC AND CORSIX_TH_USE_VLD)
-  find_package(VLD REQUIRED)
-  if(VLD_FOUND)
-    target_link_libraries(CorsixTH PRIVATE ${VLD_LIBRARY})
-    include_directories(CorsixTH PRIVATE ${VLD_INCLUDE_DIR})
-    message("  VLD found")
-  else()
-    message(FATAL_ERROR "Error: VLD Library not found, it is required to build when USE_VLD is set")
-  endif()
-endif()
-
 # Launch script to facilitate out of source builds
 if(USE_SOURCE_DATADIRS)
   # Do not generate launch script. The default is fine for this case.


### PR DESCRIPTION
VLD is no longer maintained so it's removed.

Added a convenience option for enabling AddressSanitizer: https://github.com/google/sanitizers/wiki/AddressSanitizer

The options provided here work in gcc and llvm. Address sanitizer is available in MSVC but may use a slightly different flag.

I have not enabled it in the windows dev preset because I cannot test it.
