### PR TITLE
Remove unknown HTML entities from metainfo

### DIFF
--- a/CorsixTH/com.corsixth.corsixth.metainfo.xml
+++ b/CorsixTH/com.corsixth.corsixth.metainfo.xml
@@ -126,9 +126,9 @@
       <description>
         <p>Features:</p>
         <ul>
-          <li>Custom level&sol;campaign creators can now use an existing level file
+          <li>Custom level/campaign creators can now use an existing level file
               as an overlay to copy and extend their level file with the
-              &num;overlay variable. See the &apos;Custom Level&apos; Wiki page
+              #overlay variable. See the &apos;Custom Level&apos; Wiki page
               for more information.</li>
         </ul>
         <p>Changes:</p>


### PR DESCRIPTION
The Flatpak build [failed](https://github.com/flathub-infra/vorarbeiter/actions/runs/16390734671/job/46316385526#step:14:2471) because the metainfo file contains unknown entities: `&sol;` and `&num;`. Since this is an XML file, these HTML entities are unknown and the validation fails.

**Describe what the proposed change does**
- Replace the unknown entities with the proper character
