### PR TITLE
Let staff return to training/research

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -565,8 +565,8 @@ function Staff:isIdle()
     -- In the corridor and not on_call (e.g. watering or going to room).
     -- The staff is free, unless going back to the training/research.
     room = self.last_room
-    if room then
-      return room.room_info.id ~= "training" and room.room_info.id ~= "research"
+    if room and (room.room_info.id == "training" or room.room_info.id == "research") then
+      return false
     end
 
     return true

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -562,15 +562,13 @@ function Staff:isIdle()
     -- or if the only one in sight is actually leaving.
     return not room:isRoomInDemand()
   else
-    -- In the corridor and not on_call (watering or going to room), the staff is free
-    -- unless going back to the training room or research department.
-    local x, y = self:getCurrentAction().x, self:getCurrentAction().y
-    if x then
-      room = self.world:getRoom(x, y)
-      if room and (room.room_info.id == "training" or room.room_info.id == "research") then
-        return false
-      end
+    -- In the corridor and not on_call (e.g. watering or going to room).
+    -- The staff is free, unless going back to the training/research.
+    room = self.last_room
+    if room then
+      return room.room_info.id ~= "training" and room.room_info.id ~= "research"
     end
+
     return true
   end
 end

--- a/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
@@ -173,7 +173,7 @@ function Doctor:updateSkill(consultant, trait, amount)
       if self:getRoom().room_info.id == "training" then
         self:setNextAction(self:getRoom():createLeaveAction())
         self:queueAction(MeanderAction())
-        self.last_room = nil
+        self.last_room = nil -- Consultant no longer needs to return to this room
       end
       self:updateStaffTitle()
     end

--- a/CorsixTH/Lua/rooms/training.lua
+++ b/CorsixTH/Lua/rooms/training.lua
@@ -209,7 +209,7 @@ function TrainingRoom:commandEnteringStaff(humanoid)
         self.hospital:giveAdvice({_A.staff_place_advice.not_enough_lecture_chairs})
         humanoid:setNextAction(self:createLeaveAction())
         humanoid:queueAction(MeanderAction())
-        humanoid.last_room = nil
+        humanoid.last_room = nil -- Prevent Doctor returning to this room automatically
       end
     end
   elseif humanoid.humanoid_class ~= "Handyman" then


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2964*

**Describe what the proposed change does**
- Reworked staff idle check to properly handle returning doctors to research/training.

@ARGAMX please extensively test I've not broken other call states e.g. dropping answers to rooms.