### PR TITLE
Bump vcpkg version

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "8f54ef5453e7e76ff01e15988bf243e7247c5eb5",
+    "baseline": "a67ae9b9f7afc153767a5c33607266252ff9d088",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [
@@ -13,7 +13,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/CorsixTH/vcpkg-registry",
-      "baseline": "1ec0ed6b666d6ef4843e8b8fc0f32cbf5b6fe359",
+      "baseline": "1cc12bb832d6b04a22a91d3641b4860c241e6646",
       "packages": [ "ffmpeg" ]
     }
   ]


### PR DESCRIPTION
    catch2:x64-linux@3.10.0 -- /home/stephen/.cache/vcpkg/registries/git-trees/c36d69b5c0effa33673a22897857f42d264eb1b5
    curl[core,openssl,ssl]:x64-linux@8.15.0#1 -- /home/stephen/.cache/vcpkg/registries/git-trees/c5d9f2f0044ff09a375a67bd48932a2c020f5bee
    ffmpeg[avcodec,avformat,core,swresample,swscale]:x64-linux@7.1.1#3 -- /home/stephen/.cache/vcpkg/registries/git-trees/eea6888a7ce005aa5813c769e0e179dd0b05f067
    fluidsynth[buildtools,core,sndfile]:x64-linux@2.4.6#1 -- /home/stephen/.cache/vcpkg/registries/git-trees/62a2092769a82d7302564639bca90f3ac03b17aa
    freetype[brotli,bzip2,core,png,zlib]:x64-linux@2.13.3 -- /home/stephen/.cache/vcpkg/registries/git-trees/8a2c633dcc14eaabdb31cf4637242f4e3c2f3fa2
    lpeg:x64-linux@1.1.0#1 -- /home/stephen/.cache/vcpkg/registries/git-trees/933131ff56540fca7bbfb7a4ccd5fbf2612d4b0c
    lua[core,tools]:x64-linux@5.4.8 -- /home/stephen/.cache/vcpkg/registries/git-trees/062ae235ae46d4bce8b00be2c74667e0763cc2c1
    luafilesystem:x64-linux@1.8.0#7 -- /home/stephen/.cache/vcpkg/registries/git-trees/00b7638338af5a3a2d95c3c9b1ed870ed0cfb9fc
    sdl2[core,dbus,ibus,wayland,x11]:x64-linux@2.32.10 -- /home/stephen/.cache/vcpkg/registries/git-trees/af36a2c0ace7069e28bded20480ebbaf4e9c6e98
    sdl2-mixer[core,fluidsynth,libflac,libmodplug,mpg123,opusfile,wavpack]:x64-linux@2.8.1#2 -- /home/stephen/.cache/vcpkg/registries/git-trees/ee2053a681764a5fda41536fee42df58397d0c37
