### PR TITLE
fixed various typos in comments, renamed setUninterruptable() to setUninterruptible()

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -99,7 +99,7 @@ function UIBottomPanel:drawPanels()
   panels[1]  = self:addPanel(15, 364, 0) -- Staff management button
   buttons[1] = panels[1]:makeToggleButton(6, 6, 35, 36, 16, self.dialogStaffManagement):setTooltip(_S.tooltip.toolbar.staff_list)
   if self:machineMenuButtonExists() then
-    -- Sprites for machine menu button doesnt exist in original game. Lets import them from aux_ui.dat and draw
+    -- Sprites for machine menu button doesn't exist in original game. Let's import them from aux_ui.dat and draw
     local aux_sprites = app.gfx:loadSpriteTable("Bitmap", "aux_ui", true)
     self:addPanel(0, 407, 0):makeToggleButton(2, 6, 36, 36, 0, self.dialogMachineMenu)
       :setTooltip(_S.tooltip.toolbar.machine_menu)

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -1109,7 +1109,7 @@ end
 function Patient:removeAnyEpidemicStatus()
   self:setMood("epidemy1","deactivate") -- vaccinated (step 4)
   self:setMood("epidemy2","deactivate") -- marked (step 2)
-  self:setMood("epidemy3","deactivate") -- choosed by nurse (step 3)
+  self:setMood("epidemy3","deactivate") -- chosen by nurse (step 3)
   self:setMood("epidemy4","deactivate") -- infected (step 1)
 end
 

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -142,7 +142,7 @@ function Epidemic:infectOtherPatients()
 
     -- 'victim' is already infected or is going home.
     if victim.infected or victim.cured or victim.vaccinated then return false end
-    -- Don't infect victim if it alredy under another attempt to be infected
+    -- Don't infect victim if it already under another attempt to be infected
     if victim.under_infection_attempt then return false end
     -- Don't infect emergencies.
     if victim.is_emergency then return false end

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -142,7 +142,7 @@ function Epidemic:infectOtherPatients()
 
     -- 'victim' is already infected or is going home.
     if victim.infected or victim.cured or victim.vaccinated then return false end
-    -- Don't infect victim if it already under another attempt to be infected
+    -- Don't infect victim if it is already under another attempt to be infected
     if victim.under_infection_attempt then return false end
     -- Don't infect emergencies.
     if victim.is_emergency then return false end

--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -725,7 +725,7 @@ function AnimationManager:setMarkerRaw(anim, fn, arg1, arg2, ...)
   local frame = self.anims:getFirstFrame(anim)
 
   --! Set marker position for frame
-  --!param x1y1 (boolen) use values given by x1 and y1 only if true, otherwise use
+  --!param x1y1 (boolean) use values given by x1 and y1 only if true, otherwise use
   -- linear interpolation between x1/y1 and x2/y2
   --!param x1, y1, x2 (optional), y2 (optional) pixel positions
   --!param n fraction between start and end frame of linear interpolation

--- a/CorsixTH/Lua/humanoid_action.lua
+++ b/CorsixTH/Lua/humanoid_action.lua
@@ -59,13 +59,13 @@ function HumanoidAction:setMustHappen(must_happen)
   return self
 end
 
---! Set the 'uninterruptable' flag (that is, action cannot be canceled or truncated by pickup).
---!param uninterruptable (bool) Whether or not the action uninterruptable.
+--! Set the 'uninterruptible' flag (that is, action cannot be canceled or truncated by pickup).
+--!param uninterruptible (bool) Whether or not the action uninterruptible.
 --!return (action) Returning self, for daisy-chaining.
-function HumanoidAction:setUninterruptable(uninterruptable)
-  assert(type(uninterruptable) == "boolean", "Invalid value for parameters 'uninterruptable'")
+function HumanoidAction:setUninterruptible(uninterruptible)
+  assert(type(uninterruptible) == "boolean", "Invalid value for parameters 'uninterruptible'")
 
-  self.uninterruptible = uninterruptable
+  self.uninterruptible = uninterruptible
   return self
 end
 

--- a/CorsixTH/Lua/rooms/general_diag.lua
+++ b/CorsixTH/Lua/rooms/general_diag.lua
@@ -66,14 +66,14 @@ function GeneralDiagRoom:commandEnteringPatient(patient)
       local staff_prepare = WalkAction(ox, oy)
           :setMustHappen(true)
           :disableTruncate()
-          :setUninterruptable(true)
+          :setUninterruptible(true)
       staff:setNextAction(staff_prepare)
 
       -- Doctor waits for patient near trolley
       local staff_idle = IdleAction()
           :setMustHappen(true)
           :disableTruncate()
-          :setUninterruptable(true)
+          :setUninterruptible(true)
       staff:queueAction(staff_idle)
 
       -- Patient walks to trolley

--- a/CorsixTH/Lua/rooms/operating_theatre.lua
+++ b/CorsixTH/Lua/rooms/operating_theatre.lua
@@ -123,7 +123,7 @@ function OperatingTheatreRoom._buildTableAction2(multi_use, operation_table_b)
     :setAfterUse(after_use_use_object)
     :setMustHappen(true)
     :disableTruncate()
-    :setUninterruptable(true)
+    :setUninterruptible(true)
 end
 
 function OperatingTheatreRoom:commandEnteringStaff(staff)
@@ -205,11 +205,11 @@ function OperatingTheatreRoom:queueWashHands(surgeon, before_other_actions)
   local wait = wait_for_object(surgeon, sink, true)
     :setMustHappen(true)
     :disableTruncate()
-    :setUninterruptable(true)
+    :setUninterruptible(true)
   local wash = UseObjectAction(sink)
     :setMustHappen(true)
     :disableTruncate()
-    :setUninterruptable(true)
+    :setUninterruptible(true)
 
   for pos, action in pairs({walk, wait, wash}) do
     if (before_other_actions) then
@@ -311,7 +311,7 @@ function OperatingTheatreRoom:commandEnteringPatient(patient)
     :setLoopCallback(operation_standby)
     :setMustHappen(true)
     :disableTruncate()
-    :setUninterruptable(true), 5)
+    :setUninterruptible(true), 5)
 
   -- Patient walk to the side of the operating table
   ox, oy = obj:getSecondaryUsageTile()
@@ -338,7 +338,7 @@ function OperatingTheatreRoom:commandEnteringPatient(patient)
     :setLoopCallback(operation_standby)
     :setMustHappen(true)
     :disableTruncate()
-    :setUninterruptable(true), 5)
+    :setUninterruptible(true), 5)
 
   return Room.commandEnteringPatient(self, patient)
 end

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -151,7 +151,7 @@ class chunk_renderer {
   /*!
       @param width Pixel width of the resulting image
       @param height Pixel height of the resulting image
-      @param start An interator to the start writing the resulting image to.
+      @param start An iterator to the start writing the resulting image to.
                    Must point to a container of at least width * height.
   */
   chunk_renderer(int width, int height, std::vector<uint8_t>::iterator start);


### PR DESCRIPTION
- Fixes various typos in comments (identified by [Linux apt-get Lua 5.1](https://github.com/CorsixTH/CorsixTH/actions/runs/17744976406/job/50427959171#logs))
- Refactored `setUninterruptable()` to `setUninterruptible()`