### PR TITLE
Fix font cache and lua bind casting

### DIFF
--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -438,7 +438,8 @@ function Graphics:loadLanguageFont(name, sprite_table, x_sep, y_sep, ttf_col, fo
   if name == nil then
     font = self:loadFont(sprite_table, x_sep, y_sep, ttf_col, force_bitmap)
   else
-    local cache = self.cache.language_fonts[language_font_cache_key(name, x_sep, y_sep, ttf_col, force_bitmap)]
+    local cache_key = language_font_cache_key(name, x_sep, y_sep, ttf_col, force_bitmap)
+    local cache = self.cache.language_fonts[cache_key]
     font = cache and cache[sprite_table]
     if not font then
       font = TH.freetype_font()
@@ -453,7 +454,7 @@ function Graphics:loadLanguageFont(name, sprite_table, x_sep, y_sep, ttf_col, fo
 
       if not cache then
         cache = {}
-        self.cache.language_fonts[name] = cache
+        self.cache.language_fonts[cache_key] = cache
       end
       cache[sprite_table] = font
     end

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -35,6 +35,7 @@ SOFTWARE.
 #include "lua.hpp"
 #include "th.h"
 #include "th_gfx_common.h"
+#include "th_lua.h"
 
 class lua_persist_reader;
 class lua_persist_writer;
@@ -723,43 +724,8 @@ class sprite_render_list : public animation_base {
 // method_table: { ... }
 // method_table metatable: { __class_name = class_name }
 inline animation_base* luaT_toanimationbase(lua_State* L, int idx) {
-  void* p = lua_touserdata(L, idx);
-  if (!p) {
-    return nullptr;
-  }
-  if (lua_getmetatable(L, idx) == 0) {
-    std::printf("Warn: No metatable for animation_base userdata\n");
-    return nullptr;
-  }
-  lua_getfield(L, -1, "__index");
-  if (lua_type(L, -1) != LUA_TTABLE) {
-    lua_pop(L, 2);
-    std::printf("Warn: No __index field method table animation_base\n");
-    return nullptr;
-  }
-  if (lua_getmetatable(L, -1) == 0) {
-    lua_pop(L, 2);
-    std::printf("Warn: No metatable for method table of animation_base\n");
-    return nullptr;
-  }
-  lua_getfield(L, -1, "__class_name");
-  if (lua_type(L, -1) != LUA_TSTRING) {
-    lua_pop(L, 4);
-    std::printf("Warn: No __class_name field for animation_base\n");
-    return nullptr;
-  }
-  const char* class_name = lua_tostring(L, -1);
-  if (std::strcmp(class_name, "animation") == 0) {
-    lua_pop(L, 4);
-    return static_cast<animation*>(p);
-  } else if (std::strcmp(class_name, "spriteList") == 0) {
-    lua_pop(L, 4);
-    return static_cast<sprite_render_list*>(p);
-  } else {
-    std::printf("Warn: Unknown animation_base class name %s\n", class_name);
-    lua_pop(L, 4);
-    return nullptr;
-  }
+  return luaT_touserdata_base<animation_base, animation, sprite_render_list>(
+      L, idx, {"animation", "spriteList"});
 }
 
 #endif  // CORSIX_TH_TH_GFX_H_

--- a/CorsixTH/Src/th_lua.h
+++ b/CorsixTH/Src/th_lua.h
@@ -25,8 +25,12 @@ SOFTWARE.
 #include "config.h"
 
 #include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <initializer_list>
 #include <memory>
 #include <new>
+#include <type_traits>
 
 #include "lua.hpp"
 
@@ -462,5 +466,80 @@ void luaT_execute(lua_State* L, const char* sLuaString, T1 arg1, T2 arg2,
 void luaT_pushtablebool(lua_State* L, const char* k, bool v);
 
 void preload_lua_package(lua_State* L, const char* name, lua_CFunction fn);
+
+namespace {
+int luaT_get_userdata_classname(lua_State* L, int idx, const char** class_name,
+                                void** userdata) {
+  void* p = lua_touserdata(L, idx);
+  *userdata = p;
+  if (p == nullptr) {
+    return 0;
+  }
+  int added_stack = 0;
+  if (lua_getmetatable(L, idx) == 0) {
+    std::printf("Warn: No metatable for userdata\n");
+    return 0;
+  }
+  lua_getfield(L, -1, "__index");
+  added_stack += 2;  // metadata and field
+  if (lua_type(L, -1) != LUA_TTABLE) {
+    lua_pop(L, added_stack);
+    std::printf("Warn: No __index field method table for userdata\n");
+    return 0;
+  }
+
+  if (lua_getmetatable(L, -1) == 0) {
+    lua_pop(L, added_stack);
+    std::printf("Warn: No metatable for method table of userdata\n");
+    return 0;
+  }
+  lua_getfield(L, -1, "__class_name");
+  added_stack += 2;  // method metatable and class name field
+  if (lua_type(L, -1) != LUA_TSTRING) {
+    lua_pop(L, added_stack);
+    std::printf("Warn: No __class_name field for userdata\n");
+    return 0;
+  }
+  *class_name = lua_tostring(L, -1);
+
+  return added_stack;
+}
+}  // namespace
+
+// Find the appropriate derived class of base for a given
+// userdata object.
+//
+// th_lua_internal.h defines our c++ binding class metatables:
+// metatable: { __index = method_table, ... }
+// method_table: { ... }
+// method_table metatable: { __class_name = class_name }
+template <typename B, typename T1, typename T2>
+B* luaT_touserdata_base(lua_State* L, int idx,
+                        const std::initializer_list<const char*>& class_names) {
+  static_assert(std::is_base_of<B, T1>::value, "B must be a base class for T1");
+  static_assert(std::is_base_of<B, T2>::value, "B must be a base class for T2");
+
+  const char* class_name = nullptr;
+  void* p;
+
+  int stack = luaT_get_userdata_classname(L, idx, &class_name, &p);
+  if (class_name == nullptr) {
+    return nullptr;
+  }
+
+  auto it = class_names.begin();
+  if (std::strcmp(class_name, *it) == 0) {
+    lua_pop(L, stack);
+    return static_cast<T1*>(p);
+  }
+  it++;
+  if (std::strcmp(class_name, *it) == 0) {
+    lua_pop(L, stack);
+    return static_cast<T2*>(p);
+  }
+  std::printf("Warn: Unknown class name for usertype %s\n", class_name);
+  lua_pop(L, stack);
+  return nullptr;
+}
 
 #endif  // CORSIX_TH_TH_LUA_H_

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -44,6 +44,18 @@ SOFTWARE.
 
 namespace {
 
+font* luaT_getfont(lua_State* L) {
+  font* p = luaT_touserdata_base<font, bitmap_font, freetype_font>(
+      L, 1, {"bitmap_font", "freetype_font"});
+#ifdef DEBUG
+  if (p != nullptr && dynamic_cast<bitmap_font*>(p) == nullptr &&
+      dynamic_cast<freetype_font*>(p) == nullptr) {
+    std::fprintf(stderr, "font found which is not freetype or bitmap: %p\n", p);
+  }
+#endif
+  return p;
+}
+
 int l_palette_new(lua_State* L) {
   luaT_stdnew<palette>(L);
   return 1;
@@ -326,7 +338,7 @@ int l_freetype_font_clear_cache(lua_State* L) {
 #endif
 
 int l_font_get_size(lua_State* L) {
-  font* pFont = luaT_testuserdata<font>(L);
+  font* pFont = luaT_getfont(L);
   size_t iMsgLen;
   const char* sMsg = luaT_checkstring(L, 2, &iMsgLen);
 
@@ -344,7 +356,7 @@ int l_font_get_size(lua_State* L) {
 }
 
 int l_font_draw(lua_State* L) {
-  font* pFont = luaT_testuserdata<font>(L);
+  font* pFont = luaT_getfont(L);
   render_target* pCanvas = nullptr;
   if (!lua_isnoneornil(L, 2)) {
     pCanvas = luaT_testuserdata<render_target>(L, 2);
@@ -392,7 +404,7 @@ int l_font_draw(lua_State* L) {
 }
 
 int l_font_draw_wrapped(lua_State* L) {
-  font* pFont = luaT_testuserdata<font>(L);
+  font* pFont = luaT_getfont(L);
   render_target* pCanvas = nullptr;
   if (!lua_isnoneornil(L, 2)) {
     pCanvas = luaT_testuserdata<render_target>(L, 2);
@@ -439,7 +451,7 @@ int l_font_draw_wrapped(lua_State* L) {
 }
 
 int l_font_draw_tooltip(lua_State* L) {
-  font* pFont = luaT_testuserdata<font>(L);
+  font* pFont = luaT_getfont(L);
   render_target* pCanvas = luaT_testuserdata<render_target>(L, 2);
   size_t iMsgLen;
   const char* sMsg = luaT_checkstring(L, 3, &iMsgLen);


### PR DESCRIPTION
Fixes #2885

Fixing the cache eliminated the problem. The cache being broken was a regression in my code for allowing font colors.

For correctness and because I wrote the code already this patch also fixes the chain of pointer casting when the base font class is desired, the same way animation_base was solved.
