### PR TITLE
Fix markers in toilets

### DIFF
--- a/CorsixTH/Lua/objects/loo.lua
+++ b/CorsixTH/Lua/objects/loo.lua
@@ -61,7 +61,7 @@ object.usage_animations = copy_north_to_south {
       ["Chewbacca Patient"         ] = 4162,
       ["Elvis Patient"             ] =  954,
       ["Alien Male Patient"        ] = 1716,
-      ["Alien Female Patient"      ] = 3132,
+      ["Alien Female Patient"      ] = 3136,
     },
     in_use = {
       ["Standard Male Patient"     ] = {1728, 1732},

--- a/CorsixTH/Lua/objects/sink.lua
+++ b/CorsixTH/Lua/objects/sink.lua
@@ -50,9 +50,9 @@ object.usage_animations = copy_north_to_south {
 }
 local anim_mgr = TheApp.animation_manager
 local kf1, kf2 = {0, 0}, {0, -0.7}
-anim_mgr:setStaffMarker({1776, 3160}, 0, kf1, 4, kf2)
-anim_mgr:setStaffMarker({1780, 3164}, kf2)
-anim_mgr:setStaffMarker({1784, 3168}, 0, kf2, 34, kf2, 39, kf1)
+anim_mgr:setPatientMarker(object.usage_animations.north.begin_use, 0, kf1, 4, kf2)
+anim_mgr:setPatientMarker(object.usage_animations.north.in_use, kf2)
+anim_mgr:setPatientMarker(object.usage_animations.north.finish_use, 0, kf2, 34, kf2, 39, kf1)
 
 object.orientations = {
   north = {


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Addresses #2794*

**Describe what the proposed change does**
- Fixes female `begin_use` animation markers, as the `begin_use_2` animation for female aliens was incorrectly set
- Fixes sink markers, as they accidentally were told to use staff markers
