### PR TITLE
Late diagnosis termination bug fix.

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -334,7 +334,7 @@ function Patient:isTreatmentEffective()
   return (cure_chance >= math.random(1,100))
 end
 
-function Patient:isHaveMorePossibleDiagnosticRooms()
+function Patient:hasMoreDiagnosisRoomsAvailable()
   return #self.available_diagnosis_rooms ~= 0
 end
 

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -108,9 +108,9 @@ function Patient:setDisease(disease)
     self.available_diagnosis_rooms[i] = room
   end
   -- 25% of the patients pay via insurance
-  local insurance_chance = math.random(1,12)
-  if insurance_chance < 4 then
-    self.insurance_company = insurance_chance
+  if math.random(1,4) == 1 then
+    -- randomly select one of three insurance companies
+    self.insurance_company = math.random(1,3)
   end
   -- Randomise thirst and the need to visit the loo soon.
   -- Alien patients do not have the needed animations for these things, so exclude them

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -51,6 +51,9 @@ function Patient:Patient(...)
   self.vaccination_candidate = false
   -- Has the patient passed reception?
   self.has_passed_reception = false
+  -- Diagnostics progress to diagnose the patient.
+  -- Usually this value is in the range from 0 to ~2.5
+  self.diagnosis_progress = 0
 
   -- Is the patient trying to get to the toilet? ("yes", "no", or "no-toilets")
   self.going_to_toilet = "no"
@@ -104,9 +107,10 @@ function Patient:setDisease(disease)
   for i, room in ipairs(self.disease.diagnosis_rooms) do
     self.available_diagnosis_rooms[i] = room
   end
-  local company = math.random(1,12)
-  if company < 4 then
-    self.insurance_company = company
+  -- 25% of the patients pay via insurance
+  local insurance_chance = math.random(1,12)
+  if insurance_chance < 4 then
+    self.insurance_company = insurance_chance
   end
   -- Randomise thirst and the need to visit the loo soon.
   -- Alien patients do not have the needed animations for these things, so exclude them
@@ -328,6 +332,10 @@ function Patient:isTreatmentEffective()
   cure_chance = cure_chance + (service_base * service_factor)
 
   return (cure_chance >= math.random(1,100))
+end
+
+function Patient:isHaveMorePossibleDiagnosticRooms()
+  return not (#self.available_diagnosis_rooms == 0)
 end
 
 --! Change patient internal state to "cured".

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -335,7 +335,7 @@ function Patient:isTreatmentEffective()
 end
 
 function Patient:isHaveMorePossibleDiagnosticRooms()
-  return not (#self.available_diagnosis_rooms == 0)
+  return #self.available_diagnosis_rooms ~= 0
 end
 
 --! Change patient internal state to "cured".

--- a/CorsixTH/Lua/rooms/gp.lua
+++ b/CorsixTH/Lua/rooms/gp.lua
@@ -134,7 +134,11 @@ function GPRoom:dealtWithPatient(patient)
   elseif patient.disease and not patient.diagnosed then
     self.hospital:receiveMoneyForTreatment(patient)
     patient:completeDiagnosticStep(self)
-    if patient.diagnosis_progress >= self.hospital.policies["stop_procedure"] then
+    local no_need_diagnose_further =
+      patient.diagnosis_progress >= self.hospital.policies["stop_procedure"]
+    local cant_diagnose_further_but_can_set_diagnosis =
+      (patient.diagnosis_progress >= 1.0) and (not patient:isHaveMorePossibleDiagnosticRooms())
+    if no_need_diagnose_further or cant_diagnose_further_but_can_set_diagnosis then
       patient:setDiagnosed()
       if patient:agreesToPay(patient.disease.id) then
         patient:queueAction(SeekRoomAction(patient.disease.treatment_rooms[1]):enableTreatmentRoom())
@@ -164,7 +168,7 @@ function GPRoom:dealtWithPatient(patient)
 end
 
 function GPRoom:sendPatientToNextDiagnosisRoom(patient)
-  if #patient.available_diagnosis_rooms == 0 then
+  if not patient:isHaveMorePossibleDiagnosticRooms() then
     -- The very rare case where the patient has visited all his/her possible diagnosis rooms
     -- There's not much to do then... Send home
     patient:goHome("kicked")

--- a/CorsixTH/Lua/rooms/gp.lua
+++ b/CorsixTH/Lua/rooms/gp.lua
@@ -137,7 +137,7 @@ function GPRoom:dealtWithPatient(patient)
     local no_need_diagnose_further =
       patient.diagnosis_progress >= self.hospital.policies["stop_procedure"]
     local cant_diagnose_further_but_can_set_diagnosis =
-      (patient.diagnosis_progress >= 1.0) and (not patient:isHaveMorePossibleDiagnosticRooms())
+      (patient.diagnosis_progress >= 1.0) and (not patient:hasMoreDiagnosisRoomsAvailable())
     if no_need_diagnose_further or cant_diagnose_further_but_can_set_diagnosis then
       patient:setDiagnosed()
       if patient:agreesToPay(patient.disease.id) then
@@ -168,7 +168,7 @@ function GPRoom:dealtWithPatient(patient)
 end
 
 function GPRoom:sendPatientToNextDiagnosisRoom(patient)
-  if not patient:isHaveMorePossibleDiagnosticRooms() then
+  if not patient:hasMoreDiagnosisRoomsAvailable() then
     -- The very rare case where the patient has visited all his/her possible diagnosis rooms
     -- There's not much to do then... Send home
     patient:goHome("kicked")


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2974*

**Describe what the proposed change does**
- Added earlier check for a GP that there are not enough diagnostic rooms for over-diagnosis. So if minimum diagnostic threshold has been reached the diagnosis should be set in such a case.
