### PR TITLE
Remove debug falling flag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
       description: Select all that apply
       options:
         - label: Right mouse panning
-        - label: Falling actions
+        - label: Falling actions (applies to CorsixTH versions < 0.70.0)
 # Save Game Upload
   - type: textarea
     id: savegame

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -141,7 +141,6 @@ local config_defaults = {
   allow_blocking_off_areas = false,
   direct_zoom = nil,
   new_machine_extra_info = true,
-  debug_falling = false,
   player_name = [[]],
 }
 
@@ -501,13 +500,6 @@ soundfont = nil -- [[X:\ThemeHospital\FluidR3.sf3]]
 -- and a debug menu will be visible.
 --]=] .. '\n' ..
 'debug = ' .. tostring(config_values.debug) .. '\n' .. [=[
-
--- Experimental setting for falling patients. (debug only!)
--- CorsixTH does not yet have reliable handling for falling actions and enabling it
--- could cause dropped action queues or undesired bugs. You should leave this setting
--- off unless you're developing with it
---]=] .. '\n' ..
-'debug_falling = ' .. tostring(config_values.debug_falling) .. '\n' .. [=[
 
 -- If set to true, the FPS, Lua memory usage, and entity count will be shown
 -- in the dynamic information bar. Note that setting this to true also turns

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -807,9 +807,6 @@ function UIMenuBar:makeGameMenu(app)
   local function allowBlockingAreas(item)
     app.config.allow_blocking_off_areas = item.checked
   end
-  local function allowFalling(item)
-    app.config.debug_falling = item.checked
-  end
   local levels_menu = UIMenu()
   for L = 1, 12 do
     levels_menu:appendItem(("  L%i  "):format(L), function()
@@ -824,7 +821,6 @@ function UIMenuBar:makeGameMenu(app)
       :appendCheckItem(_S.menu_debug.limit_camera,         true, limit_camera, nil, function() return self.ui.limit_to_visible_diamond end)
       :appendCheckItem(_S.menu_debug.disable_salary_raise, false, disable_salary_raise, nil, function() return self.ui.app.world.debug_disable_salary_raise end)
       :appendCheckItem(_S.menu_debug.allow_blocking_off_areas, false, allowBlockingAreas, nil, function() return self.ui.app.config.allow_blocking_off_areas end)
-      :appendCheckItem(_S.menu_debug.allow_falling, false, allowFalling, nil, function() return self.ui.app.config.debug_falling end)
       :appendItem(_S.menu_debug.make_debug_fax,     function() self.ui:makeDebugFax() end)
       :appendItem(_S.menu_debug.make_debug_patient, function() self.ui:addWindow(UIMakeDebugPatient(self.ui)) end)
       :appendItem(_S.menu_debug.cheats:format(hotkey_value_label("ingame_showCheatWindow", hotkeys)),             function() self.ui:addWindow(UICheats(self.ui)) end)

--- a/CorsixTH/Lua/earthquake.lua
+++ b/CorsixTH/Lua/earthquake.lua
@@ -149,7 +149,7 @@ function Earthquake:tick()
   local hospital = self.world:getLocalPlayerHospital()
   -- loop through the patients and allow the possibility for them to fall over
   for _, patient in ipairs(hospital.patients) do
-    if not patient.in_room and patient.falling_anim then
+    if not patient.in_room and patient.falling_anim and math.random(1,2) == 2 then
       patient:falling(false)
     end
   end

--- a/CorsixTH/Lua/earthquake.lua
+++ b/CorsixTH/Lua/earthquake.lua
@@ -145,11 +145,7 @@ function Earthquake:tick()
   self.remaining_damage = self.remaining_damage - 1
   self.damage_timer = self.damage_timer + damage_time
 
-  -- The below code triggers random patient falls during an earthquake.
-  -- It is currently disabled except for debugging purposes in the config file.
-  -- Current behaviour can cause empty action queues or other undesired behaviours.
-  -- Once working, the debugging flag can be removed.
-  if not TheApp.config.debug_falling then return end
+  -- A patient might fall over during an earthquake.
   local hospital = self.world:getLocalPlayerHospital()
   -- loop through the patients and allow the possibility for them to fall over
   for _, patient in ipairs(hospital.patients) do

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -79,10 +79,8 @@ function Patient:onClick(ui, button)
     -- The object we're using is made invisible, as the animation contains both
     -- the humanoid and the object. Hence send the click onto the object.
     self.user_of:onClick(ui, button)
-  elseif TheApp.config.debug_falling and button == "right" then
+  elseif button == "right" then
     -- Attempt to push patient over
-    -- Currently debug-only, enable in config file for testing.
-    -- Once confirmed working, the debugging flag can be removed.
     if not self.world:isPaused() and not (self.cured or self.dead or self.going_home)
          and math.random(1, 2) == 2 then
       self:falling(true)

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -205,7 +205,6 @@ menu_debug = {
   limit_camera                = "  LIMIT CAMERA  ",
   disable_salary_raise        = "  DISABLE SALARY RAISE  ",
   allow_blocking_off_areas    = "  ALLOW BLOCKING OFF AREAS  ",
-  allow_falling               = "  ALLOW FALLING  ",
   make_debug_fax              = "  MAKE DEBUG FAX  ",
   make_debug_patient          = "  MAKE DEBUG PATIENT  ",
   cheats                      = "  (%1%) CHEATS  ",

--- a/WindowsInstaller/config_template.txt
+++ b/WindowsInstaller/config_template.txt
@@ -310,13 +310,6 @@ audio_buffer_size = 2048
 --
 debug = false
 
--- Experimental setting for falling patients. (debug only!)
--- CorsixTH does not yet have reliable handling for falling actions and enabling it
--- could cause dropped action queues or undesired bugs. You should leave this setting
--- off unless you're developing with it
---
-debug_falling = false
-
 -- If set to true, the FPS, Lua memory usage, and entity count will be shown
 -- in the dynamic information bar. Note that setting this to true also turns
 -- off the FPS limiter, causing much higher CPU utilisation, but resulting in


### PR DESCRIPTION

**Describe what the proposed change does**
- Remove all debug_falling flags, with anticipated permanent go-live for 0.70.0 release
- Sets a probability roll (50%) on eligible patients falling in an earthquake (previously, it was 100%)
- Updates issue template

Changes supporting falling actions: #1848
