### PR TITLE
Fix stuck wait moods

### DIFF
--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -541,14 +541,14 @@ function Room:_checkWaitToggleValidTarget()
       class.is(self.door.queue:front(), Patient)
 end
 
+--! Handle the patient coming into the room
+--! To be extended in derived classes.
+--!param humanoid The patient entering
 function Room:commandEnteringPatient(humanoid)
-  -- To be extended in derived classes
   self.door.queue.visitor_count = self.door.queue.visitor_count + 1
   humanoid:updateDynamicInfo("")
 
-  if self:_checkWaitToggleValidTarget() then
-    self:_staffWaitToggle(false) -- Staff no longer waiting
-  end
+  self:_staffWaitToggle(false) -- Staff no longer waiting
 end
 
 function Room:tryAdvanceQueue()


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

Fixes a bug introduced in #2333 

**Describe what the proposed change does**
- If a queue was empty after a patient entered the room the wait toggle did not clear.
- Now clears the wait mood when a patient enters the room without checks. The original safeguard was for setting mood, rather than removing it.
- Tidied some doc.
