### PR TITLE
Bump vcpkg for May 2025

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,9 @@ CorsixTH/CorsixTH.sln
 .cproject
 .vs/
 
+# CLion / IntelliJ
+.idea/
+
 # Default build path
 CorsixTH/CorsixTH
 CorsixTH/corsix-th

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "57f42c11b101c1a999bbeaf941fe12752c6de399",
+    "baseline": "8f54ef5453e7e76ff01e15988bf243e7247c5eb5",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [
@@ -13,8 +13,8 @@
     {
       "kind": "git",
       "repository": "https://github.com/CorsixTH/vcpkg-registry",
-      "baseline": "b998b8771178330078a06e310c79579a690159ed",
-      "packages": [ "ffmpeg", "luafilesystem", "lpeg" ]
+      "baseline": "1ec0ed6b666d6ef4843e8b8fc0f32cbf5b6fe359",
+      "packages": [ "ffmpeg" ]
     }
   ]
 }


### PR DESCRIPTION
    + catch2 3.8.1
    + curl[core,openssl,ssl] 8.13.0#1
    ~ ffmpeg[avcodec,avformat,core,swresample,swscale] 7.1.1#2
    + fluidsynth[buildtools,core,sndfile] 2.4.6#1
    freetype[brotli,bzip2,core,png,zlib] 2.13.3
    lpeg 1.1.0#1
    lua[core,tools] 5.4.7
    ~ luafilesystem 1.8.0#7
    + sdl2[core,dbus,ibus,wayland,x11] 2.32.6
    ~ sdl2-mixer[core,fluidsynth,libflac,libmodplug,mpg123,opusfile,wavpack] 2.8.1#1
    + wxwidgets[core,debug-support,sound] 3.2.7
    
    + version bumped by this PR
    ~ port updated by this PR but same version