### PR TITLE
Check file handle of output file as well.

### DIFF
--- a/tools/rnc/rnc_decode_cli.cpp
+++ b/tools/rnc/rnc_decode_cli.cpp
@@ -115,6 +115,10 @@ int main(int argc, char* argv[]) {
   std::uint8_t* outdata = decompress(indata, insize, &outlen);
 
   FILE* outhandle = fopen(argv[2], "wb");
+  if (outhandle == nullptr) {
+    fprintf(stderr, "Cannot open output file.\n");
+    exit(1);
+  }
   count = fwrite(outdata, 1, outlen, outhandle);
   if (count != outlen) {
     fprintf(stderr, "Cannot write output file.\n");


### PR DESCRIPTION
Reported by @tobylane in the chat.

Opening output file of rmc-decode CLI was not checked.