### PR TITLE
Unicode font colour fix

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -35,11 +35,8 @@ function UIBottomPanel:UIBottomPanel(ui)
   self.width = 640
   self.height = 48
   self:setDefaultPosition(0.5, -0.1)
-  self.panel_sprites = app.gfx:loadSpriteTable("Data", "Panel02V", true)
-  self.money_font = app.gfx:loadFontAndSpriteTable("QData", "Font05V")
-  self.date_font = app.gfx:loadFontAndSpriteTable("QData", "Font16V")
-  self.white_font = app.gfx:loadFontAndSpriteTable("QData", "Font01V", nil, nil, 0, -2)
-  self.pause_font = app.gfx:loadFontAndSpriteTable("QData", "Font124V")
+
+  self:_initFonts(app.gfx)
 
   -- State relating to fax notification messages
   self.show_animation = true
@@ -97,6 +94,16 @@ function UIBottomPanel:UIBottomPanel(ui)
   end, 41, 30, 137, 42)
 
   self:registerKeyHandlers()
+end
+
+function UIBottomPanel:_initFonts(gfx)
+  local date_label_color = { red = 175, green = 50, blue = 15 }
+  local pause_label_color = { red = 35, green = 138, blue = 173 }
+  self.panel_sprites = gfx:loadSpriteTable("Data", "Panel02V", true)
+  self.money_font = gfx:loadFontAndSpriteTable("QData", "Font05V")
+  self.date_font = gfx:loadFontAndSpriteTable("QData", "Font16V", nil, nil, 0, 0, date_label_color)
+  self.white_font = gfx:loadFontAndSpriteTable("QData", "Font01V", nil, nil, 0, -2)
+  self.pause_font = gfx:loadFontAndSpriteTable("QData", "Font124V", nil, nil, 0, 0, pause_label_color)
 end
 
 function UIBottomPanel:registerKeyHandlers()
@@ -899,6 +906,9 @@ function UIBottomPanel:afterLoad(old, new)
       self.additional_buttons[i] = self.buttons[5 + i]:makeToggle() -- made them toggle buttons
     end
     self.bank_button = self.buttons[1]:makeToggle()
+  end
+  if old < 215 then
+   self:_initFonts(self.ui.app.gfx)
   end
   -- Hotfix to force re-calculation of the money font (see issue #1193)
   self.money_font = self.ui.app.gfx:loadFontAndSpriteTable("QData", "Font05V")

--- a/CorsixTH/Lua/dialogs/build_room.lua
+++ b/CorsixTH/Lua/dialogs/build_room.lua
@@ -35,9 +35,10 @@ function UIBuildRoom:UIBuildRoom(ui)
   self.width = 297
   self.height = 294
   self:setDefaultPosition(0.5, 0.5)
+  local selected_label_color = { red = 40, green = 40, blue = 250 }
   self.panel_sprites = app.gfx:loadSpriteTable("QData", "Req09V", true)
   self.white_font = app.gfx:loadFontAndSpriteTable("QData", "Font01V")
-  self.blue_font = app.gfx:loadFontAndSpriteTable("QData", "Font02V")
+  self.blue_font = app.gfx:loadFontAndSpriteTable("QData", "Font02V", nil, nil, 0, 0, selected_label_color)
   self.category_index = 0
   self.list_hover_index = 0
   self.preview_anim = false

--- a/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/annual_report.lua
@@ -59,9 +59,10 @@ function UIAnnualReport:UIAnnualReport(ui, world)
     self.stat_background = gfx:loadRaw("Award02V", 640, 480, "QData", "QData", "Award02V.pal", true)
     self.background = self.stat_background
 
+    local stone_text_color = { red = 80, green = 60, blue = 35 }
     self.stat_font = gfx:loadFontAndSpriteTable("QData", "Font45V", false, palette)
     self.write_font = gfx:loadFontAndSpriteTable("QData", "Font47V", false, palette)
-    self.stone_font = gfx:loadFontAndSpriteTable("QData", "Font46V", false, palette)
+    self.stone_font = gfx:loadFontAndSpriteTable("QData", "Font46V", false, palette, 0, 0, stone_text_color)
 
     self.panel_sprites = gfx:loadSpriteTable("QData", "Award03V", true, palette)
   end) then

