### PR TITLE
Download Noto font and include in Windows installer

### DIFF
--- a/.github/workflows/WindowsInstaller.yml
+++ b/.github/workflows/WindowsInstaller.yml
@@ -33,11 +33,16 @@ jobs:
           run-id: ${{inputs.x64}}
           path: WindowsInstaller
           github-token: ${{github.token}}
+      - name: Download Noto font
+        run: |
+          wget https://github.com/satbyy/go-noto-universal/releases/download/v7.0/GoNotoKurrent-Regular.ttf
       - name: Create installer
         run: |
           cd WindowsInstaller
           mv CorsixTH_x86 x86
           mv CorsixTH x64
+          cp ../GoNotoKurrent-Regular.ttf x86/CorsixTHUnicode.ttf
+          cp ../GoNotoKurrent-Regular.ttf x64/CorsixTHUnicode.ttf
           makensis -V4 -WX -- Win32Script.nsi
           sha256sum CorsixTHInstaller.exe >> $GITHUB_STEP_SUMMARY
       - name: Upload installer


### PR DESCRIPTION
**Describe what the proposed change does**
- Puts the Noto regular font in the installer as CorsixTHUnicode.ttf, in the folder where it is found on first run (checked on x64, not x86).
https://github.com/tobylane/CorsixTH/actions/runs/16096606383/job/45420234113#step:7:525
