### PR TITLE
[Pending] Puke sound on vomit

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/vomit.lua
+++ b/CorsixTH/Lua/humanoid_actions/vomit.lua
@@ -36,6 +36,9 @@ local action_vomit_end = permanent"action_vomit_end"( function(humanoid)
 end)
 
 local function action_vomit_start(action, humanoid)
+  local puke_sound = (math.random(0, 1) == 1) and "puke.wav" or "puke2.wav"
+  humanoid.hospital:playSound(puke_sound)
+
   if math.random(0, 1) == 1 then
     humanoid.last_move_direction = "east"
   else


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**Describe what the proposed change does**

In original TH when patient pukes you firstly hear the puke sound. And then vomit hitting the floor sound.

In CTH If patient pukes you don't hear any puke sound. Only sound vomit hitting the floor sound.

This PR add patient puke sound in CTH for this case.

[vommit_kingdom2.sav.zip](https://github.com/user-attachments/files/20506492/vommit_kingdom2.sav.zip)

btw
puke sound is `puke.wav` and `puke2.wav`.
vomit hitting the floor sound is `vomsplat.wav`.
you can hear vomit hitting the floor sound.
but there is no any `vomsplat.wav` mention on the source code.
