### PR TITLE
Extend animview

### DIFF
--- a/AnimView/frmMain.cpp
+++ b/AnimView/frmMain.cpp
@@ -736,44 +736,42 @@ void frmMain::updateMoodPosition(int centerX, int centerY) {
 }
 
 /**
-   Match the 'text' against the pattern in 'p'. The pattern should have 2 numbers.
-   @param p: Pattern to match. ' ' means optional white space, 'I' means a possibly
-       negative integer, 'R' means a possibly negative real or integer, all other
-       character match with themselves.
+   Match the 'text' against the pattern in 'p'. The pattern should have 2
+   numbers.
+   @param p: Pattern to match. ' ' means optional white space, 'I' means a
+   possibly negative integer, 'R' means a possibly negative real or integer, all
+   other character match with themselves.
    @param text: Text to completely match.
    @param num1: The text of the first number if successful.
    @param num2: The text of the second number if successful.
    @return: Whether the match was successful.
 */
-static bool matchText(const char *p, const std::string& text, std::string& num1,
-               std::string& num2) {
+static bool matchText(const char* p, const std::string& text, std::string& num1,
+                      std::string& num2) {
   bool filled_num1 = false;
   bool filled_num2 = false;
 
-  const char * const c_start = text.c_str(); // Pointer to the first input.
-  const char *c = c_start; // Pointer to the current input character.
+  const char* const c_start = text.c_str();  // Pointer to the first input.
+  const char* c = c_start;  // Pointer to the current input character.
   while (*p) {
     // Dispatch on the current pattern character.
     switch (*p) {
-      case ' ': // Optional spaces.
-        while (*c == ' ')
-          c++;
+      case ' ':  // Optional spaces.
+        while (*c == ' ') c++;
         break;
 
-      case 'R': // Possibly negative real number without exponent.
-      case 'I': { // Possibly negative integer number.
+      case 'R':    // Possibly negative real number without exponent.
+      case 'I': {  // Possibly negative integer number.
         bool seen_digit = false;
         int num_start = c - c_start;
 
-        if (*c == '-')
-          c++;
+        if (*c == '-') c++;
         while (*c >= '0' && *c <= '9') {
           c++;
           seen_digit = true;
         }
         if (*c == '.') {
-          if (*p != 'R')
-            return false;
+          if (*p != 'R') return false;
           c++;
         }
         while (*c >= '0' && *c <= '9') {
@@ -794,9 +792,8 @@ static bool matchText(const char *p, const std::string& text, std::string& num1,
         break;
       }
 
-      default: // Input should match the pattern character exactly.
-        if (*p != *c)
-          return false;
+      default:  // Input should match the pattern character exactly.
+        if (*p != *c) return false;
         c++;
         break;
     }

--- a/AnimView/frmMain.cpp
+++ b/AnimView/frmMain.cpp
@@ -306,7 +306,7 @@ frmMain::frmMain()
       new wxTextCtrl(this, ID_MOOD_POS, L"{0.0, 0.0}", wxDefaultPosition,
                      wxDefaultSize, wxTE_CENTRE);
   pMoodAdjustRow->Add(m_txtMoodFramePos, wxSizerFlags(1).Expand());
-  pMoodAdjustRow->Add(new wxButton(this, ID_MOOD_FRAME, L"This frame"),
+  pMoodAdjustRow->Add(new wxButton(this, ID_MOOD_FRAME, L"Set marker"),
                       moodAdjustFlags);
   pMoodAdjustRow->Add(new wxButton(this, ID_MOOD_LEFT, L"<", wxDefaultPosition,
                                    wxDefaultSize, wxBU_EXACTFIT),

--- a/AnimView/frmMain.cpp
+++ b/AnimView/frmMain.cpp
@@ -726,6 +726,9 @@ void frmMain::updateMoodPosition(int centerX, int centerY) {
   }
   m_txtMoodPosition[1]->SetValue(
       wxString::Format(L"{%i, %i, \"px\"}", m_iMoodDrawX, m_iMoodDrawY));
+  printf("%ld, {%i, %i, \"px\"}, -- Anim %ld\n", m_iCurrentFrame,
+      m_iMoodDrawX, m_iMoodDrawY, m_iCurrentAnim);
+
   if (m_bDrawMood) m_panFrame->Refresh(false);
 }
 

--- a/AnimView/frmMain.cpp
+++ b/AnimView/frmMain.cpp
@@ -39,6 +39,7 @@ SOFTWARE.
 #include <wx/stattext.h>
 #include <wx/tokenzr.h>
 #include <wx/wfstream.h>
+
 #include <regex>
 
 #include "backdrop.h"
@@ -303,20 +304,24 @@ frmMain::frmMain()
 
   layerSizerFlags.Align(wxALIGN_CENTER).Border(wxALL, 1);
   wxBoxSizer* pMoodAdjustRow = new wxBoxSizer(wxHORIZONTAL);
-  m_txtMoodFramePos = new wxTextCtrl(this, ID_MOOD_POS, L"{0.0, 0.0}",
-                                     wxDefaultPosition, wxDefaultSize,
-                                     wxTE_CENTRE);
+  m_txtMoodFramePos =
+      new wxTextCtrl(this, ID_MOOD_POS, L"{0.0, 0.0}", wxDefaultPosition,
+                     wxDefaultSize, wxTE_CENTRE);
   pMoodAdjustRow->Add(m_txtMoodFramePos, wxSizerFlags(1).Expand());
   pMoodAdjustRow->Add(new wxButton(this, ID_MOOD_FRAME, L"This frame"),
                       moodAdjustFlags);
   pMoodAdjustRow->Add(new wxButton(this, ID_MOOD_LEFT, L"<", wxDefaultPosition,
-                      wxDefaultSize, wxBU_EXACTFIT), moodAdjustFlags);
+                                   wxDefaultSize, wxBU_EXACTFIT),
+                      moodAdjustFlags);
   pMoodAdjustRow->Add(new wxButton(this, ID_MOOD_RIGHT, L">", wxDefaultPosition,
-                      wxDefaultSize, wxBU_EXACTFIT), moodAdjustFlags);
+                                   wxDefaultSize, wxBU_EXACTFIT),
+                      moodAdjustFlags);
   pMoodAdjustRow->Add(new wxButton(this, ID_MOOD_UP, L"^", wxDefaultPosition,
-                      wxDefaultSize, wxBU_EXACTFIT), moodAdjustFlags);
+                                   wxDefaultSize, wxBU_EXACTFIT),
+                      moodAdjustFlags);
   pMoodAdjustRow->Add(new wxButton(this, ID_MOOD_DOWN, L"v", wxDefaultPosition,
-                      wxDefaultSize, wxBU_EXACTFIT), moodAdjustFlags);
+                                   wxDefaultSize, wxBU_EXACTFIT),
+                      moodAdjustFlags);
   pMoodOverlay->Add(pMoodAdjustRow, wxSizerFlags(1).Expand().Border(wxALL, 2));
 
   pMoodOverlay->Add(
@@ -726,27 +731,27 @@ void frmMain::updateMoodPosition(int centerX, int centerY) {
   }
   m_txtMoodPosition[1]->SetValue(
       wxString::Format(L"{%i, %i, \"px\"}", m_iMoodDrawX, m_iMoodDrawY));
-  printf("%ld, {%i, %i, \"px\"}, -- Anim %ld\n", m_iCurrentFrame,
-      m_iMoodDrawX, m_iMoodDrawY, m_iCurrentAnim);
+  printf("%ld, {%i, %i, \"px\"}, -- Anim %ld\n", m_iCurrentFrame, m_iMoodDrawX,
+         m_iMoodDrawY, m_iCurrentAnim);
 
   if (m_bDrawMood) m_panFrame->Refresh(false);
 }
 
