### PR TITLE
clang-tidy fixes

### DIFF
--- a/CorsixTH/Src/config.h.in
+++ b/CorsixTH/Src/config.h.in
@@ -79,8 +79,8 @@ SOFTWARE.
 #endif
 
 /** Standard includes **/
-#include <cstddef> // IWYU pragma: export
-#include <cstdint> // IWYU pragma: export
+#include <cstddef>  // IWYU pragma: export
+#include <cstdint>  // IWYU pragma: export
 
 // We bring in the most common stddef and stdint types to avoid typing
 // clang-format off

--- a/CorsixTH/Src/iso_fs.h
+++ b/CorsixTH/Src/iso_fs.h
@@ -84,7 +84,7 @@ class iso_filesystem {
                              void* pCallbackData) const;
 
   //! Test if a file handle from find_file() is good or is invalid
-  static inline bool is_handle_good(file_handle x) { return x != 0; }
+  static bool is_handle_good(file_handle x) { return x != 0; }
 
   //! Get the byte offset of the start of the file in the loaded .iso
   /*!
@@ -116,7 +116,7 @@ class iso_filesystem {
   std::FILE* raw_file;
   char* error;
   std::vector<file_metadata> files;
-  long sector_size;
+  long sector_size{};
   char path_seperator;
 
   //! Free any memory in use
@@ -141,7 +141,7 @@ class iso_filesystem {
         contains a Theme Hospital data file. 2 if the given array is the
         top-level Theme Hospital data directory. Other values otherwise.
   */
