### PR TITLE
Fix regular expressions in readLevelInfo

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -707,7 +707,7 @@ function App:readLevelFile(level, campaign_dir)
   if filename:match(self.level_dir .. "original%d%d%.level") then
     level_info.map_file = map_file
   elseif map_file then
-    if map_file:lower():match("^level") then
+    if map_file:lower():match("^level%.l%d+$") then
       level_info.map_file = map_file
     else
       level_info.map_file = self:_checkOrFind(map_file, campaign_dir)


### PR DESCRIPTION
* Fixes #3010 

**Describe what the proposed change does**
- Make readLevelInfo load maps from Theme Hospital ONLY when map name look like "LEVEL.L(int)". Before this change, CTH would try to load any map from Theme Hospital, if map name started from "LEVEL".