-void frmMain::_onMoodFrameApply(wxCommandEvent &evt) {
+void frmMain::_onMoodFrameApply(wxCommandEvent& evt) {
   wxString wxText = m_txtMoodFramePos->GetLineText(0);
   std::string text = wxText.ToStdString();
 
-  std::regex tilePosRegex("\\{ *([-0-9]+[.][0-9]*) *, *([-0-9]+[.][0-9]*) *\\}");
+  std::regex tilePosRegex(
+      "\\{ *([-0-9]+[.][0-9]*) *, *([-0-9]+[.][0-9]*) *\\}");
   std::regex pixelPosRegex("\\{ *([-0-9]+) *, *([-0-9]+) *, *[\"]px[\"] *\\}");
 
   std::smatch m;
   if (std::regex_match(text, m, tilePosRegex)) {
     double x, y;
     try {
-        x = std::stod(m[1].str());
-        y = std::stod(m[2].str());
-    }
-    catch (...) {
+      x = std::stod(m[1].str());
+      y = std::stod(m[2].str());
+    } catch (...) {
       return;
     }
 
@@ -762,10 +767,9 @@ void frmMain::_onMoodFrameApply(wxCommandEvent &evt) {
   if (std::regex_match(text, m, pixelPosRegex)) {
     int x, y;
     try {
-        x = std::stoi(m[1].str());
-        y = std::stoi(m[2].str());
-    }
-    catch (...) {
+      x = std::stoi(m[1].str());
+      y = std::stoi(m[2].str());
+    } catch (...) {
       return;
     }
 
@@ -773,19 +777,19 @@ void frmMain::_onMoodFrameApply(wxCommandEvent &evt) {
   }
 }
 
-void frmMain::_onMoodLeft(wxCommandEvent &evt) {
+void frmMain::_onMoodLeft(wxCommandEvent& evt) {
   updateMoodPosition(m_iMoodDrawX - 1, m_iMoodDrawY);
 }
 
-void frmMain::_onMoodRight(wxCommandEvent &evt) {
+void frmMain::_onMoodRight(wxCommandEvent& evt) {
   updateMoodPosition(m_iMoodDrawX + 1, m_iMoodDrawY);
 }
 
-void frmMain::_onMoodUp(wxCommandEvent &evt) {
+void frmMain::_onMoodUp(wxCommandEvent& evt) {
   updateMoodPosition(m_iMoodDrawX, m_iMoodDrawY - 1);
 }
 
-void frmMain::_onMoodDown(wxCommandEvent &evt) {
+void frmMain::_onMoodDown(wxCommandEvent& evt) {
   updateMoodPosition(m_iMoodDrawX, m_iMoodDrawY + 1);
 }
 

--- a/AnimView/frmMain.h
+++ b/AnimView/frmMain.h
@@ -148,7 +148,7 @@ class frmMain : public wxFrame {
   wxPanel* m_panFrame;
   DECLARE_EVENT_TABLE()
 
-private:
+ private:
   /**
       Update the mood position of the current frame to the given coordinate.
       @param centerX X coordinate of the center.

--- a/AnimView/frmMain.h
+++ b/AnimView/frmMain.h
@@ -67,6 +67,12 @@ class frmMain : public wxFrame {
     ID_EXPORT,
     ID_DRAW_MOOD,
     ID_DRAW_COORDINATES,
+    ID_MOOD_POS,
+    ID_MOOD_FRAME,
+    ID_MOOD_LEFT,
+    ID_MOOD_RIGHT,
+    ID_MOOD_UP,
+    ID_MOOD_DOWN,
     ID_LAYER_CHECKS,  // Must be last ID
   };
 
@@ -101,6 +107,11 @@ class frmMain : public wxFrame {
   void _onPanelPaint(wxPaintEvent& evt);
   void _onPanelClick(wxMouseEvent& evt);
   void _onTimer(wxTimerEvent& evt);
+  void _onMoodFrameApply(wxCommandEvent& evt);
+  void _onMoodLeft(wxCommandEvent& evt);
+  void _onMoodRight(wxCommandEvent& evt);
+  void _onMoodUp(wxCommandEvent& evt);
+  void _onMoodDown(wxCommandEvent& evt);
 
   void _onAnimChange(size_t iIndex);
 
@@ -131,10 +142,19 @@ class frmMain : public wxFrame {
   wxTextCtrl* m_txtFrameCount;
   wxTextCtrl* m_txtFrameFlags[2];
   wxTextCtrl* m_txtMoodPosition[2];
+  wxTextCtrl* m_txtMoodFramePos;
   wxCheckBox* m_chkFrameFlags[16];
   wxListBox* m_lstSearchResults;
   wxPanel* m_panFrame;
   DECLARE_EVENT_TABLE()
+
+private:
+  /**
+      Update the mood position of the current frame to the given coordinate.
+      @param centerX X coordinate of the center.
+      @param centerY Y coordinate of the center.
+   */
+  void updateMoodPosition(int centerX, int centerY);
 };
 
 #endif


### PR DESCRIPTION
Adds the bottom row:

![Screenshot from 2025-05-05 16-14-05](https://github.com/user-attachments/assets/2743b393-629d-4d4a-9a1c-2a983b63e9fd)

- You can enter a mood position, and press "This frame" to set the position.
Both pixel and tile positions work, except the latter may be less accurate.
- You can click the arrow buttons to move the mood 1 pixel in the indicated position.

Each time you set a mood, a text line is printed to `stdout` of the form `frame, {x, y, "px"},` and a comment what animation it is from.
```
2, {5, 20, "px"}, -- Anim 0
3, {15, 20, "px"}, -- Anim 0
```