### PR TITLE
Fix misnamed function call loading font for hotkeys

### DIFF
--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -404,7 +404,7 @@ end
 function Graphics:loadMenuFont()
   local font
   if self.language_font then
-    font = self:loadFontAndSpriteSheet("QData", "Font01V")
+    font = self:loadFontAndSpriteTable("QData", "Font01V")
   else
     font = self:loadBuiltinFont()
   end


### PR DESCRIPTION
Fixes #2903

I had renamed loadFontAndSpriteTable from loadFontAndSpriteSheet but missed a spot.
