### PR TITLE
Add cheats for queuejumping patients and hiring super doctors

### DIFF
--- a/CorsixTH/Lua/cheats.lua
+++ b/CorsixTH/Lua/cheats.lua
@@ -283,6 +283,18 @@ function Cheats:queueJumpOff()
   self.active_cheats.queuejump = false
 end
 
+--! Enable super doctors cheat (all doctors for hire have maximum skills)
+function Cheats:superDoctorOn()
+  self.active_cheats.super_doctor = true
+  self.hospital.world:makeAvailableStaff(self.hospital.world.game_date:monthOfGame())
+end
+
+--! Disable super doctors cheat (immediately return to the normal doctors available in the for hire dialog)
+function Cheats:superDoctorOff()
+  self.active_cheats.super_doctor = false
+  self.hospital.world:makeAvailableStaff(self.hospital.world.game_date:monthOfGame())
+end
+
 --[[End toggle-based cheat functions]]
 
 --[[ The toggle_cheats list (code operated cheats)
@@ -313,6 +325,14 @@ local toggle_cheats = {
     disableAnnouncement = _A.cheats.queuejump_off_cheat,
     lower = 200.5,
     upper = 200.6,
+  },
+  super_doctor = {
+    enable = Cheats.superDoctorOn,
+    disable = Cheats.superDoctorOff,
+    enableAnnouncement = _A.cheats.superdoctor_on_cheat,
+    disableAnnouncement = _A.cheats.superdoctor_off_cheat,
+    lower = 301.5,
+    upper = 301.6,
   },
 }
 

--- a/CorsixTH/Lua/cheats.lua
+++ b/CorsixTH/Lua/cheats.lua
@@ -273,6 +273,16 @@ function Cheats:noRestOff()
   self.active_cheats["no_rest_cheat"] = nil
 end
 
+--! Enable queue jump cheat (for nearly dead patients)
+function Cheats:queueJumpOn()
+  self.active_cheats.queuejump = true
+end
+
+--! Disable queue jump cheat (so that nearly dead patients queue regularly)
+function Cheats:queueJumpOff()
+  self.active_cheats.queuejump = false
+end
+
 --[[End toggle-based cheat functions]]
 
 --[[ The toggle_cheats list (code operated cheats)
@@ -295,6 +305,14 @@ local toggle_cheats = {
     disableAnnouncement = _A.cheats.norest_off_cheat,
     lower = 185.5,
     upper = 185.6,
+  },
+  queuejump = {
+    enable = Cheats.queueJumpOn,
+    disable = Cheats.queueJumpOff,
+    enableAnnouncement = _A.cheats.queuejump_on_cheat,
+    disableAnnouncement = _A.cheats.queuejump_off_cheat,
+    lower = 200.5,
+    upper = 200.6,
   },
 }
 

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -300,6 +300,8 @@ adviser = {
     roujin_off_cheat = "Roujin's challenge deactivated. Everything will be back to normal soon.",
     norest_on_cheat = "Oh no! It appears your staff have consumed too much caffeine and no longer feel a need to rest.",
     norest_off_cheat = "Phew! Looks like that buzz finally wore off. Your staff will now rest properly.",
+    queuejump_on_cheat = "Your patients know how to queue. They let nearly dead patients go to the front of the line.",
+    queuejump_off_cheat = "People have turned selfish and are no longer letting nearly dead patients jump the queues.",
   },
   staff_place_advice = {
     not_enough_lecture_chairs = "Each student doctor needs a lecture chair to sit in!",

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -302,6 +302,8 @@ adviser = {
     norest_off_cheat = "Phew! Looks like that buzz finally wore off. Your staff will now rest properly.",
     queuejump_on_cheat = "Your patients know how to queue. They let nearly dead patients go to the front of the line.",
     queuejump_off_cheat = "People have turned selfish and are no longer letting nearly dead patients jump the queues.",
+    superdoctor_on_cheat = "A superb medical school has recommended you to their graduates! Check the staff for hire.",
+    superdoctor_off_cheat = "The medical school chief no longer recommends you to their graduates.",
   },
   staff_place_advice = {
     not_enough_lecture_chairs = "Each student doctor needs a lecture chair to sit in!",

--- a/CorsixTH/Lua/queue.lua
+++ b/CorsixTH/Lua/queue.lua
@@ -178,9 +178,12 @@ local function _getHumanoidQueuePriority(queue, humanoid)
   elseif humanoid.is_emergency then
     -- Next are Emergency patients
     return 4
+  elseif humanoid.hospital.hosp_cheats:isCheatActive("queuejump") and humanoid:getAttribute("health") < 0.10 then
+    -- If the queue jump cheat is enabled, let these nearly dead patients move ahead
+    return 5
   else
     -- All other regular patients receive this priority
-    return 5
+    return 6
   end
 end
 

--- a/CorsixTH/Lua/staff_profile.lua
+++ b/CorsixTH/Lua/staff_profile.lua
@@ -94,50 +94,54 @@ function StaffProfile:randomise(month)
   --self.skill_level_modifier = math.random(-50, 50) / 1000 -- [-0.05, +0.05]
 
   if self:isType("Doctor") then
-    -- find the correct config line (based on month) for generation of the doctor
-    local i = 0
-    while i < #level_config.staff_levels and
-    level_config.staff_levels[i+1].Month <= month do
-      i = i+1
-    end
-
-    -- list of level_config values and the corresponding staff modifiers, plus the value set for "no"
-    local mods = {
-      {"ShrkRate", "is_psychiatrist", 0},
-      {"SurgRate", "is_surgeon",      0},
-      {"RschRate", "is_researcher",   0},
-      {"JrRate",   "is_junior",     nil},
-      {"ConsRate", "is_consultant", nil},
-    }
-
-    -- The following assumes ascending month order of the staff_levels table.
-    -- TODO don't assume this but sort when loading map config
-    for _, m in ipairs(mods) do
-      local rate
-      local ind = i
-      while not rate do
-        assert(ind >= 0, "Staff modifier " .. m[1] .. " not existent (should at least be given by base_config).")
-        rate = level_config.staff_levels[ind][m[1]]
-        ind = ind - 1
-      end
-      -- 0 means none. Other values x mean "one in x"; thus 1 means "one in one" aka "all"
-      rate = (rate == 0) and 0 or 1 / rate
-      self[m[2]] = math.random() < rate and 1.0 or m[3]
-    end
-
-    -- is_consultant is forced to nil if is_junior is already 1
-    self.is_consultant = not self.is_junior and self.is_consultant or nil
-
     local jr_limit = level_config.gbv.DoctorThreshold / 1000
     local cons_limit = level_config.gbv.ConsultantThreshold / 1000
 
-    -- put the doctor in the right skill level box
-    if self.is_junior then
-      self.skill = jr_limit * self.skill
-    elseif self.is_consultant then
-      self.skill = cons_limit + ((1 - cons_limit) * self.skill)
+    if self.world:getLocalPlayerHospital().hosp_cheats:isCheatActive("super_doctor") then
+      self:initDoctor(1, 1, 1, false, true, math.random(cons_limit * 1000, 1000) / 1000)
     else
-      self.skill = jr_limit + ((cons_limit - jr_limit) * self.skill)
+      -- find the correct config line (based on month) for generation of the doctor
+      local i = 0
+      while i < #level_config.staff_levels and
+      level_config.staff_levels[i+1].Month <= month do
+        i = i+1
+      end
+
+      -- list of level_config values and the corresponding staff modifiers, plus the value set for "no"
+      local mods = {
+        {"ShrkRate", "is_psychiatrist", 0},
+        {"SurgRate", "is_surgeon",      0},
+        {"RschRate", "is_researcher",   0},
+        {"JrRate",   "is_junior",     nil},
+        {"ConsRate", "is_consultant", nil},
+      }
+
+      -- The following assumes ascending month order of the staff_levels table.
+      -- TODO don't assume this but sort when loading map config
+      for _, m in ipairs(mods) do
+        local rate
+        local ind = i
+        while not rate do
+          assert(ind >= 0, "Staff modifier " .. m[1] .. " not existent (should at least be given by base_config).")
+          rate = level_config.staff_levels[ind][m[1]]
+          ind = ind - 1
+        end
+        -- 0 means none. Other values x mean "one in x"; thus 1 means "one in one" aka "all"
+        rate = (rate == 0) and 0 or 1 / rate
+        self[m[2]] = math.random() < rate and 1.0 or m[3]
+      end
+
+      -- is_consultant is forced to nil if is_junior is already 1
+      self.is_consultant = not self.is_junior and self.is_consultant or nil
+
+      -- put the doctor in the right skill level box
+      if self.is_junior then
+        self.skill = jr_limit * self.skill
+      elseif self.is_consultant then
+        self.skill = cons_limit + ((1 - cons_limit) * self.skill)
+      else
+        self.skill = jr_limit + ((cons_limit - jr_limit) * self.skill)
+      end
     end
   end
   self.wage = self:getFairWage()


### PR DESCRIPTION

**Describe what the proposed change does**
- Add a cheat to allow nearly dead patients joining a queue to jump ahead of regular patients (behind emergencies)
- Add a cheat to make every doctor available for hire into a consultant with all three specialities. The change is better viewed ignoring whitespace: https://github.com/CorsixTH/CorsixTH/commit/7c9ccb7047dfaf3cad27419a3811e109fec14fdf?w=1

<details><summary>The cheats are enabled by entering fax codes -</summary>367141 and 386164 respectively</details>