### PR TITLE
[RFC] Set Original Campaign's Outdoor Flags

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 212 -- 'coverup_in_progress' renamed to 'coverup_selected'
+local SAVEGAME_VERSION = 213 -- Fix original campaign maps
 
 class "App"
 

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -270,12 +270,7 @@ function Map:load(level, difficulty, level_name, map_file, level_intro, map_edit
     end
   end
 
-  -- fix original level 6 map
-  if level == 6 and not map_file and not map_editor then
-    self:setCellFlags(56, 71, {hospital = true, buildable = true, buildableNorth = true, buildableSouth = true, buildableEast = true, buildableWest = true})
-    self:setCellFlags(58, 72, {passable = false})
-  end
-
+  self:_fixTiles()
   return objects
 end
 
@@ -342,7 +337,9 @@ function Map:setPlotOwner(plot_number, new_owner)
       end
     end
   end
+  -- Refresh the map's paths and flags
   self.th:updatePathfinding()
+  self:_fixTiles()
 end
 
 --[[! Saves the map to a .map file
@@ -739,6 +736,66 @@ function Map:getParcelTileCount(parcel)
   return self.parcelTileCounts[parcel] or 0
 end
 
+--! Expandable private function to fix tile issues on loading a map.
+--! Each fix should be rendered in a local function.
+function Map:_fixTiles()
+  local function isOriginalCampaign()
+    return type(self.level_number) == "number" and not self.map_file
+  end
+
+ -- Fix the original campaign's outdoor tiles from being marked with bad flags
+  local function fixOutdoorTiles()
+    local function unsetFlags(cell, x, y, allowed_set, flags_to_set)
+      if not allowed_set[cell] then
+        self:setCellFlags(x, y, flags_to_set)
+      end
+    end
+
+    -- Only buildings should be part of the hospital.
+    local hosp_tiles = list_to_set( {
+      17, 70, 18, 19, 23, 16, 21, 22, 66, 76, 20 -- indoor tiles
+    } )
+    local non_hosp_flags = { hospital = false }
+
+    -- Only indoor and certain outdoor tiles should be transverable.
+    local pathable_tiles = list_to_set( {
+      17, 70, 18, 19, 23, 16, 21, 22, 66, 76, 20, -- indoor tiles
+      4, 15, 5, -- concrete paths and helipad
+      41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58 -- road tiles
+    } )
+    -- Also make ineligible outdoor tiles non-buildable, which sometimes got set in
+    -- the original campaign.
+    local non_path_flags = {
+      passable = false, buildable = false, buildableNorth = false,
+      buildableEast = false, buildableSouth = false, buildableWest = false
+    }
+
+    for x=1, self.width do
+      for y=1, self.height do
+        local cell = self.th:getCell(x, y, 1)
+        unsetFlags(cell, x, y, hosp_tiles, non_hosp_flags)
+        unsetFlags(cell, x, y, pathable_tiles, non_path_flags)
+      end
+    end
+  end
+
+  -- Fix the original level 6 map
+  local function fixLevel6Flags()
+    if self.level_number ~= 6 then return end
+    self:setCellFlags(56, 71, {
+      hospital = true, buildable = true,
+      buildableNorth = true, buildableSouth = true,
+      buildableEast = true, buildableWest = true
+    })
+    self:setCellFlags(58, 72, {passable = false})
+  end
+
+  if isOriginalCampaign() then
+    fixOutdoorTiles()
+    fixLevel6Flags()
+  end
+end
+
 function Map:afterLoad(old, new)
   if old < 6 then
     self.parcelTileCounts = {}
@@ -797,12 +854,6 @@ function Map:afterLoad(old, new)
     -- Issue #1105 update pathfinding (rebuild walls) potentially broken by side object placement
     self.th:updatePathfinding()
   end
-  if old < 136 then
-    if self.level_number == 6 then
-      self:setCellFlags(56, 71, {hospital = true, buildable = true, buildableNorth = true, buildableSouth = true, buildableEast = true, buildableWest = true})
-      self:setCellFlags(58, 72, {passable = false})
-    end
-  end
   if old < 161 then
     -- Permanently fix the 0.65 trophy bug (#2004)
     -- make sure we erase the hofix variable too
@@ -850,5 +901,8 @@ function Map:afterLoad(old, new)
   end
   if old < 209 then
     self.level_config.gbv.SodaPrice = 20
+  end
+  if old < 213 then
+    self:_fixTiles()
   end
 end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes most of #1991 (see below)*

**Describe what the proposed change does**
- For the original campaign, every map is checked for bad flags and removed where they shouldn't be (no hospital tiles outside buildings; and no passable tiles outside of regular paths/roads.
- This check runs every time a plot is bought, as flags can be changed depending what tile types were in a parcel
- Verified that valid paths still exist from edge of map to hospital in each level.
- Removes ponds from the town map*
- Fixes a bug in Level 4 where the pond could have objects placed on it 
![image](https://github.com/user-attachments/assets/eedb741d-cb1a-4e10-a8cf-b45cf31997ec)


*Except one instance in Level 4, where the pond is visible until bought, then it disappears. I'm not sure what has made this one an exception but likely because it's defined as purchasable.  On a custom map, the ponds inside a parcel don't show up.