### PR TITLE
Improve finding player name

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1003,24 +1003,33 @@ function App:fixConfig()
     -- For language, make language name lower case
     if key == "language" and type(value) == "string" then
       self.config[key] = value:lower()
-    end
 
     -- For resolution, check that resolution is at least 640x480
-    if key == "width" and type(value) == "number" and value < 640 then
+    elseif key == "width" and type(value) == "number" and value < 640 then
       self.config[key] = 640
-    end
 
-    if key == "height" and type(value) == "number" and value < 480 then
+    elseif key == "height" and type(value) == "number" and value < 480 then
       self.config[key] = 480
-    end
 
-    if (key == "scroll_speed" or key == "shift_scroll_speed") and
+    elseif (key == "scroll_speed" or key == "shift_scroll_speed") and
         type(value) == "number" then
       if value > 10 then
         self.config[key] = 10
       elseif value < 1 then
         self.config[key] = 1
       end
+
+    -- For player name, trim spaces or fill in from environment
+    elseif key == "player_name" then
+      value = value:match('^%s*(.*%S)') or "" -- Trim spaces
+      if value:len() == 0 then -- If empty, use computer user's name,
+        value = os.getenv("USER") or os.getenv("USERNAME")
+      end
+      value = value:match('^%s*(.*%S)') or ""
+      if value:len() == 0 then -- unless that is also empty
+        value = "PLAYER"
+      end
+      self.config[key] = value
     end
   end
 end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2926*

**Describe what the proposed change does**
- Uses the config and environment to find a suitable player name on launch. On first launch, the computer user name will be in the campaign dialog. Would that be a bad surprise for anyone?
- Tidy up the repeated ifs in App:fixConfig. Were they intentional?
