### PR TITLE
[RDY] Money Bar non-CJK unicode fix

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -177,7 +177,7 @@ function UIBottomPanel:draw(canvas, x, y)
   -- Draw balance with temporary offset in unicode languages
   x, y = x + self.x, y + self.y
   local offset_x, offset_y = 0, 0
-  if self.ui.app.gfx.language_font then
+  if self.ui.app.gfx:drawNumbersFromUnicode() then
     offset_x = 4
     offset_y = 2
   end

--- a/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/town_map.lua
@@ -194,7 +194,7 @@ function UITownMap:draw(canvas, x, y)
 
   -- Draw balance with temporary offset in unicode languages
   local offset_x, offset_y = 0, 0
-  if self.ui.app.gfx.language_font then
+  if self.ui.app.gfx:drawNumbersFromUnicode() then
     offset_x = 4
     offset_y = 2
   end

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -427,6 +427,7 @@ end
 function Graphics:loadFont(sprite_table, x_sep, y_sep, ...)
   -- Allow (multiple) arguments for loading a sprite table in place of the
   -- sprite_table argument.
+  local load_font = x_sep
   if type(sprite_table) == "string" then
     local arg = {sprite_table, x_sep, y_sep, ...}
     local n_pass_on_args = #arg
@@ -445,7 +446,7 @@ function Graphics:loadFont(sprite_table, x_sep, y_sep, ...)
   end
 
   local use_bitmap_font = true
-  if not sprite_table:isVisible(46) then -- luacheck: ignore 542
+  if (not sprite_table:isVisible(46)) or (load_font == "Font05V" and self:arabicNumerals()) then -- luacheck: ignore 542
     -- The font doesn't contain an uppercase M, so (in all likelihood) is used
     -- for drawing special symbols rather than text, so the original bitmap
     -- font should be used.
@@ -466,6 +467,17 @@ function Graphics:loadFont(sprite_table, x_sep, y_sep, ...)
   font = setmetatable({_proxy = font}, font_proxy_mt)
   self.load_info[font] = {self.loadFont, self, sprite_table, x_sep, y_sep, ...}
   return font
+end
+
+function Graphics:arabicNumerals()
+  local strings = self.app.strings
+  local language = self.app.config.language
+  local arabic_numerals = strings:isArabicNumerals(language)
+  return arabic_numerals
+end
+
+function Graphics:drawNumbersFromUnicode()
+  return self.language_font and not self:arabicNumerals()
 end
 
 function Graphics:loadAnimations(dir, prefix)

--- a/CorsixTH/Lua/languages/czech.lua
+++ b/CorsixTH/Lua/languages/czech.lua
@@ -19,9 +19,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
-IsArabicNumerals(true)
 Language("Čeština", "Czech", "cs", "cze", "cz")
 Inherit("English")
