### PR TITLE
Handle in-flight actions without mood marker

### DIFF
--- a/CorsixTH/Lua/entity.lua
+++ b/CorsixTH/Lua/entity.lua
@@ -129,7 +129,7 @@ function Entity:setTile(x, y)
   -- NB: (x, y) can be nil, in which case th:setTile expects all nil arguments
   self.th:setTile(x and self.world.map.th, x, y)
   if self.mood_info then
-    self.mood_info:setParent(self.th, self.mood_marker)
+    self.mood_info:setParent(self.th, self.mood_marker or 1)
   end
 
   -- Update the entity map for the new position
@@ -266,7 +266,7 @@ function Entity:setMoodInfo(new_mood)
     if not self.mood_info then
       self.mood_info = TH.animation()
       self.mood_info:setPosition(-1, -96)
-      self.mood_info:setParent(self.th)
+      self.mood_info:setParent(self.th, self.mood_marker or 1)
     end
     self.mood_info:setAnimation(self.world.anims, new_mood.icon)
   else


### PR DESCRIPTION
Fixes a regression from #2824 where some entities had no marker for a current action.

Argument is that the save system could be investigated not to try and cache this data, so it pulls the new mood marker information.

Untested, but I think this change may have some additional knock on effects to #2177 
