### PR TITLE
Fix animation refactor regression

### DIFF
--- a/CorsixTH/Src/persist_lua.cpp
+++ b/CorsixTH/Src/persist_lua.cpp
@@ -30,7 +30,6 @@ SOFTWARE.
 #include <cstdlib>
 #include <cstring>
 #include <string>
-#include <vector>
 
 #include "th_lua.h"
 #ifdef _MSC_VER

--- a/CorsixTH/Src/th.h
+++ b/CorsixTH/Src/th.h
@@ -30,7 +30,7 @@ SOFTWARE.
 class link_list {
  public:
   link_list();
-  ~link_list();
+  virtual ~link_list();
 
   link_list* prev;
   link_list* next;

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1284,7 +1284,11 @@ void animation::persist(lua_persist_writer* pWriter) const {
 
   // Write the next chained thing
   lua_rawgeti(L, luaT_environindex, 2);
-  lua_pushlightuserdata(L, next);
+  void* np = dynamic_cast<animation*>(next);
+  if (np == nullptr) {
+    np = dynamic_cast<sprite_render_list*>(next);
+  }
+  lua_pushlightuserdata(L, np);
   lua_rawget(L, -2);
   pWriter->fast_write_stack_object(-1);
   lua_pop(L, 2);
@@ -1355,7 +1359,7 @@ void animation::depersist(lua_persist_reader* pReader) {
     // Read the chain
     if (!pReader->read_stack_object()) break;
 
-    next = luaT_testuserdata<animation_base>(L, -1, false);
+    next = luaT_toanimationbase(L, -1);
     if (next) next->prev = this;
     lua_pop(L, 1);
 
@@ -1789,7 +1793,11 @@ void sprite_render_list::persist(lua_persist_writer* pWriter) const {
 
   // Write the next chained thing
   lua_rawgeti(L, luaT_environindex, 2);
-  lua_pushlightuserdata(L, next);
+  void* np = dynamic_cast<animation*>(next);
+  if (np == nullptr) {
+    np = dynamic_cast<sprite_render_list*>(next);
+  }
+  lua_pushlightuserdata(L, np);
   lua_rawget(L, -2);
   pWriter->fast_write_stack_object(-1);
   lua_pop(L, 2);
@@ -1844,7 +1852,7 @@ void sprite_render_list::depersist(lua_persist_reader* pReader) {
     return;
   }
 
-  next = luaT_testuserdata<animation_base>(L, -1, false);
+  next = luaT_toanimationbase(L, -1);
   if (next) {
     next->prev = this;
   }

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1603,7 +1603,7 @@ void level_map::depersist(lua_persist_reader* pReader) {
     }
 
     if (!pReader->read_stack_object()) return;
-    pNode->entities.next = luaT_testuserdata<animation_base>(L, -1, false);
+    pNode->entities.next = luaT_toanimationbase(L, -1);
     if (pNode->entities.next) {
       if (pNode->entities.next->prev != nullptr) {
         std::fprintf(stderr, "Warning: THMap linked-lists are corrupted.\n");
@@ -1613,8 +1613,7 @@ void level_map::depersist(lua_persist_reader* pReader) {
     lua_pop(L, 1);
 
     if (!pReader->read_stack_object()) return;
-    pNode->oEarlyEntities.next =
-        luaT_testuserdata<animation_base>(L, -1, false);
+    pNode->oEarlyEntities.next = luaT_toanimationbase(L, -1);
     if (pNode->oEarlyEntities.next) {
       if (pNode->oEarlyEntities.next->prev != nullptr) {
         std::fprintf(stderr, "Warning: THMap linked-lists are corrupted.\n");


### PR DESCRIPTION
luaT_testuserdata only works correctly if it is passed the correct
metatable reference, and the implementation we had assumed that was the
current environment table, but in the case of map loading it wasn't.

I wrote a replacement method for determining the class of the
animation_base userdata that depends on the __class_name stored in the
metatable.

There was an additional problem with persistence breaking any new saves:
it was using the void* of link_list rather than the class itself.
link_list was not polymorphic so I added the virtual destructor to fix
that and give it a vtable, then dynamic_cast to ensure the proper
pointer type was persisted.

*Fixes #2826* 