### PR TITLE
Afterload minor fix in earthquake.lua

### DIFF
--- a/CorsixTH/Lua/earthquake.lua
+++ b/CorsixTH/Lua/earthquake.lua
@@ -224,7 +224,7 @@ end
 function Earthquake:afterLoad(old, new) -- luacheck: ignore 212 keep params from parent function
   local old_quake = self.world.next_earthquake
   if old < 115 then
-    if old_quake.active then
+    if old_quake and old_quake.active then
       local rd = 0
       for _, room in pairs(self.world.rooms) do
         for object, _ in pairs(room.objects) do


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes error on load some old saved games. Example save game attached to issue 1249.*

<img width="330" alt="Screenshot 2025-05-01 at 22 28 56" src="https://github.com/user-attachments/assets/1eb811b6-28de-487d-a914-2ae0097f7777" />

**Describe what the proposed change does**
- Made proper check `if old_quake then` before accessing `old_quake.active` in `afterLoad` which was missed.
