### PR TITLE
Remove obsolete getMarker/setFrameMarker

### DIFF
--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2689;
+return 2690;

--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -457,7 +457,7 @@ end
 function UIFullscreen:getStaffPosition(dx, dy)
   local staff = self.staff_members[self.category][self.selected_staff]
   local x, y = self.ui.app.map:WorldToScreen(staff.tile_x, staff.tile_y)
-  local px, py = staff.th:getMarker()
+  local px, py = staff.th:getPrimaryMarker()
   return x + px - (dx or 0), y + py - (dy or 0)
 end
 

--- a/CorsixTH/Lua/dialogs/patient.lua
+++ b/CorsixTH/Lua/dialogs/patient.lua
@@ -146,7 +146,7 @@ function UIPatient:draw(canvas, x_, y_)
     return
   end
   local px, py = map:WorldToScreen(patient.tile_x, patient.tile_y)
-  local dx, dy = patient.th:getMarker()
+  local dx, dy = patient.th:getPrimaryMarker()
   px = px + dx - 37
   py = py + dy - 61
   -- If the patient is spawning or despawning, or just on the map edge, then

--- a/CorsixTH/Lua/dialogs/resizables/calls_dispatcher.lua
+++ b/CorsixTH/Lua/dialogs/resizables/calls_dispatcher.lua
@@ -137,7 +137,7 @@ end
 
 function UICallsDispatcher:scrollToEntity(entity)
   local x, y = self.ui.app.map:WorldToScreen(entity.tile_x, entity.tile_y)
-  local px, py = entity.th:getMarker()
+  local px, py = entity.th:getPrimaryMarker()
   self.ui:scrollMapTo(x + px, y + py)
 end
 

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -157,7 +157,7 @@ end
 function UIStaff:getStaffPosition(dx, dy)
   local staff = self.staff
   local x, y = self.ui.app.map:WorldToScreen(staff.tile_x, staff.tile_y)
-  local px, py = staff.th:getMarker()
+  local px, py = staff.th:getPrimaryMarker()
   return x + px - (dx or 0), y + py - (dy or 0)
 end
 

--- a/CorsixTH/Lua/dialogs/staff_rise.lua
+++ b/CorsixTH/Lua/dialogs/staff_rise.lua
@@ -110,7 +110,7 @@ end
 function UIStaffRise:getStaffPosition(dx, dy)
   local staff = self.staff
   local x, y = self.ui.app.map:WorldToScreen(staff.tile_x, staff.tile_y)
-  local px, py = staff.th:getMarker()
+  local px, py = staff.th:getPrimaryMarker()
   return x + px - (dx or 0), y + py - (dy or 0)
 end
 

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -603,7 +603,7 @@ end
 --]]
 
 function AnimationManager:setMarker(anim, ...)
-  return self:setMarkerRaw(anim, "setFrameMarker", ...)
+  return self:setMarkerRaw(anim, "setFramePrimaryMarker", ...)
 end
 
 local function TableToPixels(t)

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -667,7 +667,6 @@ void lua_register_anims(const lua_register_state* pState) {
     lcb.add_function(l_anims_getfirst, "getFirstFrame");
     lcb.add_function(l_anims_getnext, "getNextFrame");
     lcb.add_function(l_anims_set_alt_pal, "setAnimationGhostPalette");
-    lcb.add_function(l_anims_set_primary_marker, "setFrameMarker");
     lcb.add_function(l_anims_set_primary_marker, "setFramePrimaryMarker");
     lcb.add_function(l_anims_set_secondary_marker, "setFrameSecondaryMarker");
     lcb.add_function(l_anims_draw, "draw", lua_metatable::surface,
@@ -727,7 +726,6 @@ void lua_register_anims(const lua_register_state* pState) {
     lcb.add_function(l_anim_set_layer<animation>, "setLayer");
     lcb.add_function(l_anim_set_layers_from, "setLayersFrom");
     lcb.add_function(l_anim_set_hitresult, "setHitTestResult");
-    lcb.add_function(l_anim_get_primary_marker, "getMarker");
     lcb.add_function(l_anim_get_primary_marker, "getPrimaryMarker");
     lcb.add_function(l_anim_get_secondary_marker, "getSecondaryMarker");
     lcb.add_function(l_anim_tick<animation>, "tick");


### PR DESCRIPTION
Remove the old `getMarker` and `setFrameMarker` CPP functions for Lua, as they are now named `getPrimaryMarker` respectively `setFramePrimaryMarker`.

Also updates the API version since some functions "vanished" :)

