### PR TITLE
Avoid calling members on uninitialized objects

### DIFF
--- a/CorsixTH/Src/persist_lua.cpp
+++ b/CorsixTH/Src/persist_lua.cpp
@@ -918,6 +918,12 @@ class lua_persist_basic_reader : public lua_persist_reader {
           if (lua_isnil(L, -1))
             lua_pop(L, 1);
           else {
+            // Call the __depersist function with the userdata.
+            // Note: Unless the __pre_depersist method was called above the
+            // new userdata has been created but any initialization such as
+            // the constructor normally called by luaT_stdnew has not yet been
+            // run. If the object is a C++ class, call the placement new
+            // constructor before performing any other operations on the object.
             lua_pushvalue(L, -2);
             lua_rawgeti(L, 1, -3);
             lua_call(L, 2, 1);

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -275,6 +275,8 @@ int l_anim_pre_depersist(lua_State* L) {
 
 template <typename T>
 int l_anim_depersist(lua_State* L) {
+  // Because anim has a pre_depersist function the userdata is already
+  // initialized as a T.
   T* pAnimation = luaT_testuserdata<T>(L);
   lua_settop(L, 2);
   lua_insert(L, 1);

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -520,18 +520,17 @@ int l_layers_persist(lua_State* L) {
 }
 
 int l_layers_depersist(lua_State* L) {
-  layers* pLayers = luaT_testuserdata<layers>(L);
+  void* layers_ud = luaT_testuserdata<layers>(L);
   lua_settop(L, 2);
   lua_insert(L, 1);
   lua_persist_reader* pReader =
       static_cast<lua_persist_reader*>(lua_touserdata(L, 1));
 
-  std::memset(pLayers->layer_contents, 0, sizeof(pLayers->layer_contents));
+  layers* ls = new (layers_ud) layers();
   int iNumLayers;
   if (!pReader->read_uint(iNumLayers)) return 0;
   if (iNumLayers > max_number_of_layers) {
-    if (!pReader->read_byte_stream(pLayers->layer_contents,
-                                   max_number_of_layers)) {
+    if (!pReader->read_byte_stream(ls->layer_contents, max_number_of_layers)) {
       return 0;
     }
     if (!pReader->read_byte_stream(nullptr,
@@ -539,8 +538,7 @@ int l_layers_depersist(lua_State* L) {
       return 0;
     }
   } else {
-    if (!pReader->read_byte_stream(pLayers->layer_contents, iNumLayers))
-      return 0;
+    if (!pReader->read_byte_stream(ls->layer_contents, iNumLayers)) return 0;
   }
   return 0;
 }
@@ -855,13 +853,13 @@ int l_line_persist(lua_State* L) {
 }
 
 int l_line_depersist(lua_State* L) {
-  line_sequence* pLine = luaT_testuserdata<line_sequence>(L);
+  void* line_ud = luaT_testuserdata<line_sequence>(L);
   lua_settop(L, 2);
   lua_insert(L, 1);
   lua_persist_reader* pReader =
       static_cast<lua_persist_reader*>(lua_touserdata(L, 1));
-  new (pLine) line_sequence();
-  pLine->depersist(pReader);
+  line_sequence* line = new (line_ud) line_sequence();
+  line->depersist(pReader);
   return 0;
 }
 

--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -70,14 +70,15 @@ int l_map_persist(lua_State* L) {
 }
 
 int l_map_depersist(lua_State* L) {
-  level_map* pMap = luaT_testuserdata<level_map>(L);
+  void* map_ud = luaT_testuserdata<level_map>(L);
   lua_settop(L, 2);
   lua_insert(L, 1);
   lua_persist_reader* pReader = (lua_persist_reader*)lua_touserdata(L, 1);
 
-  pMap->depersist(pReader);
+  level_map* map = new (map_ud) level_map();
+  map->depersist(pReader);
   luaT_getenvfield(L, 2, "sprites");
-  pMap->set_block_sheet((sprite_sheet*)lua_touserdata(L, -1));
+  map->set_block_sheet((sprite_sheet*)lua_touserdata(L, -1));
   lua_pop(L, 1);
   return 0;
 }
@@ -914,14 +915,15 @@ int l_path_persist(lua_State* L) {
 }
 
 int l_path_depersist(lua_State* L) {
-  pathfinder* pPathfinder = luaT_testuserdata<pathfinder>(L);
+  void* pathfinder_ud = luaT_testuserdata<pathfinder>(L);
   lua_settop(L, 2);
   lua_insert(L, 1);
   lua_persist_reader* pReader = (lua_persist_reader*)lua_touserdata(L, 1);
 
-  pPathfinder->depersist(pReader);
+  pathfinder* pf = new (pathfinder_ud) pathfinder();
+  pf->depersist(pReader);
   luaT_getenvfield(L, 2, "map");
-  pPathfinder->set_default_map(static_cast<level_map*>(lua_touserdata(L, -1)));
+  pf->set_default_map(static_cast<level_map*>(lua_touserdata(L, -1)));
   return 0;
 }
 

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1546,8 +1546,6 @@ void level_map::persist(lua_persist_writer* pWriter) const {
 }
 
 void level_map::depersist(lua_persist_reader* pReader) {
-  new (this) level_map;  // Call constructor
-
   lua_State* L = pReader->get_stack();
   int iWidth, iHeight;
 

--- a/CorsixTH/Src/th_pathfind.cpp
+++ b/CorsixTH/Src/th_pathfind.cpp
@@ -639,8 +639,6 @@ void pathfinder::persist(lua_persist_writer* pWriter) const {
 }
 
 void pathfinder::depersist(lua_persist_reader* pReader) {
-  new (this) pathfinder;  // Call constructor
-
   int iLength;
   if (!pReader->read_uint(iLength)) {
     return;


### PR DESCRIPTION
When __depersist is called, in most circumstances the object has not yet be initialized (i.e. by calling new), it is simply a block of malloc'd memory the right size.

This patch fixes everywhere that was calling methods or accessing members without calling placement new first.

I'm using void* and _ud as conventions to help future developers not to accidentally access the object too early; for lack of better enforcement in the language.

layers is zero initialized by the constructor which removes the need for the memset.

