### PR TITLE
Include what you use

### DIFF
--- a/AnimView/app.cpp
+++ b/AnimView/app.cpp
@@ -22,8 +22,6 @@ SOFTWARE.
 
 #include "app.h"
 
-#include "config.h"
-
 #include "frmMain.h"
 #include "frmSprites.h"
 

--- a/AnimView/app.h
+++ b/AnimView/app.h
@@ -23,7 +23,6 @@ SOFTWARE.
 #ifndef ANIMVIEW_APP_H_
 #define ANIMVIEW_APP_H_
 
-#include "config.h"
 // For compilers that support precompilation, includes "wx/wx.h".
 #include "wx/wxprec.h"
 

--- a/AnimView/config.h.in
+++ b/AnimView/config.h.in
@@ -24,8 +24,8 @@ SOFTWARE.
 #define CORSIX_AV_CONFIG_H_
 
 /** Standard includes **/
-#include <cstddef>
-#include <cstdint>
+#include <cstddef> // IWYU pragma: export
+#include <cstdint> // IWYU pragma: export
 
 // We bring in the most common stddef and stdint types to avoid typing
 using std::size_t;

--- a/AnimView/frmMain.cpp
+++ b/AnimView/frmMain.cpp
@@ -24,21 +24,36 @@ SOFTWARE.
 
 #include "config.h"
 
+#include <wx/anybutton.h>
 #include <wx/bitmap.h>
+#include <wx/button.h>
+#include <wx/chartype.h>
+#include <wx/checkbox.h>
 #include <wx/dcclient.h>
 #include <wx/dcmemory.h>
 #include <wx/defs.h>
 #include <wx/dir.h>
 #include <wx/dirdlg.h>
 #include <wx/filename.h>
+#include <wx/gdicmn.h>
 #include <wx/image.h>
+#include <wx/listbox.h>
 #include <wx/msgdlg.h>
 #include <wx/numdlg.h>
+#include <wx/object.h>
+#include <wx/panel.h>
 #include <wx/radiobut.h>
 #include <wx/sizer.h>
+#include <wx/spinbutt.h>
+#include <wx/spinctrl.h>
 #include <wx/stattext.h>
+#include <wx/stringimpl.h>
+#include <wx/textctrl.h>
 #include <wx/tokenzr.h>
-#include <wx/wfstream.h>
+#include <wx/unichar.h>
+#include <wx/utils.h>
+
+#include <cstring>
 
 #include "backdrop.h"
 

--- a/AnimView/frmMain.h
+++ b/AnimView/frmMain.h
@@ -25,19 +25,22 @@ SOFTWARE.
 
 #include "config.h"
 
-#include <wx/button.h>
-#include <wx/checkbox.h>
-#include <wx/dcclient.h>
+#include <wx/defs.h>
+#include <wx/event.h>
 #include <wx/frame.h>
-#include <wx/listbox.h>
-#include <wx/panel.h>
-#include <wx/spinctrl.h>
-#include <wx/textctrl.h>
+#include <wx/image.h>
+#include <wx/string.h>
 #include <wx/timer.h>
-#include <wx/txtstrm.h>
 
 #include "th.h"
