### PR TITLE
Eliminate world.animation_manager

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 213 -- mood markers for staff & patients
+local SAVEGAME_VERSION = 214 -- Eliminate animation_manager from world.
 
 class "App"
 

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -377,7 +377,7 @@ function PlayerHospital:showGatesToHell(entity)
 
   entity:playEntitySounds("LAVA00*.WAV", {0,1350,1150,950,750,350},
       {0,1450,1250,1050,850,450}, 40)
-  entity:setTimer(entity.world:getAnimLength(2550), anim_func)
+  entity:setTimer(TheApp.animation_manager:getAnimLength(2550), anim_func)
   entity:setAnimation(2550)
 end
 

--- a/CorsixTH/Lua/humanoid_actions/check_watch.lua
+++ b/CorsixTH/Lua/humanoid_actions/check_watch.lua
@@ -43,7 +43,7 @@ local function action_check_watch_start(action, humanoid)
   assert(humanoid.check_watch_anim, "Error: watch checking animation for humanoid " .. humanoid.humanoid_class)
   action.must_happen = true
   humanoid:setAnimation(humanoid.check_watch_anim, humanoid.last_move_direction == "east" and 0 or 1)
-  humanoid:setTimer(humanoid.world:getAnimLength(humanoid.check_watch_anim), action_check_watch_end)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.check_watch_anim), action_check_watch_end)
 end
 
 return action_check_watch_start

--- a/CorsixTH/Lua/humanoid_actions/die.lua
+++ b/CorsixTH/Lua/humanoid_actions/die.lua
@@ -34,7 +34,7 @@ local action_die_tick; action_die_tick = permanent"action_die_tick"( function(hu
   if phase == 0 then
     action.phase = 1
     if humanoid.die_anims.extra_east ~= nil then
-      humanoid:setTimer(humanoid.world:getAnimLength(humanoid.die_anims.extra_east), action_die_tick)
+      humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.die_anims.extra_east), action_die_tick)
       humanoid:setAnimation(humanoid.die_anims.extra_east, mirror)
     else
       action_die_tick(humanoid)
@@ -77,7 +77,7 @@ local action_die_tick_reaper; action_die_tick_reaper = permanent"action_die_tick
     action.phase = 1
 
     if humanoid.die_anims.extra_east ~= nil then
-      humanoid:setTimer(humanoid.world:getAnimLength(humanoid.die_anims.extra_east), action_die_tick_reaper)
+      humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.die_anims.extra_east), action_die_tick_reaper)
       humanoid:setAnimation(humanoid.die_anims.extra_east, mirror)
     else
       action_die_tick_reaper(humanoid)
@@ -212,7 +212,7 @@ local action_die_tick_reaper; action_die_tick_reaper = permanent"action_die_tick
   -- 5: The dead patient will now stand up:
   elseif phase == 5 then
     action.phase = 6
-    humanoid:setTimer(humanoid.world:getAnimLength(humanoid.die_anims.rise_hell_east), action_die_tick_reaper)
+    humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.die_anims.rise_hell_east), action_die_tick_reaper)
     humanoid:setAnimation(humanoid.die_anims.rise_hell_east, mirror)
 
   --6: The dead patient will now walk in to the lava hole, falling in as the grim reaper does his "sending patient to hell" animation:
@@ -223,19 +223,19 @@ local action_die_tick_reaper; action_die_tick_reaper = permanent"action_die_tick
     local loop_callback_swipe =--[[persistable:reaper_swipe]]function()
       grim:setAnimation(1670, grim.mirror)
     end
-    grim:queueAction(IdleAction():setCount(grim.world:getAnimLength(1670)):setLoopCallback(loop_callback_swipe))
+    grim:queueAction(IdleAction():setCount(TheApp.animation_manager:getAnimLength(1670)):setLoopCallback(loop_callback_swipe))
 
     local loop_callback_leave =--[[persistable:reaper_leave]]function()
       grim:setAnimation(1678, grim.mirror)
     end
-    grim:queueAction(IdleAction():setCount(grim.world:getAnimLength(1678)):setLoopCallback(loop_callback_leave))
+    grim:queueAction(IdleAction():setCount(TheApp.animation_manager:getAnimLength(1678)):setLoopCallback(loop_callback_leave))
 
     local lava_destroy = --[[persistable:lava_destroy]]function()
       humanoid.world:destroyEntity(lava_hole)
     end
     local loop_callback_destroy =--[[persistable:reaper_destroy]]function()
       lava_hole.playing_sounds_in_random_sequence = false
-      lava_hole:setTimer(lava_hole.world:getAnimLength(2552), lava_destroy)
+      lava_hole:setTimer(TheApp.animation_manager:getAnimLength(2552), lava_destroy)
       lava_hole:setAnimation(2552)
       grim.world:destroyEntity(grim)
     end
