### PR TITLE
Better error handling for non-existent languages

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -510,7 +510,7 @@ end
 function App:initLanguage()
   -- Make sure that we can actually show the desired language.
   -- If we can't, work out the most common issue and reset to English.
-  local success, err = true, ""
+  local success, err = true, nil
   local language = self.config.language
   local function revertToEnglish()
     language = [[English]]

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -522,8 +522,8 @@ function App:initLanguage()
   local exists = self.strings:checkLanguageExists(language)
   if not exists then
     -- Not existent language, revert to English.
-    err = "The game language set in the configuration file: " .. language ..
-          " was not valid. It has been reverted to English. Please select your" ..
+    err = "The game language set in the configuration file '" .. language ..
+          "' was not valid. It has been reverted to English. Please select your" ..
           " desired language from the Settings screen again."
     revertToEnglish()
   end
@@ -534,7 +534,7 @@ function App:initLanguage()
   else
     -- Font unavailable, revert to English.
     err = "The game language has been reverted to English because the desired" ..
-          " language: " .. language .. " could not be loaded. Please make sure" ..
+          " language '" .. language .. "' could not be loaded. Please make sure" ..
           " you have specified a font file in Settings-Folders-Font or the" ..
           " configuration file."
     revertToEnglish()

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -285,7 +285,7 @@ function App:init()
   corsixth.require("string_extensions")
   self.strings = Strings(self)
   self.strings:init()
-  local language_load_success = self:initLanguage()
+  local language_load_success, language_error = self:initLanguage()
   if (self.command_line.dump or ""):match("strings") then
     -- Specify --dump=strings on the command line to dump strings
     -- (or insert "true or" after the "if" in the above)
@@ -368,9 +368,7 @@ function App:init()
     if not language_load_success then
       -- At this point we know the language is english, so no use having
       -- localized strings.
-      self.ui:addWindow(UIInformation(self.ui, { "The game language has been reverted" ..
-          " to English because the desired language could not be loaded. " ..
-          "Please make sure you have specified a font file in the config file." }))
+      self.ui:addWindow(UIInformation(self.ui, { language_error }))
     end
 
     -- If the player wants to continue then load the youngest file in the Autosaves folder
@@ -506,21 +504,41 @@ function App:initScreenshotsDir()
   return true
 end
 
+--! Initialises the application's language based on the player's choice.
+--!return success (boolean) Whether the chosen language was initialised
+--!return err (string) What to report back to the player on failure
 function App:initLanguage()
   -- Make sure that we can actually show the desired language.
-  -- If we can't, then the player probably didn't specify a font file
-  -- in the config file properly.
-  local success = true
+  -- If we can't, work out the most common issue and reset to English.
+  local success, err = true, ""
   local language = self.config.language
+  local function revertToEnglish()
+    language = [[English]]
+    self.config.language = language
+    self:saveConfig()
+    success = false
+  end
+
+  local exists = self.strings:checkLanguageExists(language)
+  if not exists then
+    -- Not existent language, revert to English.
+    err = "The game language set in the configuration file: " .. language ..
+          " was not valid. It has been reverted to English. Please select your" ..
+          " desired language from the Settings screen again."
+    revertToEnglish()
+  end
+
   local font = self.strings:getFont(language)
   if self.gfx:hasLanguageFont(font) then
     self.gfx.language_font = font
   else
-    -- Otherwise revert to english.
-    self.gfx.language_font = self.strings:getFont("english")
-    language = "english"
-    self.config.language = "english"
-    success = false
+    -- Font unavailable, revert to English.
+    err = "The game language has been reverted to English because the desired" ..
+          " language: " .. language .. " could not be loaded. Please make sure" ..
+          " you have specified a font file in Settings-Folders-Font or the" ..
+          " configuration file."
+    revertToEnglish()
+    self.gfx.language_font = self.strings:getFont([[English]])
   end
 
   local strings, speech_file = self.strings:load(language)
@@ -553,7 +571,7 @@ function App:initLanguage()
     self.ui:onChangeLanguage()
   end
   self.audio:initSpeech(speech_file)
-  return success
+  return success, err
 end
 
 function App:worldExited()

--- a/CorsixTH/Lua/strings.lua
+++ b/CorsixTH/Lua/strings.lua
@@ -319,6 +319,13 @@ function Strings:getLocalisedText(string, table)
   end
 end
 
+--! Checks the language we specify is known to the application.
+--!param language (string) Language to check
+--!return true if known
+function Strings:checkLanguageExists(language)
+  return not not self.language_to_chunk[language:lower()]
+end
+
 function Strings:_loadPrivate(language, env, ...)
   local chunk = self.language_to_chunk[language:lower()]
   if not chunk then -- If selected language could not be found, try to revert to English


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2978*

**Describe what the proposed change does**
- Adds helper function to check player's specified language exists
- Returns language to English and shows error message on main menu (fixes crash at end of movie and elsewhere). 
- Tell the player the language value they originally set and where to go to fix (as there are now two error types).
- Also includes some refactor to accommodate new handling
- Doc, as usual.

One quirk is that as part of `App:fixConfig()` we force lowercase the language on launch. However, we still try to convert back to lowercase in other places (mostly) unnecessarily. My use of capitalised `[[English]]` on App.lua line 516 probably needs changing if there's a future PR to clean things up.


<img width="353" height="109" alt="image" src="https://github.com/user-attachments/assets/f9c15523-5b94-4c0d-9d59-884dfe1731d2" />

<img width="335" height="109" alt="image" src="https://github.com/user-attachments/assets/1ab8af4b-0baf-4534-9ef3-bf9473eef321" />
