### PR TITLE
Bump clang-format and clang-tidy for linux pipeline

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
-# -bugprone-chained-comparion is needed for catch2 < v3.5.3
-Checks:          'bugprone-*,-bugprone-assignment-in-if-condition,-bugprone-chained-comparison,-bugprone-easily-swappable-parameters,-bugprone-implicit-widening-of-multiplication-result,-bugprone-multi-level-implicit-pointer-conversion,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-switch-missing-default-case,clang-diagnostic-*,clang-analyzer-*,misc-throw-by-value-catch-by-reference,modernize-use-nullptr,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,performance-*,-performance-enum-size,-performance-no-int-to-ptr'
+# -bugprone-chained-comparison is needed for catch2 < v3.5.3
+Checks:          'bugprone-*,-bugprone-assignment-in-if-condition,-bugprone-chained-comparison,-bugprone-easily-swappable-parameters,-bugprone-implicit-widening-of-multiplication-result,-bugprone-multi-level-implicit-pointer-conversion,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-switch-missing-default-case,clang-diagnostic-*,clang-analyzer-*,misc-throw-by-value-catch-by-reference,modernize-use-nullptr,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,performance-*,-performance-enum-size'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/CorsixTH/Src/|/AnimView/|/common/'
 FormatStyle:     file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,8 @@
 ---
-Checks:          'bugprone-*,-bugprone-suspicious-enum-usage,clang-diagnostic-*,clang-analyzer-*,misc-throw-by-value-catch-by-reference,modernize-use-nullptr,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,performance-*'
-WarningsAsErrors: ''
+# -bugprone-chained-comparion is needed for catch2 < v3.5.3
+Checks:          'bugprone-*,-bugprone-assignment-in-if-condition,-bugprone-chained-comparison,-bugprone-easily-swappable-parameters,-bugprone-implicit-widening-of-multiplication-result,-bugprone-multi-level-implicit-pointer-conversion,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-switch-missing-default-case,clang-diagnostic-*,clang-analyzer-*,misc-throw-by-value-catch-by-reference,modernize-use-nullptr,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,performance-*,-performance-avoid-endl,-performance-enum-size,-performance-no-int-to-ptr'
+WarningsAsErrors: '*'
 HeaderFilterRegex: '/CorsixTH/Src/|/AnimView/|/common/'
-AnalyzeTemporaryDtors: false
 FormatStyle:     file
 CheckOptions:
   - key:             cert-dcl16-c.NewSuffixes

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 # -bugprone-chained-comparison is needed for catch2 < v3.5.3
-Checks:          'bugprone-*,-bugprone-assignment-in-if-condition,-bugprone-chained-comparison,-bugprone-easily-swappable-parameters,-bugprone-implicit-widening-of-multiplication-result,-bugprone-multi-level-implicit-pointer-conversion,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-switch-missing-default-case,clang-diagnostic-*,clang-analyzer-*,misc-throw-by-value-catch-by-reference,modernize-use-nullptr,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,performance-*,-performance-enum-size'
+Checks:          'bugprone-*,-bugprone-chained-comparison,-bugprone-easily-swappable-parameters,-bugprone-implicit-widening-of-multiplication-result,-bugprone-multi-level-implicit-pointer-conversion,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-switch-missing-default-case,clang-diagnostic-*,clang-analyzer-*,misc-throw-by-value-catch-by-reference,modernize-use-nullptr,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,performance-*,-performance-enum-size'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/CorsixTH/Src/|/AnimView/|/common/'
 FormatStyle:     file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 # -bugprone-chained-comparion is needed for catch2 < v3.5.3
-Checks:          'bugprone-*,-bugprone-assignment-in-if-condition,-bugprone-chained-comparison,-bugprone-easily-swappable-parameters,-bugprone-implicit-widening-of-multiplication-result,-bugprone-multi-level-implicit-pointer-conversion,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-switch-missing-default-case,clang-diagnostic-*,clang-analyzer-*,misc-throw-by-value-catch-by-reference,modernize-use-nullptr,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,performance-*,-performance-avoid-endl,-performance-enum-size,-performance-no-int-to-ptr'
+Checks:          'bugprone-*,-bugprone-assignment-in-if-condition,-bugprone-chained-comparison,-bugprone-easily-swappable-parameters,-bugprone-implicit-widening-of-multiplication-result,-bugprone-multi-level-implicit-pointer-conversion,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-switch-missing-default-case,clang-diagnostic-*,clang-analyzer-*,misc-throw-by-value-catch-by-reference,modernize-use-nullptr,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,performance-*,-performance-enum-size,-performance-no-int-to-ptr'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/CorsixTH/Src/|/AnimView/|/common/'
 FormatStyle:     file

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -55,7 +55,11 @@ jobs:
       - name: Install static analysis requirements
         if: matrix.static_analysis
         run: |
-          sudo apt-get install doxygen yamllint clang-format-11 clang-tidy-11
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20
+
+          sudo apt-get install doxygen yamllint clang-format-20 clang-tidy-20
 
           sudo pip3 install -I codespell==2.2 cmakelint==1.4
 