--- a/CorsixTH/Lua/dialogs/furnish_corridor.lua
+++ b/CorsixTH/Lua/dialogs/furnish_corridor.lua
@@ -45,9 +45,10 @@ function UIFurnishCorridor:UIFurnishCorridor(ui, objects, edit_dialog)
   self.width = 360
   self.height = 274
   self:setDefaultPosition(0.5, 0.4)
+  local selected_label_color = { red = 40, green = 40, blue = 250 }
   self.panel_sprites = app.gfx:loadSpriteTable("QData", "Req10V", true)
   self.white_font = app.gfx:loadFontAndSpriteTable("QData", "Font01V")
-  self.blue_font = app.gfx:loadFontAndSpriteTable("QData", "Font02V")
+  self.blue_font = app.gfx:loadFontAndSpriteTable("QData", "Font02V", nil, nil, 0, 0, selected_label_color)
   self.title_text = _S.buy_objects_window.choose_items
   self.price_text = (_S.buy_objects_window.price .. " "):gsub("  $", " ")
   self.total_text = (_S.buy_objects_window.total .. " "):gsub("  $", " ")

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -39,9 +39,10 @@ function UIMenuBar:UIMenuBar(ui, map_editor)
   self.width = app.config.width
   self.height = 16
   self.visible = false
+  local selected_label_color = { red = 40, green = 40, blue = 250 }
   self.panel_sprites = app.gfx:loadSpriteTable("Data", "PullDV", true)
   self.white_font = app.gfx:loadFontAndSpriteTable("QData", "Font01V")
-  self.blue_font = app.gfx:loadFontAndSpriteTable("QData", "Font02V")
+  self.blue_font = app.gfx:loadFontAndSpriteTable("QData", "Font02V", nil, nil, 0, 0, selected_label_color)
   -- The list of top-level menus, from left to right
   self.menus = {}
   -- The menu which the cursor was most recently over

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -55,9 +55,10 @@ function UIPlaceObjects:UIPlaceObjects(ui, object_list, pay_for)
   self.width = 186
   self.height = 167 + #object_list * 29
   self:setDefaultPosition(0.9, 0.1)
+  local selected_label_color = { red = 40, green = 40, blue = 250 }
   self.panel_sprites = app.gfx:loadSpriteTable("QData", "Req05V", true)
   self.white_font = app.gfx:loadFontAndSpriteTable("QData", "Font01V")
-  self.blue_font = app.gfx:loadFontAndSpriteTable("QData", "Font02V")
+  self.blue_font = app.gfx:loadFontAndSpriteTable("QData", "Font02V", nil, nil, 0, 0, selected_label_color)
   self.title_text = _S.rooms_short.corridor_objects
   self.desc_text = _S.place_objects_window.place_objects_in_corridor
 

--- a/CorsixTH/Lua/dialogs/resizables/main_menu.lua
+++ b/CorsixTH/Lua/dialogs/resizables/main_menu.lua
@@ -25,9 +25,9 @@ class "UIMainMenu" (UIResizable)
 local UIMainMenu = _G["UIMainMenu"]
 
 local col_bg = {
-  red = 154,
-  green = 146,
-  blue = 198,
+  red = 90,
+  green = 160,
+  blue = 90
 }
 
 local label_ttf_col = { -- off white


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2819*
*Fixes #2744*

**Describe what the proposed change does**
- For Unicode fonts: 
- fixed text color for the calendar in the bottom panel,  
- fixed text color on the statue in the annual report,  
- fixed text color of the pause inscription have been fixed,
- fixed text color of selected item in build or furnish menu.

<img width="912" alt="Screenshot 2025-05-25 at 16 35 23" src="https://github.com/user-attachments/assets/e0d0295f-b079-44cd-9f48-e2bdb8140a4a" />

