### PR TITLE
Allow using the secondary marker

### DIFF
--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2688;
+return 2689;

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1536,8 +1536,8 @@ void animation::set_parent(animation* pParent, bool use_primary) {
     set_animation_kind(animation_kind::normal);
     speed = {0, 0};
   } else {
-    set_animation_kind(use_primary ? animation_kind::primary_child :
-        animation_kind::secondary_child);
+    set_animation_kind(use_primary ? animation_kind::primary_child
+                                   : animation_kind::secondary_child);
     parent = pParent;
     next = parent->next;
     if (next) next->prev = this;

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -227,8 +227,8 @@ bool animation_manager::load_from_th_file(
     oFrame.sound = pFrame->sound;
     oFrame.flags = pFrame->flags;
     // Bounding box fields initialised later
-    oFrame.marker_x = 0;
-    oFrame.marker_y = 0;
+    oFrame.primary_marker_x = 0;
+    oFrame.primary_marker_y = 0;
     oFrame.secondary_marker_x = 0;
     oFrame.secondary_marker_y = 0;
 
@@ -638,8 +638,8 @@ bool animation_manager::load_custom_animations(const uint8_t* pData,
 
       // Set later
       oFrame.flags = 0;
-      oFrame.marker_x = 0;
-      oFrame.marker_y = 0;
+      oFrame.primary_marker_x = 0;
+      oFrame.primary_marker_y = 0;
       oFrame.secondary_marker_x = 0;
       oFrame.secondary_marker_y = 0;
 
@@ -784,13 +784,14 @@ void animation_manager::set_animation_alt_palette_map(size_t iAnimation,
   } while (iFrame != iFirstFrame);
 }
 
-bool animation_manager::set_frame_marker(size_t iFrame, int iX, int iY) {
+bool animation_manager::set_frame_primary_marker(size_t iFrame, int iX,
+                                                 int iY) {
   if (iFrame >= frame_count) {
     return false;
   }
 
-  frames[iFrame].marker_x = iX;
-  frames[iFrame].marker_y = iY;
+  frames[iFrame].primary_marker_x = iX;
+  frames[iFrame].primary_marker_y = iY;
   return true;
 }
 
@@ -805,13 +806,14 @@ bool animation_manager::set_frame_secondary_marker(size_t iFrame, int iX,
   return true;
 }
 
-bool animation_manager::get_frame_marker(size_t iFrame, int* pX, int* pY) {
+bool animation_manager::get_frame_primary_marker(size_t iFrame, int* pX,
+                                                 int* pY) {
   if (iFrame >= frame_count) {
     return false;
   }
 
-  *pX = frames[iFrame].marker_x;
-  *pY = frames[iFrame].marker_y;
+  *pX = frames[iFrame].primary_marker_x;
+  *pY = frames[iFrame].primary_marker_y;
   return true;
 }
 
@@ -1170,7 +1172,7 @@ void animation::draw_child(render_target* pCanvas, int iDestX, int iDestY) {
   if (are_flags_set(flags, thdf_alpha_50 | thdf_alpha_75)) return;
   if (are_flags_set(parent->flags, thdf_alpha_50 | thdf_alpha_75)) return;
   int iX = 0, iY = 0;
-  parent->get_marker(&iX, &iY);
+  parent->get_primary_marker(&iX, &iY);
   iX += x_relative_to_tile + iDestX;
   iY += y_relative_to_tile + iDestY;
   if (sound_to_play) {
@@ -1540,8 +1542,8 @@ void animation::set_animation(animation_manager* pManager, size_t iAnimation) {
   }
 }
 
-bool animation::get_marker(int* pX, int* pY) {
-  if (!manager || !manager->get_frame_marker(frame_index, pX, pY)) {
+bool animation::get_primary_marker(int* pX, int* pY) {
+  if (!manager || !manager->get_frame_primary_marker(frame_index, pX, pY)) {
     return false;
   }
 

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1289,7 +1289,7 @@ void animation::persist(lua_persist_writer* pWriter) const {
 
   if (anim_kind == animation_kind::normal) {
     pWriter->write_uint(1);
-  } else if (anim_kind == animation_kind::child) {
+  } else if (anim_kind == animation_kind::primary_child) {
     pWriter->write_uint(2);
   } else if (anim_kind == animation_kind::morph) {
     // NB: Prior version of code used the number 3 here, and forgot
@@ -1320,7 +1320,7 @@ void animation::persist(lua_persist_writer* pWriter) const {
   }
 
   // Write the unioned fields
-  if (anim_kind != animation_kind::child) {
+  if (anim_kind != animation_kind::primary_child) {
     pWriter->write_int(speed.dx);
     pWriter->write_int(speed.dy);
   } else {
@@ -1364,7 +1364,7 @@ void animation::depersist(lua_persist_reader* pReader) {
         set_animation_kind(animation_kind::normal);
         break;
       case 2:
-        set_animation_kind(animation_kind::child);
+        set_animation_kind(animation_kind::primary_child);
         break;
       case 4:
         set_animation_kind(animation_kind::morph);
@@ -1397,7 +1397,7 @@ void animation::depersist(lua_persist_reader* pReader) {
     }
 
     // Read the unioned fields
-    if (anim_kind != animation_kind::child) {
+    if (anim_kind != animation_kind::primary_child) {
       if (!pReader->read_int(speed.dx)) break;
       if (!pReader->read_int(speed.dy)) break;
     } else {
@@ -1467,7 +1467,7 @@ const std::map<size_t, int> frame_sound_replacements{
 
 void animation::tick() {
   frame_index = manager->get_next_frame(frame_index);
-  if (anim_kind != animation_kind::child) {
+  if (anim_kind != animation_kind::primary_child) {
     x_relative_to_tile += speed.dx;
     y_relative_to_tile += speed.dy;
   }
@@ -1523,7 +1523,7 @@ void animation::set_parent(animation* pParent) {
     set_animation_kind(animation_kind::normal);
     speed = {0, 0};
   } else {
-    set_animation_kind(animation_kind::child);
+    set_animation_kind(animation_kind::primary_child);
     parent = pParent;
     next = parent->next;
     if (next) next->prev = this;

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -435,10 +435,10 @@ class animation_manager {
     // Markers are used to know where humanoids are on an frame. The
     // positions are pixels offsets from the centre of the frame's base
     // tile to the centre of the humanoid's feet.
-    int primary_marker_x;  ///< X position of the first center of a humanoids
-                           ///< feet.
-    int primary_marker_y;  ///< Y position of the first center of a humanoids
-                           ///< feet.
+    int primary_marker_x;    ///< X position of the first center of a humanoids
+                             ///< feet.
+    int primary_marker_y;    ///< Y position of the first center of a humanoids
+                             ///< feet.
     int secondary_marker_x;  ///< X position of the second center of a
                              ///< humanoids feet.
     int secondary_marker_y;  ///< Y position of the second center of a
@@ -572,7 +572,8 @@ class animation : public animation_base {
   bool hit_test(int iDestX, int iDestY, int iTestX, int iTestY);
   void draw_morph(render_target* pCanvas, int iDestX, int iDestY);
   bool hit_test_morph(int iDestX, int iDestY, int iTestX, int iTestY);
-  void draw_child(render_target* pCanvas, int iDestX, int iDestY, bool use_primary);
+  void draw_child(render_target* pCanvas, int iDestX, int iDestY,
+                  bool use_primary);
   bool hit_test_child(int iDestX, int iDestY, int iTestX, int iTestY);
 
   void draw_fn(render_target* pCanvas, int iDestX, int iDestY) override {

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -559,20 +559,20 @@ struct xy_diff {
 };
 
 //! The kind of animation.
-enum class animation_kind { normal, primary_child, morph };
+enum class animation_kind { primary_child, secondary_child, normal, morph };
 
 class animation : public animation_base {
  public:
   animation();
 
-  void set_parent(animation* pParent);
+  void set_parent(animation* pParent, bool use_primary);
 
   void tick();
   void draw(render_target* pCanvas, int iDestX, int iDestY);
   bool hit_test(int iDestX, int iDestY, int iTestX, int iTestY);
   void draw_morph(render_target* pCanvas, int iDestX, int iDestY);
   bool hit_test_morph(int iDestX, int iDestY, int iTestX, int iTestY);
-  void draw_child(render_target* pCanvas, int iDestX, int iDestY);
+  void draw_child(render_target* pCanvas, int iDestX, int iDestY, bool use_primary);
   bool hit_test_child(int iDestX, int iDestY, int iTestX, int iTestY);
 
   void draw_fn(render_target* pCanvas, int iDestX, int iDestY) override {
@@ -581,7 +581,10 @@ class animation : public animation_base {
         draw(pCanvas, iDestX, iDestY);
         return;
       case animation_kind::primary_child:
-        draw_child(pCanvas, iDestX, iDestY);
+        draw_child(pCanvas, iDestX, iDestY, true);
+        return;
+      case animation_kind::secondary_child:
+        draw_child(pCanvas, iDestX, iDestY, false);
         return;
       case animation_kind::morph:
         draw_morph(pCanvas, iDestX, iDestY);
@@ -594,6 +597,7 @@ class animation : public animation_base {
       case animation_kind::normal:
         return hit_test(iDestX, iDestY, iTestX, iTestY);
       case animation_kind::primary_child:
+      case animation_kind::secondary_child:
         return hit_test_child(iDestX, iDestY, iTestX, iTestY);
       case animation_kind::morph:
         return hit_test_morph(iDestX, iDestY, iTestX, iTestY);

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -354,9 +354,9 @@ class animation_manager {
   bool hit_test(size_t iFrame, const ::layers& oLayers, int iX, int iY,
                 uint32_t iFlags, int iTestX, int iTestY) const;
 
-  bool set_frame_marker(size_t iFrame, int iX, int iY);
+  bool set_frame_primary_marker(size_t iFrame, int iX, int iY);
   bool set_frame_secondary_marker(size_t iFrame, int iX, int iY);
-  bool get_frame_marker(size_t iFrame, int* pX, int* pY);
+  bool get_frame_primary_marker(size_t iFrame, int* pX, int* pY);
   bool get_frame_secondary_marker(size_t iFrame, int* pX, int* pY);
 
   //! Retrieve a custom animation by name and tile size.
@@ -435,8 +435,10 @@ class animation_manager {
     // Markers are used to know where humanoids are on an frame. The
     // positions are pixels offsets from the centre of the frame's base
     // tile to the centre of the humanoid's feet.
-    int marker_x;  ///< X position of the first center of a humanoids feet.
-    int marker_y;  ///< Y position of the first center of a humanoids feet.
+    int primary_marker_x;  ///< X position of the first center of a humanoids
+                           ///< feet.
+    int primary_marker_y;  ///< Y position of the first center of a humanoids
+                           ///< feet.
     int secondary_marker_x;  ///< X position of the second center of a
                              ///< humanoids feet.
     int secondary_marker_y;  ///< Y position of the second center of a
@@ -608,7 +610,7 @@ class animation : public animation_base {
 
   link_list* get_previous() { return prev; }
   size_t get_animation() const { return animation_index; }
-  bool get_marker(int* pX, int* pY);
+  bool get_primary_marker(int* pX, int* pY);
   bool get_secondary_marker(int* pX, int* pY);
   size_t get_frame() const { return frame_index; }
   int get_crop_column() const { return crop_column; }
@@ -636,8 +638,8 @@ class animation : public animation_base {
   size_t frame_index;      ///< Frame number.
   union {
     xy_diff speed;
-    //! Some animations are tied to the marker of another animation and
-    //! hence have a parent rather than a speed.
+    //! Some animations are tied to the primary or secondary marker of another
+    //! animation and hence have a parent rather than a speed.
     animation* parent;
   };
 

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -559,7 +559,7 @@ struct xy_diff {
 };
 
 //! The kind of animation.
-enum class animation_kind { normal, child, morph };
+enum class animation_kind { normal, primary_child, morph };
 
 class animation : public animation_base {
  public:
@@ -580,7 +580,7 @@ class animation : public animation_base {
       case animation_kind::normal:
         draw(pCanvas, iDestX, iDestY);
         return;
-      case animation_kind::child:
+      case animation_kind::primary_child:
         draw_child(pCanvas, iDestX, iDestY);
         return;
       case animation_kind::morph:
@@ -593,7 +593,7 @@ class animation : public animation_base {
     switch (anim_kind) {
       case animation_kind::normal:
         return hit_test(iDestX, iDestY, iTestX, iTestY);
-      case animation_kind::child:
+      case animation_kind::primary_child:
         return hit_test_child(iDestX, iDestY, iTestX, iTestY);
       case animation_kind::morph:
         return hit_test_morph(iDestX, iDestY, iTestX, iTestY);

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -174,9 +174,9 @@ int l_anims_set_alt_pal(lua_State* L) {
 int l_anims_set_primary_marker(lua_State* L) {
   animation_manager* pAnims = luaT_testuserdata<animation_manager>(L);
   lua_pushboolean(
-      L, pAnims->set_frame_primary_marker(luaL_checkinteger(L, 2),
-                                  static_cast<int>(luaL_checkinteger(L, 3)),
-                                  static_cast<int>(luaL_checkinteger(L, 4)))
+      L, pAnims->set_frame_primary_marker(
+             luaL_checkinteger(L, 2), static_cast<int>(luaL_checkinteger(L, 3)),
+             static_cast<int>(luaL_checkinteger(L, 4)))
              ? 1
              : 0);
   return 1;
@@ -436,11 +436,12 @@ int l_anim_set_parent(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   animation* pParent =
       luaT_testuserdata<animation>(L, 2, luaT_environindex, false);
-  bool use_primary = lua_isnone(L, 3); // No number means '1'.
+  bool use_primary = lua_isnone(L, 3);  // No number means '1'.
   if (!use_primary) {
     uint32_t value = luaL_checkinteger(L, 3);
     if (value < 1 || value > 2)
-      luaL_argerror(L, 3, "Marker index out of bounds (only values 1 and 2 are allowed)");
+      luaL_argerror(
+          L, 3, "Marker index out of bounds (only values 1 and 2 are allowed)");
     use_primary = (value == 1);
   }
   pAnimation->set_parent(pParent, use_primary);

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -436,7 +436,14 @@ int l_anim_set_parent(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   animation* pParent =
       luaT_testuserdata<animation>(L, 2, luaT_environindex, false);
-  pAnimation->set_parent(pParent);
+  bool use_primary = lua_isnone(L, 3); // No number means '1'.
+  if (!use_primary) {
+    uint32_t value = luaL_checkinteger(L, 3);
+    if (value < 1 || value > 2)
+      luaL_argerror(L, 3, "Marker index out of bounds (only values 1 and 2 are allowed)");
+    use_primary = (value == 1);
+  }
+  pAnimation->set_parent(pParent, use_primary);
   lua_settop(L, 1);
   return 1;
 }

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -171,10 +171,10 @@ int l_anims_set_alt_pal(lua_State* L) {
   return 1;
 }
 
-int l_anims_set_marker(lua_State* L) {
+int l_anims_set_primary_marker(lua_State* L) {
   animation_manager* pAnims = luaT_testuserdata<animation_manager>(L);
   lua_pushboolean(
-      L, pAnims->set_frame_marker(luaL_checkinteger(L, 2),
+      L, pAnims->set_frame_primary_marker(luaL_checkinteger(L, 2),
                                   static_cast<int>(luaL_checkinteger(L, 3)),
                                   static_cast<int>(luaL_checkinteger(L, 4)))
              ? 1
@@ -559,11 +559,11 @@ int l_anim_get_tag(lua_State* L) {
   return 1;
 }
 
-int l_anim_get_marker(lua_State* L) {
+int l_anim_get_primary_marker(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   int iX = 0;
   int iY = 0;
-  pAnimation->get_marker(&iX, &iY);
+  pAnimation->get_primary_marker(&iX, &iY);
   lua_pushinteger(L, iX);
   lua_pushinteger(L, iY);
   return 2;
@@ -659,7 +659,8 @@ void lua_register_anims(const lua_register_state* pState) {
     lcb.add_function(l_anims_getfirst, "getFirstFrame");
     lcb.add_function(l_anims_getnext, "getNextFrame");
     lcb.add_function(l_anims_set_alt_pal, "setAnimationGhostPalette");
-    lcb.add_function(l_anims_set_marker, "setFrameMarker");
+    lcb.add_function(l_anims_set_primary_marker, "setFrameMarker");
+    lcb.add_function(l_anims_set_primary_marker, "setFramePrimaryMarker");
     lcb.add_function(l_anims_set_secondary_marker, "setFrameSecondaryMarker");
     lcb.add_function(l_anims_draw, "draw", lua_metatable::surface,
                      lua_metatable::layers);
@@ -718,7 +719,8 @@ void lua_register_anims(const lua_register_state* pState) {
     lcb.add_function(l_anim_set_layer<animation>, "setLayer");
     lcb.add_function(l_anim_set_layers_from, "setLayersFrom");
     lcb.add_function(l_anim_set_hitresult, "setHitTestResult");
-    lcb.add_function(l_anim_get_marker, "getMarker");
+    lcb.add_function(l_anim_get_primary_marker, "getMarker");
+    lcb.add_function(l_anim_get_primary_marker, "getPrimaryMarker");
     lcb.add_function(l_anim_get_secondary_marker, "getSecondaryMarker");
     lcb.add_function(l_anim_tick<animation>, "tick");
     lcb.add_function(l_anim_draw<animation>, "draw", lua_metatable::surface);


### PR DESCRIPTION
*Fixes animations with both a staff member and a patient, with different moods.

**Describe what the proposed change does**
- Rename the first marker.
- Add a child animation that follows the second marker.
- Add a way to follow the second marker position of the parent animation.

Can be read by commit if so desired.