### PR TITLE
Add drawing layers constants

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -23,7 +23,8 @@ self = false
 globals = { -- Globals
             "_A", "_S",
             "corsixth",
-            "action_queue_leave_bench", "class", "compare_tables",
+            "action_queue_leave_bench", "class", "compare_tables", "DrawFlags",
+            "DrawingLayers",
             "destrict", "flag_clear", "flag_isset", "flag_set", "flag_toggle",
             "lfs", "list_to_set", "loadfile_envcall", "loadstring_envcall",
             "permanent", "print_table", "rangeMapLookup", "rnc",
@@ -33,7 +34,7 @@ globals = { -- Globals
 
             -- Game classes
             "AIHospital", "AnimationManager", "AnimationEffect", "App", "Audio",
-            "CallsDispatcher", "Cheats", "ChildClass", "Command", "Door", "DrawFlags",
+            "CallsDispatcher", "Cheats", "ChildClass", "Command", "Door",
             "DummyRootNode", "Earthquake", "EndConditions", "Entity", "EntityMap",
             "Epidemic", "FileSystem", "FileTreeNode", "FilteredFileTreeNode", "GameUI",
             "Graphics", "GrimReaper", "Hospital", "Humanoid", "HumanoidRawWalk",

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -972,10 +972,6 @@ function Humanoid:unregisterCallbacks()
   end
 end
 
-function Humanoid:getDrawingLayer()
-  return 4
-end
-
 function Humanoid:getCurrentAction()
   if next(self.action_queue) == nil then
     error("Action queue was empty. This should never happen.\n" .. self:tostring())

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -728,10 +728,6 @@ function Staff:afterLoad(old, new)
   Humanoid.afterLoad(self, old, new)
 end
 
-function Staff:getDrawingLayer()
-  return 4
-end
-
 --! Estimate staff service quality based on skills, restfulness (inverse of fatigue) and happiness.
 --!return (float) between [0-1] indicating quality of the service.
 function Staff:getServiceQuality()

--- a/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
@@ -87,9 +87,9 @@ end
 function Receptionist:getDrawingLayer()
   local direction = self.last_move_direction
   if direction == "west" or direction == "north" then
-    return 5
+    return DrawingLayers.ReceptionistFacingAway
   end
-  return 3
+  return DrawingLayers.ReceptionistFacingUser
 end
 
 function Receptionist:afterLoad(old, new)
@@ -99,4 +99,3 @@ function Receptionist:afterLoad(old, new)
   end
   Staff.afterLoad(self, old, new)
 end
-

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -33,10 +33,6 @@ local orient_mirror = {
   south = "east",
 }
 
-function Object:getDrawingLayer()
-  return 4
-end
-
 function Object:Object(hospital, object_type, x, y, direction, etc)
   assert(class.is(hospital, Hospital), "First argument is not a Hospital instance.")
 

--- a/CorsixTH/Lua/entity.lua
+++ b/CorsixTH/Lua/entity.lua
@@ -366,5 +366,5 @@ end
   objects layer 9.
 ]]
 function Entity:getDrawingLayer()
-  return 4
+  return DrawingLayers.Entity
 end

--- a/CorsixTH/Lua/objects/analyser.lua
+++ b/CorsixTH/Lua/objects/analyser.lua
@@ -66,7 +66,7 @@ function AtomAnalyser:AtomAnalyser(...)
 end
 
 function AtomAnalyser:getDrawingLayer()
-  return 3
+  return DrawingLayers.AtomAnalyser
 end
 
 return object

--- a/CorsixTH/Lua/objects/bin.lua
+++ b/CorsixTH/Lua/objects/bin.lua
@@ -51,9 +51,9 @@ end
 
 function SideObject:getDrawingLayer()
   if self.direction == "north" then
-    return 1
+    return DrawingLayers.NorthSideObject
   elseif self.direction == "west" then
-    return 2
+    return DrawingLayers.WestSideObject
   else
     if self.direction == "east" then
       if self.object_type.thob == 50 then
@@ -61,12 +61,12 @@ function SideObject:getDrawingLayer()
         the north and west part of the tile respectively which could lead to
         a graphical glitch in which a bin in the west part of the tile is
         displayed over a doctor in the middle of the tile ]]
-        return 2
+        return DrawingLayers.WestSideObject
       else
-        return 8
+        return DrawingLayers.EastSideObject
       end
     else --south
-      return 9
+      return DrawingLayers.SouthSideObject
     end
   end
 end

--- a/CorsixTH/Lua/objects/door.lua
+++ b/CorsixTH/Lua/objects/door.lua
@@ -166,7 +166,7 @@ function Door:closeDoor()
 end
 
 function Door:getDrawingLayer()
-  return 0
+  return DrawingLayers.Door
 end
 
 function Door:checkForDeadlock()

--- a/CorsixTH/Lua/objects/litter.lua
+++ b/CorsixTH/Lua/objects/litter.lua
@@ -108,7 +108,7 @@ function Litter:remove()
 end
 
 function Litter:getDrawingLayer()
-  return 0
+  return DrawingLayers.Litter
 end
 
 function Litter:vomitInducing()

--- a/CorsixTH/Lua/objects/rathole.lua
+++ b/CorsixTH/Lua/objects/rathole.lua
@@ -59,4 +59,8 @@ function Rathole:Rathole(hospital, oject_type, x, y, direction, etc)
   self:Object(hospital, oject_type, x, y, direction, etc)
 end
 
+function Rathole:getDrawingLayer()
+  return DrawingLayers.RatHole
+end
+
 return object

--- a/CorsixTH/Lua/utility.lua
+++ b/CorsixTH/Lua/utility.lua
@@ -216,6 +216,22 @@ DrawFlags.ListBottom      = 2^11
 DrawFlags.BoundBoxHitTest = 2^12
 DrawFlags.Crop            = 2^13
 
+-- Order of animations within a tile. Animations with a smaller number are
+-- drawn first.
+DrawingLayers = {}
+DrawingLayers.Litter = 0
+DrawingLayers.Door = 0
+DrawingLayers.RatHole = 0
+DrawingLayers.NorthSideObject = 1
+DrawingLayers.WestSideObject = 2
+DrawingLayers.AtomAnalyser = 3
+DrawingLayers.ReceptionistFacingUser = 3 -- Facing east or south.
+DrawingLayers.Entity = 4 -- All 'normal' animations.
+DrawingLayers.ReceptionistFacingAway = 5 -- Facing west or north.
+-- Values 6 and 7 not used.
+DrawingLayers.EastSideObject = 8
+DrawingLayers.SouthSideObject = 9
+
 -- Keep in sync with animation_effect in th_gfx_common.h
 AnimationEffect = {}
 AnimationEffect.None = 0

--- a/CorsixTH/Luatest/spec/entities/machine_spec.lua
+++ b/CorsixTH/Luatest/spec/entities/machine_spec.lua
@@ -21,6 +21,7 @@ require("corsixth")
 
 require("class_test_base")
 
+require("utility")
 require("announcer")
 require("entity")
 require("entities/object")

--- a/CorsixTH/Luatest/spec/entities/object_spec.lua
+++ b/CorsixTH/Luatest/spec/entities/object_spec.lua
@@ -20,6 +20,7 @@ SOFTWARE. --]]
 
 require("class_test_base")
 
+require("utility")
 require("entity")
 require("entities.object")
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes Rat hole layer

**Describe what the proposed change does**
- Introduce constants for the various drawing layers.
- Apply constants instead of magic numbers.
- Drop layers of objects, humanoids, and staff, as they are derived entities.
- Draw a rathole before a side object (instead of after it).