@@ -279,7 +279,7 @@ local function action_die_start(action, humanoid)
 
   action.phase = 0
 
-  local fall_anim_duration = humanoid.world:getAnimLength(fall)
+  local fall_anim_duration = TheApp.animation_manager:getAnimLength(fall)
   if humanoid.humanoid_class == "Chewbacca Patient" then
     --After 21 ticks the first frame of the buggy falling part of this animation is reached
     --so this animation is ended early, action_die_tick will then use the standard male fall animation:

--- a/CorsixTH/Lua/humanoid_actions/falling.lua
+++ b/CorsixTH/Lua/humanoid_actions/falling.lua
@@ -43,7 +43,7 @@ local function action_falling_start(action, humanoid)
   assert(humanoid.falling_anim, "Error: no falling animation for humanoid " .. humanoid.humanoid_class)
 
   humanoid:setAnimation(humanoid.falling_anim, humanoid.last_move_direction == "east" and 0 or 1)
-  humanoid:setTimer(humanoid.world:getAnimLength(humanoid.falling_anim), action_falling_end)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.falling_anim), action_falling_end)
 end
 
 return action_falling_start

--- a/CorsixTH/Lua/humanoid_actions/get_up.lua
+++ b/CorsixTH/Lua/humanoid_actions/get_up.lua
@@ -37,7 +37,7 @@ local function action_get_up_start(action, humanoid)
   assert(humanoid.get_up_anim, "Error: no getting up animation for humanoid " .. humanoid.humanoid_class)
 
   humanoid:setAnimation(humanoid.get_up_anim, humanoid.last_move_direction == "east" and 0 or 1)
-  humanoid:setTimer(humanoid.world:getAnimLength(humanoid.get_up_anim), action_get_up_end)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.get_up_anim), action_get_up_end)
 end
 
 return action_get_up_start

--- a/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/idle_spawn.lua
@@ -48,7 +48,8 @@ local function action_idle_spawn_start(action, humanoid)
       humanoid:setAnimation(action.spawn_animation)
     end
 
-    humanoid:queueAction(IdleAction():setCount(humanoid.world:getAnimLength(action.spawn_animation))
+    humanoid:queueAction(IdleAction()
+        :setCount(TheApp.animation_manager:getAnimLength(action.spawn_animation))
         :setLoopCallback(loop_callback_spawn))
 
   elseif action.spawn_sound then

--- a/CorsixTH/Lua/humanoid_actions/knock_door.lua
+++ b/CorsixTH/Lua/humanoid_actions/knock_door.lua
@@ -70,7 +70,7 @@ function KnockDoorAction:update()
     end
     self.humanoid:setAnimation(anim, flag_mirror)
     self.humanoid:setTilePositionSpeed(self.humanoid.tile_x, self.humanoid.tile_y)
-    self.humanoid:setTimer(self.humanoid.world:getAnimLength(anim), action_knock_door_tick)
+    self.humanoid:setTimer(TheApp.animation_manager:getAnimLength(anim), action_knock_door_tick)
     self.humanoid.user_of = door
     door:setUser(self.humanoid)
     door.th:makeVisible()

--- a/CorsixTH/Lua/humanoid_actions/multi_use_object.lua
+++ b/CorsixTH/Lua/humanoid_actions/multi_use_object.lua
@@ -184,7 +184,7 @@ local function action_multi_use_phase(action, humanoid, phase)
   humanoid:setTilePositionSpeed(tx, ty, offset[1], offset[2])
 
   humanoid.user_of = object
-  local length = humanoid.world:getAnimLength(anim)
+  local length = TheApp.animation_manager:getAnimLength(anim)
   local secondary_anim = action.anims.secondary and action.anims.secondary[anim_name]
   if action.secondary_anim then
     secondary_anim = action.secondary_anim
@@ -211,7 +211,7 @@ local function action_multi_use_phase(action, humanoid, phase)
       use_with:setAnimation(secondary_anim, action.mirror_flags)
     end
     use_with.th:makeVisible()
-    local secondary_length = use_with.world:getAnimLength(secondary_anim)
+    local secondary_length = TheApp.animation_manager:getAnimLength(secondary_anim)
     if secondary_length > length then
       length = secondary_length
     end

--- a/CorsixTH/Lua/humanoid_actions/on_ground.lua
+++ b/CorsixTH/Lua/humanoid_actions/on_ground.lua
@@ -37,7 +37,7 @@ local function action_on_ground_start(action, humanoid)
   assert(humanoid.on_ground_anim, "Error: no on the ground animation for humanoid " .. humanoid.humanoid_class)
 
   humanoid:setAnimation(humanoid.on_ground_anim, humanoid.last_move_direction == "east" and 0 or 1)
-  humanoid:setTimer(humanoid.world:getAnimLength(humanoid.on_ground_anim), action_on_ground_end)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.on_ground_anim), action_on_ground_end)
 end
 
 return action_on_ground_start

