### PR TITLE
Store the tile position of an animation in the animation.

### DIFF
--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1129,13 +1129,11 @@ void animation::draw(render_target* pCanvas, int iDestX, int iDestY) {
       rcNew.x = iDestX + (crop_column - 1) * 32;
       rcNew.w = 64;
       render_target::scoped_clip clip(pCanvas, &rcNew);
-      manager->draw_frame(pCanvas, frame_index, layers,
-                          iDestX + pixel_offset.x,
+      manager->draw_frame(pCanvas, frame_index, layers, iDestX + pixel_offset.x,
                           iDestY + pixel_offset.y, flags, patient_effect,
                           patient_effect_offset);
     } else
-      manager->draw_frame(pCanvas, frame_index, layers,
-                          iDestX + pixel_offset.x,
+      manager->draw_frame(pCanvas, frame_index, layers, iDestX + pixel_offset.x,
                           iDestY + pixel_offset.y, flags, patient_effect,
                           patient_effect_offset);
   }
@@ -1185,8 +1183,7 @@ void animation::draw_morph(render_target* pCanvas, int iDestX, int iDestY) {
   oMorphRect.x = 0;
   oMorphRect.w = pCanvas->get_width();
   oMorphRect.y = iDestY + morph_target->pixel_offset.x;
-  oMorphRect.h =
-      morph_target->pixel_offset.y - morph_target->pixel_offset.x;
+  oMorphRect.h = morph_target->pixel_offset.y - morph_target->pixel_offset.x;
   {
     render_target::scoped_clip clip(pCanvas, &oMorphRect);
     manager->draw_frame(pCanvas, frame_index, layers, iDestX, iDestY, flags);
@@ -1224,8 +1221,7 @@ bool animation::hit_test_morph(int iDestX, int iDestY, int iTestX, int iTestY) {
   }
 
   return manager->hit_test(frame_index, layers, pixel_offset.x + iDestX,
-                           pixel_offset.y + iDestY, flags, iTestX,
-                           iTestY) ||
+                           pixel_offset.y + iDestY, flags, iTestX, iTestY) ||
          morph_target->hit_test(iDestX, iDestY, iTestX, iTestY);
 }
 

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1501,18 +1501,22 @@ void animation::tick() {
   }
 }
 
-void animation_base::remove_from_tile() { link_list::remove_from_list(); }
+void animation_base::remove_from_tile() {
+  link_list::remove_from_list();
+  tile = {-1, -1};
+}
 
