### PR TITLE
Add screen shake configuration option

### DIFF
--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -125,6 +125,7 @@ local config_defaults = {
   enable_avg_contents = false,
   remove_destroyed_rooms = false,
   machine_menu_button = true,
+  enable_screen_shake = true,
   audio_frequency = 22050,
   audio_channels = 2,
   audio_buffer_size = 2048,

--- a/CorsixTH/Lua/dialogs/resizables/customise.lua
+++ b/CorsixTH/Lua/dialogs/resizables/customise.lua
@@ -43,7 +43,7 @@ local col_caption = {
 }
 
 function UICustomise:UICustomise(ui, mode)
-  self:UIResizable(ui, 340, 325, col_bg)
+  self:UIResizable(ui, 340, 350, col_bg)
 
   local app = ui.app
   self.mode = mode
@@ -132,8 +132,16 @@ function UICustomise:UICustomise(ui, mode)
   self.machine_menu_button = self.machine_menu_panel:makeToggleButton(0, 0, 140, 20, nil, self.buttonMachine_menu)
     :setToggleState(app.config.machine_menu_button):setTooltip(_S.tooltip.customise_window.machine_menu_button)
 
+  -- Allow user to disable screen shake during earthquakes
+  self:addBevelPanel(15, 265, 165, 20, col_shadow, col_bg, col_bg)
+    :setLabel(_S.customise_window.enable_screen_shake):setTooltip(_S.tooltip.customise_window.enable_screen_shake).lowered = true
+  self.screen_shake_panel =
+    self:addBevelPanel(185, 265, 140, 20, col_bg):setLabel(app.config.enable_screen_shake and _S.customise_window.option_on or _S.customise_window.option_off)
+  self.screen_shake_button = self.screen_shake_panel:makeToggleButton(0, 0, 140, 20, nil, self.buttonScreen_shake)
+    :setToggleState(app.config.enable_screen_shake):setTooltip(_S.tooltip.customise_window.enable_screen_shake)
+
   -- "Back" button
-  self:addBevelPanel(15, 270, 310, 40, col_bg):setLabel(_S.customise_window.back)
+  self:addBevelPanel(15, 295, 310, 40, col_bg):setLabel(_S.customise_window.back)
     :makeButton(0, 0, 310, 40, nil, self.buttonBack):setTooltip(_S.tooltip.customise_window.back)
 end
 
@@ -225,6 +233,15 @@ function UICustomise:buttonMachine_menu()
   app.config.machine_menu_button = not app.config.machine_menu_button
   self.destroyed_rooms_button:toggle()
   self.destroyed_rooms_panel:setLabel(app.config.machine_menu_button and _S.customise_window.option_on or _S.customise_window.option_off)
+  app:saveConfig()
+  self:reload()
+end
+
+function UICustomise:buttonScreen_shake()
+  local app = self.ui.app
+  app.config.enable_screen_shake = not app.config.enable_screen_shake
+  self.screen_shake_button:toggle()
+  self.screen_shake_panel:setLabel(app.config.enable_screen_shake and _S.customise_window.option_on or _S.customise_window.option_off)
   app:saveConfig()
   self:reload()
 end

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -965,11 +965,15 @@ function GameUI:scrollMap(dx, dy)
   self.screen_offset_y = floor(dy + 0.5)
 end
 
---! Start shaking the screen, e.g. an earthquake effect
+--! Start shaking the screen, e.g. an earthquake effect (unless disabled in config)
 --!param intensity (number) The magnitude of the effect, between 0 for no
 -- movement to 1 for significant shaking.
 function GameUI:beginShakeScreen(intensity)
-  self.shake_screen_intensity = intensity
+  if self.app.config.enable_screen_shake then
+    self.shake_screen_intensity = intensity
+  else
+    self.shake_screen_intensity = 0
+  end
 end
 
 --! Stop the screen from shaking after beginShakeScreen is called.

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -541,7 +541,6 @@ customise_window = {
   average_contents = "Average Contents",
   remove_destroyed_rooms = "Remove destroyed rooms",
   machine_menu_button = "Machine menu button",
-  enable_screen_shake = "Earthquakes will cause the entire screen to shake. If you would prefer the screen to remain still, turn this option off",
   enable_screen_shake = "Enable Screen Shake",
 }
 
@@ -555,6 +554,7 @@ tooltip.customise_window = {
   average_contents = "If you would like the game to remember what extra objects you usually add when you build rooms, then turn this option on",
   remove_destroyed_rooms = "If you would like to be able to remove destroyed rooms, for a fee, turn this option on",
   machine_menu_button = "If you would like to have a machine menu button in bottom panel, turn this option on. Keep in mind that this button will not be available in small screen resolutions",
+  enable_screen_shake = "Earthquakes will cause the entire screen to shake. If you would prefer the screen to remain still, turn this option off",
   back = "Close this menu and go back to the Settings Menu",
 }
 

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -541,6 +541,8 @@ customise_window = {
   average_contents = "Average Contents",
   remove_destroyed_rooms = "Remove destroyed rooms",
   machine_menu_button = "Machine menu button",
+  enable_screen_shake = "Earthquakes will cause the entire screen to shake. If you would prefer the screen to remain still, turn this option off",
+  enable_screen_shake = "Enable Screen Shake",
 }
 
 tooltip.customise_window = {

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -541,7 +541,7 @@ customise_window = {
   average_contents = "Average Contents",
   remove_destroyed_rooms = "Remove destroyed rooms",
   machine_menu_button = "Machine menu button",
-  enable_screen_shake = "Enable Screen Shake",
+  enable_screen_shake = "Screen Shake",
 }
 
 tooltip.customise_window = {

--- a/WindowsInstaller/config_template.txt
+++ b/WindowsInstaller/config_template.txt
@@ -215,7 +215,7 @@ machine_menu_button = true
 -- By default the entire screen will shake during earthquakes. If you would
 -- like the game to keep the screen stationary, change this option to false.
 --
-enable_screen_shake = false
+enable_screen_shake = true
 
 ------------------------------- FOLDER SETTINGS -------------------------------
 -- These settings can also be changed from the Folders Menu

--- a/WindowsInstaller/config_template.txt
+++ b/WindowsInstaller/config_template.txt
@@ -211,6 +211,12 @@ remove_destroyed_rooms = false
 --
 machine_menu_button = true
 
+-------------------------------------------------------------------------------
+-- By default the entire screen will shake during earthquakes. If you would
+-- like the game to keep the screen stationary, change this option to false.
+--
+enable_screen_shake = false
+
 ------------------------------- FOLDER SETTINGS -------------------------------
 -- These settings can also be changed from the Folders Menu
 -------------------------------------------------------------------------------


### PR DESCRIPTION
*Fixes #3007*

- Adds a configuration option that allows the player to disable screen shake during earthquakes.
- Appears in Custom Settings menu
- Enabled by default