--- a/CorsixTH/Lua/humanoid_actions/pee.lua
+++ b/CorsixTH/Lua/humanoid_actions/pee.lua
@@ -45,7 +45,7 @@ local function action_pee_start(action, humanoid)
   assert(humanoid.pee_anim, "Error: no pee animation for humanoid " .. humanoid.humanoid_class)
   action.must_happen = true
   humanoid:setAnimation(humanoid.pee_anim, humanoid.last_move_direction == "east" and 0 or 1)
-  humanoid:setTimer(humanoid.world:getAnimLength(humanoid.pee_anim), action_pee_end)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.pee_anim), action_pee_end)
 end
 
 return action_pee_start

--- a/CorsixTH/Lua/humanoid_actions/shake_fist.lua
+++ b/CorsixTH/Lua/humanoid_actions/shake_fist.lua
@@ -43,7 +43,7 @@ local function action_shake_fist_start(action, humanoid)
   assert(humanoid.shake_fist_anim, "Error: no shaking fist animation for humanoid " .. humanoid.humanoid_class)
   action.must_happen = true
   humanoid:setAnimation(humanoid.shake_fist_anim, humanoid.last_move_direction == "east" and 0 or 1)
-  humanoid:setTimer(humanoid.world:getAnimLength(humanoid.shake_fist_anim), action_shake_fist_end)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.shake_fist_anim), action_shake_fist_end)
 end
 
 return action_shake_fist_start

--- a/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
+++ b/CorsixTH/Lua/humanoid_actions/sweep_floor.lua
@@ -45,13 +45,13 @@ local remove_litter = permanent"action_sweep_floor_remove_litter"( function(huma
   humanoid.user_of:remove()
   humanoid.user_of:setTile(nil)
   humanoid.user_of = nil
-  humanoid:setTimer(humanoid.world:getAnimLength(animation_numbers[2]) * 2, finish)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(animation_numbers[2]) * 2, finish)
 end)
 
 local sweep = permanent"action_sweep_floor_sweep"( function(humanoid)
   local anim = animation_numbers[2]
   humanoid:setAnimation(anim)
-  humanoid:setTimer(humanoid.world:getAnimLength(anim) * 2, remove_litter)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(anim) * 2, remove_litter)
 end)
 
 local function action_sweep_floor_start(action, humanoid)
@@ -64,7 +64,7 @@ local function action_sweep_floor_start(action, humanoid)
   hospital:removeHandymanTask(taskIndex, "cleaning")
   local anim = animation_numbers[1]
   humanoid:setAnimation(anim)
-  humanoid:setTimer(humanoid.world:getAnimLength(anim), sweep)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(anim), sweep)
 end
 
 return action_sweep_floor_start

--- a/CorsixTH/Lua/humanoid_actions/tap_foot.lua
+++ b/CorsixTH/Lua/humanoid_actions/tap_foot.lua
@@ -42,7 +42,7 @@ local function action_tap_foot_start(action, humanoid)
   assert(humanoid.tap_foot_anim, "Error: foot tapping animation for humanoid " .. humanoid.humanoid_class)
   action.must_happen = true
   humanoid:setAnimation(humanoid.tap_foot_anim, humanoid.last_move_direction == "east" and 0 or 1)
-  humanoid:setTimer(humanoid.world:getAnimLength(humanoid.tap_foot_anim), action_tap_foot_end)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.tap_foot_anim), action_tap_foot_end)
 end
 
 return action_tap_foot_start

--- a/CorsixTH/Lua/humanoid_actions/use_object.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_object.lua
@@ -285,7 +285,7 @@ local function action_use_phase(action, humanoid, phase)
   setHumanoidTileSpeed(action, humanoid)
   humanoid.user_of = object
 
-  local frame_count = humanoid.world:getAnimLength(anim)
+  local frame_count = TheApp.animation_manager:getAnimLength(anim)
   local action_anim_count = 1 -- Number of times to show 'in_use' animation for the action.
   if action.min_length and phase == 0 then
     -- 'action.min_length' is a frame count, convert to number of complete animations.

--- a/CorsixTH/Lua/humanoid_actions/use_screen.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_screen.lua
@@ -209,7 +209,7 @@ local function action_use_screen_start(action, humanoid)
   humanoid:setPosition(offset[1], offset[2])
   humanoid.mood_info = mood_info
   humanoid:setSpeed(0, 0)