-//#include <vector>
+
+class wxButton;
+class wxCheckBox;
+class wxListBox;
+class wxPaintDC;
+class wxPanel;
+class wxSpinEvent;
+class wxTextCtrl;
 
 class frmMain : public wxFrame {
  public:

--- a/AnimView/frmSprites.cpp
+++ b/AnimView/frmSprites.cpp
@@ -24,13 +24,19 @@ SOFTWARE.
 
 #include "config.h"
 
+#include <wx/button.h>
+#include <wx/chartype.h>
 #include <wx/dcclient.h>
-#include <wx/dirdlg.h>
 #include <wx/filedlg.h>
+#include <wx/filefn.h>
+#include <wx/gdicmn.h>
+#include <wx/image.h>
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
-#include <wx/vscroll.h>
+#include <wx/textctrl.h>
+#include <wx/unichar.h>
+#include <wx/utils.h>
 
 BEGIN_EVENT_TABLE(frmSprites, wxFrame)
   EVT_BUTTON(ID_LOAD, frmSprites::_onLoad)

--- a/AnimView/frmSprites.h
+++ b/AnimView/frmSprites.h
@@ -26,18 +26,19 @@ SOFTWARE.
 #include "config.h"
 
 #include <wx/bitmap.h>
-#include <wx/button.h>
-#include <wx/checkbox.h>
+#include <wx/defs.h>
+#include <wx/event.h>
 #include <wx/frame.h>
-#include <wx/listbox.h>
-#include <wx/panel.h>
-#include <wx/textctrl.h>
-#include <wx/timer.h>
+#include <wx/string.h>
+#include <wx/types.h>
 #include <wx/vscroll.h>
 
 #include <vector>
 
 #include "th.h"
+
+class wxTextCtrl;
+class wxWindow;
 
 static const int ROW_COUNT = 1000;
 

--- a/AnimView/th.cpp
+++ b/AnimView/th.cpp
@@ -24,9 +24,8 @@ SOFTWARE.
 
 #include "config.h"
 
-#include <wx/app.h>
-#include <wx/filename.h>
-#include <wx/toplevel.h>
+#include <wx/gdicmn.h>
+#include <wx/image.h>
 
 #include <algorithm>
 #include <array>

--- a/AnimView/th.h
+++ b/AnimView/th.h
@@ -39,14 +39,15 @@ SOFTWARE.
 
 #include "config.h"
 
-#include <stdint.h>
 #include <wx/file.h>
-#include <wx/image.h>
 #include <wx/string.h>
-#include <wx/txtstrm.h>
 
 #include <array>
+#include <cstring>
 #include <vector>
+
+class wxImage;
+class wxSize;
 
 #pragma pack(push)
 #pragma pack(1)

--- a/CorsixTH/CppTest/test_th_lua.cpp
+++ b/CorsixTH/CppTest/test_th_lua.cpp
@@ -1,3 +1,4 @@
+#include "../Src/lua.hpp"
 #include "../Src/th_lua.h"
 #include <catch2/catch_test_macros.hpp>
 

--- a/CorsixTH/CppTest/test_th_strings.cpp
+++ b/CorsixTH/CppTest/test_th_strings.cpp
@@ -1,7 +1,8 @@
-#include <cstring>
+#include <string>
 
 #include "../Src/th_strings.h"
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
 TEST_CASE("skip whitespace", "[skip_utf8_whitespace]") {

--- a/CorsixTH/Src/config.h.in
+++ b/CorsixTH/Src/config.h.in
@@ -79,8 +79,8 @@ SOFTWARE.
 #endif
 
 /** Standard includes **/
-#include <cstddef>
-#include <cstdint>
+#include <cstddef> // IWYU pragma: export
+#include <cstdint> // IWYU pragma: export
 
 // We bring in the most common stddef and stdint types to avoid typing
 // clang-format off

--- a/CorsixTH/Src/cp437_table.h
+++ b/CorsixTH/Src/cp437_table.h
@@ -1,6 +1,8 @@
 #ifndef CORSIX_TH_CP437_TO_UNICODE_TABLE_H
 #define CORSIX_TH_CP437_TO_UNICODE_TABLE_H
 
+#include "config.h"
+
 #include <array>
 
 // clang-format off

--- a/CorsixTH/Src/cp936_table.h
+++ b/CorsixTH/Src/cp936_table.h
@@ -1,6 +1,8 @@
 #ifndef CORSIX_TH_CP936_TO_UNICODE_TABLE_H
 #define CORSIX_TH_CP936_TO_UNICODE_TABLE_H
 
+#include "config.h"
+
 #include <array>
 // Generated from the following document:
 // http://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP936.TXT

--- a/CorsixTH/Src/iso_fs.cpp
+++ b/CorsixTH/Src/iso_fs.cpp
@@ -23,14 +23,14 @@ SOFTWARE.
 #include "iso_fs.h"
 
 #include <algorithm>
-#include <array>
 #include <cstdarg>
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <iterator>
 #include <memory>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include "th.h"

--- a/CorsixTH/Src/iso_fs.h
+++ b/CorsixTH/Src/iso_fs.h
@@ -27,8 +27,7 @@ SOFTWARE.
 
 #include <cstdio>
 #include <string>
-
-#include "th_lua.h"
+#include <vector>
 
 //! Layer for reading Theme Hospital files out of an .iso disk image
 /*!

--- a/CorsixTH/Src/lua.hpp
+++ b/CorsixTH/Src/lua.hpp
@@ -24,9 +24,12 @@ SOFTWARE.
 #define CORSIX_TH_LUA_HPP_
 
 extern "C" {
-#include <lauxlib.h>
+// IWYU pragma: begin_exports
 #include <lua.h>
+#include <luaconf.h>
 #include <lualib.h>
+#include <lauxlib.h>
+// IWYU pragma: end_exports
 }
 
 #if LUA_VERSION_NUM >= 502

--- a/CorsixTH/Src/lua_rnc.cpp
+++ b/CorsixTH/Src/lua_rnc.cpp
@@ -1,5 +1,7 @@
 #include "lua_rnc.h"
 
+#include "config.h"
+
 #include <array>
 
 #include "rnc.h"

--- a/CorsixTH/Src/lua_rnc.h
+++ b/CorsixTH/Src/lua_rnc.h
@@ -1,7 +1,7 @@
 #ifndef CORSIX_TH_LUA_RNC
 #define CORSIX_TH_LUA_RNC
 
-#include "th_lua.h"
+#include "lua.hpp"
 
 int luaopen_rnc(lua_State* L);
 

--- a/CorsixTH/Src/main.cpp
+++ b/CorsixTH/Src/main.cpp
@@ -22,13 +22,12 @@ SOFTWARE.
 
 #include "config.h"
 
-#include <array>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <string>
 
-#include "iso_fs.h"
 #include "lua.hpp"
 #include "lua_rnc.h"
 #include "lua_sdl.h"

--- a/CorsixTH/Src/persist_lua.cpp
+++ b/CorsixTH/Src/persist_lua.cpp
@@ -22,15 +22,19 @@ SOFTWARE.
 
 #include "persist_lua.h"
 
+#include "config.h"
+
 #include <errno.h>
 
 #include <array>
+#include <climits>
 #include <cmath>
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
+#include <new>
 #include <string>
 
+#include "lua.hpp"
 #include "th_lua.h"
 #ifdef _MSC_VER
 #pragma warning( \

--- a/CorsixTH/Src/persist_lua.h
+++ b/CorsixTH/Src/persist_lua.h
@@ -24,10 +24,10 @@ SOFTWARE.
 #define CORSIX_TH_PERSIST_LUA_H_
 #include "config.h"
 
-#include <cstdlib>
+#include <type_traits>
 #include <vector>
 
-#include "th_lua.h"
+#include "lua.hpp"
 
 template <class T>
 struct lua_persist_int {};

--- a/CorsixTH/Src/random.c
+++ b/CorsixTH/Src/random.c
@@ -43,6 +43,7 @@
 
 #include <lauxlib.h>
 #include <lua.h>
+#include <stddef.h>
 #ifdef _MSC_VER
 typedef unsigned __int16 uint16_t;
 typedef unsigned __int32 uint32_t;

--- a/CorsixTH/Src/sdl_audio.cpp
+++ b/CorsixTH/Src/sdl_audio.cpp
@@ -22,13 +22,18 @@ SOFTWARE.
 
 #include "config.h"
 
+#include "lua.hpp"
 #include "lua_sdl.h"
 #include "th_lua.h"
 #ifdef CORSIX_TH_USE_SDL_MIXER
+#include <SDL_events.h>
 #include <SDL_mixer.h>
+#include <SDL_rwops.h>
+#include <SDL_thread.h>
 
 #include <array>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 
 #include "xmi2mid.h"

--- a/CorsixTH/Src/sdl_core.cpp
+++ b/CorsixTH/Src/sdl_core.cpp
@@ -20,12 +20,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include "config.h"
+#include <SDL.h>
 
 #include <array>
 #include <cstdio>
 #include <cstring>
 
+#include "lua.hpp"
 #include "lua_sdl.h"
 #include "th_lua.h"
 

--- a/CorsixTH/Src/sdl_wm.cpp
+++ b/CorsixTH/Src/sdl_wm.cpp
@@ -20,9 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include "config.h"
-
-#include "lua_sdl.h"
+#include "lua.hpp"
 #include "th_lua.h"
 #ifdef CORSIX_TH_USE_WIN32_SDK
 #include <SDL_syswm.h>
@@ -30,6 +28,8 @@ SOFTWARE.
 
 #include "../resource.h"
 #endif
+#include <SDL_mouse.h>
+
 #include <array>
 
 namespace {

--- a/CorsixTH/Src/th.cpp
+++ b/CorsixTH/Src/th.cpp
@@ -24,8 +24,11 @@ SOFTWARE.
 
 #include "config.h"
 
-#include <cstring>
+#include <array>
 #include <stdexcept>
+
+#include "cp437_table.h"
+#include "cp936_table.h"
 
 link_list::link_list() {
   prev = nullptr;
@@ -44,9 +47,6 @@ void link_list::remove_from_list() {
   }
   prev = nullptr;
 }
-
-#include "cp437_table.h"
-#include "cp936_table.h"
 
 namespace {
 

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -27,10 +27,14 @@ SOFTWARE.
 #include <algorithm>
 #include <cassert>
 #include <climits>
+#include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <new>
 
 #include "persist_lua.h"
+#include "th_gfx_sdl.h"
+#include "th_lua.h"
 #include "th_map.h"
 #include "th_sound.h"
 

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -23,19 +23,26 @@ SOFTWARE.
 #ifndef CORSIX_TH_TH_GFX_H_
 #define CORSIX_TH_TH_GFX_H_
 
+#include "config.h"
+
 #include <cstdio>
 #include <cstring>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "lua.hpp"
 #include "th.h"
 #include "th_gfx_common.h"
-#include "th_gfx_sdl.h"
-#include "th_lua.h"
 
 class lua_persist_reader;
 class lua_persist_writer;
+class memory_reader;
+class render_target;
+class sprite_sheet;
+struct clip_rect;
+struct map_tile;
 
 enum class scaled_items { none, sprite_sheets, bitmaps, all };
 
@@ -209,8 +216,6 @@ const int max_number_of_layers = 13;
 struct layers {
   uint8_t layer_contents[max_number_of_layers];
 };
-
-class memory_reader;
 
 /** Key value for finding an animation. */
 struct animation_key {
@@ -525,7 +530,6 @@ class animation_manager {
   void fix_next_frame(uint32_t iFirst, size_t iLength);
 };
 
-struct map_tile;
 class animation_base : public drawable {
  public:
   animation_base();

--- a/CorsixTH/Src/th_gfx_font.cpp
+++ b/CorsixTH/Src/th_gfx_font.cpp
@@ -26,14 +26,18 @@ SOFTWARE.
 
 #include "th_strings.h"
 #ifdef CORSIX_TH_USE_FREETYPE2
+#include <ft2build.h>  // IWYU pragma: keep
+#include FT_FREETYPE_H
+#include FT_ERRORS_H
 #include FT_GLYPH_H
+#include FT_IMAGE_H
+#include FT_TYPES_H
 #include <map>
 #include <vector>
 #endif
 #include <algorithm>
-#include <cstdio>
 #include <cstring>
-#include <stdexcept>
+#include <utility>
 
 bitmap_font::bitmap_font() {
   sheet = nullptr;

--- a/CorsixTH/Src/th_gfx_font.h
+++ b/CorsixTH/Src/th_gfx_font.h
@@ -22,15 +22,19 @@ SOFTWARE.
 
 #ifndef CORSIX_TH_TH_GFX_FONT_H_
 #define CORSIX_TH_TH_GFX_FONT_H_
-#include "th_gfx.h"
+#include "config.h"
+
+#include <SDL_render.h>
+
+#include <climits>
+
+#include "th_gfx_sdl.h"
 #ifdef CORSIX_TH_USE_FREETYPE2
-#include <ft2build.h>
+#include <ft2build.h>  // IWYU pragma: keep
 #include FT_FREETYPE_H
+#include FT_IMAGE_H
+#include FT_TYPES_H
 #endif
-
-class render_target;
-
-class sprite_sheet;
 
 enum class text_alignment {
   left = 0,

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -26,19 +26,23 @@ SOFTWARE.
 #ifdef CORSIX_TH_USE_FREETYPE2
 #include "th_gfx_font.h"
 #endif
+#include <SDL.h>
 
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <limits>
 #include <memory>
 #include <new>
+#include <stack>
 #include <stdexcept>
+#include <vector>
 
-#include "th_map.h"
+#include "persist_lua.h"
+#include "th_gfx_common.h"
+#include "th_gfx_sdl.h"
 
 #if SDL_VERSION_ATLEAST(2, 0, 10)
 

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -32,11 +32,12 @@ SOFTWARE.
 #include <stdexcept>
 #include <vector>
 
-#include "persist_lua.h"
-#include "th.h"
 #include "th_gfx_common.h"
 
 class cursor;
+class line_sequence;
+class lua_persist_reader;
+class lua_persist_writer;
 
 struct clip_rect : public SDL_Rect {
   typedef Sint16 x_y_type;

--- a/CorsixTH/Src/th_lua.cpp
+++ b/CorsixTH/Src/th_lua.cpp
@@ -32,7 +32,9 @@ SOFTWARE.
 #endif
 
 #include "bootstrap.h"
+#include "lua.hpp"
 #include "th.h"
+#include "th_lua.h"
 #include "th_lua_internal.h"
 
 const char* update_check_url =
@@ -237,7 +239,7 @@ int l_load_strings(lua_State* L) {
 }
 
 int get_api_version() {
-#include "../Lua/api_version.lua"
+#include "../Lua/api_version.lua"  // IWYU pragma: keep
 }
 
 int l_get_compile_options(lua_State* L) {

--- a/CorsixTH/Src/th_lua.h
+++ b/CorsixTH/Src/th_lua.h
@@ -25,9 +25,7 @@ SOFTWARE.
 #include "config.h"
 
 #include <cassert>
-#include <cstdio>
 #include <new>
-#include <vector>
 
 #include "lua.hpp"
 

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -20,9 +20,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include "config.h"
+
+#include <new>
+#include <string>
+
+#include "lua.hpp"
+#include "persist_lua.h"
+#include "th.h"
 #include "th_gfx.h"
+#include "th_lua.h"
 #include "th_lua_internal.h"
 #include "th_map.h"
+
+class render_target;
+class sprite_sheet;
+enum class animation_effect;
 
 namespace {
 

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -20,14 +20,27 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include <SDL.h>
+#include "config.h"
 
+#include <SDL_stdinc.h>
+
+#include <climits>
 #include <cstring>
-#include <exception>
+#include <new>
 
+#include "lua.hpp"
+#include "persist_lua.h"
 #include "th_gfx.h"
 #include "th_gfx_font.h"
+#include "th_gfx_sdl.h"
+#include "th_lua.h"
 #include "th_lua_internal.h"
+
+#ifdef CORSIX_TH_USE_FREETYPE2
+#include <ft2build.h>  // IWYU pragma: keep
+#include FT_ERRORS_H
+#include FT_TYPES_H
+#endif
 
 namespace {
 

--- a/CorsixTH/Src/th_lua_iso.cpp
+++ b/CorsixTH/Src/th_lua_iso.cpp
@@ -20,9 +20,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include <cstdio>
+#include "config.h"
 
 #include "iso_fs.h"
+#include "lua.hpp"
+#include "th_lua.h"
 #include "th_lua_internal.h"
 
 namespace {

--- a/CorsixTH/Src/th_lua_lfs_ext.cpp
+++ b/CorsixTH/Src/th_lua_lfs_ext.cpp
@@ -21,8 +21,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include "config.h"
-
+#include "lua.hpp"
+#include "th_lua.h"
 #include "th_lua_internal.h"
 #ifdef CORSIX_TH_USE_WIN32_SDK
 #include <windows.h>

--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -20,13 +20,27 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include <cstring>
-#include <exception>
-#include <string>
+#include "config.h"
 
+#include <cstring>
+#include <list>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "lua.hpp"
+#include "th_gfx.h"
+#include "th_lua.h"
 #include "th_lua_internal.h"
 #include "th_map.h"
 #include "th_pathfind.h"
+
+class lua_persist_reader;
+class lua_persist_writer;
+class render_target;
+class sprite_sheet;
 
 namespace {
 

--- a/CorsixTH/Src/th_lua_movie.cpp
+++ b/CorsixTH/Src/th_lua_movie.cpp
@@ -20,7 +20,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include "th_gfx.h"
+#include <SDL_rect.h>
+
+#include "lua.hpp"
+#include "th_gfx_sdl.h"
+#include "th_lua.h"
 #include "th_lua_internal.h"
 #include "th_movie.h"
 

--- a/CorsixTH/Src/th_lua_sound.cpp
+++ b/CorsixTH/Src/th_lua_sound.cpp
@@ -20,11 +20,20 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include "config.h"
+
+#include <SDL_events.h>
+#include <SDL_rwops.h>
+#include <SDL_stdinc.h>
+#include <SDL_timer.h>
+
 #include <array>
 #include <cctype>
-#include <cstring>
+#include <cstdio>
 #include <map>
+#include <utility>
 
+#include "lua.hpp"
 #include "lua_sdl.h"
 #include "th_lua.h"
 #include "th_lua_internal.h"

--- a/CorsixTH/Src/th_lua_strings.cpp
+++ b/CorsixTH/Src/th_lua_strings.cpp
@@ -20,10 +20,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include "config.h"
+
 #include <cstring>
 #include <vector>
 
+#include "lua.hpp"
 #include "persist_lua.h"
+#include "th_lua.h"
 #include "th_lua_internal.h"
 
 /*

--- a/CorsixTH/Src/th_lua_ui.cpp
+++ b/CorsixTH/Src/th_lua_ui.cpp
@@ -20,9 +20,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include <algorithm>
+#include "config.h"
 
-#include "th_gfx.h"
+#include <algorithm>
+#include <list>
+
+#include "lua.hpp"
+#include "th_gfx_sdl.h"
+#include "th_lua.h"
 #include "th_lua_internal.h"
 #include "th_map.h"
 

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -24,19 +24,20 @@ SOFTWARE.
 
 #include "config.h"
 
-#include <SDL.h>
-
-#include <algorithm>
 #include <cstdio>
 #include <cstring>
-#include <exception>
 #include <fstream>
 #include <new>
+#include <stdexcept>
 #include <string>
 
+#include "lua.hpp"
+#include "persist_lua.h"
 #include "run_length_encoder.h"
 #include "th.h"
 #include "th_gfx.h"
+#include "th_gfx_sdl.h"
+#include "th_lua.h"
 #include "th_map_overlays.h"
 
 constexpr int max_player_count = 4;

--- a/CorsixTH/Src/th_map.h
+++ b/CorsixTH/Src/th_map.h
@@ -22,10 +22,21 @@ SOFTWARE.
 
 #ifndef CORSIX_TH_TH_MAP_H_
 #define CORSIX_TH_TH_MAP_H_
+#include "config.h"
+
 #include <list>
 #include <string>
+#include <utility>
+#include <vector>
 
-#include "th_gfx.h"
+#include "th.h"
+
+class lua_persist_reader;
+class lua_persist_writer;
+class map_overlay;
+class render_target;
+class sprite_sheet;
+struct drawable;
 
 /*
     Object type enumeration uses same values as original TH does.
@@ -212,8 +223,6 @@ struct map_tile {
   std::list<object_type> objects;
 };
 
-class sprite_sheet;
-
 //! Prototype for object callbacks from THMap::loadFromTHFile
 /*!
     The callback function will receive 5 arguments:
@@ -225,8 +234,6 @@ class sprite_sheet;
 */
 typedef void (*map_load_object_callback_fn)(void*, int, int, object_type,
                                             uint8_t);
-
-class map_overlay;
 
 class level_map {
  public:

--- a/CorsixTH/Src/th_map_overlays.cpp
+++ b/CorsixTH/Src/th_map_overlays.cpp
@@ -23,10 +23,11 @@ SOFTWARE.
 #include "th_map_overlays.h"
 
 #include <array>
+#include <list>
 #include <sstream>
 
-#include "th_gfx.h"
 #include "th_gfx_font.h"
+#include "th_gfx_sdl.h"
 #include "th_map.h"
 
 map_overlay_pair::map_overlay_pair() {

--- a/CorsixTH/Src/th_movie.cpp
+++ b/CorsixTH/Src/th_movie.cpp
@@ -27,21 +27,31 @@ SOFTWARE.
 #include "lua_sdl.h"
 #if defined(CORSIX_TH_USE_FFMPEG) && defined(CORSIX_TH_USE_SDL_MIXER)
 
-#include "th_gfx.h"
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavutil/avutil.h>
 #include <libavutil/channel_layout.h>
+#include <libavutil/error.h>
 #include <libavutil/imgutils.h>
-#include <libavutil/mathematics.h>
-#include <libavutil/opt.h>
+#include <libavutil/rational.h>
+#include <libavutil/samplefmt.h>
+#include <libswresample/version.h>
 #include <libswscale/swscale.h>
 }
+#include <SDL_error.h>
+#include <SDL_events.h>
 #include <SDL_mixer.h>
+#include <SDL_pixels.h>
+#include <SDL_rect.h>
+#include <SDL_render.h>
+#include <SDL_timer.h>
 
+#include <cerrno>
 #include <chrono>
 #include <cstring>
 #include <iostream>
+#include <stdexcept>
+#include <utility>
 
 namespace {
 

--- a/CorsixTH/Src/th_movie.h
+++ b/CorsixTH/Src/th_movie.h
@@ -25,11 +25,13 @@ SOFTWARE.
 
 #include "config.h"
 
-#include <SDL.h>
+#include <SDL_rect.h>
+#include <SDL_render.h>
 
 #include <array>
 #include <atomic>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -45,10 +47,11 @@ extern "C" {
 #endif
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
-#include <libavutil/avutil.h>
+#include <libavutil/avutil.h>  // IWYU pragma: keep
 #include <libswresample/swresample.h>
-#include <libswscale/swscale.h>
 }
+
+struct SwsContext;
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 0, 100)
 using av_codec_ptr = AVCodec*;

--- a/CorsixTH/Src/th_pathfind.cpp
+++ b/CorsixTH/Src/th_pathfind.cpp
@@ -26,12 +26,15 @@ SOFTWARE.
 
 #include <cmath>
 #include <cstdlib>
-#include <queue>
+#include <initializer_list>
+#include <list>
+#include <new>
 #include <stdexcept>
 #include <vector>
 
 #include "lua.hpp"
 #include "persist_lua.h"
+#include "th_map.h"
 
 abstract_pathfinder::abstract_pathfinder(pathfinder* pf) : parent(pf) {}
 

--- a/CorsixTH/Src/th_pathfind.h
+++ b/CorsixTH/Src/th_pathfind.h
@@ -22,11 +22,20 @@ SOFTWARE.
 
 #ifndef CORSIX_TH_TH_PATHFIND_H_
 #define CORSIX_TH_TH_PATHFIND_H_
-#include "th_map.h"
 
+#include "config.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "lua.hpp"
+
+class level_map;
 class lua_persist_reader;
 class lua_persist_writer;
 class pathfinder;
+enum class object_type : uint8_t;
+struct map_tile_flags;
 
 /** Directions of movement. */
 enum class travel_direction {

--- a/CorsixTH/Src/th_sound.cpp
+++ b/CorsixTH/Src/th_sound.cpp
@@ -24,11 +24,16 @@ SOFTWARE.
 
 #include "config.h"
 
+#include <SDL_rwops.h>
+
 #include <cmath>
 #include <cstring>
 #include <new>
 
 #include "th.h"
+#ifdef CORSIX_TH_USE_SDL_MIXER
+#include <SDL_mixer.h>
+#endif
 
 sound_archive::sound_archive() {
   sound_files = nullptr;

--- a/CorsixTH/Src/th_sound.h
+++ b/CorsixTH/Src/th_sound.h
@@ -24,7 +24,7 @@ SOFTWARE.
 #define CORSIX_TH_TH_SOUND_H_
 #include "config.h"
 
-#include <SDL.h>
+#include <SDL_rwops.h>
 #ifdef CORSIX_TH_USE_SDL_MIXER
 #include <SDL_mixer.h>
 #endif

--- a/CorsixTH/Src/xmi2mid.cpp
+++ b/CorsixTH/Src/xmi2mid.cpp
@@ -24,7 +24,6 @@ SOFTWARE.
 #ifdef CORSIX_TH_USE_SDL_MIXER
 #include <algorithm>
 #include <cstring>
-#include <iterator>
 #include <new>
 #include <vector>
 

--- a/CorsixTH/SrcUnshared/main.cpp
+++ b/CorsixTH/SrcUnshared/main.cpp
@@ -27,9 +27,9 @@ SOFTWARE.
 #include <SDL.h>
 
 #include <cstdio>
-#include <stack>
 
 #include "../Src/bootstrap.h"
+#include "../Src/lua.hpp"
 #ifdef CORSIX_TH_USE_SDL_MIXER
 #include <SDL_mixer.h>
 #endif

--- a/libs/rnc/rnc.cpp
+++ b/libs/rnc/rnc.cpp
@@ -38,7 +38,6 @@ SOFTWARE.
 
 #include <cstddef>
 #include <cstdint>
-#include <vector>
 
 static const std::uint32_t rnc_signature = 0x524E4301; /*!< "RNC\001" */
 

--- a/tools/rnc/rnc_decode_cli.cpp
+++ b/tools/rnc/rnc_decode_cli.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
Applied IWYU recommendations (mostly).

I deviated on libraries, it always wanted me to include the inner headers for SDL, ffmpeg, etc. but the definitions were normally expected to be exported by a top level header. wxWidgets was particularly problematic since it wanted me to use the gtk specific includes instead of the generic ones.

I do not intend to add include-what-you-use to the CI/CD pipelines at this time but some pragmas were added to the code to make it report somewhat cleaner.

See: https://github.com/include-what-you-use/include-what-you-use

I am happy it sorted out some of the weird header dependencies around gfx that required including files in a specific order.
