### PR TITLE
Don't allow patient entry if staff want rest

### DIFF
--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -251,7 +251,8 @@ function Room:getMissingStaff(criteria)
       -- check if answering a call to another room
       if class.is(humanoid, Staff) and humanoid:fulfillsCriterion(attribute) and
           not humanoid:isLeaving() and not humanoid.fired and
-          not (humanoid.on_call and humanoid.on_call.object ~= self) then
+          not (humanoid.on_call and humanoid.on_call.object ~= self) and
+          not humanoid.going_to_staffroom then
         count = count - 1
       end
     end


### PR DESCRIPTION


<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2982*

**Describe what the proposed change does**
- Fixes the issue where staff wanting to go to the staff room shouldn't be considered as available to the room.
- This is due to some use_object actions (e.g. GP desk) being a prolonged cycle, which can let a patient enter and then gets abandoned when the staff member leaves.
