### PR TITLE
Use %zd for printing a size_t value.

### DIFF
--- a/AnimView/frmMain.cpp
+++ b/AnimView/frmMain.cpp
@@ -744,7 +744,7 @@ void frmMain::updateMoodPosition(int centerX, int centerY) {
   }
   m_txtMoodPosition[1]->SetValue(
       wxString::Format(L"{%i, %i, \"px\"}", m_iMoodDrawX, m_iMoodDrawY));
-  printf("%ld, {%i, %i, \"px\"}, -- Anim %ld\n", m_iCurrentFrame, m_iMoodDrawX,
+  printf("%zd, {%i, %i, \"px\"}, -- Anim %zd\n", m_iCurrentFrame, m_iMoodDrawX,
          m_iMoodDrawY, m_iCurrentAnim);
 
   if (m_bDrawMood) m_panFrame->Refresh(false);


### PR DESCRIPTION
Found by lewri, `printf` of a `size_t` value needs `%zd` rather than `%ld`.
