### PR TITLE
Replace clang::suppress attribute

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -864,9 +864,9 @@ void render_target::draw(SDL_Texture* pTexture, const SDL_Rect* prcSrcRect,
   if (iSDLFlip != 0) {
     // iSDLFlip may be 3 (HORIZONTAL | VERTICAL) but there is no enum value for
     // that
-    [[clang::suppress]] SDL_RenderCopyExF(renderer, pTexture, prcSrcRect,
-                                          &scaledDstRect, 0, nullptr,
-                                          (SDL_RendererFlip)iSDLFlip);
+    SDL_RenderCopyExF(renderer, pTexture, prcSrcRect, &scaledDstRect, 0,
+                      nullptr,
+                      (SDL_RendererFlip)iSDLFlip);  // NOLINT
   } else {
     SDL_RenderCopyF(renderer, pTexture, prcSrcRect, &scaledDstRect);
   }


### PR DESCRIPTION
NOLINT comment also works for clang-tidy and doesn't trigger a warning in other compilers. Hopefully in the future compilers adopt the attribute or make it easier to suppress, but for now the comment is a better experience.