### PR TITLE
Fix operating theatre and screen markers

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/use_screen.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_screen.lua
@@ -48,33 +48,6 @@ local finish = permanent"action_use_screen_finish"( function(humanoid)
   humanoid:finishAction()
 end)
 
--- Set markers for all animations involved.
-local animation_numbers = {
-  946,
-  --1022,
-  1048,
-  1052,
-  --1204,
-  --2772,
-  --2774,
-  --2776,
-  2780,
-  2782,
-  2784,
-  2790,
-  2792,
-  2794,
-  2796,
-  2844,
-  2848,
-  4760,
-  4762,
-  4768,
-  4770,
-}
-TheApp.animation_manager:setPatientMarker(animation_numbers, {-1.05, -0.05})
-TheApp.animation_manager:setStaffMarker(animation_numbers, {-1.05, -0.05})
-
 local patient_clothes_state = permanent"action_use_screen_patient_clothes_state"( function(humanoid)
   humanoid.user_of:setAnimation(1204)
   humanoid.user_of:setLayer(1, humanoid.layers[1])
@@ -202,12 +175,9 @@ local function action_use_screen_start(action, humanoid)
   end
 
   humanoid:setAnimation(anim)
-  local mood_info = humanoid.mood_info
-  humanoid.mood_info = nil -- Do not move mood_info
   humanoid:setTile(screen:getRenderAttachTile())
   local offset = screen.object_type.orientations[screen.direction].animation_offset
   humanoid:setPosition(offset[1], offset[2])
-  humanoid.mood_info = mood_info
   humanoid:setSpeed(0, 0)
   humanoid:setTimer(TheApp.animation_manager:getAnimLength(anim), when_done)
 

--- a/CorsixTH/Lua/objects/machines/operating_table.lua
+++ b/CorsixTH/Lua/objects/machines/operating_table.lua
@@ -85,6 +85,7 @@ anim_mgr:setAnimLength(2938, 1)
 
 -- Mood icon positions
 anim_mgr:setPatientMarker(object.idle_animations.north, {-1.59, -2.41})
+anim_mgr:setStaffMarker({2318, 2322, 2348, 2346, 2338, 2318, 2932, 2938, 2936, 2238}, {-1, -2})
 
 anim_mgr:setStaffMarker(object.usage_animations.north.in_use.Handyman, {29, -52, "px"})
 

--- a/CorsixTH/Lua/objects/machines/operating_table_b.lua
+++ b/CorsixTH/Lua/objects/machines/operating_table_b.lua
@@ -44,6 +44,14 @@ object.usage_animations = copy_north_to_south {
   }
 }
 
+local anim_mgr = TheApp.animation_manager
+local kf1, kf2 = {0, 0}, {-0.7, -0.4}
+anim_mgr:setStaffMarker({2306, 2342}, kf1)
+anim_mgr:setStaffMarker(2330, kf1, kf2)
+anim_mgr:setStaffMarker({4890, 2326}, kf2)
+anim_mgr:setStaffMarker(2334, kf2, kf1)
+
+
 object.orientations = {
   north = {
     use_position = {0, 0},

--- a/CorsixTH/Lua/objects/screen.lua
+++ b/CorsixTH/Lua/objects/screen.lua
@@ -26,6 +26,7 @@ object.tooltip = _S.tooltip.objects.screen
 object.ticks = false
 object.build_preview_animation = 926
 object.show_in_town_map = true
+-- More than one idle animation exists, but we can only set one to the object
 object.idle_animations = {
   north = 1022,
 }
@@ -36,5 +37,42 @@ object.orientations = {
     use_position = "passable",
   },
 }
+
+-- Animation numbers below correspond to non-operating theatre uses only
+-- See surgeon_screen.lua for that room
+object.usage_animations = {
+  north = {
+    in_use = {
+      ["Elvis Patient"] = 946, -- specifically, transformation
+      ["Standard Male Patient"] = {
+        undress = 1048,
+        dress   = 1052,
+      },
+      ["Standard Female Patient"] = {
+        undress = 2848,
+        dress   = 2844,
+      },
+    },
+  },
+}
+
+
+local anim_mgr = TheApp.animation_manager
+local kf1, kf2, kf3 = {-1, -1}, {-0.9, -0.8}, {-0.6, -0.6}
+local anims = { object.idle_animations.north, 1204 } -- idle anims
+anim_mgr:setPatientMarker(anims, kf1)
+anim_mgr:setStaffMarker(anims, kf1)
+
+anims = object.usage_animations.north.in_use
+anim_mgr:setPatientMarker(anims["Elvis Patient"],
+    0, kf1, 6, kf1, 7, kf2, 11, kf2, 12, kf1, 24, kf1, 28, kf3, 32, kf3, 36, kf1, 43, kf1)
+anim_mgr:setPatientMarker(anims["Standard Male Patient"].undress,
+    0, kf1, 7, kf1, 8, kf2, 12, kf2, 13, kf1)
+anim_mgr:setPatientMarker(anims["Standard Male Patient"].dress,
+    0, kf1, 10, kf1, 11, kf2, 21, kf2, 22, kf1)
+anim_mgr:setPatientMarker(anims["Standard Female Patient"].undress,
+    0, kf1, 2, kf2, 3, kf2, 9, kf2, 11, kf1, 17, kf1, 18, kf2, 25, kf2, 26, kf1)
+anim_mgr:setPatientMarker(anims["Standard Female Patient"].dress,
+    0, kf1, 2, kf1, 3, kf2, 12, kf2, 13, kf1)
 
 return object

--- a/CorsixTH/Lua/objects/surgeon_screen.lua
+++ b/CorsixTH/Lua/objects/surgeon_screen.lua
@@ -27,6 +27,7 @@ object.tooltip = _S.tooltip.objects.surgeon_screen
 object.ticks = false
 object.build_preview_animation = 926
 object.show_in_town_map = true
+-- More than one idle animation exists, but we can only set one to the object
 object.idle_animations = {
   north = 2772,
 }
@@ -37,6 +38,67 @@ object.orientations = {
     use_position = "passable",
   },
 }