-  int find_hosp_directory(const uint8_t* pDirEnt, const uint32_t dirEntsSize,
+  int find_hosp_directory(const uint8_t* pDirEnt, uint32_t dirEntsSize,
                           int level);
 
   //! Build the list of Theme Hospital data files
@@ -151,7 +151,7 @@ class iso_filesystem {
       \param dirEntsSize The number of bytes in the directory entry array.
       \param prefix The path name to prepend to filenames in the directory.
   */
-  void build_file_lookup_table(uint32_t iSector, const uint32_t dirEntsSize,
+  void build_file_lookup_table(uint32_t iSector, uint32_t dirEntsSize,
                                const std::string& prefix);
 
   //! std:less like implementation for file_metadata. Based on the path.

--- a/CorsixTH/Src/lua.hpp
+++ b/CorsixTH/Src/lua.hpp
@@ -25,10 +25,10 @@ SOFTWARE.
 
 extern "C" {
 // IWYU pragma: begin_exports
+#include <lauxlib.h>
 #include <lua.h>
 #include <luaconf.h>
 #include <lualib.h>
-#include <lauxlib.h>
 // IWYU pragma: end_exports
 }
 

--- a/CorsixTH/Src/main.cpp
+++ b/CorsixTH/Src/main.cpp
@@ -54,20 +54,17 @@ int luaopen_lpeg(lua_State* L);
 
 namespace {
 
-inline void preload_lua_package(lua_State* L, const char* name,
-                                lua_CFunction fn) {
+void preload_lua_package(lua_State* L, const char* name, lua_CFunction fn) {
   luaT_execute(
       L, std::string("package.preload.").append(name).append(" = ...").c_str(),
       fn);
 }
 
 // relace me with C++17 std::filesystem::exists
-inline bool file_exists(const char* f) {
+bool file_exists(const char* f) {
   std::ifstream file(f);
   return file.is_open();
 }
-
-inline bool file_exists(const std::string& f) { return file_exists(f.c_str()); }
 
 std::string search_script_file(lua_State* L) {
   // 1. Check for --interpreter

--- a/CorsixTH/Src/persist_lua.h
+++ b/CorsixTH/Src/persist_lua.h
@@ -66,7 +66,7 @@ class lua_persist_writer {
     int iNumBytes;
     for (iNumBytes = 1; tTemp >= (T)0x80; tTemp /= (T)0x80) ++iNumBytes;
     if (iNumBytes == 1) {
-      uint8_t iByte = (uint8_t)tValue;
+      uint8_t iByte = static_cast<uint8_t>(tValue);
       write_byte_stream(&iByte, 1);
     } else {
       std::vector<uint8_t> bytes(iNumBytes);
@@ -83,10 +83,11 @@ class lua_persist_writer {
   void write_int(T tValue) {
     typename lua_persist_int<T>::T tValueToWrite;
     if (tValue >= 0) {
-      tValueToWrite = (typename lua_persist_int<T>::T)tValue;
+      tValueToWrite = static_cast<typename lua_persist_int<T>::T>(tValue);
       tValueToWrite <<= 1;
     } else {
-      tValueToWrite = (typename lua_persist_int<T>::T)(-(tValue + 1));
+      tValueToWrite =
+          static_cast<typename lua_persist_int<T>::T>(-(tValue + 1));
       tValueToWrite <<= 1;
       tValueToWrite |= 1;
     }

--- a/CorsixTH/Src/random.c
+++ b/CorsixTH/Src/random.c
@@ -143,7 +143,7 @@ static int l_random(lua_State* L) {
       lua_pushinteger(L, 1 + (lua_Integer)(genrand_int32() % max));
       break;
     case 0:
-      lua_pushnumber(L, (lua_Number)genrand_res53());
+      lua_pushnumber(L, genrand_res53());
       break;
   }
   return 1;

--- a/CorsixTH/Src/run_length_encoder.cpp
+++ b/CorsixTH/Src/run_length_encoder.cpp
@@ -27,11 +27,7 @@ SOFTWARE.
 
 #include "persist_lua.h"
 
-integer_run_length_encoder::integer_run_length_encoder() {
-  buffer = nullptr;
-  output = nullptr;
-  clean();
-}
+integer_run_length_encoder::integer_run_length_encoder() = default;
 
 integer_run_length_encoder::~integer_run_length_encoder() { clean(); }
 

--- a/CorsixTH/Src/run_length_encoder.h
+++ b/CorsixTH/Src/run_length_encoder.h
@@ -80,27 +80,27 @@ class integer_run_length_encoder {
   bool move_object_to_output(size_t iObjSize, size_t iObjCount);
 
   //! A circular fixed-size buffer holding the most recent input
-  uint32_t* buffer;
+  uint32_t* buffer{};
   //! A variable-length array holding the output sequence
-  uint32_t* output;
+  uint32_t* output{};
   //! The number of integers in a record
-  size_t record_size;
+  size_t record_size{};
   //! The maximum number of integers stored in the buffer
-  size_t buffer_capacity;
+  size_t buffer_capacity{};
   //! The current number of integers stored in the buffer
-  size_t buffer_size;
+  size_t buffer_size{};
   //! The index into buffer of the 1st integer
-  size_t buffer_offset;
+  size_t buffer_offset{};
   //! The maximum number of integers storable in the output (before the
   //! output array has to be resized).
-  size_t output_capacity;
+  size_t output_capacity{};
   //! The current number of integers stored in the output
-  size_t output_size;
+  size_t output_size{};
   //! The number of integers in the current object (multiple of record size)
-  size_t object_size;
+  size_t object_size{};
   //! The number of copies of the current object already seen and removed
   //! from the buffer.
-  size_t object_copies;
+  size_t object_copies{};
 };
 
 class integer_run_length_decoder {

--- a/CorsixTH/Src/sdl_audio.cpp
+++ b/CorsixTH/Src/sdl_audio.cpp
@@ -99,7 +99,7 @@ struct load_music_async_data {
 };
 
 int load_music_async_thread(void* arg) {
-  load_music_async_data* async = (load_music_async_data*)arg;
+  load_music_async_data* async = static_cast<load_music_async_data*>(arg);
 
   async->music = Mix_LoadMUS_RW(async->rwop, 1);
   async->rwop = nullptr;
@@ -227,18 +227,18 @@ int l_transcode_xmi(lua_State* L) {
     lua_pushliteral(L, "Unable to transcode XMI to MIDI");
     return 2;
   }
-  lua_pushlstring(L, (const char*)pMidData, iMidLength);
+  lua_pushlstring(L, reinterpret_cast<const char*>(pMidData), iMidLength);
   delete[] pMidData;
 
   return 1;
 }
 
-constexpr std::array<struct luaL_Reg, 3> sdl_audiolib{
+constexpr std::array<luaL_Reg, 3> sdl_audiolib{
     {{"init", l_init},
      {"transcodeXmiToMid", l_transcode_xmi},
      {nullptr, nullptr}}};
 
-constexpr std::array<struct luaL_Reg, 8> sdl_musiclib{
+constexpr std::array<luaL_Reg, 8> sdl_musiclib{
     {{"loadMusic", l_load_music},
      {"loadMusicAsync", l_load_music_async},
      {"playMusic", l_play_music},
@@ -251,7 +251,8 @@ constexpr std::array<struct luaL_Reg, 8> sdl_musiclib{
 }  // namespace
 
 int l_load_music_async_callback(lua_State* L) {
-  load_music_async_data* async = (load_music_async_data*)lua_touserdata(L, 1);
+  load_music_async_data* async =
+      static_cast<load_music_async_data*>(lua_touserdata(L, 1));
 
   // Frees resources allocated to the thread
   SDL_WaitThread(async->thread, nullptr);
@@ -281,7 +282,7 @@ int l_load_music_async_callback(lua_State* L) {
     }
   } else {
     lua_rawgeti(L, 2, 2);
-    music* pLMusic = (music*)lua_touserdata(L, -1);
+    music* pLMusic = static_cast<music*>(lua_touserdata(L, -1));
     pLMusic->pMusic = async->music;
     async->music = nullptr;
   }

--- a/CorsixTH/Src/sdl_core.cpp
+++ b/CorsixTH/Src/sdl_core.cpp
@@ -136,7 +136,8 @@ int l_mainloop(lua_State* L) {
   lua_State* dispatcher = lua_tothread(L, 1);
   int resume_stack_size = 0;
 
-  fps_ctrl* fps_control = (fps_ctrl*)lua_touserdata(L, luaT_upvalueindex(1));
+  fps_ctrl* fps_control =
+      static_cast<fps_ctrl*>(lua_touserdata(L, luaT_upvalueindex(1)));
   SDL_TimerID timer =
       SDL_AddTimer(usertick_period_ms, timer_frame_callback, nullptr);
   SDL_Event e;
@@ -239,8 +240,7 @@ int l_mainloop(lua_State* L) {
           nargs = 1;
           break;
         case SDL_USEREVENT_MUSIC_LOADED:
-          if (luaT_cpcall(L, (lua_CFunction)l_load_music_async_callback,
-                          e.user.data1)) {
+          if (luaT_cpcall(L, l_load_music_async_callback, e.user.data1)) {
             SDL_RemoveTimer(timer);
             lua_pushliteral(L, "callback");
             return 2;

--- a/CorsixTH/Src/th.cpp
+++ b/CorsixTH/Src/th.cpp
@@ -174,13 +174,13 @@ th_string_list::th_string_list(const uint8_t* data, size_t length) {
   *sDataOut = 0;
 }
 
-size_t th_string_list::get_section_count() { return sections.size(); }
+size_t th_string_list::get_section_count() const { return sections.size(); }
 
-size_t th_string_list::get_section_size(size_t section) {
+size_t th_string_list::get_section_size(size_t section) const {
   return section < sections.size() ? sections[section].size() : 0;
 }
 
-const char* th_string_list::get_string(size_t section, size_t index) {
+const char* th_string_list::get_string(size_t section, size_t index) const {
   if (index < get_section_size(section)) {
     return sections[section][index];
   }

--- a/CorsixTH/Src/th.h
+++ b/CorsixTH/Src/th.h
@@ -63,10 +63,10 @@ class th_string_list {
   ~th_string_list() = default;
 
   //! Get the number of sections in the string list
-  size_t get_section_count();
+  size_t get_section_count() const;
 
   //! Get the number of strings in a section of the string list
-  size_t get_section_size(size_t section);
+  size_t get_section_size(size_t section) const;
 
   //! Get a string from the string list
   /*!
@@ -75,7 +75,7 @@ class th_string_list {
       @return nullptr if the index is invalid, otherwise a UTF-8 encoded
      string.
   */
-  const char* get_string(size_t section, size_t index);
+  const char* get_string(size_t section, size_t index) const;
 
  private:
   //! Section information

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -363,8 +363,8 @@ class animation_manager {
 
   bool set_frame_primary_marker(size_t iFrame, int iX, int iY);
   bool set_frame_secondary_marker(size_t iFrame, int iX, int iY);
-  bool get_frame_primary_marker(size_t iFrame, int* pX, int* pY);
-  bool get_frame_secondary_marker(size_t iFrame, int* pX, int* pY);
+  bool get_frame_primary_marker(size_t iFrame, int* pX, int* pY) const;
+  bool get_frame_secondary_marker(size_t iFrame, int* pX, int* pY) const;
 
   //! Retrieve a custom animation by name and tile size.
   /*!

--- a/CorsixTH/Src/th_gfx_font.h
+++ b/CorsixTH/Src/th_gfx_font.h
@@ -133,7 +133,7 @@ class bitmap_font final : public font {
   */
   void set_sprite_sheet(sprite_sheet* pSpriteSheet);
 
-  sprite_sheet* get_sprite_sheet() { return sheet; }
+  sprite_sheet* get_sprite_sheet() const { return sheet; }
 
   //! Set the separation between characters and between lines
   /*!
@@ -272,8 +272,8 @@ class freetype_font final : public font {
   };
 
   //! Render a FreeType2 monochrome bitmap to a cache canvas.
-  void render_mono(cached_text* pCacheEntry, FT_Bitmap* pBitmap, FT_Pos x,
-                   FT_Pos y) const;
+  static void render_mono(cached_text* pCacheEntry, FT_Bitmap* pBitmap,
+                          FT_Pos x, FT_Pos y);
 
   //! Render a FreeType2 grayscale bitmap to a cache canvas.
   void render_gray(cached_text* pCacheEntry, FT_Bitmap* pBitmap, FT_Pos x,
@@ -306,7 +306,7 @@ class freetype_font final : public font {
           an object which can be used by the rendering engine, and store the
           result in the pTexture or iTexture field.
   */
-  void make_texture(render_target* pEventualCanvas,
+  void make_texture(const render_target* pEventualCanvas,
                     cached_text* pCacheEntry) const;
 
   //! Free a previously-made texture of a cache entry.
@@ -327,8 +327,8 @@ class freetype_font final : public font {
       @param iX The X position at which to draw the texture on the canvas.
       @param iY The Y position at which to draw the texture on the canvas.
   */
-  void draw_texture(render_target* pCanvas, cached_text* pCacheEntry, int iX,
-                    int iY) const;
+  static void draw_texture(const render_target* pCanvas,
+                           const cached_text* pCacheEntry, int iX, int iY);
 };
 #endif  // CORSIX_TH_USE_FREETYPE2
 

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -54,7 +54,7 @@ typedef uint32_t argb_colour;
 //! 8bpp palette class.
 class palette {
  public:  // External API
-  palette();
+  palette() = default;
 
   //! Load palette from the supplied data.
   /*!
@@ -76,7 +76,7 @@ class palette {
   */
   bool set_entry(int iEntry, uint8_t iR, uint8_t iG, uint8_t iB);
 
- public:  // Internal (this rendering engine only) API
+  // public internal (this rendering engine only) API
   //! Convert A, R, G, B values to a 32bpp colour.
   /*!
       @param iA Amount of opacity (0-255).
@@ -146,16 +146,16 @@ class palette {
       @param iEntry Entry to modify.
       @param iVal Palette value to set.
   */
-  inline void set_argb(int iEntry, uint32_t iVal) {
+  void set_argb(int iEntry, uint32_t iVal) {
     colour_index_to_argb_map[iEntry] = iVal;
   }
 
  private:
   //! 32bpp palette colours associated with the 8bpp colour index.
-  uint32_t colour_index_to_argb_map[256];
+  uint32_t colour_index_to_argb_map[256]{};
 
   //! Number of colours in the palette.
-  int colour_count;
+  int colour_count{};
 };
 
 /*!
@@ -256,7 +256,7 @@ class render_target {
   void destroy();
 
   //! Get the reason for the last operation failing
-  const char* get_last_error();
+  static const char* get_last_error();
 
   //! Begin rendering a new frame
   bool start_frame();
@@ -265,14 +265,14 @@ class render_target {
   bool end_frame();
 
   //! Paint the entire render target black
-  bool fill_black();
+  bool fill_black() const;
 
   //! Sets a blue filter on the current surface.
   // Used to add the blue effect when the game is paused.
   void set_blue_filter_active(bool bActivate);
 
   //! Fill a rectangle of the render target with a solid colour
-  bool fill_rect(uint32_t iColour, int iX, int iY, int iW, int iH);
+  bool fill_rect(uint32_t iColour, int iX, int iY, int iW, int iH) const;
 
   class scoped_clip {
    public:
@@ -296,10 +296,10 @@ class render_target {
   int get_height() const;
 
   //! Enable optimisations for non-overlapping draws
-  void start_nonoverlapping_draws();
+  static void start_nonoverlapping_draws();
 
   //! Disable optimisations for non-overlapping draws
-  void finish_nonoverlapping_draws();
+  static void finish_nonoverlapping_draws();
 
   //! Set the cursor to be used
   void set_cursor(cursor* pCursor);
@@ -308,7 +308,7 @@ class render_target {
   void set_cursor_position(int iX, int iY);
 
   //! Take a screenshot and save it as a bitmap
-  bool take_screenshot(const char* sFile);
+  bool take_screenshot(const char* sFile) const;
 
   //! Set the amount by which future draw operations are scaled.
   /*!
@@ -319,10 +319,10 @@ class render_target {
   bool set_scale_factor(double fScale, scaled_items eWhatToScale);
 
   //! Set the window caption
-  void set_caption(const char* sCaption);
+  void set_caption(const char* sCaption) const;
 
   //! Toggle mouse capture on the window.
-  void set_window_grab(bool bActivate);
+  void set_window_grab(bool bActivate) const;
 
   //! Get any user-displayable information to describe the renderer path used
   const char* get_renderer_details() const;
@@ -345,7 +345,7 @@ class render_target {
           for scaling (can be \c nullptr if not interested in the value).
       @return Whether bitmaps should be scaled.
    */
-  bool should_scale_bitmaps(double* pFactor);
+  bool should_scale_bitmaps(double* pFactor) const;
 
   SDL_Texture* create_palettized_texture(int iWidth, int iHeight,
                                          const uint8_t* pPixels,
@@ -354,8 +354,8 @@ class render_target {
   SDL_Texture* create_texture(int iWidth, int iHeight,
                               const uint32_t* pPixels) const;
   void draw(SDL_Texture* pTexture, const SDL_Rect* prcSrcRect,
-            const SDL_Rect* prcDstRect, int iFlags);
-  void draw_line(line_sequence* pLine, int iX, int iY);
+            const SDL_Rect* prcDstRect, int iFlags) const;
+  void draw_line(line_sequence* pLine, int iX, int iY) const;
 
   //! Begin drawing to an intermediate unscaled texture targeting the given
   //! location and size. The intermediate drawing will be committed once
@@ -438,7 +438,7 @@ class raw_bitmap {
       @param iX Destination x position.
       @param iY Destination y position.
   */
-  void draw(render_target* pCanvas, int iX, int iY);
+  void draw(render_target* pCanvas, int iX, int iY) const;
 
   //! Draw part of the image at a given position at the given canvas.
   /*!
@@ -451,7 +451,7 @@ class raw_bitmap {
       @param iHeight Height of the part to display.
   */
   void draw(render_target* pCanvas, int iX, int iY, int iSrcX, int iSrcY,
-            int iWidth, int iHeight);
+            int iWidth, int iHeight) const;
 
  private:
   //! Image stored in SDL format for quick rendering.
@@ -473,7 +473,7 @@ class raw_bitmap {
 //! Sheet of sprites.
 class sprite_sheet {
  public:  // External API
-  sprite_sheet();
+  sprite_sheet() = default;
   ~sprite_sheet();
 
   //! Set the palette to use for the sprites in the sheet.
@@ -519,7 +519,7 @@ class sprite_sheet {
       @param iAlt32 What to do for a 32bpp sprite (#thdf_alt32_mask bits).
   */
   void set_sprite_alt_palette_map(size_t iSprite, const uint8_t* pMap,
-                                  uint32_t iAlt32);
+                                  uint32_t iAlt32) const;
 
   //! Get the number of sprites at the sheet.
   /*!
@@ -603,7 +603,7 @@ class sprite_sheet {
       @param pRGBData Output RGB data array.
       @param pAData Output Alpha channel array.
   */
-  void wx_draw_sprite(size_t iSprite, uint8_t* pRGBData, uint8_t* pAData);
+  void wx_draw_sprite(size_t iSprite, uint8_t* pRGBData, uint8_t* pAData) const;
 
  private:
   friend class cursor;
@@ -648,22 +648,22 @@ class sprite_sheet {
 
     //! Height of the sprite.
     int height;
-  } * sprites;
+  } * sprites{};
 
   //! Original palette.
-  const ::palette* palette;
+  const ::palette* palette{};
 
   //! Target to render to.
-  render_target* target;
+  render_target* target{};
 
   //! Number of sprites in the sprite sheet.
-  size_t sprite_count;
+  size_t sprite_count{};
 
   //! Free memory of a single sprite.
   /*!
       @param iNumber Number of the sprite to clear.
   */
-  void _freeSingleSprite(size_t iNumber);
+  void _freeSingleSprite(size_t iNumber) const;
 
   //! Free the memory used by the sprites. Also releases the SDL bitmaps.
   void _freeSprites();
@@ -674,12 +674,12 @@ class sprite_sheet {
       @param pSprite Sprite to change.
       @return SDL texture containing the sprite.
   */
-  SDL_Texture* _makeAltBitmap(sprite* pSprite);
+  SDL_Texture* _makeAltBitmap(sprite* pSprite) const;
 };
 
 class cursor {
  public:
-  cursor();
+  cursor() = default;
   ~cursor();
 
   bool create_from_sprite(sprite_sheet* pSheet, size_t iSprite,
@@ -692,10 +692,10 @@ class cursor {
   void draw(render_target* pCanvas, int iX, int iY);
 
  private:
-  SDL_Surface* bitmap;
-  SDL_Cursor* hidden_cursor;
-  int hotspot_x;
-  int hotspot_y;
+  SDL_Surface* bitmap{};
+  SDL_Cursor* hidden_cursor{};
+  int hotspot_x{};
+  int hotspot_y{};
 };
 
 class line_sequence {
@@ -730,8 +730,8 @@ class line_sequence {
   };
 
   std::vector<line_element> line_elements;
-  double width;
-  uint8_t red, green, blue, alpha;
+  double width{1};
+  uint8_t red{0}, green{0}, blue{0}, alpha{255};
 };
 
 #endif  // CORSIX_TH_TH_GFX_SDL_H_

--- a/CorsixTH/Src/th_lua.h
+++ b/CorsixTH/Src/th_lua.h
@@ -64,7 +64,7 @@ inline int luaT_upvalueindex(int i) {
 }
 
 template <class Collection>
-inline void luaT_register(lua_State* L, const char* n, Collection& l) {
+void luaT_register(lua_State* L, const char* n, Collection& l) {
 #if LUA_VERSION_NUM >= 502
   lua_createtable(L, 0, static_cast<int>(l.size()));
   lua_pushvalue(L, luaT_environindex);
@@ -177,8 +177,7 @@ void luaT_setenvfield(lua_State* L, int index, const char* k);
 void luaT_getenvfield(lua_State* L, int index, const char* k);
 
 template <class T>
-inline T* luaT_stdnew(lua_State* L, int mt_idx = luaT_environindex,
-                      bool env = false) {
+T* luaT_stdnew(lua_State* L, int mt_idx = luaT_environindex, bool env = false) {
   T* p = luaT_new<T>(L);
   lua_pushvalue(L, mt_idx);
   lua_setmetatable(L, -2);
@@ -195,141 +194,141 @@ struct luaT_classinfo {};
 class render_target;
 template <>
 struct luaT_classinfo<render_target> {
-  static inline const char* name() { return "Surface"; }
+  static const char* name() { return "Surface"; }
 };
 
 class level_map;
 template <>
 struct luaT_classinfo<level_map> {
-  static inline const char* name() { return "Map"; }
+  static const char* name() { return "Map"; }
 };
 
 class sprite_sheet;
 template <>
 struct luaT_classinfo<sprite_sheet> {
-  static inline const char* name() { return "SpriteSheet"; }
+  static const char* name() { return "SpriteSheet"; }
 };
 
 class animation;
 template <>
 struct luaT_classinfo<animation> {
-  static inline const char* name() { return "Animation"; }
+  static const char* name() { return "Animation"; }
 };
 
 class animation_manager;
 template <>
 struct luaT_classinfo<animation_manager> {
-  static inline const char* name() { return "Animator"; }
+  static const char* name() { return "Animator"; }
 };
 
 class palette;
 template <>
 struct luaT_classinfo<palette> {
-  static inline const char* name() { return "Palette"; }
+  static const char* name() { return "Palette"; }
 };
 
 class raw_bitmap;
 template <>
 struct luaT_classinfo<raw_bitmap> {
-  static inline const char* name() { return "RawBitmap"; }
+  static const char* name() { return "RawBitmap"; }
 };
 
 class font;
 template <>
 struct luaT_classinfo<font> {
-  static inline const char* name() { return "Font"; }
+  static const char* name() { return "Font"; }
 };
 
 class bitmap_font;
 template <>
 struct luaT_classinfo<bitmap_font> {
-  static inline const char* name() { return "BitmapFont"; }
+  static const char* name() { return "BitmapFont"; }
 };
 
 #ifdef CORSIX_TH_USE_FREETYPE2
 class freetype_font;
 template <>
 struct luaT_classinfo<freetype_font> {
-  static inline const char* name() { return "FreeTypeFont"; }
+  static const char* name() { return "FreeTypeFont"; }
 };
 #endif
 
 struct layers;
 template <>
 struct luaT_classinfo<layers> {
-  static inline const char* name() { return "Layers"; }
+  static const char* name() { return "Layers"; }
 };
 
 class pathfinder;
 template <>
 struct luaT_classinfo<pathfinder> {
-  static inline const char* name() { return "Pathfinder"; }
+  static const char* name() { return "Pathfinder"; }
 };
 
 class cursor;
 template <>
 struct luaT_classinfo<cursor> {
-  static inline const char* name() { return "Cursor"; }
+  static const char* name() { return "Cursor"; }
 };
 
 class line_sequence;
 template <>
 struct luaT_classinfo<line_sequence> {
-  static inline const char* name() { return "Line"; }
+  static const char* name() { return "Line"; }
 };
 
 class music;
 template <>
 struct luaT_classinfo<music> {
-  static inline const char* name() { return "Music"; }
+  static const char* name() { return "Music"; }
 };
 
 class sound_archive;
 template <>
 struct luaT_classinfo<sound_archive> {
-  static inline const char* name() { return "SoundArchive"; }
+  static const char* name() { return "SoundArchive"; }
 };
 
 class sound_player;
 template <>
 struct luaT_classinfo<sound_player> {
-  static inline const char* name() { return "SoundEffects"; }
+  static const char* name() { return "SoundEffects"; }
 };
 
 class movie_player;
 template <>
 struct luaT_classinfo<movie_player> {
-  static inline const char* name() { return "Movie"; }
+  static const char* name() { return "Movie"; }
 };
 
 class abstract_window;
 template <>
 struct luaT_classinfo<abstract_window> {
-  static inline const char* name() { return "WindowBase"; }
+  static const char* name() { return "WindowBase"; }
 };
 
 class sprite_render_list;
 template <>
 struct luaT_classinfo<sprite_render_list> {
-  static inline const char* name() { return "SpriteRenderList"; }
+  static const char* name() { return "SpriteRenderList"; }
 };
 
 class string_proxy;
 template <>
 struct luaT_classinfo<string_proxy> {
-  static inline const char* name() { return "StringProxy"; }
+  static const char* name() { return "StringProxy"; }
 };
 
 class lfs_ext;
 template <>
 struct luaT_classinfo<lfs_ext> {
-  static inline const char* name() { return "LfsExt"; }
+  static const char* name() { return "LfsExt"; }
 };
 
 class iso_filesystem;
 template <>
 struct luaT_classinfo<iso_filesystem> {
-  static inline const char* name() { return "ISO Filesystem"; }
+  static const char* name() { return "ISO Filesystem"; }
 };
 
 template <class T>

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -248,7 +248,8 @@ int l_anim_persist(lua_State* L) {
     // Fast __persist call
     pAnimation = (T*)lua_touserdata(L, -1);
   }
-  lua_persist_writer* pWriter = (lua_persist_writer*)lua_touserdata(L, 1);
+  lua_persist_writer* pWriter =
+      static_cast<lua_persist_writer*>(lua_touserdata(L, 1));
 
   pAnimation->persist(pWriter);
   lua_rawgeti(L, luaT_environindex, 1);
@@ -423,7 +424,7 @@ int l_anim_get_tile(lua_State* L) {
   if (lua_isnil(L, 2)) {
     return 0;
   }
-  level_map* pMap = (level_map*)lua_touserdata(L, 2);
+  level_map* pMap = static_cast<level_map*>(lua_touserdata(L, 2));
   const link_list* pListNode = pAnimation->get_previous();
   while (pListNode->prev) {
     pListNode = pListNode->prev;
@@ -498,7 +499,7 @@ template <typename T>
 int l_anim_make_invisible(lua_State* L) {
   T* pAnimation = luaT_testuserdata<T>(L);
   pAnimation->set_flags(pAnimation->get_flags() |
-                        static_cast<uint32_t>(thdf_alpha_50 | thdf_alpha_75));
+                        (thdf_alpha_50 | thdf_alpha_75));
 
   lua_settop(L, 1);
   return 1;

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -562,13 +562,12 @@ int l_cursor_position(lua_State* L) {
 /** Construct the helper structure for making a #THRenderTarget. */
 render_target_creation_params l_surface_creation_params(lua_State* L,
                                                         int iArgStart) {
-  render_target_creation_params oParams;
-  oParams.width = static_cast<int>(luaL_checkinteger(L, iArgStart));
-  oParams.height = static_cast<int>(luaL_checkinteger(L, iArgStart + 1));
-
-  oParams.fullscreen = false;
-  oParams.present_immediate = false;
-  oParams.direct_zoom = false;
+  render_target_creation_params oParams{
+      .width = static_cast<int>(luaL_checkinteger(L, iArgStart)),
+      .height = static_cast<int>(luaL_checkinteger(L, iArgStart + 1)),
+      .fullscreen = false,
+      .present_immediate = false,
+      .direct_zoom = false};
 
   // Parse string arguments, looking for matching parameter names.
   for (int iArg = iArgStart + 2, iArgCount = lua_gettop(L); iArg <= iArgCount;

--- a/CorsixTH/Src/th_lua_iso.cpp
+++ b/CorsixTH/Src/th_lua_iso.cpp
@@ -118,18 +118,17 @@ int l_isofs_read_contents(lua_State* L) {
     return 2;
   }
   void* pBuffer = lua_newuserdata(L, pSelf->get_file_size(iFile));
-  if (!pSelf->get_file_data(iFile, reinterpret_cast<uint8_t*>(pBuffer))) {
+  if (!pSelf->get_file_data(iFile, static_cast<uint8_t*>(pBuffer))) {
     lua_pushnil(L);
     lua_pushstring(L, pSelf->get_error());
     return 2;
   }
-  lua_pushlstring(L, reinterpret_cast<char*>(pBuffer),
-                  pSelf->get_file_size(iFile));
+  lua_pushlstring(L, static_cast<char*>(pBuffer), pSelf->get_file_size(iFile));
   return 1;
 }
 
 void l_isofs_list_files_callback(void* p, const char* name, const char* path) {
-  lua_State* L = reinterpret_cast<lua_State*>(p);
+  lua_State* L = static_cast<lua_State*>(p);
   lua_pushstring(L, name);
   lua_pushstring(L, path);
   lua_settable(L, 3);

--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -72,7 +72,8 @@ int l_map_depersist(lua_State* L) {
   level_map* pMap = luaT_testuserdata<level_map>(L);
   lua_settop(L, 2);
   lua_insert(L, 1);
-  lua_persist_reader* pReader = (lua_persist_reader*)lua_touserdata(L, 1);
+  lua_persist_reader* pReader =
+      static_cast<lua_persist_reader*>(lua_touserdata(L, 1));
 
   pMap->depersist(pReader);
   luaT_getenvfield(L, 2, "sprites");
@@ -83,7 +84,7 @@ int l_map_depersist(lua_State* L) {
 
 void l_map_load_obj_cb(void* pL, int iX, int iY, object_type eTHOB,
                        uint8_t iFlags) {
-  lua_State* L = reinterpret_cast<lua_State*>(pL);
+  lua_State* L = static_cast<lua_State*>(pL);
   lua_createtable(L, 4, 0);
 
   lua_pushinteger(L, 1 + (lua_Integer)iX);
@@ -509,8 +510,8 @@ const std::map<std::string, map_tile_flags::key> lua_tile_flag_map{
  * @param flag Flag of the tile to check (and report).
  * @param name Name of the flag in Lua code.
  */
-inline void add_cellflag(lua_State* L, const map_tile* tile,
-                         map_tile_flags::key flag, const std::string& name) {
+void add_cellflag(lua_State* L, const map_tile* tile, map_tile_flags::key flag,
+                  const std::string& name) {
   lua_pushlstring(L, name.c_str(), name.size());
   lua_pushboolean(L, tile->flags[flag] ? 1 : 0);
   lua_settable(L, 4);
@@ -522,7 +523,7 @@ inline void add_cellflag(lua_State* L, const map_tile* tile,
  * @param value Value of the tile field to add.
  * @param name Name of the field in Lua code.
  */
-inline void add_cellint(lua_State* L, int value, const std::string& name) {
+void add_cellint(lua_State* L, int value, const std::string& name) {
   lua_pushlstring(L, name.c_str(), name.size());
   lua_pushinteger(L, value);
   lua_settable(L, 4);
@@ -591,7 +592,7 @@ int l_map_remove_cell_thob(lua_State* L) {
   }
   auto thob = static_cast<object_type>(luaL_checkinteger(L, 4));
   for (auto iter = pNode->objects.begin(); iter != pNode->objects.end();
-       iter++) {
+       ++iter) {
     if (*iter == thob) {
       pNode->objects.erase(iter);
       break;
@@ -857,7 +858,7 @@ int l_map_get_litter_fraction(lua_State* L) {
 
       tile_count++;
       for (auto iter = pNode->objects.begin(); iter != pNode->objects.end();
-           iter++) {
+           ++iter) {
         if (*iter == object_type::litter) {
           litter_count++;
           break;

--- a/CorsixTH/Src/th_lua_movie.cpp
+++ b/CorsixTH/Src/th_lua_movie.cpp
@@ -49,13 +49,11 @@ int l_movie_enabled(lua_State* L) {
 }
 
 int l_movie_load(lua_State* L) {
-  bool loaded;
-  const char* warning;
   movie_player* pMovie = luaT_testuserdata<movie_player>(L);
   const char* filepath = lua_tolstring(L, 2, nullptr);
   pMovie->clear_last_error();
-  loaded = pMovie->load(filepath);
-  warning = pMovie->get_last_error();
+  bool loaded = pMovie->load(filepath);
+  const char* warning = pMovie->get_last_error();
   lua_pushboolean(L, loaded);
   lua_pushstring(L, warning);
   return 2;
@@ -68,11 +66,10 @@ int l_movie_unload(lua_State* L) {
 }
 
 int l_movie_play(lua_State* L) {
-  const char* warning;
   movie_player* pMovie = luaT_testuserdata<movie_player>(L);
   pMovie->clear_last_error();
   pMovie->play(static_cast<int>(luaL_checkinteger(L, 2)));
-  warning = pMovie->get_last_error();
+  const char* warning = pMovie->get_last_error();
   lua_pushstring(L, warning);
   return 1;
 }

--- a/CorsixTH/Src/th_lua_sound.cpp
+++ b/CorsixTH/Src/th_lua_sound.cpp
@@ -87,7 +87,7 @@ int ignorecase_cmp(const char* s1, const char* s2) {
 
 size_t l_soundarc_checkidx(lua_State* L, int iArg, sound_archive* pArchive) {
   if (lua_isnumber(L, iArg)) {
-    size_t iIndex = (size_t)lua_tonumber(L, iArg);
+    size_t iIndex = static_cast<size_t>(lua_tonumber(L, iArg));
     if (iIndex >= pArchive->get_number_of_sounds()) {
       lua_pushnil(L);
       lua_pushfstring(L,

--- a/CorsixTH/Src/th_lua_strings.cpp
+++ b/CorsixTH/Src/th_lua_strings.cpp
@@ -63,9 +63,9 @@ namespace {
 
 // We need 2 lightuserdata keys for naming the weak tables in the registry,
 // which we get by having 2 bytes of dummy global variables.
-uint8_t weak_table_keys[2] = {0};
+uint8_t weak_table_keys[2] = {};
 
-inline void aux_push_weak_table(lua_State* L, int iIndex) {
+void aux_push_weak_table(lua_State* L, int iIndex) {
   lua_pushlightuserdata(L, &weak_table_keys[iIndex]);
   lua_rawget(L, LUA_REGISTRYINDEX);
 }

--- a/CorsixTH/Src/th_map.h
+++ b/CorsixTH/Src/th_map.h
@@ -246,7 +246,7 @@ class level_map {
                          map_load_object_callback_fn fnObjectCallback,
                          void* pCallbackToken);
 
-  void save(const std::string& filename);
+  void save(const std::string& filename) const;
 
   //! Set the sprite sheet to be used for drawing the map
   /*!
@@ -262,8 +262,8 @@ class level_map {
   */
   void set_all_wall_draw_flags(uint8_t iFlags);
 
-  void update_pathfinding();
-  void update_shadows();
+  void update_pathfinding() const;
+  void update_shadows() const;
   void set_temperature_display(temperature_theme eTempDisplay);
   inline temperature_theme get_temperature_display() const {
     return current_temperature_theme;
@@ -368,7 +368,7 @@ class level_map {
 
   //! Convert world (tile) coordinates to absolute screen coordinates
   template <typename T>
-  static inline void world_to_screen(T& x, T& y) {
+  static void world_to_screen(T& x, T& y) {
     T x_(x);
     x = (T)32 * (x_ - y);
     y = (T)16 * (x_ + y);
@@ -376,7 +376,7 @@ class level_map {
 
   //! Convert absolute screen coordinates to world (tile) coordinates
   template <typename T>
-  static inline void screen_to_world(T& x, T& y) {
+  static void screen_to_world(T& x, T& y) {
     T x_(x);
     x = y / (T)32 + x_ / (T)64;
     y = y / (T)32 - x_ / (T)64;
@@ -388,8 +388,8 @@ class level_map {
   void set_overlay(map_overlay* pOverlay, bool bTakeOwnership);
 
  private:
-  drawable* hit_test_drawables(link_list* pListStart, int iXs, int iYs,
-                               int iTestX, int iTestY) const;
+  static drawable* hit_test_drawables(link_list* pListStart, int iXs, int iYs,
+                                      int iTestX, int iTestY);
   void read_tile_index(const uint8_t* pData, int& iX, int& iY) const;
   void write_tile_index(uint8_t* pData, int iX, int iY) const;
 
@@ -481,29 +481,29 @@ class map_tile_iterator {
                         map_scanline_iterator_direction::forward);
 
   //! Returns false if the iterator has exhausted its tiles
-  inline operator bool() const { return tile != nullptr; }
+  explicit operator bool() const { return tile != nullptr; }
 
   //! Advances the iterator to the next tile
   inline map_tile_iterator& operator++();
 
   //! Accessor for the current tile
-  inline const map_tile* operator->() const { return tile; }
+  const map_tile* operator->() const { return tile; }
 
   //! Get the X position of the tile relative to the top-left corner of the
   //! screen-space rectangle
-  inline int tile_x_position_on_screen() const { return x_relative_to_screen; }
+  int tile_x_position_on_screen() const { return x_relative_to_screen; }
 
   //! Get the Y position of the tile relative to the top-left corner of the
   //! screen-space rectangle
-  inline int tile_y_position_on_screen() const { return y_relative_to_screen; }
+  int tile_y_position_on_screen() const { return y_relative_to_screen; }
 
-  inline int tile_x() const { return world_x; }
-  inline int tile_y() const { return world_y; }
+  int tile_x() const { return world_x; }
+  int tile_y() const { return world_y; }
 
-  inline const level_map* get_map() { return container; }
-  inline const map_tile* get_map_tile() { return tile; }
-  inline int get_scanline_count() { return scanline_count; }
-  inline int get_tile_step() {
+  const level_map* get_map() const { return container; }
+  const map_tile* get_map_tile() const { return tile; }
+  int get_scanline_count() const { return scanline_count; }
+  int get_tile_step() {
     return (static_cast<int>(direction) - 1) * (1 - container->get_width());
   }
 
@@ -519,29 +519,29 @@ class map_tile_iterator {
   // to the top-most corner of an isometric cell)
   // If set too low, things will disappear when near the screen edge
   // If set too high, rendering will slow down
-  static const int margin_top = 150;
-  static const int margin_left = 110;
-  static const int margin_right = 110;
-  static const int margin_bottom = 150;
+  static constexpr int margin_top = 150;
+  static constexpr int margin_left = 110;
+  static constexpr int margin_right = 110;
+  static constexpr int margin_bottom = 150;
 
   friend class map_scanline_iterator;
 
-  const map_tile* tile;
+  const map_tile* tile{};
   const level_map* container;
 
   // TODO: Consider removing these, they are trivial to calculate
-  int x_relative_to_screen;
-  int y_relative_to_screen;
+  int x_relative_to_screen{};
+  int y_relative_to_screen{};
 
   const int screen_offset_x;
   const int screen_offset_y;
   const int screen_width;
   const int screen_height;
-  int base_x;
-  int base_y;
-  int world_x;
-  int world_y;
-  int scanline_count;
+  int base_x{};
+  int base_y{};
+  int world_x{};
+  int world_y{};
+  int scanline_count{};
   map_scanline_iterator_direction direction;
 
   void advance_until_visible();
@@ -563,16 +563,16 @@ class map_scanline_iterator {
                         map_scanline_iterator_direction eDirection,
                         int iXOffset = 0, int iYOffset = 0);
 
-  inline operator bool() const { return tile != end_tile; }
+  explicit operator bool() const { return tile != end_tile; }
   inline map_scanline_iterator& operator++();
 
-  inline const map_tile* operator->() const { return tile; }
-  inline int x() const { return x_relative_to_screen; }
-  inline int y() const { return y_relative_to_screen; }
-  inline const map_tile* get_next_tile() { return tile + tile_step; }
-  inline const map_tile* get_previous_tile() { return tile - tile_step; }
-  map_scanline_iterator operator=(const map_scanline_iterator& iterator);
-  inline const map_tile* get_tile() { return tile; }
+  const map_tile* operator->() const { return tile; }
+  int x() const { return x_relative_to_screen; }
+  int y() const { return y_relative_to_screen; }
+  const map_tile* get_next_tile() const { return tile + tile_step; }
+  const map_tile* get_previous_tile() const { return tile - tile_step; }
+  map_scanline_iterator& operator=(const map_scanline_iterator& iterator);
+  const map_tile* get_tile() const { return tile; }
 
  private:
   const map_tile* tile;

--- a/CorsixTH/Src/th_map_overlays.cpp
+++ b/CorsixTH/Src/th_map_overlays.cpp
@@ -177,8 +177,7 @@ void map_parcels_overlay::draw_cell(render_target* pCanvas, int iCanvasX,
     return;
   }
   if (font) {
-    draw_text(pCanvas, iCanvasX, iCanvasY,
-              std::to_string((int)pNode->iParcelId));
+    draw_text(pCanvas, iCanvasX, iCanvasY, std::to_string(pNode->iParcelId));
   }
   if (sprites) {
     for (const parcel_edge_sprite& dir_sprite : parcel_edges) {
@@ -192,7 +191,7 @@ void map_parcels_overlay::draw_cell(render_target* pCanvas, int iCanvasX,
 }
 
 void map_typical_overlay::draw_text(render_target* pCanvas, int iX, int iY,
-                                    const std::string& str) {
+                                    const std::string& str) const {
   text_layout oArea = font->get_text_dimensions(str.c_str(), str.length());
   font->draw_text(pCanvas, str.c_str(), str.length(),
                   iX + (64 - oArea.end_x) / 2, iY + (32 - oArea.end_y) / 2);

--- a/CorsixTH/Src/th_map_overlays.h
+++ b/CorsixTH/Src/th_map_overlays.h
@@ -65,7 +65,7 @@ class map_typical_overlay : public map_overlay {
 
  protected:
   void draw_text(render_target* pCanvas, int iX, int iY,
-                 const std::string& str);
+                 const std::string& str) const;
 
   sprite_sheet* sprites;
   ::font* font;

--- a/CorsixTH/Src/th_movie.h
+++ b/CorsixTH/Src/th_movie.h
@@ -64,7 +64,7 @@ using av_codec_ptr = const AVCodec*;
 //! Deletes AVPacket pointers that are allocated with av_malloc
 class av_packet_deleter {
  public:
-  void operator()(AVPacket* p) {
+  void operator()(AVPacket* p) const {
     av_packet_unref(p);
     av_free(p);
   }
@@ -75,14 +75,14 @@ using av_packet_unique_ptr = std::unique_ptr<AVPacket, av_packet_deleter>;
 
 class av_frame_deleter {
  public:
-  void operator()(AVFrame* f) { av_frame_free(&f); }
+  void operator()(AVFrame* f) const { av_frame_free(&f); }
 };
 
 using av_frame_unique_ptr = std::unique_ptr<AVFrame, av_frame_deleter>;
 
 class av_codec_context_deleter {
  public:
-  void operator()(AVCodecContext* c) { avcodec_free_context(&c); }
+  void operator()(AVCodecContext* c) const { avcodec_free_context(&c); }
 };
 
 using av_codec_context_unique_ptr =
@@ -205,7 +205,7 @@ class movie_picture_buffer {
   //! Return whether there is space to add any more frame data to the queue
   //!
   //! \remark Requires external locking
-  bool unsafe_full();
+  bool unsafe_full() const;
 
   //! The number of elements to allocate in the picture queue
   static constexpr std::size_t picture_buffer_size = 4;
@@ -304,7 +304,7 @@ class movie_player {
   void set_renderer(SDL_Renderer* pRenderer);
 
   //! Return whether movies were compiled into CorsixTH
-  bool movies_enabled() const;
+  static bool movies_enabled();
 
   //! Load the movie with the given file name
   bool load(const char* szFilepath);
@@ -382,8 +382,8 @@ class movie_player {
       128;  ///< Buffer to hold last error description
 
   //! Get the AVCodecContext associated with a given stream
-  av_codec_context_unique_ptr get_codec_context_for_stream(
-      av_codec_ptr codec, AVStream* stream) const;
+  static av_codec_context_unique_ptr get_codec_context_for_stream(
+      av_codec_ptr codec, AVStream* stream);
 
   void play_audio(int requested_audio_channel);
 
@@ -414,7 +414,8 @@ class movie_player {
   //! \param frame An empty frame which gets populated by the data in the
   //! packet queue.
   //! \returns FFMPEG result of avcodec_receive_frame
-  int populate_frame(AVCodecContext& ctx, av_packet_queue& pq, AVFrame& frame);
+  static int populate_frame(AVCodecContext& ctx, av_packet_queue& pq,
+                            AVFrame& frame);
 
   SDL_Renderer* renderer;  ///< The renderer to draw to
 

--- a/CorsixTH/Src/th_pathfind.cpp
+++ b/CorsixTH/Src/th_pathfind.cpp
@@ -36,7 +36,8 @@ SOFTWARE.
 #include "persist_lua.h"
 #include "th_map.h"
 
-abstract_pathfinder::abstract_pathfinder(pathfinder* pf) : parent(pf) {}
+abstract_pathfinder::abstract_pathfinder(pathfinder* pf)
+    : parent(pf), map(nullptr) {}
 
 path_node* abstract_pathfinder::init(const level_map* pMap, int iStartX,
                                      int iStartY) {

--- a/CorsixTH/Src/th_pathfind.h
+++ b/CorsixTH/Src/th_pathfind.h
@@ -45,7 +45,7 @@ enum class travel_direction {
   west = 3    ///< Move to the west.
 };
 
-/** Node in the path finder routines. */
+/** Node in the pathfinder routines. */
 struct path_node {
   //! Pointer to the previous node in the path to this cell.
   /*!
@@ -91,13 +91,13 @@ struct path_node {
   inline int value() const { return distance + guess; }
 };
 
-/** Base class of the path finders. */
+/** Base class of the pathfinders. */
 class abstract_pathfinder {
  public:
-  abstract_pathfinder(pathfinder* pf);
+  explicit abstract_pathfinder(pathfinder* pf);
   virtual ~abstract_pathfinder() = default;
 
-  //! Initialize the path finder.
+  //! Initialize the pathfinder.
   /*!
       @param pMap Map to search on.
       @param iStartX X coordinate of the start position.
@@ -143,7 +143,7 @@ class abstract_pathfinder {
 
 class basic_pathfinder : public abstract_pathfinder {
  public:
-  basic_pathfinder(pathfinder* pf) : abstract_pathfinder(pf) {}
+  explicit basic_pathfinder(pathfinder* pf) : abstract_pathfinder(pf) {}
 
   int guess_distance(path_node* pNode) override;
   bool try_node(path_node* pNode, map_tile_flags flags, path_node* pNeighbour,
@@ -152,13 +152,13 @@ class basic_pathfinder : public abstract_pathfinder {
   bool find_path(const level_map* pMap, int iStartX, int iStartY, int iEndX,
                  int iEndY);
 
-  int destination_x;  ///< X coordinate of the destination of the path.
-  int destination_y;  ///< Y coordinate of the destination of the path.
+  int destination_x{};  ///< X coordinate of the destination of the path.
+  int destination_y{};  ///< Y coordinate of the destination of the path.
 };
 
 class hospital_finder : public abstract_pathfinder {
  public:
-  hospital_finder(pathfinder* pf) : abstract_pathfinder(pf) {}
+  explicit hospital_finder(pathfinder* pf) : abstract_pathfinder(pf) {}
 
   int guess_distance(path_node* pNode) override;
   bool try_node(path_node* pNode, map_tile_flags flags, path_node* pNeighbour,
@@ -169,7 +169,7 @@ class hospital_finder : public abstract_pathfinder {
 
 class idle_tile_finder : public abstract_pathfinder {
  public:
-  idle_tile_finder(pathfinder* pf) : abstract_pathfinder(pf) {}
+  explicit idle_tile_finder(pathfinder* pf) : abstract_pathfinder(pf) {}
 
   int guess_distance(path_node* pNode) override;
   bool try_node(path_node* pNode, map_tile_flags flags, path_node* pNeighbour,
@@ -188,15 +188,15 @@ class idle_tile_finder : public abstract_pathfinder {
   bool find_idle_tile(const level_map* pMap, int iStartX, int iStartY, int iN,
                       int parcelId);
 
-  path_node* best_next_node;
-  double best_distance;
-  int start_x;  ///< X coordinate of the start position.
-  int start_y;  ///< Y coordinate of the start position.
+  path_node* best_next_node{};
+  double best_distance{};
+  int start_x{};
+  int start_y{};
 };
 
 class object_visitor : public abstract_pathfinder {
  public:
-  object_visitor(pathfinder* pf) : abstract_pathfinder(pf) {}
+  explicit object_visitor(pathfinder* pf) : abstract_pathfinder(pf) {}
 
   int guess_distance(path_node* pNode) override;
   bool try_node(path_node* pNode, map_tile_flags flags, path_node* pNeighbour,
@@ -206,11 +206,11 @@ class object_visitor : public abstract_pathfinder {
                      object_type eTHOB, int iMaxDistance, lua_State* L,
                      int iVisitFunction, bool anyObjectType);
 
-  lua_State* L;
-  int visit_function_index;
-  int max_distance;
-  bool target_any_object_type;
-  object_type target;
+  lua_State* L{};
+  int visit_function_index{};
+  int max_distance{};
+  bool target_any_object_type{};
+  object_type target{};
 };
 
 //! Finds paths through maps
@@ -222,7 +222,7 @@ class object_visitor : public abstract_pathfinder {
     path.
 
     Internally, the A* search algorithm is used. The open set is implemented as
-    a heap in open_heap, and there is no explicit closed set. For each cell
+    a heap in open_heap, and there is no explicitly closed set. For each cell
     of the map, a path_node structure is created (and cached between searches if
     the map size is constant), which holds information about said map cell in
     the current search. The algorithm is implemented in such a way that most
@@ -235,25 +235,24 @@ class pathfinder {
 
   void set_default_map(const level_map* pMap);
 
-  inline bool find_path(const level_map* pMap, int iStartX, int iStartY,
-                        int iEndX, int iEndY) {
+  bool find_path(const level_map* pMap, int iStartX, int iStartY, int iEndX,
+                 int iEndY) {
     return basic_pathfinder.find_path(pMap, iStartX, iStartY, iEndX, iEndY);
   }
 
-  inline bool find_idle_tile(const level_map* pMap, int iStartX, int iStartY,
-                             int iN, int parcelId) {
+  bool find_idle_tile(const level_map* pMap, int iStartX, int iStartY, int iN,
+                      int parcelId) {
     return idle_tile_finder.find_idle_tile(pMap, iStartX, iStartY, iN,
                                            parcelId);
   }
 
-  inline bool find_path_to_hospital(const level_map* pMap, int iStartX,
-                                    int iStartY) {
+  bool find_path_to_hospital(const level_map* pMap, int iStartX, int iStartY) {
     return hospital_finder.find_path_to_hospital(pMap, iStartX, iStartY);
   }
 
-  inline bool visit_objects(const level_map* pMap, int iStartX, int iStartY,
-                            object_type eTHOB, int iMaxDistance, lua_State* L,
-                            int iVisitFunction, bool anyObjectType) {
+  bool visit_objects(const level_map* pMap, int iStartX, int iStartY,
+                     object_type eTHOB, int iMaxDistance, lua_State* L,
+                     int iVisitFunction, bool anyObjectType) {
     return object_visitor.visit_objects(pMap, iStartX, iStartY, eTHOB,
                                         iMaxDistance, L, iVisitFunction,
                                         anyObjectType);

--- a/CorsixTH/Src/th_sound.h
+++ b/CorsixTH/Src/th_sound.h
@@ -44,13 +44,13 @@ class sound_archive {
   const char* get_sound_name(size_t iIndex) const;
 
   //! Gets the duration (in milliseconds) of the sound at a given index
-  size_t get_sound_duration(size_t iIndex);
+  size_t get_sound_duration(size_t iIndex) const;
 
   //! Opens the sound at a given index into an SDL_RWops structure
   /*!
       The caller is responsible for closing/freeing the result.
   */
-  SDL_RWops* load_sound(size_t iIndex);
+  SDL_RWops* load_sound(size_t iIndex) const;
 
  private:
 #if CORSIX_TH_USE_PACK_PRAGMAS

--- a/CorsixTH/Src/th_strings.h
+++ b/CorsixTH/Src/th_strings.h
@@ -9,7 +9,7 @@
 constexpr unsigned int invalid_char_codepoint = 0xFFFD;
 constexpr unsigned int ideographic_space_codepoint = 0x3000;
 
-size_t discard_leading_set_bits(uint8_t& byte) {
+inline size_t discard_leading_set_bits(uint8_t& byte) {
   size_t count = 0;
   while ((byte & 0x80) != 0) {
     count++;
@@ -19,7 +19,7 @@ size_t discard_leading_set_bits(uint8_t& byte) {
   return count;
 }
 
-unsigned int next_utf8_codepoint(const char*& sString, const char* end) {
+inline unsigned int next_utf8_codepoint(const char*& sString, const char* end) {
   if (sString >= end) {
     throw std::out_of_range("pointer is outside of string");
   }
@@ -51,18 +51,18 @@ unsigned int next_utf8_codepoint(const char*& sString, const char* end) {
   return codepoint;
 }
 
-unsigned int decode_utf8(const char* sString, const char* end) {
+inline unsigned int decode_utf8(const char* sString, const char* end) {
   return next_utf8_codepoint(sString, end);
 }
 
-const char* previous_utf8_codepoint(const char* sString) {
+inline const char* previous_utf8_codepoint(const char* sString) {
   do {
     --sString;
   } while (((*sString) & 0xC0) == 0x80);
   return sString;
 }
 
-void skip_utf8_whitespace(const char*& sString, const char* end) {
+inline void skip_utf8_whitespace(const char*& sString, const char* end) {
   if (sString >= end) {
     return;
   }
@@ -86,7 +86,7 @@ constexpr uint16_t unicode_to_cp437_table[0x60] = {
     0x8A, 0x82, 0x88, 0x89, 0x8D, 0xA1, 0x8C, 0x8B, 0x3F, 0xA4, 0x95, 0xA2,
     0x93, 0x3F, 0x94, 0xF6, 0x3F, 0x97, 0xA3, 0x96, 0x81, 0x3F, 0x3F, 0x98};
 
-unsigned int unicode_to_codepage_437(unsigned int iCodePoint) {
+inline unsigned int unicode_to_codepage_437(unsigned int iCodePoint) {
   if (iCodePoint < 0x80) return iCodePoint;
   if (iCodePoint < 0xA0) return '?';
   if (iCodePoint < 0x100) return unicode_to_cp437_table[iCodePoint - 0xA0];

--- a/CorsixTH/Src/xmi2mid.cpp
+++ b/CorsixTH/Src/xmi2mid.cpp
@@ -98,8 +98,7 @@ class memory_buffer {
     uint8_t iByte0, iByte1, iByte2;
     if (read(iByte0) && read(iByte1) && read(iByte2))
       return (((iByte0 << 8) | iByte1) << 8) | iByte2;
-    else
-      return 0;
+    return 0;
   }
 
   uint32_t read_variable_length_uint() {
@@ -227,10 +226,8 @@ uint8_t* transcode_xmi_to_midi(const unsigned char* xmi_data, size_t xmi_length,
     while (true) {
       if (!bufInput.read(iTokenType)) return nullptr;
 
-      if (iTokenType & 0x80)
-        break;
-      else
-        iTokenTime += static_cast<int>(iTokenType) * 3;
+      if (iTokenType & 0x80) break;
+      iTokenTime += static_cast<int>(iTokenType) * 3;
     }
     pToken = lstTokens.append(iTokenTime, iTokenType);
     pToken->buffer = bufInput.get_pointer() + 1;
@@ -303,8 +300,7 @@ uint8_t* transcode_xmi_to_midi(const unsigned char* xmi_data, size_t xmi_length,
   iTokenType = 0;
   bEnd = false;
 
-  for (midi_token_list::iterator itr = lstTokens.begin(),
-                                 itrEnd = lstTokens.end();
+  for (auto itr = lstTokens.begin(), itrEnd = lstTokens.end();
        itr != itrEnd && !bEnd; ++itr) {
     if (!bufOutput.write_variable_length_uint(itr->time - iTokenTime))
       return nullptr;


### PR DESCRIPTION
A collection of mostly trivial fixes for problems identified by clang-tidy. This commit does not address all of the problems presented.

Most of the fixes were automatically applied, such as converting to ranged loops, c++ style casts, and creating initialization for uninitialized member variables.

A few were manual, in particular the fixed assignment operator for scanline_iterator.

There are also some clang-format fixes for files skipped last time.

<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
-
-
-
