### PR TITLE
Marker split add and improve

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -21,7 +21,7 @@ SOFTWARE. --]]
 self = false
 
 globals = { -- Globals
-            "_A", "_S",
+            "_A", "_S", "TheApp",
             "corsixth",
             "action_queue_leave_bench", "class", "compare_tables",
             "destrict", "flag_clear", "flag_isset", "flag_set", "flag_toggle",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -21,7 +21,7 @@ SOFTWARE. --]]
 self = false
 
 globals = { -- Globals
-            "_A", "_S", "TheApp",
+            "_A", "_S",
             "corsixth",
             "action_queue_leave_bench", "class", "compare_tables",
             "destrict", "flag_clear", "flag_isset", "flag_set", "flag_toggle",

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 212 -- 'coverup_in_progress' renamed to 'coverup_selected'
+local SAVEGAME_VERSION = 213 -- mood markers for staff & patients
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -457,7 +457,7 @@ end
 function UIFullscreen:getStaffPosition(dx, dy)
   local staff = self.staff_members[self.category][self.selected_staff]
   local x, y = self.ui.app.map:WorldToScreen(staff.tile_x, staff.tile_y)
-  local px, py = staff.th:getPrimaryMarker()
+  local px, py = staff.th:getSecondaryMarker()
   return x + px - (dx or 0), y + py - (dy or 0)
 end
 

--- a/CorsixTH/Lua/dialogs/place_staff.lua
+++ b/CorsixTH/Lua/dialogs/place_staff.lua
@@ -130,7 +130,7 @@ function UIPlaceStaff:onMouseUp(button, x, y)
         if self.staff then
           self.staff:setTile(self.tile_x, self.tile_y)
         else
-          local entity = self.world:newEntity(self.profile.humanoid_class, 2)
+          local entity = self.world:newEntity(self.profile.humanoid_class, 2, 2)
           entity:setProfile(self.profile)
           self.profile = nil
           entity:setTile(self.tile_x, self.tile_y)

--- a/CorsixTH/Lua/dialogs/resizables/calls_dispatcher.lua
+++ b/CorsixTH/Lua/dialogs/resizables/calls_dispatcher.lua
@@ -137,7 +137,7 @@ end
 
 function UICallsDispatcher:scrollToEntity(entity)
   local x, y = self.ui.app.map:WorldToScreen(entity.tile_x, entity.tile_y)
-  local px, py = entity.th:getPrimaryMarker()
+  local px, py = entity.th:getSecondaryMarker()
   self.ui:scrollMapTo(x + px, y + py)
 end
 

--- a/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/make_debug_patient.lua
+++ b/CorsixTH/Lua/dialogs/resizables/menu_list_dialogs/make_debug_patient.lua
@@ -42,7 +42,7 @@ end
 
 function UIMakeDebugPatient:buttonClicked(num)
   local item = self.items[num + self.scrollbar.value - 1]
-  local patient = self.ui.app.world:newEntity("Patient", 2)
+  local patient = self.ui.app.world:newEntity("Patient", 2, 1)
   patient.is_debug = true
   table.insert(self.ui.hospital.debug_patients, patient)
   patient:setDisease(item.disease)

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -157,7 +157,7 @@ end
 function UIStaff:getStaffPosition(dx, dy)
   local staff = self.staff
   local x, y = self.ui.app.map:WorldToScreen(staff.tile_x, staff.tile_y)
-  local px, py = staff.th:getPrimaryMarker()
+  local px, py = staff.th:getSecondaryMarker()
   return x + px - (dx or 0), y + py - (dy or 0)
 end
 

--- a/CorsixTH/Lua/dialogs/staff_rise.lua
+++ b/CorsixTH/Lua/dialogs/staff_rise.lua
@@ -110,7 +110,7 @@ end
 function UIStaffRise:getStaffPosition(dx, dy)
   local staff = self.staff
   local x, y = self.ui.app.map:WorldToScreen(staff.tile_x, staff.tile_y)
-  local px, py = staff.th:getPrimaryMarker()
+  local px, py = staff.th:getSecondaryMarker()
   return x + px - (dx or 0), y + py - (dy or 0)
 end
 

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -165,13 +165,24 @@ anims("VIP",                        266,  268,  274,  276)
 anims("Inspector",                  266,  268,  274,  276)
 anims("Grim Reaper",                994,  996, 1002, 1004)
 
-assignPatientMarkers(door_animations, "entering", 0, {-1, 0}, 3, {-1, 0}, 9, {0, 0})
-assignPatientMarkers(door_animations, "leaving", 1, {0, 0.4}, 4, {0, 0.4}, 7, {0, 0}, 11, {0, -1})
+local doorE_markers = { -- Anim 3288 in particular
+  {-19, -15, "px"}, {-26, -17, "px"}, {-26, -17, "px"}, {-26, -17, "px"},
+  {-26, -15, "px"}, {-22, -13, "px"}, {-19, -9, "px"}, {-13, -5, "px"},
+  {-8, -4, "px"}, {-5, 0, "px"},
+}
+local doorL_markers = { -- Anim 3286 in particular.
+  {-7, 0, "px"}, {-14, 6, "px"}, {-14, 6, "px"}, {-12, 5, "px"}, {-11, 5, "px"},
+  {-7, 3, "px"}, {-4, 0, "px"}, {2, -1, "px"}, {2, -1, "px"}, {10, -3, "px"},
+  {14, -7, "px"}, {20, -11, "px"},
+}
+
+assignPatientMarkers(door_animations, "entering", doorE_markers)
+assignPatientMarkers(door_animations, "leaving", doorL_markers)
 assignPatientMarkers(door_animations, "entering_swing", 0, {-1.0, 0.0}, 8, {0.0, 0.0})
 assignPatientMarkers(door_animations, "leaving_swing", 0, {0.1, 0.0}, 9, {0.0, -1.0})
 
-assignStaffMarkers(door_animations, "entering", 0, {-1.0, 0.0}, 8, {0.0, 0.0})
-assignStaffMarkers(door_animations, "leaving", 0, {0.1, 0.0}, 9, {0.0, -1.0})
+assignStaffMarkers(door_animations, "entering", doorE_markers)
+assignStaffMarkers(door_animations, "leaving", doorL_markers)
 assignStaffMarkers(door_animations, "entering_swing", 0, {-1.0, 0.0}, 8, {0.0, 0.0})
 assignStaffMarkers(door_animations, "leaving_swing", 0, {0.1, 0.0}, 9, {0.0, -1.0})
 
@@ -220,6 +231,7 @@ get_up_anim("Standard Female Patient",   580)
 ----+--------------------------------+-----+-----+-----+-----+------+------+
 shake_fist_anim("Standard Male Patient",   392) -- bloaty head patients lose head!
 
+assignPatientMarkers(shake_fist_animations, nil, {0.0, 0.0})
 
 --  | Vomit Animations                  |
 --  | Name                              |Anim | Notes
@@ -234,6 +246,8 @@ vomit_anim("Slack Male Patient",         4324)
 vomit_anim("Transparent Female Patient", 4452)
 vomit_anim("Transparent Male Patient",   4384)
 
+assignPatientMarkers(vomit_animations, nil, {0.0, 0.0})
+
 --  | Yawn Animations                  |
 --  | Name                              |Anim | Notes
 ----+-----------------------------------+-----+
@@ -242,12 +256,16 @@ yawn_anim("Standard Male Patient",      368)
 --yawn_anim("Alternate Male Patient",     2968)  is this one the same as standard male?
 -- whichever one is used for male, if he wears a hat it will lift when he yawns
 
+assignPatientMarkers(yawn_animations, nil, {0.0, 0.0})
+
 --  | Foot tapping Animations                  |
 --  | Name                              |Anim | Notes
 ----+-----------------------------------+-----+
 tap_foot_anim("Standard Female Patient",    4464)
 tap_foot_anim("Standard Male Patient",      2960)
 tap_foot_anim("Alternate Male Patient",     360)
+
+assignPatientMarkers(tap_foot_animations, nil, {0.0, 0.0})
 
 --  | Check watch Animations                  |
 --  | Name                              |Anim | Notes
@@ -256,6 +274,8 @@ check_watch_anim("Standard Female Patient",    4468)
 check_watch_anim("Standard Male Patient",      2964)
 check_watch_anim("Alternate Male Patient",     364)
 check_watch_anim("Slack Male Patient",         4060)
+
+assignPatientMarkers(check_watch_animations, nil, {0.0, 0.0})
 
 --  | pee Animations                  |
 --  | Name                              |Anim | Notes
@@ -270,6 +290,8 @@ pee_anim("Chewbacca Patient",          4178)
 pee_anim("Invisible Patient",          4208)
 pee_anim("Transparent Female Patient", 4852)
 pee_anim("Transparent Male Patient",   4848)
+
+assignPatientMarkers(pee_animations, nil, {0.0, 0.0})
 
 -- Some icons should only appear when the player hovers over the humanoid
 -- Higher priority is more important.

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -114,8 +114,8 @@ end
 anims("Standard Male Patient",       16,   18,   24,   26,  182,  184,   286,   288,  2040,  2042) -- 0-16, ABC
 anims("Gowned Male Patient",        406,  408,  414,  416)                           -- 0-10
 anims("Stripped Male Patient",      818,  820,  826,  828)                           -- 0-16
-anims("Stripped Male Patient 2",      818,  820,  826,  828)                           -- 0-16
-anims("Stripped Male Patient 3",      818,  820,  826,  828)
+anims("Stripped Male Patient 2",    818,  820,  826,  828)                           -- 0-16
+anims("Stripped Male Patient 3",    818,  820,  826,  828)
 anims("Alternate Male Patient",    2704, 2706, 2712, 2714, 2748, 2750,  2764,  2766) -- 0-10, ABC
 anims("Slack Male Patient",        1484, 1486, 1492, 1494, 1524, 1526,  2764,  1494) -- 0-14, ABC
 anims("Slack Female Patient",         0,    2,    8,   10,  258,  260,   294,   296,  2864,  2866) -- 0-16, ABC
@@ -123,8 +123,8 @@ anims("Transparent Male Patient",  1064, 1066, 1072, 1074, 1104, 1106,  1120,  1
 anims("Standard Female Patient",      0,    2,    8,   10,  258,  260,   294,   296,  2864,  2866) -- 0-16, ABC
 anims("Gowned Female Patient",     2876, 2878, 2884, 2886)                           -- 0-8
 anims("Stripped Female Patient",    834,  836,  842,  844)                           -- 0-16
-anims("Stripped Female Patient 2",    834,  836,  842,  844)                           -- 0-16
-anims("Stripped Female Patient 3",    834,  836,  842,  844)
+anims("Stripped Female Patient 2",  834,  836,  842,  844)                           -- 0-16
+anims("Stripped Female Patient 3",  834,  836,  842,  844)
 anims("Transparent Female Patient",3012, 3014, 3020, 3022, 3052, 3054,  3068,  3070) -- 0-8, ABC
 anims("Chewbacca Patient",          858,  860,  866,  868, 3526, 3528,  4150,  4152)
 anims("Elvis Patient",              978,  980,  986,  988, 3634, 3636,  4868,  4870)
@@ -157,10 +157,11 @@ die_anims("Invisible Patient",         4200, 2434,       384, 2438,  2446, 2450)
 die_anims("Alien Male Patient",        4882, 2434,       384, 2438,  2446, 2450)
 die_anims("Alien Female Patient",      4886, 3208,       580, 3212,  3216, 3220)
 
--- The next fours sets belong together, but are done like this so we can use them on there own
--- I also had difficulty in keeping them together, as the patient needs to on the floor
+-- The next fours sets belong together, but are done like this so we can use them on their own
+-- I also had difficulty in keeping them together, as the patient needs to be on the floor
 -- for the duration of the earth quake before getting back up
 -- Shaking of fist could perhaps be used when waiting too long
+
 --  | Falling Animations                   |
 --  | Name                                 |Anim| Notes
 ----+--------------------------------+-----+-----+-----+-----+------+------+
@@ -170,8 +171,8 @@ falling_anim("Standard Female Patient",   3116)
 --  | On_ground Animations                   |
 --  | Name                                 |Anim| Notes
 ----+--------------------------------+-----+-----+-----+-----+------+------+
-on_ground_anim("Standard Male Patient",     1258)
-on_ground_anim("Standard Female Patient",   1764)
+on_ground_anim("Standard Male Patient",   1258)
+on_ground_anim("Standard Female Patient", 1764)
 
 --  | Get_up Animations                   |
 --  | Name                                 |Anim| Notes
@@ -182,7 +183,7 @@ get_up_anim("Standard Female Patient",   580)
 --  | Shake_fist Animations                   |
 --  | Name                                 |Anim| Notes
 ----+--------------------------------+-----+-----+-----+-----+------+------+
-shake_fist_anim("Standard Male Patient",     392) -- bloaty head patients lose head!
+shake_fist_anim("Standard Male Patient",   392) -- bloaty head patients lose head!
 
 
 --  | Vomit Animations                  |

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -39,7 +39,7 @@ local check_watch_animations = permanent"humanoid_check_watch_animations"({})
 
 local mood_icons = permanent"humanoid_mood_icons"({})
 
-local function anims(name, walkN, walkE, idleN, idleE, doorL, doorE, knockN, knockE, swingL, swingE)
+local function walk_anims(name, walkN, walkE, idleN, idleE, doorL, doorE, knockN, knockE, swingL, swingE)
   walk_animations[name] = {
     walk_east = walkE,
     walk_north = walkN,
@@ -133,37 +133,37 @@ local function assignStaffMarkers(anims, name, ...)
 end
 
 
---   | Walk animations           |
---   | Name                      |WalkN|WalkE|IdleN|IdleE|DoorL|DoorE|KnockN|KnockE|SwingL|SwingE| Notes
------+---------------------------+-----+-----+-----+-----+-----+-----+------+------+-------+---------+
-anims("Standard Male Patient",       16,   18,   24,   26,  182,  184,   286,   288,  2040,  2042) -- 0-16, ABC
-anims("Gowned Male Patient",        406,  408,  414,  416)                           -- 0-10
-anims("Stripped Male Patient",      818,  820,  826,  828)                           -- 0-16
-anims("Stripped Male Patient 2",    818,  820,  826,  828)                           -- 0-16
-anims("Stripped Male Patient 3",    818,  820,  826,  828)
-anims("Alternate Male Patient",    2704, 2706, 2712, 2714, 2748, 2750,  2764,  2766) -- 0-10, ABC
-anims("Slack Male Patient",        1484, 1486, 1492, 1494, 1524, 1526,  2764,  1494) -- 0-14, ABC
-anims("Slack Female Patient",         0,    2,    8,   10,  258,  260,   294,   296,  2864,  2866) -- 0-16, ABC
-anims("Transparent Male Patient",  1064, 1066, 1072, 1074, 1104, 1106,  1120,  1074) -- 0-16, ABC
-anims("Standard Female Patient",      0,    2,    8,   10,  258,  260,   294,   296,  2864,  2866) -- 0-16, ABC
-anims("Gowned Female Patient",     2876, 2878, 2884, 2886)                           -- 0-8
-anims("Stripped Female Patient",    834,  836,  842,  844)                           -- 0-16
-anims("Stripped Female Patient 2",  834,  836,  842,  844)                           -- 0-16
-anims("Stripped Female Patient 3",  834,  836,  842,  844)
-anims("Transparent Female Patient",3012, 3014, 3020, 3022, 3052, 3054,  3068,  3070) -- 0-8, ABC
-anims("Chewbacca Patient",          858,  860,  866,  868, 3526, 3528,  4150,  4152)
-anims("Elvis Patient",              978,  980,  986,  988, 3634, 3636,  4868,  4870)
-anims("Invisible Patient",         1642, 1644, 1840, 1842, 1796, 1798,  4192,  4194)
-anims("Alien Male Patient",        3598, 3600, 3606, 3608,  182,  184,   286,   288, 3626,  3628) -- remember, no "normal"-doors animation
-anims("Alien Female Patient",      3598, 3600, 3606, 3608,  258,  260,   294,   296, 3626,  3628) -- identical to male; however death animations differ
-anims("Doctor",                      32,   34,   40,   42,  670,  672,   nil,   nil, 4750,  4752)
-anims("Surgeon",                   2288, 2290, 2296, 2298)
-anims("Nurse",                     1206, 1208, 1650, 1652, 3264, 3266,   nil,   nil, 3272,  3274)
-anims("Handyman",                  1858, 1860, 1866, 1868, 3286, 3288,   nil,   nil, 3518,  3520)
-anims("Receptionist",              3668, 3670, 3676, 3678) -- Could do with door animations
-anims("VIP",                        266,  268,  274,  276)
-anims("Inspector",                  266,  268,  274,  276)
-anims("Grim Reaper",                994,  996, 1002, 1004)
+--   | Walk animations                 |
+--   | Name                            |WalkN|WalkE|IdleN|IdleE|DoorL|DoorE|KnockN|KnockE|SwingL|SwingE| Notes
+-----+---------------------------------------+-----+-----+-----+-----+-----+-----+------+------+-------+---------+
+walk_anims("Standard Male Patient",       16,   18,   24,   26,  182,  184,   286,   288,  2040,  2042) -- 0-16, ABC
+walk_anims("Gowned Male Patient",        406,  408,  414,  416)                           -- 0-10
+walk_anims("Stripped Male Patient",      818,  820,  826,  828)                           -- 0-16
+walk_anims("Stripped Male Patient 2",    818,  820,  826,  828)                           -- 0-16
+walk_anims("Stripped Male Patient 3",    818,  820,  826,  828)
+walk_anims("Alternate Male Patient",    2704, 2706, 2712, 2714, 2748, 2750,  2764,  2766) -- 0-10, ABC
+walk_anims("Slack Male Patient",        1484, 1486, 1492, 1494, 1524, 1526,  2764,  1494) -- 0-14, ABC
+walk_anims("Slack Female Patient",         0,    2,    8,   10,  258,  260,   294,   296,  2864,  2866) -- 0-16, ABC
+walk_anims("Transparent Male Patient",  1064, 1066, 1072, 1074, 1104, 1106,  1120,  1074) -- 0-16, ABC
+walk_anims("Standard Female Patient",      0,    2,    8,   10,  258,  260,   294,   296,  2864,  2866) -- 0-16, ABC
+walk_anims("Gowned Female Patient",     2876, 2878, 2884, 2886)                           -- 0-8
+walk_anims("Stripped Female Patient",    834,  836,  842,  844)                           -- 0-16
+walk_anims("Stripped Female Patient 2",  834,  836,  842,  844)                           -- 0-16
+walk_anims("Stripped Female Patient 3",  834,  836,  842,  844)
+walk_anims("Transparent Female Patient",3012, 3014, 3020, 3022, 3052, 3054,  3068,  3070) -- 0-8, ABC
+walk_anims("Chewbacca Patient",          858,  860,  866,  868, 3526, 3528,  4150,  4152)
+walk_anims("Elvis Patient",              978,  980,  986,  988, 3634, 3636,  4868,  4870)
+walk_anims("Invisible Patient",         1642, 1644, 1840, 1842, 1796, 1798,  4192,  4194)
+walk_anims("Alien Male Patient",        3598, 3600, 3606, 3608,  182,  184,   286,   288, 3626,  3628) -- remember, no "normal"-doors animation
+walk_anims("Alien Female Patient",      3598, 3600, 3606, 3608,  258,  260,   294,   296, 3626,  3628) -- identical to male; however death animations differ
+walk_anims("Doctor",                      32,   34,   40,   42,  670,  672,   nil,   nil, 4750,  4752)
+walk_anims("Surgeon",                   2288, 2290, 2296, 2298)
+walk_anims("Nurse",                     1206, 1208, 1650, 1652, 3264, 3266,   nil,   nil, 3272,  3274)
+walk_anims("Handyman",                  1858, 1860, 1866, 1868, 3286, 3288,   nil,   nil, 3518,  3520)
+walk_anims("Receptionist",              3668, 3670, 3676, 3678) -- Could do with door animations
+walk_anims("VIP",                        266,  268,  274,  276)
+walk_anims("Inspector",                  266,  268,  274,  276)
+walk_anims("Grim Reaper",                994,  996, 1002, 1004)
 
 local doorE_markers = { -- Anim 3288 in particular
   {-19, -15, "px"}, {-26, -17, "px"}, {-26, -17, "px"}, {-26, -17, "px"},

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -108,6 +108,31 @@ local function moods(name, iconNo, prio, onHover)
   mood_icons[name] = {icon = iconNo, priority = prio, on_hover = onHover}
 end
 
+--! Filter animations for patients and set the give marker positions.
+local function assignPatientMarkers(anims, name, ...)
+  local anim_mgr = TheApp.animation_manager
+
+  for hum_type, anim in pairs(anims) do
+    if string.find(hum_type, "Patient") then
+      if name then anim = anim[name] end
+      anim_mgr:setPatientMarker(anim, ...)
+    end
+  end
+end
+
+--! Filter animations for staff and set the give marker positions.
+local function assignStaffMarkers(anims, name, ...)
+  local anim_mgr = TheApp.animation_manager
+
+  for hum_type, anim in pairs(anims) do
+    if not string.find(hum_type, "Patient") then
+      if name then anim = anim[name] end
+      anim_mgr:setStaffMarker(anim, ...)
+    end
+  end
+end
+
+
 --   | Walk animations           |
 --   | Name                      |WalkN|WalkE|IdleN|IdleE|DoorL|DoorE|KnockN|KnockE|SwingL|SwingE| Notes
 -----+---------------------------+-----+-----+-----+-----+-----+-----+------+------+-------+---------+
@@ -139,6 +164,16 @@ anims("Receptionist",              3668, 3670, 3676, 3678) -- Could do with door
 anims("VIP",                        266,  268,  274,  276)
 anims("Inspector",                  266,  268,  274,  276)
 anims("Grim Reaper",                994,  996, 1002, 1004)
+
+assignPatientMarkers(door_animations, "entering", 0, {-1, 0}, 3, {-1, 0}, 9, {0, 0})
+assignPatientMarkers(door_animations, "leaving", 1, {0, 0.4}, 4, {0, 0.4}, 7, {0, 0}, 11, {0, -1})
+assignPatientMarkers(door_animations, "entering_swing", 0, {-1.0, 0.0}, 8, {0.0, 0.0})
+assignPatientMarkers(door_animations, "leaving_swing", 0, {0.1, 0.0}, 9, {0.0, -1.0})
+
+assignStaffMarkers(door_animations, "entering", 0, {-1.0, 0.0}, 8, {0.0, 0.0})
+assignStaffMarkers(door_animations, "leaving", 0, {0.1, 0.0}, 9, {0.0, -1.0})
+assignStaffMarkers(door_animations, "entering_swing", 0, {-1.0, 0.0}, 8, {0.0, 0.0})
+assignStaffMarkers(door_animations, "leaving_swing", 0, {0.1, 0.0}, 9, {0.0, -1.0})
 
 --  | Die Animations                 |
 --  | Name                           |FallE|RiseE|RiseE Hell|WingsE|HandsE|FlyE|ExtraE| Notes 2248
@@ -273,19 +308,6 @@ moods("cured",          4048,      60)
 moods("emergency",      3914,      50)
 moods("exit",           4052,      60)
 
-local anim_mgr = TheApp.animation_manager
-for anim in values(door_animations, "*.entering") do
-  anim_mgr:setMarker(anim, 0, {-1, 0}, 3, {-1, 0}, 9, {0, 0})
-end
-for anim in values(door_animations, "*.leaving") do
-  anim_mgr:setMarker(anim, 1, {0, 0.4}, 4, {0, 0.4}, 7, {0, 0}, 11, {0, -1})
-end
-for anim in values(door_animations, "*.entering_swing") do
-  anim_mgr:setMarker(anim, 0, {-1, 0}, 8, {0, 0})
-end
-for anim in values(door_animations, "*.leaving_swing") do
-  anim_mgr:setMarker(anim, 0, {0.1, 0}, 9, {0, -1})
-end
 
 --!param ... Arguments for base class constructor.
 function Humanoid:Humanoid(...)

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -165,15 +165,19 @@ walk_anims("VIP",                        266,  268,  274,  276)
 walk_anims("Inspector",                  266,  268,  274,  276)
 walk_anims("Grim Reaper",                994,  996, 1002, 1004)
 
+
+local kfp1, kfp2, kfp3, kfp4, kfp5, kfp6, kfp7, kfp8
+kfp1, kfp2, kfp3, kfp4 = {-19, -15, "px"}, {-26, -17, "px"}, {-26, -15, "px"}, {-22, -13, "px"}
+kfp5, kfp6, kfp7, kfp8 = {-19, -9, "px"}, {-13, -5, "px"}, {-8, -4, "px"}, {-5, 0, "px"}
 local doorE_markers = { -- Anim 3288 in particular
-  {-19, -15, "px"}, {-26, -17, "px"}, {-26, -17, "px"}, {-26, -17, "px"},
-  {-26, -15, "px"}, {-22, -13, "px"}, {-19, -9, "px"}, {-13, -5, "px"},
-  {-8, -4, "px"}, {-5, 0, "px"},
+  kfp1, kfp2, kfp2, kfp2, kfp3, kfp4, kfp5, kfp6, kfp7, kfp8,
 }
+
+local kfp9, kfp10
+kfp1, kfp2, kfp3, kfp4, kfp5 = {-7, 0, "px"}, {-14, 6, "px"}, {-12, 5, "px"}, {-11, 5, "px"}, {-7, 3, "px"}
+kfp6, kfp7, kfp8, kfp9, kfp10 = {-4, 0, "px"}, {2, -1, "px"}, {10, -3, "px"}, {14, -7, "px"}, {20, -11, "px"}
 local doorL_markers = { -- Anim 3286 in particular.
-  {-7, 0, "px"}, {-14, 6, "px"}, {-14, 6, "px"}, {-12, 5, "px"}, {-11, 5, "px"},
-  {-7, 3, "px"}, {-4, 0, "px"}, {2, -1, "px"}, {2, -1, "px"}, {10, -3, "px"},
-  {14, -7, "px"}, {20, -11, "px"},
+  kfp1, kfp2, kfp2, kfp3, kfp4, kfp5, kfp6, kfp7, kfp7, kfp8, kfp9, kfp10,
 }
 
 assignPatientMarkers(door_animations, "entering", doorE_markers)

--- a/CorsixTH/Lua/entities/humanoids/grim_reaper.lua
+++ b/CorsixTH/Lua/entities/humanoids/grim_reaper.lua
@@ -40,7 +40,7 @@ function GrimReaper:tickDay()
 end
 
 function GrimReaper:afterLoad(old, new)
-  if old < 213 and new >= 213 then
+  if old < 213 then
     self.mood_marker = 2
   end
 

--- a/CorsixTH/Lua/entities/humanoids/grim_reaper.lua
+++ b/CorsixTH/Lua/entities/humanoids/grim_reaper.lua
@@ -38,3 +38,12 @@ end
 function GrimReaper:tickDay()
   return false
 end
+
+function GrimReaper:afterLoad(old, new)
+  if old < 213 and new >= 213 then
+    self.mood_marker = 2
+  end
+
+  self:updateDynamicInfo()
+  Humanoid.afterLoad(self, old, new)
+end

--- a/CorsixTH/Lua/entities/humanoids/inspector.lua
+++ b/CorsixTH/Lua/entities/humanoids/inspector.lua
@@ -62,7 +62,7 @@ function Inspector:announce()
 end
 
 function Inspector:afterLoad(old, new)
-  if old < 213 and new >= 213 then
+  if old < 213 then
     self.mood_marker = 2
   end
 

--- a/CorsixTH/Lua/entities/humanoids/inspector.lua
+++ b/CorsixTH/Lua/entities/humanoids/inspector.lua
@@ -60,3 +60,12 @@ end
 function Inspector:announce()
   self.world.ui:playAnnouncement("vip008.wav", AnnouncementPriority.High)
 end
+
+function Inspector:afterLoad(old, new)
+  if old < 213 and new >= 213 then
+    self.mood_marker = 2
+  end
+
+  self:updateDynamicInfo()
+  Humanoid.afterLoad(self, old, new)
+end

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -1175,7 +1175,7 @@ function Patient:afterLoad(old, new)
   end
 
   if old < 213 and new >= 213 then
-    self.mood_marker = 2
+    self.mood_marker = 1
   end
 
   self:updateDynamicInfo()

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -1174,7 +1174,7 @@ function Patient:afterLoad(old, new)
     self.attempted_to_infect = nil
   end
 
-  if old < 213 and new >= 213 then
+  if old < 213 then
     self.mood_marker = 1
   end
 

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -1173,6 +1173,11 @@ function Patient:afterLoad(old, new)
     self.under_infection_attempt = self.attempted_to_infect
     self.attempted_to_infect = nil
   end
+
+  if old < 213 and new >= 213 then
+    self.mood_marker = 2
+  end
+
   self:updateDynamicInfo()
   Humanoid.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -706,7 +706,7 @@ function Staff:afterLoad(old, new)
     return
   end
 
-  if old < 213 and new >= 213 then
+  if old < 213 then
     self.mood_marker = 2
   end
 

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -706,6 +706,10 @@ function Staff:afterLoad(old, new)
     return
   end
 
+  if old < 213 and new >= 213 then
+    self.mood_marker = 2
+  end
+
   self:updateDynamicInfo()
   Humanoid.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/entities/humanoids/vip.lua
+++ b/CorsixTH/Lua/entities/humanoids/vip.lua
@@ -507,7 +507,7 @@ function Vip:afterLoad(old, new)
     self.slow_animation = true
   end
 
-  if old < 213 and new >= 213 then
+  if old < 213 then
     self.mood_marker = 2
   end
 

--- a/CorsixTH/Lua/entities/humanoids/vip.lua
+++ b/CorsixTH/Lua/entities/humanoids/vip.lua
@@ -502,8 +502,15 @@ function Vip:afterLoad(old, new)
       end
     end
   end
+
   if old < 207 then
     self.slow_animation = true
   end
+
+  if old < 213 and new >= 213 then
+    self.mood_marker = 2
+  end
+
+  self:updateDynamicInfo()
   Humanoid.afterLoad(self, old, new)
 end

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -27,8 +27,8 @@ class "Machine" (Object)
 local Machine = _G["Machine"]
 
 function Machine:Machine(hospital, object_type, x, y, direction, etc)
-  self.total_usage = 0
   self:Object(hospital, object_type, x, y, direction, etc)
+  self.mood_marker = 1 -- Machine reuses the patient marker.
 
   if object_type.default_strength then
     -- Only for the main object. The slave doesn't need any strength
@@ -41,6 +41,7 @@ function Machine:Machine(hospital, object_type, x, y, direction, etc)
   -- Change hover cursor once the room has been finished.
   self.waiting_for_finalize = true -- Waiting until the room is completed (reset by new-room callback).
 
+  self.total_usage = 0
   self:setHandymanRepairPosition(direction)
 end
 

--- a/CorsixTH/Lua/entity.lua
+++ b/CorsixTH/Lua/entity.lua
@@ -27,6 +27,13 @@ local Entity = _G["Entity"]
 local TH = require("TH")
 
 function Entity:Entity(animation)
+  -- World of the entity, set by World:newEntity()
+  self.world = nil
+
+  -- Index of the marker to use for displaying moods of the entity,
+  -- set by World:newEntity()
+  self.mood_marker = nil
+
   self.th = animation
   self.layers = {}
   animation:setHitTestResult(self)
@@ -122,7 +129,7 @@ function Entity:setTile(x, y)
   -- NB: (x, y) can be nil, in which case th:setTile expects all nil arguments
   self.th:setTile(x and self.world.map.th, x, y)
   if self.mood_info then
-    self.mood_info:setParent(self.th)
+    self.mood_info:setParent(self.th, self.mood_marker)
   end
 
   -- Update the entity map for the new position

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -548,7 +548,7 @@ end
 --[[ Spawns the inspector who will walk to the reception desk. ]]
 function Epidemic:spawnInspector()
   self.world.ui.adviser:say(_A.information.epidemic_health_inspector)
-  local inspector = self.world:newEntity("Inspector", 2)
+  local inspector = self.world:newEntity("Inspector", 2, 2)
   self.inspector = inspector
   inspector:setType("Inspector")
 

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -640,6 +640,12 @@ function AnimationManager:setStaffMarker(anim, ...)
   self:_unfoldAnims(anim, "setFrameSecondaryMarker", ...)
 end
 
+--! Convert a humanoid position to a pixel offset.
+--!param pos (table) Humanoid center position to convert. Is either a tile
+--  position of the form {x, y} with floating point numbers, or a pixel
+--  position of the form {x, y, "px"} with integer numbers. In both cases,
+--  the origin is at the center of tile (0, 0), at floor level.
+--!return (int, int) The computed offset wrt to the origin in pixels.
 local function positionToXy(pos)
   if pos[3] == "px" then
     return pos[1], pos[2]

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -604,11 +604,32 @@ function AnimationManager:getAnimLength(anim)
   return self.anim_length_cache[anim]
 end
 
---[[ Markers can be set using a variety of different arguments:
-  set{Patient,Staff}Marker(anim_number, position)
-  set{Patient,Staff}Marker(anim_number, {position1, position2, ..., positionN})
-  set{Patient,Staff}Marker(anim_number, start_position, end_position)
-  set{Patient,Staff}Marker(anim_number, keyframe_1, keyframe_1_position, keyframe_2, ...)
+--[[ A marker position can be used to indicate the position of en entity in the
+  frame of an animation relative to the position of drawing the animation.
+
+  The marker position is used to display a humanoid in the circular area of its
+  window. It is also used to position mood icons or smoke of a machine above
+  the entity.
+
+  There are two marker positions associated with each frame of an animation.
+  The primary marker is reserved for patients and machines. The secondary
+  marker is used for staff and other officials such as VIPs and inspectors.
+
+  Markers are set as part of the animation definitions of entities with code like
+
+  -- Sets the primary markers of all frames of an animation:
+  local anim_mgr = TheApp.animation_manager
+  anim_mgr:setPatientMarker(...)
+
+  -- Sets the secondary markers of all frames of an animation:
+  local anim_mgr = TheApp.animation_manager
+  anim_mgr:setStaffMarker(...)
+
+  Markers can be set using a variety of different arguments:
+  * set{Patient/Staff}Marker(anim_number, position)
+  * set{Patient/Staff}Marker(anim_number, {position1, position2, ..., positionN})
+  * set{Patient/Staff}Marker(anim_number, start_position, end_position)
+  * set{Patient/Staff}Marker(anim_number, keyframe_1, keyframe_1_position, keyframe_2, ...)
 
   The 'position' should be a table; An {x, y} pair for a tile position or
   {x, y, "px"} for a pixel position. In both cases the position should be the
@@ -628,6 +649,8 @@ end
   can be a table, in which case the marker is set for all values in the table.
   Alternatively, the values function (defined in utility.lua) can be used in
   conjection with a for loop to set markers for multiple things.
+
+  The AnimView program can be used to easily obtain position information in frames.
 --]]
 
 --! Define the centre of a patient at floor level in an animation.

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -590,15 +590,14 @@ function AnimationManager:setAnimLength(anim, length)
 end
 
 function AnimationManager:getAnimLength(anim)
-  local anims = self.anims
   if not self.anim_length_cache[anim] then
     local length = 0
     local seen = {}
-    local frame = anims:getFirstFrame(anim)
+    local frame = self.anims:getFirstFrame(anim)
     while not seen[frame] do
       seen[frame] = true
       length = length + 1
-      frame = anims:getNextFrame(frame)
+      frame = self.anims:getNextFrame(frame)
     end
     self.anim_length_cache[anim] = length
   end
@@ -658,10 +657,10 @@ function AnimationManager:_unfoldAnims(anim, fn, ...)
 end
 
 function AnimationManager:setMarkerRaw(anim, fn, arg1, arg2, ...)
-  local tp_arg1 = type(arg1)
   local anim_length = self:getAnimLength(anim)
-  local anims = self.anims
-  local frame = anims:getFirstFrame(anim)
+  local frame = self.anims:getFirstFrame(anim)
+
+  local tp_arg1 = type(arg1)
   if tp_arg1 == "table" then
     if arg2 then
       -- Linear-interpolation positions
@@ -669,15 +668,15 @@ function AnimationManager:setMarkerRaw(anim, fn, arg1, arg2, ...)
       local x2, y2 = positionToXy(arg2)
       for i = 0, anim_length - 1 do
         local n = math.floor(i / (anim_length - 1))
-        anims[fn](anims, frame, (x2 - x1) * n + x1, (y2 - y1) * n + y1)
-        frame = anims:getNextFrame(frame)
+        self.anims[fn](self.anims, frame, (x2 - x1) * n + x1, (y2 - y1) * n + y1)
+        frame = self.anims:getNextFrame(frame)
       end
     else
       -- Static position
       local x, y = positionToXy(arg1)
       for _ = 1, anim_length do
-        anims[fn](anims, frame, x, y)
-        frame = anims:getNextFrame(frame)
+        self.anims[fn](self.anims, frame, x, y)
+        frame = self.anims:getNextFrame(frame)
       end
     end
   elseif tp_arg1 == "number" then
@@ -706,14 +705,12 @@ function AnimationManager:setMarkerRaw(anim, fn, arg1, arg2, ...)
       end
       if f2 then
         local n = math.floor((f - f1) / (f2 - f1))
-        anims[fn](anims, frame, (x2 - x1) * n + x1, (y2 - y1) * n + y1)
+        self.anims[fn](self.anims, frame, (x2 - x1) * n + x1, (y2 - y1) * n + y1)
       else
-        anims[fn](anims, frame, x1, y1)
+        self.anims[fn](self.anims, frame, x1, y1)
       end
-      frame = anims:getNextFrame(frame)
+      frame = self.anims:getNextFrame(frame)
     end
-  elseif tp_arg1 == "string" then
-    error("TODO")
   else
     error("Invalid arguments to setMarker", 2)
   end

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -630,11 +630,16 @@ function AnimationManager:setMarker(anim, ...)
   return self:setMarkerRaw(anim, "setFramePrimaryMarker", ...)
 end
 
-local function TableToPixels(t)
-  if t[3] == "px" then
-    return t[1], t[2]
+--! Convert a {x, y} tile position or a {x, y, "px"} pixel position to an X/Y
+--  pair that represents the center of the humanoid at floor level, relative to
+--  the center of tile (0,0) in an animation.
+--!param pos (table) The tile or pixel position to convert.
+--!return The X/Y pair.
+local function positionToXy(pos)
+  if pos[3] == "px" then
+    return pos[1], pos[2]
   else
-    local x, y = Map:WorldToScreen(t[1] + 1, t[2] + 1)
+    local x, y = Map:WorldToScreen(pos[1] + 1, pos[2] + 1)
     return math.floor(x), math.floor(y)
   end
 end
@@ -653,8 +658,8 @@ function AnimationManager:setMarkerRaw(anim, fn, arg1, arg2, ...)
   if tp_arg1 == "table" then
     if arg2 then
       -- Linear-interpolation positions
-      local x1, y1 = TableToPixels(arg1)
-      local x2, y2 = TableToPixels(arg2)
+      local x1, y1 = positionToXy(arg1)
+      local x2, y2 = positionToXy(arg2)
       for i = 0, anim_length - 1 do
         local n = math.floor(i / (anim_length - 1))
         anims[fn](anims, frame, (x2 - x1) * n + x1, (y2 - y1) * n + y1)
@@ -662,7 +667,7 @@ function AnimationManager:setMarkerRaw(anim, fn, arg1, arg2, ...)
       end
     else
       -- Static position
-      local x, y = TableToPixels(arg1)
+      local x, y = positionToXy(arg1)
       for _ = 1, anim_length do
         anims[fn](anims, frame, x, y)
         frame = anims:getNextFrame(frame)
@@ -673,7 +678,7 @@ function AnimationManager:setMarkerRaw(anim, fn, arg1, arg2, ...)
     local f1, x1, y1 = 0, 0, 0
     local args
     if arg1 == 0 then
-      x1, y1 = TableToPixels(arg2)
+      x1, y1 = positionToXy(arg2)
       args = {...}
     else
       args = {arg1, arg2, ...}
@@ -688,7 +693,7 @@ function AnimationManager:setMarkerRaw(anim, fn, arg1, arg2, ...)
       if not f2 then
         f2 = args[args_i]
         if f2 then
-          x2, y2 = TableToPixels(args[args_i + 1])
+          x2, y2 = positionToXy(args[args_i + 1])
           args_i = args_i + 2
         end
       end

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -627,7 +627,7 @@ end
 --]]
 
 function AnimationManager:setMarker(anim, ...)
-  return self:setMarkerRaw(anim, "setFramePrimaryMarker", ...)
+  self:_unfoldAnims(anim, "setFramePrimaryMarker", ...)
 end
 
 --! Convert a {x, y} tile position or a {x, y, "px"} pixel position to an X/Y
@@ -644,13 +644,20 @@ local function positionToXy(pos)
   end
 end
 
-function AnimationManager:setMarkerRaw(anim, fn, arg1, arg2, ...)
+--! Unfold tables containing animation numbers.
+function AnimationManager:_unfoldAnims(anim, fn, ...)
+  if not anim then return end
+
   if type(anim) == "table" then
     for _, val in pairs(anim) do
-      self:setMarkerRaw(val, fn, arg1, arg2, ...)
+      self:_unfoldAnims(val, fn, ...)
     end
-    return
+  else
+    self:setMarkerRaw(anim, fn, ...)
   end
+end
+
+function AnimationManager:setMarkerRaw(anim, fn, arg1, arg2, ...)
   local tp_arg1 = type(arg1)
   local anim_length = self:getAnimLength(anim)
   local anims = self.anims

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -612,7 +612,7 @@ end
 
   The 'position' should be a table; An {x, y} pair for a tile position or
   {x, y, "px"} for a pixel position. In both cases the position should be the
-  humanoid center at floor level, with the center of the (0, 0) tile being the
+  humanoid centre at floor level, with the centre of the (0, 0) tile being the
   origin in both cases.
 
   The first variant of set{Patient,Staff}Marker sets the same marker for each frame.
@@ -630,12 +630,12 @@ end
   conjection with a for loop to set markers for multiple things.
 --]]
 
---! Define the center of a patient at floor level in an animation.
+--! Define the centre of a patient at floor level in an animation.
 function AnimationManager:setPatientMarker(anim, ...)
   self:_unfoldAnims(anim, "setFramePrimaryMarker", ...)
 end
 
---! Define the center of a staff member at floor level in an animation.
+--! Define the centre of a staff member at floor level in an animation.
 function AnimationManager:setStaffMarker(anim, ...)
   self:_unfoldAnims(anim, "setFrameSecondaryMarker", ...)
 end

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -605,17 +605,17 @@ function AnimationManager:getAnimLength(anim)
 end
 
 --[[ Markers can be set using a variety of different arguments:
-  setMarker(anim_number, position)
-  setMarker(anim_number, {position1, position2, ..., positionN})
-  setMarker(anim_number, start_position, end_position)
-  setMarker(anim_number, keyframe_1, keyframe_1_position, keyframe_2, ...)
+  set{Patient,Staff}Marker(anim_number, position)
+  set{Patient,Staff}Marker(anim_number, {position1, position2, ..., positionN})
+  set{Patient,Staff}Marker(anim_number, start_position, end_position)
+  set{Patient,Staff}Marker(anim_number, keyframe_1, keyframe_1_position, keyframe_2, ...)
 
   The 'position' should be a table; An {x, y} pair for a tile position or
   {x, y, "px"} for a pixel position. In both cases the position should be the
   humanoid center at floor level, with the center of the (0, 0) tile being the
   origin in both cases.
 
-  The first variant of setMarker sets the same marker for each frame.
+  The first variant of set{Patient,Staff}Marker sets the same marker for each frame.
   The second variant of has a unique position for each frame. 'nil' can be used to
   repeat the previous position.
   The third variant does linear interpolation of the two positions between the first
@@ -630,15 +630,16 @@ end
   conjection with a for loop to set markers for multiple things.
 --]]
 
-function AnimationManager:setMarker(anim, ...)
+--! Define the center of a patient at floor level in an animation.
+function AnimationManager:setPatientMarker(anim, ...)
   self:_unfoldAnims(anim, "setFramePrimaryMarker", ...)
 end
 
---! Convert a {x, y} tile position or a {x, y, "px"} pixel position to an X/Y
---  pair that represents the center of the humanoid at floor level, relative to
---  the center of tile (0,0) in an animation.
---!param pos (table) The tile or pixel position to convert.
---!return The X/Y pair.
+--! Define the center of a staff member at floor level in an animation.
+function AnimationManager:setStaffMarker(anim, ...)
+  self:_unfoldAnims(anim, "setFrameSecondaryMarker", ...)
+end
+
 local function positionToXy(pos)
   if pos[3] == "px" then
     return pos[1], pos[2]

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -606,18 +606,23 @@ end
 
 --[[ Markers can be set using a variety of different arguments:
   setMarker(anim_number, position)
+  setMarker(anim_number, {position1, position2, ..., positionN})
   setMarker(anim_number, start_position, end_position)
   setMarker(anim_number, keyframe_1, keyframe_1_position, keyframe_2, ...)
 
-  position should be a table; {x, y} for a tile position, {x, y, "px"} for a
-  pixel position, with (0, 0) being the origin in both cases.
+  The 'position' should be a table; An {x, y} pair for a tile position or
+  {x, y, "px"} for a pixel position. In both cases the position should be the
+  humanoid center at floor level, with the center of the (0, 0) tile being the
+  origin in both cases.
 
   The first variant of setMarker sets the same marker for each frame.
-  The second variant does linear interpolation of the two positions between
-  the first frame and the last frame.
-  The third variant does linear interpolation between keyframes, and then the
-  final position for frames after the last keyframe. The keyframe arguments
-  should be 0-based integers, as in the animation viewer.
+  The second variant of has a unique position for each frame. 'nil' can be used to
+  repeat the previous position.
+  The third variant does linear interpolation of the two positions between the first
+  frame and the last frame.
+  The fourth variant does linear interpolation between keyframes, and then the final
+  position for frames after the last keyframe. The keyframe arguments should be
+  0-based integers, as in the animation viewer.
 
   To set the markers for multiple animations at once, the anim_number argument
   can be a table, in which case the marker is set for all values in the table.
@@ -669,6 +674,16 @@ function AnimationManager:setMarkerRaw(anim, fn, arg1, arg2, ...)
       for i = 0, anim_length - 1 do
         local n = math.floor(i / (anim_length - 1))
         self.anims[fn](self.anims, frame, (x2 - x1) * n + x1, (y2 - y1) * n + y1)
+        frame = self.anims:getNextFrame(frame)
+      end
+    elseif type(arg1[1]) == "table" then
+      -- A position for each frame.
+      local x, y
+      for rel_frame = 1, anim_length do
+        if arg1[rel_frame] then
+          x, y = positionToXy(arg1[rel_frame])
+        end
+        self.anims[fn](self.anims, frame, x, y)
         frame = self.anims:getNextFrame(frame)
       end
     else

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1192,7 +1192,7 @@ function Hospital:spawnContagiousPatient()
   end
 
   if self:hasStaffedDesk() then
-    local patient = self.world:newEntity("Patient", 2)
+    local patient = self.world:newEntity("Patient", 2, 1)
     local contagious_diseases = get_available_contagious_diseases()
     if #contagious_diseases > 0 then
       local disease = contagious_diseases[math.random(1,#contagious_diseases)]
@@ -1541,7 +1541,7 @@ function Hospital:initStaff()
         added_staff = false
       end
       if added_staff then
-        local staff = self.world:newEntity(profile.humanoid_class, 2)
+        local staff = self.world:newEntity(profile.humanoid_class, 2, 2)
         staff:setProfile(profile)
 
         -- Identify a safe starting place and

--- a/CorsixTH/Lua/humanoid_actions/die.lua
+++ b/CorsixTH/Lua/humanoid_actions/die.lua
@@ -172,7 +172,7 @@ local action_die_tick_reaper; action_die_tick_reaper = permanent"action_die_tick
 
     --Spawn the grim reaper and the lava hole:
     local lava_hole = humanoid.world:newObject("gates_to_hell", hole_x, hole_y, holes_orientation)
-    local grim_reaper = humanoid.world:newEntity("GrimReaper", 1660)
+    local grim_reaper = humanoid.world:newEntity("GrimReaper", 1660, 2)
 
     local point_dir = {x = grim_x, y = grim_y, direction = grim_spawn_idle_direction}
     grim_reaper:setNextAction(IdleSpawnAction(1660, point_dir):setCount(40))

--- a/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
+++ b/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
@@ -35,7 +35,7 @@ local animation_numbers = {
   1874,
   1878,
 }
-TheApp.animation_manager:setStaffMarker(animation_numbers, {-1.05, -0.05})
+TheApp.animation_manager:setStaffMarker(animation_numbers, {-1, 0, "px"})
 
 local finish = permanent"action_sweep_floor_finish"( function(humanoid)
   humanoid:finishAction()

--- a/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
+++ b/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
@@ -35,7 +35,7 @@ local animation_numbers = {
   1874,
   1878,
 }
-TheApp.animation_manager:setMarker(animation_numbers, {-1.05, -0.05})
+TheApp.animation_manager:setStaffMarker(animation_numbers, {-1.05, -0.05})
 
 local finish = permanent"action_sweep_floor_finish"( function(humanoid)
   humanoid:finishAction()

--- a/CorsixTH/Lua/humanoid_actions/use_screen.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_screen.lua
@@ -73,6 +73,7 @@ local animation_numbers = {
   4770,
 }
 TheApp.animation_manager:setPatientMarker(animation_numbers, {-1.05, -0.05})
+TheApp.animation_manager:setStaffMarker(animation_numbers, {-1.05, -0.05})
 
 local patient_clothes_state = permanent"action_use_screen_patient_clothes_state"( function(humanoid)
   humanoid.user_of:setAnimation(1204)

--- a/CorsixTH/Lua/humanoid_actions/use_screen.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_screen.lua
@@ -72,7 +72,7 @@ local animation_numbers = {
   4768,
   4770,
 }
-TheApp.animation_manager:setMarker(animation_numbers, {-1.05, -0.05})
+TheApp.animation_manager:setPatientMarker(animation_numbers, {-1.05, -0.05})
 
 local patient_clothes_state = permanent"action_use_screen_patient_clothes_state"( function(humanoid)
   humanoid.user_of:setAnimation(1204)

--- a/CorsixTH/Lua/objects/autopsy.lua
+++ b/CorsixTH/Lua/objects/autopsy.lua
@@ -109,7 +109,7 @@ object.orientations = {
   },
 }
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.idle_animations.north, {0.0 , 0.0})
+anim_mgr:setPatientMarker(object.idle_animations.north, {0.0 , 0.0})
 
 -- In (some versions of?) the original animations, 4086 has a builtin repeat,
 -- which looks very wrong, hence trim it to the length of a similar animation.

--- a/CorsixTH/Lua/objects/bed.lua
+++ b/CorsixTH/Lua/objects/bed.lua
@@ -65,10 +65,10 @@ object.usage_animations = {
 
 local anim_mgr = TheApp.animation_manager
 local kf1, kf2, kf3 = {1, -1}, {0.4, -1}, {-0.3, -1}
-anim_mgr:setMarker(object.usage_animations.north.begin_use, 0, kf1, 4, kf2, 12, kf2, 18, kf3)
-anim_mgr:setMarker(object.usage_animations.north.in_use, kf3)
-anim_mgr:setMarker(object.usage_animations.north.finish_use, 0, kf3, 6, kf3, 12, kf2, 14, kf1)
--- TODO: The other direction
+anim_mgr:setPatientMarker(object.usage_animations.north.begin_use, 0, kf1, 4, kf2, 12, kf2, 18, kf3)
+anim_mgr:setPatientMarker(object.usage_animations.north.in_use, kf3)
+anim_mgr:setPatientMarker(object.usage_animations.north.finish_use, 0, kf3, 6, kf3, 12, kf2, 14, kf1)
+-- TODO: The other direction setPatientMarker
 
 object.orientations = {
   north = {

--- a/CorsixTH/Lua/objects/cabinet.lua
+++ b/CorsixTH/Lua/objects/cabinet.lua
@@ -42,8 +42,8 @@ object.usage_animations = {
   },
 }
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.usage_animations.east.in_use, {-1, 0})
-anim_mgr:setMarker(object.usage_animations.north.in_use, {-1, 0})
+anim_mgr:setStaffMarker(object.usage_animations.east.in_use, {-1, 0})
+anim_mgr:setStaffMarker(object.usage_animations.north.in_use, {-1, 0})
 
 object.orientations = {
   north = {

--- a/CorsixTH/Lua/objects/desk.lua
+++ b/CorsixTH/Lua/objects/desk.lua
@@ -64,22 +64,22 @@ object.usage_animations = {
 }
 local anim_mgr = TheApp.animation_manager
 local kf1, kf2, kf3 = {0, 0}, {-1, -0.3}, {-0.9, -0.1}
-anim_mgr:setMarker(  56, 0, kf1, 10, kf2, 13, kf3)
-anim_mgr:setMarker(3240, 0, kf1, 10, kf2, 13, kf3)
-anim_mgr:setMarker(  72, kf3)
-anim_mgr:setMarker( 718, kf3)
-anim_mgr:setMarker(3256, kf3)
-anim_mgr:setMarker(  64, 0, kf3, 3, kf2, 12, kf1)
-anim_mgr:setMarker(3248, 0, kf3, 3, kf2, 12, kf1)
+anim_mgr:setStaffMarker(  56, 0, kf1, 10, kf2, 13, kf3)
+anim_mgr:setStaffMarker(3240, 0, kf1, 10, kf2, 13, kf3)
+anim_mgr:setStaffMarker(  72, kf3)
+anim_mgr:setStaffMarker( 718, kf3)
+anim_mgr:setStaffMarker(3256, kf3)
+anim_mgr:setStaffMarker(  64, 0, kf3, 3, kf2, 12, kf1)
+anim_mgr:setStaffMarker(3248, 0, kf3, 3, kf2, 12, kf1)
 kf1, kf2, kf3 = {-1, 0}, {-1, -1.1}, {-0.8, -0.9}
-anim_mgr:setMarker(  58, 0, kf1, 9, kf2, 11, kf3)
-anim_mgr:setMarker(3242, 0, kf1, 9, kf2, 11, kf3)
+anim_mgr:setStaffMarker(  58, 0, kf1, 9, kf2, 11, kf3)
+anim_mgr:setStaffMarker(3242, 0, kf1, 9, kf2, 11, kf3)
 kf1 = {-0.7, -1}
-anim_mgr:setMarker(  74, kf1)
-anim_mgr:setMarker(3258, kf1)
+anim_mgr:setStaffMarker(  74, kf1)
+anim_mgr:setStaffMarker(3258, kf1)
 kf2, kf1 = {-0.8, -1}, {-1, -2}
-anim_mgr:setMarker(  66, 0, kf3, 3, kf2, 8, kf1)
-anim_mgr:setMarker(3250, 0, kf3, 3, kf2, 8, kf1)
+anim_mgr:setStaffMarker(  66, 0, kf3, 3, kf2, 8, kf1)
+anim_mgr:setStaffMarker(3250, 0, kf3, 3, kf2, 8, kf1)
 
 object.orientations = {
   north = {

--- a/CorsixTH/Lua/objects/gates_to_hell.lua
+++ b/CorsixTH/Lua/objects/gates_to_hell.lua
@@ -45,8 +45,8 @@ object.usage_animations = {
 }
 
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.usage_animations.south.in_use, 0, {0,0})
-anim_mgr:setMarker(object.usage_animations.east.in_use,  0, {0,0})
+anim_mgr:setPatientMarker(object.usage_animations.south.in_use, 0, {0,0})
+anim_mgr:setPatientMarker(object.usage_animations.east.in_use,  0, {0,0})
 
 -- Orientation directions are relative to the patient's death location:
 object.orientations = {

--- a/CorsixTH/Lua/objects/helicopter.lua
+++ b/CorsixTH/Lua/objects/helicopter.lua
@@ -85,7 +85,7 @@ end
 function Helicopter:spawnPatient()
   local hospital = self.hospital
   self.spawned_patients = self.spawned_patients + 1
-  local patient = self.world:newEntity("Patient", 2)
+  local patient = self.world:newEntity("Patient", 2, 1)
   patient:setDisease(hospital.emergency.disease)
   patient.diagnosis_progress = 1
   patient.is_emergency = self.spawned_patients

--- a/CorsixTH/Lua/objects/lecture_chair.lua
+++ b/CorsixTH/Lua/objects/lecture_chair.lua
@@ -43,9 +43,9 @@ object.usage_animations = copy_north_to_south {
 }
 local anim_mgr = TheApp.animation_manager
 local kf1, kf2 = {0, 0}, {-1, -0.1}
-anim_mgr:setMarker(object.usage_animations.north.begin_use, 0, kf1, 10, kf2)
-anim_mgr:setMarker(object.usage_animations.north.in_use, kf2)
-anim_mgr:setMarker(object.usage_animations.north.finish_use, 0, kf2, 11, kf2, 18, kf1)
+anim_mgr:setStaffMarker(object.usage_animations.north.begin_use, 0, kf1, 10, kf2)
+anim_mgr:setStaffMarker(object.usage_animations.north.in_use, kf2)
+anim_mgr:setStaffMarker(object.usage_animations.north.finish_use, 0, kf2, 11, kf2, 18, kf1)
 
 object.orientations = {
   north = {

--- a/CorsixTH/Lua/objects/loo.lua
+++ b/CorsixTH/Lua/objects/loo.lua
@@ -109,13 +109,13 @@ object.usage_animations = copy_north_to_south {
 }
 local anim_mgr = TheApp.animation_manager
 local kf1, kf2 = {0, 0}, {-0.1, -0.9}
-anim_mgr:setMarker(object.usage_animations.north.begin_use, 1, kf1, 6, kf2)
+anim_mgr:setPatientMarker(object.usage_animations.north.begin_use, 1, kf1, 6, kf2)
 kf1 = {-0.1, -0.9}
-anim_mgr:setMarker(object.usage_animations.north.begin_use_2, kf1)
-anim_mgr:setMarker(object.usage_animations.north.in_use, kf1)
-anim_mgr:setMarker(object.usage_animations.north.finish_use, kf1)
+anim_mgr:setPatientMarker(object.usage_animations.north.begin_use_2, kf1)
+anim_mgr:setPatientMarker(object.usage_animations.north.in_use, kf1)
+anim_mgr:setPatientMarker(object.usage_animations.north.finish_use, kf1)
 kf1, kf2 = {-0.1, -0.9}, {0, 0}
-anim_mgr:setMarker(object.usage_animations.north.finish_use_2, 0, kf1, 1, kf1, 6, kf2)
+anim_mgr:setPatientMarker(object.usage_animations.north.finish_use_2, 0, kf1, 1, kf1, 6, kf2)
 
 object.orientations = {
   north = {

--- a/CorsixTH/Lua/objects/machines/blood_machine.lua
+++ b/CorsixTH/Lua/objects/machines/blood_machine.lua
@@ -113,6 +113,6 @@ object.orientations = {
   },
 }
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.idle_animations.north, {-1.5, -0.8})
+anim_mgr:setPatientMarker(object.idle_animations.north, {-1.5, -0.8})
 
 return object

--- a/CorsixTH/Lua/objects/machines/cardio.lua
+++ b/CorsixTH/Lua/objects/machines/cardio.lua
@@ -140,6 +140,6 @@ object.orientations = {
   },
 }
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.idle_animations.north, {-0.9, -0.9})
+anim_mgr:setPatientMarker(object.idle_animations.north, {-0.9, -0.9})
 
 return object

--- a/CorsixTH/Lua/objects/machines/cardio.lua
+++ b/CorsixTH/Lua/objects/machines/cardio.lua
@@ -48,13 +48,17 @@ object.usage_animations = copy_north_to_south {
   },
 }
 
+local kfp1, kfp2, kfp3, kfp4, kfp5, kfp6, kfp7
+kfp1, kfp2, kfp3, kfp4 = {-10, -7, "px"}, {-13, -11, "px"}, {-17, -11, "px"}, {-21, -13, "px"}
+kfp5, kfp6, kfp7 = {-27, -14, "px"}, {-31, -16, "px"}, {-37, -17, "px"}
 TheApp.animation_manager:setStaffMarker(object.usage_animations.north.in_use.Handyman,
-  0, {-10, -7, "px"}, 1, {-13, -11, "px"}, 2, {-17, -11, "px"}, 3, {-21, -13, "px"},
-  4, {-27, -14, "px"}, 5, {-31, -16, "px"}, 6, {-37, -17, "px"}
+  0, kfp1, 1, kfp2, 2, kfp3, 3, kfp4, 4, kfp5, 5, kfp6, 6, kfp7
 )
+
+kfp1, kfp2, kfp3, kfp4 = {-37, -17, "px"}, {-29, -15, "px"}, {-25, -15, "px"}, {-20, -13, "px"}
+kfp5, kfp6, kfp7 = {-19, -13, "px"}, {-18, -13, "px"}, {-12, -10, "px"}
 TheApp.animation_manager:setStaffMarker(object.usage_animations.north.finish_use.Handyman,
-  0, {-37, -17, "px"}, 5, {-37, -17, "px"}, 6, {-29, -15, "px"}, 7, {-25, -15, "px"},
-  8, {-20, -13, "px"}, 9, {-19, -13, "px"}, 10, {-18, -13, "px"}, 11, {-12, -10, "px"}
+  0, kfp1, 5, kfp1, 6, kfp2, 7, kfp3, 8, kfp4, 9, kfp5, 10, kfp6, 11, kfp7
 )
 
 object.multi_usage_animations = {

--- a/CorsixTH/Lua/objects/machines/cardio.lua
+++ b/CorsixTH/Lua/objects/machines/cardio.lua
@@ -47,6 +47,16 @@ object.usage_animations = copy_north_to_south {
     },
   },
 }
+
+TheApp.animation_manager:setStaffMarker(object.usage_animations.north.in_use.Handyman,
+  0, {-10, -7, "px"}, 1, {-13, -11, "px"}, 2, {-17, -11, "px"}, 3, {-21, -13, "px"},
+  4, {-27, -14, "px"}, 5, {-31, -16, "px"}, 6, {-37, -17, "px"}
+)
+TheApp.animation_manager:setStaffMarker(object.usage_animations.north.finish_use.Handyman,
+  0, {-37, -17, "px"}, 5, {-37, -17, "px"}, 6, {-29, -15, "px"}, 7, {-25, -15, "px"},
+  8, {-20, -13, "px"}, 9, {-19, -13, "px"}, 10, {-18, -13, "px"}, 11, {-12, -10, "px"}
+)
+
 object.multi_usage_animations = {
   ["Stripped Male Patient - Doctor"] = copy_north_to_south {
     north = {

--- a/CorsixTH/Lua/objects/machines/cast_remover.lua
+++ b/CorsixTH/Lua/objects/machines/cast_remover.lua
@@ -97,6 +97,6 @@ object.orientations = {
   },
 }
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.idle_animations.north, {-1.6, -0.8})
+anim_mgr:setPatientMarker(object.idle_animations.north, {-1.6, -0.8})
 
 return object

--- a/CorsixTH/Lua/objects/machines/electrolyser.lua
+++ b/CorsixTH/Lua/objects/machines/electrolyser.lua
@@ -84,6 +84,6 @@ object.orientations = {
   },
 }
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.idle_animations.north, {-1.3, -1.2})
+anim_mgr:setPatientMarker(object.idle_animations.north, {-1.3, -1.2})
 
 return object

--- a/CorsixTH/Lua/objects/machines/hair_restorer.lua
+++ b/CorsixTH/Lua/objects/machines/hair_restorer.lua
@@ -77,4 +77,7 @@ object.orientations = {
 local anim_mgr = TheApp.animation_manager
 anim_mgr:setPatientMarker(object.idle_animations.north, {-1.0, -1.1})
 
+anim_mgr:setStaffMarker(object.usage_animations.north.in_use["Handyman"], {61, -36, "px"})
+
+
 return object

--- a/CorsixTH/Lua/objects/machines/hair_restorer.lua
+++ b/CorsixTH/Lua/objects/machines/hair_restorer.lua
@@ -75,6 +75,6 @@ object.orientations = {
   },
 }
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.idle_animations.north, {-1.0, -1.1})
+anim_mgr:setPatientMarker(object.idle_animations.north, {-1.0, -1.1})
 
 return object

--- a/CorsixTH/Lua/objects/machines/inflator.lua
+++ b/CorsixTH/Lua/objects/machines/inflator.lua
@@ -76,9 +76,9 @@ object.orientations = {
 }
 local anim_mgr = TheApp.animation_manager
 local kf1, kf2 = {0, 1}, {0, 0}
-anim_mgr:setMarker(object.multi_usage_animations["Standard Male Patient - Doctor"].north.begin_use, 0, kf1, 5, kf2)
+anim_mgr:setPatientMarker(object.multi_usage_animations["Standard Male Patient - Doctor"].north.begin_use, 0, kf1, 5, kf2)
 kf1, kf2 = {0, 0}, {1, 0}
-anim_mgr:setMarker(object.multi_usage_animations["Standard Male Patient - Doctor"].north.finish_use, 1, kf1, 11, kf2)
-anim_mgr:setMarker(object.idle_animations.north, {-0.9, -1.0})
+anim_mgr:setPatientMarker(object.multi_usage_animations["Standard Male Patient - Doctor"].north.finish_use, 1, kf1, 11, kf2)
+anim_mgr:setPatientMarker(object.idle_animations.north, {-0.9, -1.0})
 
 return object

--- a/CorsixTH/Lua/objects/machines/operating_table.lua
+++ b/CorsixTH/Lua/objects/machines/operating_table.lua
@@ -86,6 +86,8 @@ anim_mgr:setAnimLength(2938, 1)
 -- Mood icon positions
 anim_mgr:setPatientMarker(object.idle_animations.north, {-1.59, -2.41})
 
+anim_mgr:setStaffMarker(object.usage_animations.north.in_use.Handyman, {29, -52, "px"})
+
 
 object.orientations = {
   north = {

--- a/CorsixTH/Lua/objects/machines/operating_table.lua
+++ b/CorsixTH/Lua/objects/machines/operating_table.lua
@@ -84,7 +84,7 @@ anim_mgr:setAnimLength(2348, 1)
 anim_mgr:setAnimLength(2938, 1)
 
 -- Mood icon positions
-anim_mgr:setMarker(object.idle_animations.north, {-1.59, -2.41})
+anim_mgr:setPatientMarker(object.idle_animations.north, {-1.59, -2.41})
 
 
 object.orientations = {

--- a/CorsixTH/Lua/objects/machines/scanner.lua
+++ b/CorsixTH/Lua/objects/machines/scanner.lua
@@ -219,6 +219,6 @@ object.orientations = {
   },
 }
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.idle_animations.north, {-1.1, -1.1})
+anim_mgr:setPatientMarker(object.idle_animations.north, {-1.1, -1.1})
 
 return object

--- a/CorsixTH/Lua/objects/machines/scanner.lua
+++ b/CorsixTH/Lua/objects/machines/scanner.lua
@@ -221,4 +221,6 @@ object.orientations = {
 local anim_mgr = TheApp.animation_manager
 anim_mgr:setPatientMarker(object.idle_animations.north, {-1.1, -1.1})
 
+anim_mgr:setStaffMarker(object.usage_animations.north.begin_use_2["Handyman"], {-3, -3, "px"})
+
 return object

--- a/CorsixTH/Lua/objects/machines/slicer.lua
+++ b/CorsixTH/Lua/objects/machines/slicer.lua
@@ -79,6 +79,6 @@ object.orientations = {
   },
 }
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.idle_animations.north, {-1.2, -0.8})
+anim_mgr:setPatientMarker(object.idle_animations.north, {-1.2, -0.8})
 
 return object

--- a/CorsixTH/Lua/objects/machines/ultrascanner.lua
+++ b/CorsixTH/Lua/objects/machines/ultrascanner.lua
@@ -89,6 +89,6 @@ object.orientations = {
   },
 }
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.idle_animations.north, {-0.9, -0.9})
+anim_mgr:setPatientMarker(object.idle_animations.north, {-0.9, -0.9})
 
 return object

--- a/CorsixTH/Lua/objects/machines/ultrascanner.lua
+++ b/CorsixTH/Lua/objects/machines/ultrascanner.lua
@@ -91,4 +91,6 @@ object.orientations = {
 local anim_mgr = TheApp.animation_manager
 anim_mgr:setPatientMarker(object.idle_animations.north, {-0.9, -0.9})
 
+anim_mgr:setStaffMarker(object.usage_animations.north.in_use.Handyman, {60, -4, "px"})
+
 return object

--- a/CorsixTH/Lua/objects/machines/x_ray.lua
+++ b/CorsixTH/Lua/objects/machines/x_ray.lua
@@ -92,6 +92,6 @@ object.orientations = {
   },
 }
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setMarker(object.idle_animations.north, {-2, -2})
+anim_mgr:setPatientMarker(object.idle_animations.north, {-2, -2})
 
 return object

--- a/CorsixTH/Lua/objects/plant.lua
+++ b/CorsixTH/Lua/objects/plant.lua
@@ -67,11 +67,11 @@ object.orientations = {
   },
 }
 
+local kf1, kf2 = {-1, 1, "px"}, {4, -1, "px"}
 local anim_mgr = TheApp.animation_manager
-anim_mgr:setStaffMarker(1972,
-    0, {-1, 1, "px"}, 12, {-1, 1, "px"}, 13, {4, -1, "px"})
-anim_mgr:setStaffMarker(1974,
-    0, {-1, 1, "px"}, 19, {-1, 1, "px"}, 20, {2, -1, "px"}, 21, {6, 0, "px"})
+anim_mgr:setStaffMarker(1972, 0, kf1, 12, kf1, 13, kf2)
+local kf3, kf4 = {2, -1, "px"}, {6, 0, "px"}
+anim_mgr:setStaffMarker(1974, 0, kf1, 19, kf1, 20, kf3, 21, kf4)
 
 
 -- For litter: put broom back 356

--- a/CorsixTH/Lua/objects/plant.lua
+++ b/CorsixTH/Lua/objects/plant.lua
@@ -67,6 +67,13 @@ object.orientations = {
   },
 }
 
+local anim_mgr = TheApp.animation_manager
+anim_mgr:setStaffMarker(1972,
+    0, {-1, 1, "px"}, 12, {-1, 1, "px"}, 13, {4, -1, "px"})
+anim_mgr:setStaffMarker(1974,
+    0, {-1, 1, "px"}, 19, {-1, 1, "px"}, 20, {2, -1, "px"}, 21, {6, 0, "px"})
+
+
 -- For litter: put broom back 356
 -- take broom out: 1874
 -- swoop: 1878

--- a/CorsixTH/Lua/objects/projector.lua
+++ b/CorsixTH/Lua/objects/projector.lua
@@ -47,11 +47,11 @@ object.usage_animations = copy_north_to_south {
 }
 local anim_mgr = TheApp.animation_manager
 local kf1, kf2 = {0, 0}, {-0.4, 0.5}
-anim_mgr:setMarker(object.usage_animations.north.begin_use_2, kf2)
-anim_mgr:setMarker(object.usage_animations.north.begin_use_3, kf2)
-anim_mgr:setMarker(object.usage_animations.north.in_use, kf2)
-anim_mgr:setMarker(object.usage_animations.north.finish_use, kf2)
-anim_mgr:setMarker(object.usage_animations.north.finish_use_2, 0, kf2, 11, kf2, 16, kf1)
+anim_mgr:setStaffMarker(object.usage_animations.north.begin_use_2, kf2)
+anim_mgr:setStaffMarker(object.usage_animations.north.begin_use_3, kf2)
+anim_mgr:setStaffMarker(object.usage_animations.north.in_use, kf2)
+anim_mgr:setStaffMarker(object.usage_animations.north.finish_use, kf2)
+anim_mgr:setStaffMarker(object.usage_animations.north.finish_use_2, 0, kf2, 11, kf2, 16, kf1)
 
 object.orientations = {
   north = {

--- a/CorsixTH/Lua/objects/sink.lua
+++ b/CorsixTH/Lua/objects/sink.lua
@@ -50,9 +50,9 @@ object.usage_animations = copy_north_to_south {
 }
 local anim_mgr = TheApp.animation_manager
 local kf1, kf2 = {0, 0}, {0, -0.7}
-anim_mgr:setMarker({1776, 3160}, 0, kf1, 4, kf2)
-anim_mgr:setMarker({1780, 3164}, kf2)
-anim_mgr:setMarker({1784, 3168}, 0, kf2, 34, kf2, 39, kf1)
+anim_mgr:setStaffMarker({1776, 3160}, 0, kf1, 4, kf2)
+anim_mgr:setStaffMarker({1780, 3164}, kf2)
+anim_mgr:setStaffMarker({1784, 3168}, 0, kf2, 34, kf2, 39, kf1)
 
 object.orientations = {
   north = {

--- a/CorsixTH/Lua/objects/sofa.lua
+++ b/CorsixTH/Lua/objects/sofa.lua
@@ -78,21 +78,21 @@ object.usage_animations = {
 }
 local anim_mgr = TheApp.animation_manager
 local kf1, kf2 = {-1, -1}, {-1, -0.6}
-anim_mgr:setMarker(object.usage_animations.north.begin_use, 0, kf1, 2, kf2)
+anim_mgr:setStaffMarker(object.usage_animations.north.begin_use, 0, kf1, 2, kf2)
 kf1 = {-0.6, 0.3}
-anim_mgr:setMarker(object.usage_animations.north.begin_use_2, 0, kf2, 2, kf1)
-anim_mgr:setMarker(object.usage_animations.north.in_use, kf1)
+anim_mgr:setStaffMarker(object.usage_animations.north.begin_use_2, 0, kf2, 2, kf1)
+anim_mgr:setStaffMarker(object.usage_animations.north.in_use, kf1)
 kf2 = {-1, -0.6}
 local kf3 = {-1, -1}
-anim_mgr:setMarker(object.usage_animations.north.finish_use, 0, kf1, 2, kf2, 5, kf3)
+anim_mgr:setStaffMarker(object.usage_animations.north.finish_use, 0, kf1, 2, kf2, 5, kf3)
 kf1, kf2 = {1, -1}, {0.6, -1}
-anim_mgr:setMarker(object.usage_animations.east.begin_use, 0, kf1, 2, kf2)
+anim_mgr:setStaffMarker(object.usage_animations.east.begin_use, 0, kf1, 2, kf2)
 kf1 = {0.3, -0.6}
-anim_mgr:setMarker(object.usage_animations.east.begin_use_2, 0, kf2, 3, kf1)
-anim_mgr:setMarker(object.usage_animations.east.in_use, kf1)
+anim_mgr:setStaffMarker(object.usage_animations.east.begin_use_2, 0, kf2, 3, kf1)
+anim_mgr:setStaffMarker(object.usage_animations.east.in_use, kf1)
 kf2 = {0.6, -1}
 kf3 = {1, -1}
-anim_mgr:setMarker(object.usage_animations.east.finish_use, 0, kf1, 1, kf1, 3, kf2, 5, kf3)
+anim_mgr:setStaffMarker(object.usage_animations.east.finish_use, 0, kf1, 1, kf1, 3, kf2, 5, kf3)
 
 object.orientations = {
   north = {

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -451,7 +451,7 @@ function World:spawnPatient(hospital)
       self:_findClosestSpawnToDesk(hospital:getStaffedDesks(), spawns) or
       spawns[math.random(1, #spawns)]
 
-  local patient = self:newEntity("Patient", 2)
+  local patient = self:newEntity("Patient", 2, 1)
   patient:setDisease(disease)
   patient:setNextAction(SpawnAction("spawn", spawn_point))
   patient:setHospital(hospital)
@@ -463,7 +463,7 @@ end
 function World:spawnVIP(name)
   local hospital = self:getLocalPlayerHospital()
 
-  local vip = self:newEntity("Vip", 2)
+  local vip = self:newEntity("Vip", 2, 2)
   vip:setType("VIP")
   vip.name = name
   vip.enter_deaths = hospital.num_deaths
@@ -1681,12 +1681,20 @@ function World:newFloatingDollarSign(patient, amount)
   self.floating_dollars[spritelist] = true
 end
 
-function World:newEntity(class, animation)
+--! Create a new entity.
+--!param class Class to use for the new entity.
+--!param animation (int)Initial animation to use.
+--!param mood_marker (int) Whether to use the first (default), or the second marker.
+function World:newEntity(class, animation, mood_marker)
+  mood_marker = mood_marker and mood_marker or 1
+  assert(mood_marker == 1 or mood_marker == 2, "mood_marker is neither 1 nor 2.")
+
   local th = TH.animation()
   th:setAnimation(self.anims, animation)
   local entity = _G[class](th)
   self.entities[#self.entities + 1] = entity
   entity.world = self
+  entity.mood_marker = mood_marker
   return entity
 end
 

--- a/CorsixTH/Luatest/TH.lua
+++ b/CorsixTH/Luatest/TH.lua
@@ -40,6 +40,10 @@ TheApp = {
     isCurrentSpeed = function(self, s) return s == self.speed end,
     gameLog = function() end,
   },
+  animation_manager = {
+    setPatientMarker = function(...) end,
+    setStaffMarker = function(...) end,
+  },
 }
 
 local sub_S = setmetatable({key = ''}, {


### PR DESCRIPTION
Use primary marker for patients and secondary marker for staff.

- Allow setting marker positions both for patients and staff.
- Adjust existing marker positions
- Fix sweeping and normal door animations
- Add first shot marker positions for 'simple' ones (standing animations).

Probably simplest to read by individual commit

*Addresses #2794
