### PR TITLE
Always crop at tile edges.

### DIFF
--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1149,8 +1149,6 @@ bool are_flags_set(uint32_t val, uint32_t flags) {
 void animation::draw(render_target* pCanvas, int iDestX, int iDestY) {
   if (are_flags_set(flags, thdf_alpha_50 | thdf_alpha_75)) return;
 
-  iDestX += x_relative_to_tile;
-  iDestY += y_relative_to_tile;
   if (sound_to_play) {
     sound_player* pSounds = sound_player::get_singleton();
     if (pSounds) pSounds->play_at(sound_to_play, iDestX, iDestY);
@@ -1164,11 +1162,15 @@ void animation::draw(render_target* pCanvas, int iDestX, int iDestY) {
       rcNew.x = iDestX + (crop_column - 1) * 32;
       rcNew.w = 64;
       render_target::scoped_clip clip(pCanvas, &rcNew);
-      manager->draw_frame(pCanvas, frame_index, layers, iDestX, iDestY, flags,
-                          patient_effect, patient_effect_offset);
+      manager->draw_frame(pCanvas, frame_index, layers,
+                          iDestX + x_relative_to_tile,
+                          iDestY + y_relative_to_tile, flags, patient_effect,
+                          patient_effect_offset);
     } else
-      manager->draw_frame(pCanvas, frame_index, layers, iDestX, iDestY, flags,
-                          patient_effect, patient_effect_offset);
+      manager->draw_frame(pCanvas, frame_index, layers,
+                          iDestX + x_relative_to_tile,
+                          iDestY + y_relative_to_tile, flags, patient_effect,
+                          patient_effect_offset);
   }
 }
 


### PR DESCRIPTION
In particular, do not crop relative to pixel offsets of an animation. 

In the current code, pixel offset of an animation is added to the tile position before installing a crop rectangle of 64 pixels wide. (Lines 1152 to 1166 in the patched file.)
This means that the crop rectangle moves along with the pixel offset of the animation, and thus doesn't crop at tiles edges.

This patch fixes that.

Pixel offsets in tiles are used for humanoids walking, spawning (also a walk), and dying (didn't look closely, perhaps flying?).
Cropping is used for objects.