-  humanoid:setTimer(humanoid.world:getAnimLength(anim), when_done)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(anim), when_done)
 
   screen:setUser(humanoid)
   humanoid.user_of = screen

--- a/CorsixTH/Lua/humanoid_actions/vomit.lua
+++ b/CorsixTH/Lua/humanoid_actions/vomit.lua
@@ -45,7 +45,7 @@ local function action_vomit_start(action, humanoid)
   assert(humanoid.vomit_anim, "Error: no vomit animation for humanoid " .. humanoid.humanoid_class)
   action.must_happen = true
   humanoid:setAnimation(humanoid.vomit_anim, humanoid.last_move_direction == "east" and 0 or 1)
-  humanoid:setTimer(humanoid.world:getAnimLength(humanoid.vomit_anim), action_vomit_end)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.vomit_anim), action_vomit_end)
 end
 
 return action_vomit_start

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -351,25 +351,25 @@ navigateDoor = function(humanoid, x1, y1, dir)
   local duration, direction
   if dir == "north" then
     humanoid:setAnimation(leaving, flag_list_bottom)
-    duration = humanoid.world:getAnimLength(leaving)
+    duration = TheApp.animation_manager:getAnimLength(leaving)
     to_x, to_y = dx, dy - 1
     direction = "in"
 
   elseif dir == "west" then
     humanoid:setAnimation(leaving, flag_list_bottom + flag_flip_h)
-    duration = humanoid.world:getAnimLength(leaving)
+    duration = TheApp.animation_manager:getAnimLength(leaving)
     to_x, to_y = dx - 1, dy
     direction = "in"
 
   elseif dir == "east" then
     humanoid:setAnimation(entering, flag_list_bottom)
-    duration = humanoid.world:getAnimLength(entering)
+    duration = TheApp.animation_manager:getAnimLength(entering)
     to_x, to_y = dx, dy
     direction = "out"
 
   elseif dir == "south" then
     humanoid:setAnimation(entering, flag_list_bottom + flag_flip_h)
-    duration = humanoid.world:getAnimLength(entering)
+    duration = TheApp.animation_manager:getAnimLength(entering)
     to_x, to_y = dx, dy
     direction = "out"
   end

--- a/CorsixTH/Lua/humanoid_actions/yawn.lua
+++ b/CorsixTH/Lua/humanoid_actions/yawn.lua
@@ -37,7 +37,7 @@ local function action_yawn_start(action, humanoid)
   assert(humanoid.yawn_anim, "Error: yawning animation for humanoid " .. humanoid.humanoid_class)
   action.must_happen = true
   humanoid:setAnimation(humanoid.yawn_anim, humanoid.last_move_direction == "east" and 0 or 1)
-  humanoid:setTimer(humanoid.world:getAnimLength(humanoid.yawn_anim), action_yawn_end)
+  humanoid:setTimer(TheApp.animation_manager:getAnimLength(humanoid.yawn_anim), action_yawn_end)
 end
 
 return action_yawn_start

--- a/CorsixTH/Lua/objects/doors/swing_door_right.lua
+++ b/CorsixTH/Lua/objects/doors/swing_door_right.lua
@@ -165,7 +165,7 @@ function SwingDoor:swing(anim, flags)
       self:getRoom():tryAdvanceQueue()
     end
   end
-  self:setTimer(self.world:getAnimLength(anim), callback)
+  self:setTimer(TheApp.animation_manager:getAnimLength(anim), callback)
 end
 
 function SwingDoor:getWalkableTiles()

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -57,7 +57,6 @@ function World:World(app, free_build_mode)
   self.wall_types = app.walls
   self.object_types = app.objects
   self.anims = app.anims
-  self.animation_manager = app.animation_manager
   self.pathfinder = TH.pathfinder()
   self.pathfinder:setMap(app.map.th)
   self.entities = {} -- List of entities in the world.
@@ -594,10 +593,6 @@ function World:setPlotOwner(parcel, owner)
     end
   end
   self.map.th:updateShadows()
-end
-
-function World:getAnimLength(anim)
-  return self.animation_manager:getAnimLength(anim)
 end
 
 -- Register a function to be called whenever a room has been deactivated (crashed or edited).
@@ -2555,6 +2550,9 @@ function World:afterLoad(old, new)
       self.tick_rate = tick_rates["Pause"][2]
       self:setSpeed("Normal")
     end
+  end
+  if old < 214 then
+    self.animation_manager = nil -- Use TheApp.animation_manager instead.
   end
 
   -- Fix the initial of staff names


### PR DESCRIPTION
World supplies the length of an animation for some reason while the better way to do that is through `TheApp.animation_manager`.

- It goes there eventually anyway.
- World is about world and not about animations.
- No other uses of `world.animation_manager` exist.