-void animation_base::attach_to_tile(map_tile* pMapNode, int layer) {
+void animation_base::attach_to_tile(int x, int y, map_tile* node, int layer) {
   remove_from_tile();
   link_list* pList;
   if (flags & thdf_early_list) {
-    pList = &pMapNode->oEarlyEntities;
+    pList = &node->oEarlyEntities;
   } else {
-    pList = &pMapNode->entities;
+    pList = &node->entities;
   }
 
   this->set_drawing_layer(layer);
+  this->set_tile(x, y);
 
   while (pList->next &&
          static_cast<drawable*>(pList->next)->get_drawing_layer() < layer) {

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1192,7 +1192,7 @@ void animation::draw_morph(render_target* pCanvas, int iDestX, int iDestY) {
     manager->draw_frame(pCanvas, frame_index, layers, iDestX, iDestY, flags);
   }
   oMorphRect.y = iDestY + morph_target->y_relative_to_tile;
-  oMorphRect.h = morph_target->speed.dx - morph_target->y_relative_to_tile;
+  oMorphRect.h = morph_target->speed.x - morph_target->y_relative_to_tile;
   {
     render_target::scoped_clip clip(pCanvas, &oMorphRect);
     manager->draw_frame(pCanvas, morph_target->frame_index,
@@ -1287,8 +1287,8 @@ void animation::persist(lua_persist_writer* pWriter) const {
   // Write the unioned fields
   if (anim_kind != animation_kind::primary_child &&
       anim_kind != animation_kind::secondary_child) {
-    pWriter->write_int(speed.dx);
-    pWriter->write_int(speed.dy);
+    pWriter->write_int(speed.x);
+    pWriter->write_int(speed.y);
   } else {
     lua_rawgeti(L, luaT_environindex, 2);
     lua_pushlightuserdata(L, parent);
@@ -1368,8 +1368,8 @@ void animation::depersist(lua_persist_reader* pReader) {
     // Read the unioned fields
     if (anim_kind != animation_kind::primary_child &&
         anim_kind != animation_kind::secondary_child) {
-      if (!pReader->read_int(speed.dx)) break;
-      if (!pReader->read_int(speed.dy)) break;
+      if (!pReader->read_int(speed.x)) break;
+      if (!pReader->read_int(speed.y)) break;
     } else {
       if (!pReader->read_stack_object()) break;
       parent = static_cast<animation*>(lua_touserdata(L, -1));
@@ -1480,12 +1480,12 @@ void animation::tick() {
   frame_index = manager->get_next_frame(frame_index);
   if (anim_kind != animation_kind::primary_child &&
       anim_kind != animation_kind::secondary_child) {
-    x_relative_to_tile += speed.dx;
-    y_relative_to_tile += speed.dy;
+    x_relative_to_tile += speed.x;
+    y_relative_to_tile += speed.y;
   }
 
   if (morph_target) {
-    morph_target->y_relative_to_tile += morph_target->speed.dy;
+    morph_target->y_relative_to_tile += morph_target->speed.y;
     if (morph_target->y_relative_to_tile < morph_target->x_relative_to_tile) {
       morph_target->y_relative_to_tile = morph_target->x_relative_to_tile;
     }
@@ -1628,8 +1628,8 @@ void animation::set_morph_target(animation* pMorphTarget, int iDurationFactor) {
   the morph target animation:
     * The y value top limit - morph_target->x
     * The y value threshold - morph_target->y
-    * The y value bottom limit - morph_target->speed.dx
-    * The y value increment per frame - morph_target->speed.dy
+    * The y value bottom limit - morph_target->speed.x
+    * The y value increment per frame - morph_target->speed.y
   This obviously means that the morph target should not be ticked or rendered
   as it's position and speed contain other values.
   */
@@ -1654,14 +1654,14 @@ void animation::set_morph_target(animation* pMorphTarget, int iDurationFactor) {
   }
 
   if (iOrigMaxY > iMorphMaxY) {
-    morph_target->speed.dx = iOrigMaxY;
+    morph_target->speed.x = iOrigMaxY;
   } else {
-    morph_target->speed.dx = iMorphMaxY;
+    morph_target->speed.x = iMorphMaxY;
   }
 
-  int iDist = morph_target->x_relative_to_tile - morph_target->speed.dx;
-  morph_target->speed.dy = (iDist - iMorphDuration + 1) / iMorphDuration;
-  morph_target->y_relative_to_tile = morph_target->speed.dx;
+  int iDist = morph_target->x_relative_to_tile - morph_target->speed.x;
+  morph_target->speed.y = (iDist - iMorphDuration + 1) / iMorphDuration;
+  morph_target->y_relative_to_tile = morph_target->speed.x;
 }
 
 void animation::set_frame(size_t iFrame) { frame_index = iFrame; }

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -524,21 +524,20 @@ class animation_base : public drawable {
   void attach_to_tile(map_tile* pMapNode, int layer);
 
   uint32_t get_flags() const { return flags; }
-  int get_x() const { return x_relative_to_tile; }
-  int get_y() const { return y_relative_to_tile; }
+  int get_x() const { return pixel_offset.x; }
+  int get_y() const { return pixel_offset.y; }
 
   void set_flags(uint32_t iFlags) { flags = iFlags; }
-  void set_position(int iX, int iY) {
-    x_relative_to_tile = iX, y_relative_to_tile = iY;
+  void set_position(int x, int y) {
+    pixel_offset.x = x;
+    pixel_offset.y = y;
   }
   void set_layer(int iLayer, int iId);
   void set_layers_from(const animation_base* pSrc) { layers = pSrc->layers; }
 
  protected:
-  //! X position on tile (not tile x-index)
-  int x_relative_to_tile{};
-  //! Y position on tile (not tile y-index)
-  int y_relative_to_tile{};
+  //! Offset in pixels relative to the center of the animation tile.
+  xy_pair pixel_offset{0, 0};
 
   ::layers layers{};
 };

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -532,7 +532,7 @@ class animation_base : public drawable {
     tile.x = x;
     tile.y = y;
   }
-  void set_position(int x, int y) {
+  void set_pixel_offset(int x, int y) {
     pixel_offset.x = x;
     pixel_offset.y = y;
   }

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -521,13 +521,17 @@ class animation_base : public drawable {
   animation_base();
 
   void remove_from_tile();
-  void attach_to_tile(map_tile* pMapNode, int layer);
+  void attach_to_tile(int x, int y, map_tile* node, int layer);
 
   uint32_t get_flags() const { return flags; }
-  int get_x() const { return pixel_offset.x; }
-  int get_y() const { return pixel_offset.y; }
+  const xy_pair &get_pixel_offset() const { return pixel_offset; }
+  const xy_pair &get_tile() const { return tile; }
 
   void set_flags(uint32_t iFlags) { flags = iFlags; }
+  void set_tile(int x, int y) {
+    tile.x = x;
+    tile.y = y;
+  }
   void set_position(int x, int y) {
     pixel_offset.x = x;
     pixel_offset.y = y;
@@ -536,6 +540,9 @@ class animation_base : public drawable {
   void set_layers_from(const animation_base* pSrc) { layers = pSrc->layers; }
 
  protected:
+  //! Tile containing the animation. A negative x or y means it is not active.
+  xy_pair tile{-1, -1};
+
   //! Offset in pixels relative to the center of the animation tile.
   xy_pair pixel_offset{0, 0};
 

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -524,8 +524,8 @@ class animation_base : public drawable {
   void attach_to_tile(int x, int y, map_tile* node, int layer);
 
   uint32_t get_flags() const { return flags; }
-  const xy_pair &get_pixel_offset() const { return pixel_offset; }
-  const xy_pair &get_tile() const { return tile; }
+  const xy_pair& get_pixel_offset() const { return pixel_offset; }
+  const xy_pair& get_tile() const { return tile; }
 
   void set_flags(uint32_t iFlags) { flags = iFlags; }
   void set_tile(int x, int y) {

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -510,6 +510,12 @@ class animation_manager {
   void fix_next_frame(uint32_t iFirst, size_t iLength);
 };
 
+// Integer 2D pair.
+struct xy_pair {
+  int x{};  ///< Value of the X coordinate.
+  int y{};  ///< Value of the Y coordinate.
+};
+
 class animation_base : public drawable {
  public:
   animation_base();
@@ -535,13 +541,6 @@ class animation_base : public drawable {
   int y_relative_to_tile{};
 
   ::layers layers{};
-};
-
-struct xy_diff {
-  //! Amount to change x per tick
-  int dx{};
-  //! Amount to change y per tick
-  int dy{};
 };
 
 //! The kind of animation.
@@ -610,7 +609,10 @@ class animation : public animation_base {
   void set_morph_target(animation* pMorphTarget, int iDurationFactor = 1);
   void set_frame(size_t iFrame);
 
-  void set_speed(int iX, int iY) { speed.dx = iX, speed.dy = iY; }
+  void set_speed(int x, int y) {
+    speed.x = x;
+    speed.y = y;
+  }
   void set_crop_column(int iColumn) { crop_column = iColumn; }
 
   void persist(lua_persist_writer* pWriter) const;
@@ -628,7 +630,8 @@ class animation : public animation_base {
   size_t animation_index{};  ///< Animation number.
   size_t frame_index{};      ///< Frame number.
   union {
-    xy_diff speed{};
+    xy_pair speed{};  ///< Speed in pixels per tick.
+
     //! Some animations are tied to the primary or secondary marker of another
     //! animation and hence have a parent rather than a speed.
     animation* parent;

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -503,18 +503,18 @@ int l_anim_get_flag(lua_State* L) {
 }
 
 template <typename T>
-int l_anim_set_position(lua_State* L) {
+int l_anim_set_pixel_offset(lua_State* L) {
   T* pAnimation = luaT_testuserdata<T>(L);
 
   int x = static_cast<int>(luaL_optinteger(L, 2, 0));
   int y = static_cast<int>(luaL_optinteger(L, 3, 0));
-  pAnimation->set_position(x, y);
+  pAnimation->set_pixel_offset(x, y);
 
   lua_settop(L, 1);
   return 1;
 }
 
-int l_anim_get_position(lua_State* L) {
+int l_anim_get_pixel_offset(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
 
   const xy_pair& offset = pAnimation->get_pixel_offset();
@@ -726,8 +726,8 @@ void lua_register_anims(const lua_register_state* pState) {
     lcb.add_function(l_anim_make_invisible<animation>, "makeInvisible");
     lcb.add_function(l_anim_set_tag, "setTag");
     lcb.add_function(l_anim_get_tag, "getTag");
-    lcb.add_function(l_anim_set_position<animation>, "setPosition");
-    lcb.add_function(l_anim_get_position, "getPosition");
+    lcb.add_function(l_anim_set_pixel_offset<animation>, "setPosition");
+    lcb.add_function(l_anim_get_pixel_offset, "getPosition");
     lcb.add_function(l_anim_set_speed<animation>, "setSpeed");
     lcb.add_function(l_anim_set_layer<animation>, "setLayer");
     lcb.add_function(l_anim_set_layers_from, "setLayersFrom");
@@ -776,7 +776,8 @@ void lua_register_anims(const lua_register_state* pState) {
     lcb.add_function(l_anim_make_visible<sprite_render_list>, "makeVisible");
     lcb.add_function(l_anim_make_invisible<sprite_render_list>,
                      "makeInvisible");
-    lcb.add_function(l_anim_set_position<sprite_render_list>, "setPosition");
+    lcb.add_function(l_anim_set_pixel_offset<sprite_render_list>,
+                     "setPosition");
     lcb.add_function(l_anim_set_speed<sprite_render_list>, "setSpeed");
     lcb.add_function(l_anim_set_layer<sprite_render_list>, "setLayer");
     lcb.add_function(l_anim_tick<sprite_render_list>, "tick");

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -425,8 +425,13 @@ int l_anim_get_tile(lua_State* L) {
   }
 
   const xy_pair& tile = pAnimation->get_tile();
-  lua_pushinteger(L, tile.x + 1);
-  lua_pushinteger(L, tile.y + 1);
+  if (tile.x >= 0 && tile.y >= 0) {
+    lua_pushinteger(L, tile.x + 1);
+    lua_pushinteger(L, tile.y + 1);
+  } else {
+    lua_pushnil(L);
+    lua_pushnil(L);
+  }
   return 3;  // map, x, y
 }
 

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -506,8 +506,8 @@ template <typename T>
 int l_anim_set_pixel_offset(lua_State* L) {
   T* pAnimation = luaT_testuserdata<T>(L);
 
-  int x = static_cast<int>(luaL_optinteger(L, 2, 0));
-  int y = static_cast<int>(luaL_optinteger(L, 3, 0));
+  int x = static_cast<int>(luaL_checkinteger(L, 2));
+  int y = static_cast<int>(luaL_checkinteger(L, 3));
   pAnimation->set_pixel_offset(x, y);
 
   lua_settop(L, 1);

--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -323,7 +323,7 @@ int l_map_updateblueprint(lua_State* L) {
                             ? 0
                             : thdf_alt_palette));
       pAnim->attach_to_tile(iX, iNewY, pNode, 0);
-      pAnim->set_position(0, 0);
+      pAnim->set_pixel_offset(0, 0);
     }
     pAnim = l_map_updateblueprint_getnextanim(L, iNextAnim);
     pNode = pMap->get_tile_unchecked(iX, iNewY + iNewH - 1);
@@ -334,7 +334,7 @@ int l_map_updateblueprint(lua_State* L) {
                           : thdf_alt_palette));
     pNode = pMap->get_tile_unchecked(iX, iNewY + iNewH);
     pAnim->attach_to_tile(iX, iNewY + iNewH, pNode, 0);
-    pAnim->set_position(0, -1);
+    pAnim->set_pixel_offset(0, -1);
   }
   for (int iY = iNewY; iY < iNewY + iNewH; ++iY) {
     if (iY != iNewY) {
@@ -346,7 +346,7 @@ int l_map_updateblueprint(lua_State* L) {
                             ? 0
                             : thdf_alt_palette));
       pAnim->attach_to_tile(iNewX, iY, pNode, 0);
-      pAnim->set_position(2, 0);
+      pAnim->set_pixel_offset(2, 0);
     }
     pAnim = l_map_updateblueprint_getnextanim(L, iNextAnim);
     pNode = pMap->get_tile_unchecked(iNewX + iNewW - 1, iY);
@@ -357,7 +357,7 @@ int l_map_updateblueprint(lua_State* L) {
                           : thdf_alt_palette));
     pNode = pMap->get_tile_unchecked(iNewX + iNewW, iY);
     pAnim->attach_to_tile(iNewX + iNewW - 1, iY, pNode, 0);
-    pAnim->set_position(2, -1);
+    pAnim->set_pixel_offset(2, -1);
   }
 
   // Clear away extra animations

--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -311,7 +311,7 @@ int l_map_updateblueprint(lua_State* L) {
                    (is_valid(entire_invalid, pNode, pMap, player_id)
                         ? 0
                         : thdf_alt_palette));
-  pAnim->attach_to_tile(pNode, 0);
+  pAnim->attach_to_tile(iNewX, iNewY, pNode, 0);
 
   for (int iX = iNewX; iX < iNewX + iNewW; ++iX) {
     if (iX != iNewX) {
@@ -322,7 +322,7 @@ int l_map_updateblueprint(lua_State* L) {
                        (is_valid(entire_invalid, pNode, pMap, player_id)
                             ? 0
                             : thdf_alt_palette));
-      pAnim->attach_to_tile(pNode, 0);
+      pAnim->attach_to_tile(iX, iNewY, pNode, 0);
       pAnim->set_position(0, 0);
     }
     pAnim = l_map_updateblueprint_getnextanim(L, iNextAnim);
@@ -333,7 +333,7 @@ int l_map_updateblueprint(lua_State* L) {
                           ? 0
                           : thdf_alt_palette));
     pNode = pMap->get_tile_unchecked(iX, iNewY + iNewH);
-    pAnim->attach_to_tile(pNode, 0);
+    pAnim->attach_to_tile(iX, iNewY + iNewH, pNode, 0);
     pAnim->set_position(0, -1);
   }
   for (int iY = iNewY; iY < iNewY + iNewH; ++iY) {
@@ -345,7 +345,7 @@ int l_map_updateblueprint(lua_State* L) {
                        (is_valid(entire_invalid, pNode, pMap, player_id)
                             ? 0
                             : thdf_alt_palette));
-      pAnim->attach_to_tile(pNode, 0);
+      pAnim->attach_to_tile(iNewX, iY, pNode, 0);
       pAnim->set_position(2, 0);
     }
     pAnim = l_map_updateblueprint_getnextanim(L, iNextAnim);
@@ -356,7 +356,7 @@ int l_map_updateblueprint(lua_State* L) {
                           ? 0
                           : thdf_alt_palette));
     pNode = pMap->get_tile_unchecked(iNewX + iNewW, iY);
-    pAnim->attach_to_tile(pNode, 0);
+    pAnim->attach_to_tile(iNewX + iNewW - 1, iY, pNode, 0);
     pAnim->set_position(2, -1);
   }
 


### PR DESCRIPTION
Instead of afterwards re-constructing the animation position from the map, store it in the animation itself.

Commits:
- First commit does renaming of the existing pixel position offset.
- Second commit introduces storage of the animation tile.
- Update api.
- Reformat cpp.

With respect to the pixel position offset, the docs claim that it is updated in the `tick`, but that could have been written afterwards (possibly even by me).
- The `animation` actually does that.
- The `render_sprite_list` however does it both in `tick` and in `draw`.
  That looks wrong, since if a sprite is ever active (didn't check but I am guessing we currently don't have that at all), then movement is twice as fast as it should be.
- Morph target updating also looks fishy at first sight, but didn't check either.