### PR TITLE
Fix font74v compat

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/hospital_policy.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/hospital_policy.lua
@@ -124,22 +124,22 @@ function UIPolicy:draw(canvas, x, y)
   local text = self.text_font
   local label = self.label_font
 
-  -- Labels on the panels
+  -- Labels on the panels. Labels are always capitalised.
   local added_x = self.sliders["send_home"].x
   local added_y = self.sliders["send_home"].y
-  label:draw(canvas, _S.policy.sliders.send_home, x + added_x, y + added_y + 2, 82, 0)
+  label:draw(canvas, _S.policy.sliders.send_home:upper(), x + added_x, y + added_y + 2, 82, 0)
 
   added_x = self.sliders["guess_cure"].x
   added_y = self.sliders["guess_cure"].y
-  label:draw(canvas, _S.policy.sliders.guess, x + added_x, y + added_y + 2, 82, 0)
+  label:draw(canvas, _S.policy.sliders.guess:upper(), x + added_x, y + added_y + 2, 82, 0)
 
   added_x = self.sliders["stop_procedure"].x
   added_y = self.sliders["stop_procedure"].y
-  label:draw(canvas, _S.policy.sliders.stop, x + added_x, y + added_y + 2, 92, 0)
+  label:draw(canvas, _S.policy.sliders.stop:upper(), x + added_x, y + added_y + 2, 92, 0)
 
   added_x = self.sliders["goto_staffroom"].x
   added_y = self.sliders["goto_staffroom"].y
-  label:draw(canvas, _S.policy.sliders.staff_room, x + added_x, y + added_y + 2, 92, 0)
+  label:draw(canvas, _S.policy.sliders.staff_room:upper(), x + added_x, y + added_y + 2, 92, 0)
 
   -- All other text
   text:draw(canvas, _S.policy.header,            x + 160, y + 78, 300, 0)

--- a/CorsixTH/Lua/dialogs/patient.lua
+++ b/CorsixTH/Lua/dialogs/patient.lua
@@ -172,12 +172,13 @@ function UIPatient:draw(canvas, x_, y_)
 end
 
 --! List the treatments that were performed on the patient.
+-- This text is always capitalised.
 --!param canvas Destination to draw on.
 --!param x (int) X position of the top of the list.
 --!param y (int) Y position of the top of the list.
 function UIPatient:drawTreatmentHistory(canvas, x, y)
   for _, room in ipairs(self.patient.treatment_history) do
-    y = self.font:drawWrapped(canvas, room, x, y, 95)
+    y = self.font:drawWrapped(canvas, room:upper(), x, y, 95)
   end
 end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2948*

**Describe what the proposed change does**
- Forces uppercasing of all text in the patient history and hospital policy where it is used (the font `FONT74V` already had uppercase letters in lowercase spots, but also in its uppercase spots). Previously, Unicode fonts did not show history in uppercase.
- Accents that had uppercase inclusions had no lowercase entry.

Potential further enhancement is to see if we can pull missing uppercase letters from another font.

@ARGAMX if possible, can you check this change is compatible with Cyrillic languages in unicode?