+IsArabicNumerals(true)
 
 high_score = {
   player = "HRÁČ",

--- a/CorsixTH/Lua/languages/czech.lua
+++ b/CorsixTH/Lua/languages/czech.lua
@@ -19,6 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
+IsArabicNumerals(true)
 Language("Čeština", "Czech", "cs", "cze", "cz")
 Inherit("English")
 

--- a/CorsixTH/Lua/languages/greek.lua
+++ b/CorsixTH/Lua/languages/greek.lua
@@ -19,10 +19,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
-IsArabicNumerals(true)
 Language("Ελληνικά", "Greek", "el", "gre", "ell")
 Inherit("English")
 Encoding(utf8)
+IsArabicNumerals(true)
 
 menu_file = {
   quit = "  (%1%) ΕΞΟΔΟΣ   ",

--- a/CorsixTH/Lua/languages/greek.lua
+++ b/CorsixTH/Lua/languages/greek.lua
@@ -19,6 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
+IsArabicNumerals(true)
 Language("Ελληνικά", "Greek", "el", "gre", "ell")
 Inherit("English")
 Encoding(utf8)

--- a/CorsixTH/Lua/languages/hungarian.lua
+++ b/CorsixTH/Lua/languages/hungarian.lua
@@ -68,10 +68,10 @@ This file contains UTF-8 text. Make sure your editor is set to UTF-8.
 
 
 Font("unicode")
-IsArabicNumerals(true)
 Language("Magyar", "Hungarian", "hu", "hun")
 Inherit("English")
 Encoding(utf8)
+IsArabicNumerals(true)
 
 
 -- 2. Faxes

--- a/CorsixTH/Lua/languages/hungarian.lua
+++ b/CorsixTH/Lua/languages/hungarian.lua
@@ -68,6 +68,7 @@ This file contains UTF-8 text. Make sure your editor is set to UTF-8.
 
 
 Font("unicode")
+IsArabicNumerals(true)
 Language("Magyar", "Hungarian", "hu", "hun")
 Inherit("English")
 Encoding(utf8)

--- a/CorsixTH/Lua/languages/japanese.lua
+++ b/CorsixTH/Lua/languages/japanese.lua
@@ -19,10 +19,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
-IsArabicNumerals(false)
 Language("日本語", "Japanese", "ja", "jp")
 Inherit("english")
 Encoding(utf8)
+IsArabicNumerals(false)
 
 main_menu = {
   new_game = "新しく始める",

--- a/CorsixTH/Lua/languages/japanese.lua
+++ b/CorsixTH/Lua/languages/japanese.lua
@@ -19,6 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
+IsArabicNumerals(false)
 Language("日本語", "Japanese", "ja", "jp")
 Inherit("english")
 Encoding(utf8)

--- a/CorsixTH/Lua/languages/korean.lua
+++ b/CorsixTH/Lua/languages/korean.lua
@@ -19,6 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
+IsArabicNumerals(false)
 Language("한국어", "Korean", "ko", "kor")
 Inherit("English")
 Encoding(utf8)

--- a/CorsixTH/Lua/languages/korean.lua
+++ b/CorsixTH/Lua/languages/korean.lua
@@ -19,10 +19,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
-IsArabicNumerals(false)
 Language("한국어", "Korean", "ko", "kor")
 Inherit("English")
 Encoding(utf8)
+IsArabicNumerals(false)
 
 misc = {
   hospital_open = "병원이 문을 열었습니다",

--- a/CorsixTH/Lua/languages/polish.lua
+++ b/CorsixTH/Lua/languages/polish.lua
@@ -29,10 +29,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
-IsArabicNumerals(true)
 Language("Polski", "Polish", "pl", "pol")
 Inherit("English")
 Encoding(utf8)
+IsArabicNumerals(true)
 
 font_location_window.caption = "Wybierz czcionkę (%1%)"
 

--- a/CorsixTH/Lua/languages/polish.lua
+++ b/CorsixTH/Lua/languages/polish.lua
@@ -29,6 +29,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
+IsArabicNumerals(true)
 Language("Polski", "Polish", "pl", "pol")
 Inherit("English")
 Encoding(utf8)

--- a/CorsixTH/Lua/languages/russian.lua
+++ b/CorsixTH/Lua/languages/russian.lua
@@ -19,10 +19,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
-IsArabicNumerals(true)
 Language("Русский", "Russian", "ru", "rus")
 Inherit("English")
 Encoding(utf8)
+IsArabicNumerals(true)
 
 --[[  Оглавление
   1.  Главное меню

--- a/CorsixTH/Lua/languages/russian.lua
+++ b/CorsixTH/Lua/languages/russian.lua
@@ -19,6 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
+IsArabicNumerals(true)
 Language("Русский", "Russian", "ru", "rus")
 Inherit("English")
 Encoding(utf8)

--- a/CorsixTH/Lua/languages/simplified_chinese.lua
+++ b/CorsixTH/Lua/languages/simplified_chinese.lua
@@ -21,10 +21,10 @@ SOFTWARE. --]]
 -- Note: This file contains UTF-8 text. Make sure your editor is set to UTF-8.
 
 Font("unicode")
-IsArabicNumerals(false)
 Language("简体中文", "Chinese (simplified)", "zh(s)", "chi(s)", "zho(s)")
 Inherit("english")
 Encoding(utf8)
+IsArabicNumerals(false)
 
 -- Search OVERRIDE and NEW STRINGS for workspace
 

--- a/CorsixTH/Lua/languages/simplified_chinese.lua
+++ b/CorsixTH/Lua/languages/simplified_chinese.lua
@@ -21,6 +21,7 @@ SOFTWARE. --]]
 -- Note: This file contains UTF-8 text. Make sure your editor is set to UTF-8.
 
 Font("unicode")
+IsArabicNumerals(false)
 Language("简体中文", "Chinese (simplified)", "zh(s)", "chi(s)", "zho(s)")
 Inherit("english")
 Encoding(utf8)

--- a/CorsixTH/Lua/languages/traditional_chinese.lua
+++ b/CorsixTH/Lua/languages/traditional_chinese.lua
@@ -21,6 +21,7 @@ SOFTWARE. --]]
 -- Note: This file contains UTF-8 text. Make sure your editor is set to UTF-8.
 
 Font("unicode")
+IsArabicNumerals(false)
 Language("繁體中文", "Chinese (traditional)", "zh(t)", "chi(t)", "zho(t)")
 Inherit("english")
 Encoding(utf8)

--- a/CorsixTH/Lua/languages/traditional_chinese.lua
+++ b/CorsixTH/Lua/languages/traditional_chinese.lua
@@ -21,10 +21,10 @@ SOFTWARE. --]]
 -- Note: This file contains UTF-8 text. Make sure your editor is set to UTF-8.
 
 Font("unicode")
-IsArabicNumerals(false)
 Language("繁體中文", "Chinese (traditional)", "zh(t)", "chi(t)", "zho(t)")
 Inherit("english")
 Encoding(utf8)
+IsArabicNumerals(false)
 
 -- Search OVERRIDE and NEW STRINGS for workspace
 