@@ -130,12 +134,11 @@ jobs:
         if: matrix.static_analysis
         run: |
           # Check cpp format
-          clang-format-11 -i CorsixTH/Src/*.cpp CorsixTH/Src/*.h AnimView/*.cpp \
+          clang-format-20 -i CorsixTH/Src/*.cpp CorsixTH/Src/*.h AnimView/*.cpp \
             AnimView/*.h libs/rnc/*.cpp libs/rnc/*.h CorsixTH/SrcUnshared/main.cpp
           git diff
           # Clang-tidy linter
-          clang-tidy-11 -p build --warnings-as-errors=\* \
-            CorsixTH/Src/*.c CorsixTH/Src/*.cpp libs/rnc/*.cpp CorsixTH/SrcUnshared/main.cpp
+          run-clang-tidy-20 -p build
           git diff --quiet # exit if clang-format made any changes
       - name: Generate documentation
         if: matrix.docs

--- a/AnimView/frmMain.cpp
+++ b/AnimView/frmMain.cpp
@@ -834,7 +834,7 @@ static bool matchTilePos(const std::string& text, double& x, double& y) {
       y = std::stod(num2.c_str());
       return true;
     } catch (...) {
-      // Drop into fail return value.
+      return false;
     }
   }
   return false;
@@ -856,7 +856,7 @@ static bool matchPixelPos(const std::string& text, int& x, int& y) {
       y = std::stoi(num2.c_str());
       return true;
     } catch (...) {
-      // Drop into fail return value.
+      return false;
     }
   }
   return false;

--- a/CorsixTH/Src/persist_lua.cpp
+++ b/CorsixTH/Src/persist_lua.cpp
@@ -1161,7 +1161,7 @@ int l_persist_dofile(lua_State* L) {
   }
   size_t iBufferSize = lua_objlen(L, luaT_upvalueindex(1));
   size_t iBufferUsed = 0;
-  while (!std::feof(fFile)) {
+  while (!std::ferror(fFile) && !std::feof(fFile)) {
     iBufferUsed += std::fread(
         reinterpret_cast<char*>(lua_touserdata(L, luaT_upvalueindex(1))) +
             iBufferUsed,

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -560,7 +560,7 @@ bool render_target::set_scale_factor(double fScale, scaled_items eWhatToScale) {
     if (!zoom_buffer->is_target()) {
       global_scale_factor = 1.0;
       std::cout << "Warning: Could not render to zoom texture - "
-                << SDL_GetError() << std::endl;
+                << SDL_GetError() << "\n";
 
       return false;
     }

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -862,8 +862,11 @@ void render_target::draw(SDL_Texture* pTexture, const SDL_Rect* prcSrcRect,
   getScaleRect(prcDstRect, draw_scale(), &scaledDstRect);
   if (current_target) current_target->offset(scaledDstRect);
   if (iSDLFlip != 0) {
-    SDL_RenderCopyExF(renderer, pTexture, prcSrcRect, &scaledDstRect, 0,
-                      nullptr, (SDL_RendererFlip)iSDLFlip);
+    // iSDLFlip may be 3 (HORIZONTAL | VERTICAL) but there is no enum value for
+    // that
+    [[clang::suppress]] SDL_RenderCopyExF(renderer, pTexture, prcSrcRect,
+                                          &scaledDstRect, 0, nullptr,
+                                          (SDL_RendererFlip)iSDLFlip);
   } else {
     SDL_RenderCopyF(renderer, pTexture, prcSrcRect, &scaledDstRect);
   }

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -648,7 +648,7 @@ class sprite_sheet {
 
     //! Height of the sprite.
     int height;
-  } * sprites;
+  }* sprites;
 
   //! Original palette.
   const ::palette* palette;

--- a/CorsixTH/Src/th_lua_sound.cpp
+++ b/CorsixTH/Src/th_lua_sound.cpp
@@ -103,8 +103,8 @@ size_t l_soundarc_checkidx(lua_State* L, int iArg, sound_archive* pArchive) {
   lua_getfenv(L, 1);
   lua_pushvalue(L, iArg);
   lua_rawget(L, -2);
-  if (lua_type(L, -1) == LUA_TLIGHTUSERDATA) {
-    size_t iIndex = (size_t)lua_topointer(L, -1);
+  if (lua_type(L, -1) == LUA_TNUMBER) {
+    size_t iIndex = static_cast<size_t>(lua_tointeger(L, -1));
     lua_pop(L, 2);
     return iIndex;
   }
@@ -114,7 +114,7 @@ size_t l_soundarc_checkidx(lua_State* L, int iArg, sound_archive* pArchive) {
     if (ignorecase_cmp(sName, pArchive->get_sound_name(i)) == 0) {
       lua_getfenv(L, 1);
       lua_pushvalue(L, iArg);
-      lua_pushlightuserdata(L, (void*)i);
+      lua_pushinteger(L, static_cast<lua_Integer>(i));
       lua_settable(L, -3);
       lua_pop(L, 1);
       return i;

--- a/CorsixTH/Src/th_lua_ui.cpp
+++ b/CorsixTH/Src/th_lua_ui.cpp
@@ -48,7 +48,7 @@ uint8_t range_scale(uint16_t low, uint16_t high, uint16_t val, uint16_t start,
 }
 
 inline bool is_wall(uint16_t blk) {
-  return ((82 <= ((blk)&0xFF)) && (((blk)&0xFF) <= 164));
+  return ((82 <= ((blk) & 0xFF)) && (((blk) & 0xFF) <= 164));
 }
 
 inline bool is_wall_drawn(const level_map& map, const map_tile& node,

--- a/CorsixTH/Src/th_movie.cpp
+++ b/CorsixTH/Src/th_movie.cpp
@@ -622,7 +622,7 @@ void movie_player::run_video() {
       break;
     } else if (iError < 0) {
       std::cerr << "Unexpected error " << iError
-                << " while decoding video packet" << std::endl;
+                << " while decoding video packet\n";
       break;
     }
 
@@ -709,7 +709,7 @@ int movie_player::decode_audio_frame(uint8_t* stream, int stream_size) {
       swr_convert(audio_resample_context, &stream, iOutSamples, nullptr, 0);
   if (actual_samples < 0) {
     std::cerr << "WARN: Unexpected error " << actual_samples
-              << " while converting audio" << std::endl;
+              << " while converting audio\n";
     return 0;
   } else if (actual_samples > 0) {
     return actual_samples * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16) *
@@ -723,7 +723,7 @@ int movie_player::decode_audio_frame(uint8_t* stream, int stream_size) {
     return 0;
   } else if (iError < 0) {
     std::cerr << "WARN: Unexpected error " << iError
-              << " while decoding audio packet" << std::endl;
+              << " while decoding audio packet\n";
     return 0;
   }
 
@@ -738,7 +738,7 @@ int movie_player::decode_audio_frame(uint8_t* stream, int stream_size) {
                   audio_frame->nb_samples);
   if (actual_samples < 0) {
     std::cerr << "WARN: Unexpected error " << actual_samples
-              << " while converting audio" << std::endl;
+              << " while converting audio\n";
     return 0;
   }
   return actual_samples * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16) *

--- a/CorsixTH/Src/xmi2mid.cpp
+++ b/CorsixTH/Src/xmi2mid.cpp
@@ -310,7 +310,8 @@ uint8_t* transcode_xmi_to_midi(const unsigned char* xmi_data, size_t xmi_length,
       return nullptr;
     iTokenTime = itr->time;
     if (itr->type >= 0xF0) {
-      if (!bufOutput.write(iTokenType = itr->type)) return nullptr;
+      iTokenType = itr->type;
+      if (!bufOutput.write(iTokenType)) return nullptr;
       if (iTokenType == 0xFF) {
         if (!bufOutput.write(itr->data)) return nullptr;
         if (itr->data == 0x2F) bEnd = true;
@@ -320,7 +321,8 @@ uint8_t* transcode_xmi_to_midi(const unsigned char* xmi_data, size_t xmi_length,
       if (!bufOutput.write(itr->buffer, itr->buffer_length)) return nullptr;
     } else {
       if (itr->type != iTokenType) {
-        if (!bufOutput.write(iTokenType = itr->type)) return nullptr;
+        iTokenType = itr->type;
+        if (!bufOutput.write(iTokenType)) return nullptr;
       }
       if (!bufOutput.write(itr->data)) return nullptr;
       if (itr->buffer) {

--- a/libs/rnc/rnc.cpp
+++ b/libs/rnc/rnc.cpp
@@ -36,6 +36,7 @@ SOFTWARE.
 
 #include "rnc.h"
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 
@@ -187,8 +188,14 @@ static void bitread_init(bit_stream* bs, const std::uint8_t* p,
     @param bs Bit stream to correct
 */
 static void bitread_fix(bit_stream* bs) {
-  // Remove the top 16 bits
+  // Remove the top 16 bits if present
   bs->bitcount -= 16;
+  if (bs->bitcount <= 0) {
+    bs->bitcount = 0;
+  }
+
+  // bs->bitcount is never greater than 32 and we just subtracted 16
+  assert(bs->bitcount <= 16);
   bs->bitbuf &= (1 << bs->bitcount) - 1;
 
   // Replace with what is in the new current location
@@ -219,6 +226,8 @@ static std::uint32_t bit_peek(bit_stream* bs, const std::uint32_t mask) {
         between 0 and 16
 */
 static void bit_advance(bit_stream* bs, int n) {
+  assert(n >= 0 && n <= 16);
+
   bs->bitbuf >>= n;
   bs->bitcount -= n;
 


### PR DESCRIPTION
Switched to 20 of the clang-tools, the current latest.

It is fairly easy to acquire any version of these tools, either for debian based distros packaged by llvm, https://apt.llvm.org/ or static compiled 3rd party binaries at https://github.com/muttleyxd/clang-tools-static-binaries/releases - I will add these links to the wiki after this is merged.

For now I suppressed all rules that resulted in new warnings and only addressed the new errors. Future work should review the suppressed rules and fix any that we do want to enforce.