### PR TITLE
[WIP] Fix #2749: Standardize back button positions in UI windows

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/hotkey_assign.lua
+++ b/CorsixTH/Lua/dialogs/resizables/hotkey_assign.lua
@@ -487,21 +487,23 @@ function UIHotkeyAssign:UIHotkeyAssign(ui, mode)
 
   self:showKeyPane("global")
 
-  -- "Accept" button
+  -- "Cancel" button (rename to "Back" and move to left)
   self:addBevelPanel(self.panel_pos_table_x[1], 430, 200, 40, col_bg)
-      :setLabel(_S.hotkey_window.button_accept)
-      :makeButton(0, 0, 180, 40, nil, self.buttonAccept)
-      :setTooltip(_S.tooltip.hotkey_window.button_accept)
-  -- Reset to defaults button.
+      :setLabel(_S.hotkey_window.button_back)
+      :makeButton(0, 0, 180, 40, nil, self.buttonCancel)
+      :setTooltip(_S.tooltip.hotkey_window.button_back)
+
+  -- Reset to defaults button (keep in middle)
   self:addBevelPanel(self.panel_pos_table_x[2], 430, 200, 40, col_bg)
       :setLabel(_S.hotkey_window.button_defaults)
       :makeButton(0, 0, 180, 40, nil, self.buttonDefaults)
       :setTooltip(_S.tooltip.hotkey_window.button_defaults)
-  -- "Cancel" button
+
+  -- "Accept" button (move to right)
   self:addBevelPanel(self.panel_pos_table_x[3], 430, 200, 40, col_bg)
-      :setLabel(_S.hotkey_window.button_cancel)
-      :makeButton(0, 0, 180, 40, nil, self.buttonCancel)
-      :setTooltip(_S.tooltip.hotkey_window.button_cancel)
+      :setLabel(_S.hotkey_window.button_accept)
+      :makeButton(0, 0, 180, 40, nil, self.buttonAccept)
+      :setTooltip(_S.tooltip.hotkey_window.button_accept)
 
   self.built_in_font = built_in
 end

--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -234,8 +234,13 @@ function UIOptions:UIOptions(ui, mode)
   -- "Back" button
   -- Give some extra space to back button. This is fine as long as it is the last button in the options menu
   local back_button_y_pos = self:_getOptionYPos() + 20
-  self:addBevelPanel(175, back_button_y_pos, BTN_WIDTH * 2, 40, col_bg):setLabel(_S.options_window.back)
-    :makeButton(0, 0, 280, 40, nil, self.buttonBack):setTooltip(_S.tooltip.options_window.back)
+
+  -- Position on left with width of Customize + Folders buttons combined
+  local back_x = 20  -- Same left margin as other left-aligned buttons
+  local back_width = BTN_WIDTH * 2 + 10  -- Width of two buttons plus spacing between them
+
+  self:addBevelPanel(back_x, back_button_y_pos, back_width, 40, col_bg):setLabel(_S.options_window.back)
+    :makeButton(0, 0, back_width, 40, nil, self.buttonBack):setTooltip(_S.tooltip.options_window.back)
 end
 
 -- Stubs for backward compatibility

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -684,6 +684,7 @@ hotkey_window = {
   ingame_recallPosition_8 = "8",
   ingame_recallPosition_9 = "9",
   ingame_recallPosition_0 = "10",
+  back = "Back",
 }
 
 tooltip.hotkey_window = {
@@ -700,6 +701,7 @@ tooltip.hotkey_window = {
   button_recallPosKeys = "Assign hotkeys to save and recall camera positions",
   panel_debugKeys = "Assign hotkeys for debugging",
   button_back_02 = "Go back to the main hotkey window. Hotkeys changed in this window can be accepted there",
+  button_back = "Return to the options screen without saving changes",
 }
 
 font_location_window = {


### PR DESCRIPTION
*Fixes #2749 *

**Describe what the proposed change does**
-Standardizes the position of the back button in the Options (Settings) menu by moving it to the left side and widening it to match the width of other buttons
-Swaps the positions of Accept and Cancel buttons in the Hotkey Assignment dialog, moving Accept to the right and Cancel (renamed to "Back") to the left
-Adds new string keys for the renamed "Back" button

Note: These changes were tested with the demo version of the game, which limited access to some windows. Future work may be needed to apply similar changes to other windows.
