### PR TITLE
Kill staff returned to crashed rooms

### DIFF
--- a/CorsixTH/Lua/dialogs/place_staff.lua
+++ b/CorsixTH/Lua/dialogs/place_staff.lua
@@ -57,7 +57,14 @@ function UIPlaceStaff:close()
     self.staff.pickup = false
     self.staff.going_to_staffroom = nil
     self.staff:getCurrentAction().window = nil
-    self.staff:setNextAction(MeanderAction())
+    local room = self.world:getRoom(self.staff.tile_x, self.staff.tile_y)
+    if room and room == self.staff.last_room and room.crashed then
+      self.staff:die()
+      self.staff:despawn()
+      self.world:destroyEntity(self.staff)
+    else
+      self.staff:setNextAction(MeanderAction())
+    end
   elseif self.profile then
     self.ui:tutorialStep(2, {6, 7}, 1)
     self.ui:tutorialStep(4, {4, 5}, 1)

--- a/CorsixTH/Lua/humanoid_actions/pickup.lua
+++ b/CorsixTH/Lua/humanoid_actions/pickup.lua
@@ -47,7 +47,10 @@ local action_pickup_interrupt = permanent"action_pickup_interrupt"( function(act
   end
   humanoid.th:makeVisible()
   local room = humanoid:getRoom()
-  if room then
+  if room and room.crashed then
+    action.ui:setDefaultCursor(nil)
+    return
+  elseif room then
     room:onHumanoidEnter(humanoid)
   else
     humanoid:onPlaceInCorridor()


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2696*

**Describe what the proposed change does**
- If a staff member is picked up from a room that then explodes, they can't be returned to the room by closing the pickup 'window', they instead die.