+
+-- Animation numbers below correspond to operating theatre uses only.
+-- See screen.lua for everything else.
+object.usage_animations = {
+  north = {
+    --[[ unused
+    begin_use = {
+      scrubs_on  = 2786,
+      scrubs_off = 2788
+    },
+    ]]--
+    in_use = {
+      Surgeon = {
+        scrubs_on_t1 =  2780,
+        scrubs_on_t2 =  2782,
+        scrubs_on_t3 =  2784,
+        scrubs_off_t1 = 2790,
+        scrubs_off_t2 = 2792,
+        scrubs_off_t3 = 2794,
+        scrubs_off_t4 = 2796,
+      },
+      ["Standard Male Patient"] = {
+        gown_on  = 4760,
+        gown_off = 4768,
+      },
+      ["Standard Female Patient"] = {
+        gown_on  = 4762,
+        gown_off = 4770,
+      },
+    },
+  },
+}
+
+local anim_mgr = TheApp.animation_manager
+local kf1, kf2, kf3 = {-1.23, -1.14}, {-0.9, -0.8}, {-0.7, -0.6}
+local anims = { object.idle_animations.north, 2774, 2776 } -- idle anims
+anim_mgr:setPatientMarker(anims, kf1)
+anim_mgr:setStaffMarker(anims, kf1)
+
+anims = object.usage_animations.north.in_use
+anim_mgr:setStaffMarker(anims.Surgeon.scrubs_on_t1,
+    0, kf1, 2, kf1, 7, kf3, 22, kf3, 25, kf1, 26, kf1)
+anim_mgr:setStaffMarker(anims.Surgeon.scrubs_on_t2,
+    0, kf1, 3, kf1, 6, kf2, 8, kf2, 9, kf3, 14, kf3, 18, kf1, 22, kf1, 27, kf3, 34, kf3, 37, kf1)
+anim_mgr:setStaffMarker(anims.Surgeon.scrubs_on_t3,
+    0, kf1, 3, kf1, 6, kf3, 14, kf3, 18, kf1, 23, kf1, 28, kf3, 33, kf3, 36, kf1)
+anim_mgr:setStaffMarker(anims.Surgeon.scrubs_off_t1, 0, kf1, 4, kf3, 12, kf3, 17,
+    kf1, 24, kf1, 28, kf3, 35, kf3, 39, kf1)
+anim_mgr:setStaffMarker(anims.Surgeon.scrubs_off_t2, 0, kf1, 4, kf1, 8, kf3, 16,
+    kf3, 21, kf1, 31, kf1, 34, kf3, 42, kf3, 46, kf1)
+anim_mgr:setStaffMarker(anims.Surgeon.scrubs_off_t3, 0, kf1, 5, kf3, 15, kf3, 21, kf1)
+anim_mgr:setStaffMarker(anims.Surgeon.scrubs_off_t4, 0, kf1, 4, kf3, 17, kf3, 21, kf1)
+kf1, kf2 = {-1, -1}, {-0.6, -0.6}
+anim_mgr:setPatientMarker(anims["Standard Male Patient"].gown_on, 0, kf1, 4, kf2, 16,
+    kf2, 19, kf1)
+anim_mgr:setPatientMarker(anims["Standard Male Patient"].gown_off, 0, kf1, 2, kf1, 5,
+    kf2, 11, kf2, 15, kf1)
+anim_mgr:setPatientMarker(anims["Standard Female Patient"].gown_on, 0, kf1, 5, kf2, 16,
+    kf2, 19, kf1)
+anim_mgr:setPatientMarker(anims["Standard Female Patient"].gown_off, 0, kf1, 3, kf1, 10,
+    kf2, 15, kf1)
 
 class "SurgeonScreen" (Object)
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Addresses #2794*

**Describe what the proposed change does**
- Adds staff markers for operating theatre [Done]
- Moves animation marker set out of use_screen action back to their object files [Done]
- Adds markers for screens and surgeon screens [Done]
