### PR TITLE
Fix swingdoor mood

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -182,13 +182,13 @@ local doorL_markers = { -- Anim 3286 in particular.
 
 assignPatientMarkers(door_animations, "entering", doorE_markers)
 assignPatientMarkers(door_animations, "leaving", doorL_markers)
-assignPatientMarkers(door_animations, "entering_swing", 0, {-1.0, 0.0}, 8, {0.0, 0.0})
-assignPatientMarkers(door_animations, "leaving_swing", 0, {0.1, 0.0}, 9, {0.0, -1.0})
+assignPatientMarkers(door_animations, "leaving_swing", {3, 4, "px"}, {32, -14, "px"})
+assignPatientMarkers(door_animations, "entering_swing", {-32, -10, "px"}, {0, -2, "px"})
 
 assignStaffMarkers(door_animations, "entering", doorE_markers)
 assignStaffMarkers(door_animations, "leaving", doorL_markers)
-assignStaffMarkers(door_animations, "entering_swing", 0, {-1.0, 0.0}, 8, {0.0, 0.0})
-assignStaffMarkers(door_animations, "leaving_swing", 0, {0.1, 0.0}, 9, {0.0, -1.0})
+assignStaffMarkers(door_animations, "leaving_swing", {3, 4, "px"}, {32, -14, "px"})
+assignStaffMarkers(door_animations, "entering_swing", {-32, -10, "px"}, {0, -2, "px"})
 
 --  | Die Animations                 |
 --  | Name                           |FallE|RiseE|RiseE Hell|WingsE|HandsE|FlyE|ExtraE| Notes 2248


### PR DESCRIPTION
*Fixes swingdoor mood position.

The old positions were not entirely correct (animations don't start and/or end center-tile). Also, it used hard-coded frame offsets but the various animations differ in the number of frames, so the end-position was often outside the frame range.

I ran a test in a somewhat flaky version, but the nurse worked:

![Screenshot from 2025-05-14 22-32-20](https://github.com/user-attachments/assets/81c765a2-2c30-4301-828a-b64e9f114a97)
![Screenshot from 2025-05-14 22-32-43](https://github.com/user-attachments/assets/c9be320b-1073-43a2-9fa7-c5fcafe8883b)
