### PR TITLE
Restore handyman cleaning abilities

### DIFF
--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -518,8 +518,10 @@ function PlayerHospital:onEndDay()
     end
   end
 
+  -- Look for work for staff who have nothing to do
   for _, staff in ipairs(self.staff) do
-    if staff:isIdle() then
+    -- Handymen currently have their own method to look for work
+    if staff.humanoid_class ~= "Handyman" and staff:isIdle() then
       self.world.dispatcher:answerCall(staff)
     end
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2913*

**Describe what the proposed change does**
- Changes in #2133 targeted handymen unnecessarily.
- Excludes handymen from daily find work task; which will stop so many orphaned tasks happening.
