### PR TITLE
Afteload minor fix in world.lua

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2425,6 +2425,9 @@ function World:afterLoad(old, new)
     self:resetSideObjects()
   end
 
+  if old < 132 then
+    self.app = self.ui.app
+  end
   if old < 153 then
     -- Set the new variable next_emergency_date
     -- Also set the new variable next_emergency


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2796*

**Describe what the proposed change does**
-
- Made proper `self.app = self.ui.app` in `afterLoad` which was missed.