--- a/CorsixTH/Lua/languages/ukrainian.lua
+++ b/CorsixTH/Lua/languages/ukrainian.lua
@@ -19,6 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
+IsArabicNumerals(true)
 Language("Українська", "Ukrainian", "uk", "ukr")
 Inherit("english")
 Encoding(utf8)

--- a/CorsixTH/Lua/languages/ukrainian.lua
+++ b/CorsixTH/Lua/languages/ukrainian.lua
@@ -19,10 +19,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 Font("unicode")
-IsArabicNumerals(true)
 Language("Українська", "Ukrainian", "uk", "ukr")
 Inherit("english")
 Encoding(utf8)
+IsArabicNumerals(true)
 
 main_menu = {
   new_game = "Нова гра",

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -63,7 +63,6 @@ function Strings:init()
   self.language_to_chunk = {}
   self.chunk_to_font = {}
   self.chunk_to_names = {}
-  self.chunk_to_is_arabic_numerals = {}
   self.language_to_lang_code = {}
   self.languages_with_arabic_numerals = {}
   for chunk, filename in pairs(self.language_chunks) do

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -63,6 +63,7 @@ function Strings:init()
   self.language_to_chunk = {}
   self.chunk_to_font = {}
   self.chunk_to_names = {}
+  self.chunk_to_is_arabic_numerals = {}
   self.language_to_lang_code = {}
   for chunk, filename in pairs(self.language_chunks) do
     -- To allow the file to set global variables without causing an error, it
@@ -108,6 +109,9 @@ function Strings:init()
       Inherit = function() end,
       SetSpeechFile = function() end,
       Encoding = function() end,
+      IsArabicNumerals = function(...)
+        self.chunk_to_is_arabic_numerals[chunk] = ...
+      end,
       -- Set LoadStrings to return an infinite table
       LoadStrings = infinite_table_mt.__index,
     }, infinite_table_mt)
@@ -233,6 +237,8 @@ function Strings:load(language, no_restriction, no_inheritance)
     SetSpeechFile = function(...)
       speech_file = ...
     end,
+    IsArabicNumerals = function()
+    end,
     _G = env,
     type = type,
   }
@@ -296,6 +302,11 @@ end
 function Strings:getLangCode(language)
   local lang = language or self.app.config.language
   return self.language_to_lang_code[lang:lower()]
+end
+
+function Strings:isArabicNumerals(language)
+  local chunk = self.language_to_chunk[language:lower()]
+  return chunk and self.chunk_to_is_arabic_numerals[chunk]
 end
 
 --! Use local language text where possible.

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -65,6 +65,7 @@ function Strings:init()
   self.chunk_to_names = {}
   self.chunk_to_is_arabic_numerals = {}
   self.language_to_lang_code = {}
+  self.languages_with_arabic_numerals = {}
   for chunk, filename in pairs(self.language_chunks) do
     -- To allow the file to set global variables without causing an error, it
     -- is given an infinite table as an environment. Reading a non-existent
@@ -109,9 +110,7 @@ function Strings:init()
       Inherit = function() end,
       SetSpeechFile = function() end,
       Encoding = function() end,
-      IsArabicNumerals = function(...)
-        self.chunk_to_is_arabic_numerals[chunk] = ...
-      end,
+      IsArabicNumerals = function() end,
       -- Set LoadStrings to return an infinite table
       LoadStrings = infinite_table_mt.__index,
     }, infinite_table_mt)
@@ -237,7 +236,8 @@ function Strings:load(language, no_restriction, no_inheritance)
     SetSpeechFile = function(...)
       speech_file = ...
     end,
-    IsArabicNumerals = function()
+    IsArabicNumerals = function(is_enabled)
+      self.languages_with_arabic_numerals[language] = is_enabled
     end,
     _G = env,
     type = type,
@@ -305,8 +305,7 @@ function Strings:getLangCode(language)
 end
 
 function Strings:isArabicNumerals(language)
-  local chunk = self.language_to_chunk[language:lower()]
-  return chunk and self.chunk_to_is_arabic_numerals[chunk]
+  return self.languages_with_arabic_numerals[language:lower()]
 end
 
 --! Use local language text where possible.


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2650*

**Describe what the proposed change does**
- This algorithm has been implemented (link to comment):
https://github.com/CorsixTH/CorsixTH/issues/2650#issuecomment-2386443272

Feature is working fine.




~~Problem that is no longer relevant:~~

<details>

<summary>problem details</summary>

But during the work on PR I encountered a problem that I unable to solve gracefully.

I had to place `IsArabicNumerals(true)` in the language files in a specific way for this parameter to work - before `Language()` parameter.

![461cb5581a](https://github.com/user-attachments/assets/9b246e2c-eef1-4585-85d3-42acda22f7ff)

If I place `IsArabicNumerals(true)` under `Language()` then the things works like there is no any `IsArabicNumerals(true)` in language file.

If I move `Language()` lower, so that it is under `IsArabicNumerals(true)`, then all works fine. 

Can anyone explain why this is happening?
Why don't other parameters experience this problem?
How can I make the parameter `IsArabicNumerals(true)` readable anywhere in the file, not just above `Language()`?

Thanks.

</details>


