### PR TITLE
Remove dynamic info for GrimReaper

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/grim_reaper.lua
+++ b/CorsixTH/Lua/entities/humanoids/grim_reaper.lua
@@ -44,6 +44,6 @@ function GrimReaper:afterLoad(old, new)
     self.mood_marker = 2
   end
 
-  self:updateDynamicInfo()
+  -- The grim repear has no dynamic info currently, so don't refresh it
   Humanoid.afterLoad(self, old, new)
 end


### PR DESCRIPTION
Accidentally added in a previous PR a request to update the GrimReaper's dynamic info, but this method doesn't exist for that entity.

Instead, remove the line but leave a comment so people know they're special :)