### PR TITLE
Option for CMake to fetch Catch2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@
 #   - WITH_LUAJIT     : Use LuaJIT instead of Lua (must specify library path) (no)
 #   - USE_PRECOMPILED_DEPS : Use precompiled dependencies on *nix (no)
 #   - WITH_LUAROCKS : Install required luarocks in the macOS app (requires luarocks)
+#   - FETCH_CATCH2: Use FetchContent to obtain Catch2 if ENABLE_UNIT_TESTS=yes
 
 # Tests and debug options
 #   - ENABLE_UNIT_TESTS : Enable Unit Testing Target (requires Catch2) (no)

--- a/CorsixTH/CppTest/CMakeLists.txt
+++ b/CorsixTH/CppTest/CMakeLists.txt
@@ -20,7 +20,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-find_package(Catch2 3 CONFIG REQUIRED)
+if(FETCH_CATCH2)
+  include(FetchContent)
+
+  fetchcontent_declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG        v3.8.1
+  )
+
+  fetchcontent_makeavailable(Catch2)
+else()
+  find_package(Catch2 3 CONFIG REQUIRED)
+endif()
 
 add_custom_target(AllTests)
 


### PR DESCRIPTION
Trying to build CorsixTH on Debian 12, Catch2 was one dependency I couldn't satisfy. This option allows CMake to fetch the files it needs for unit tests.
