### PR TITLE
Add missing hover and click sound effects in various places

### DIFF
--- a/CorsixTH/Lua/dialogs/build_room.lua
+++ b/CorsixTH/Lua/dialogs/build_room.lua
@@ -206,7 +206,7 @@ function UIBuildRoom:onMouseMove(x, y, dx, dy)
   end
 
   if hover_idx ~= self.list_hover_index then
-    self.ui:playSound("HLightP2.wav")
+    self.ui:playSound("HLight5.wav")
     if hover_idx == 0 then
       self.cost_box = _S.build_room_window.cost .. "0"
       self.preview_anim = false

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -577,7 +577,6 @@ function UIEditRoom:finishRoom()
 end
 
 function UIEditRoom:purchaseItems()
-  self.ui:playSound("selectx.wav")
   self.visible = false
   self.place_objects = false
   self:stopPickupItems()
@@ -619,7 +618,6 @@ end
 
 -- callback for item pick up button
 function UIEditRoom:pickupItems()
-  self.ui:playSound("selectx.wav")
   if self.in_pickup_mode then
     self:stopPickupItems()
   else

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -577,6 +577,7 @@ function UIEditRoom:finishRoom()
 end
 
 function UIEditRoom:purchaseItems()
+  self.ui:playSound("selectx.wav")
   self.visible = false
   self.place_objects = false
   self:stopPickupItems()
@@ -618,6 +619,7 @@ end
 
 -- callback for item pick up button
 function UIEditRoom:pickupItems()
+  self.ui:playSound("selectx.wav")
   if self.in_pickup_mode then
     self:stopPickupItems()
   else

--- a/CorsixTH/Lua/dialogs/fullscreen/hospital_policy.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/hospital_policy.lua
@@ -66,11 +66,13 @@ function UIPolicy:UIPolicy(ui)
 
   self.allow_button = self:addPanel(0, 348, 379)
       :makeToggleButton(0, 0, 48, 17, 4, allowStaff, "Allow")
-      :setTooltip(_S.tooltip.policy.staff_leave) -- Allow staff to move
+      :setTooltip(_S.tooltip.policy.staff_leave)
+      :setSound("selectx.wav") -- Allow staff to move
 
   self.prohibit_button = self:addPanel(0, 395, 379)
       :makeToggleButton(0, 0, 48, 17, 5, allowStaff, "Prohibit")
-      :setTooltip(_S.tooltip.policy.staff_stay) -- Prohibit staff to move
+      :setTooltip(_S.tooltip.policy.staff_stay)
+      :setSound("selectx.wav") -- Prohibit staff to move
 
   if self.hospital.policies["staff_allowed_to_move"] then
     self.allow_button:toggle()

--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -447,17 +447,20 @@ end
 function UIStaffManagement:onMouseMove(x, y, dx, dy)
   local current_hover_id
   local inside_staff_list_area
-
-  if self.page*10 >= #self.staff_members[self.category] then
+  local header_height = 81
+  local row_height = 27
+  local active_hover_id = math_floor((y - header_height)/row_height)
+  if self.page*10 > #self.staff_members[self.category] then
+    -- Make sure area contains no hollow space
     inside_staff_list_area = (x > 50 and x < 624) and
-    (y > 82 and y < 82 + 27 * (#self.staff_members[self.category] % 10))
+    (y > header_height and y < header_height + row_height * (#self.staff_members[self.category] % 10))
   else
-    inside_staff_list_area = (x > 50 and x < 624) and (y > 82 and y < 351)
+    inside_staff_list_area = (x > 50 and x < 624) and (y > header_height and y < 351)
   end
 
   if inside_staff_list_area then
-    if #self.staff_members[self.category] - (self.page - 1)*10 > math_floor((y - 81)/27) then
-      current_hover_id = math_floor((y - 81)/27) + 1 + (self.page - 1)*10
+    if #self.staff_members[self.category] - (self.page - 1)*10 > active_hover_id then
+      current_hover_id = active_hover_id + 1 + (self.page - 1)*10
       if self.hover_id ~= current_hover_id then
         self.ui:playSound("Hlight5.wav")
         self.hover_id = current_hover_id

--- a/CorsixTH/Lua/dialogs/furnish_corridor.lua
+++ b/CorsixTH/Lua/dialogs/furnish_corridor.lua
@@ -89,7 +89,7 @@ function UIFurnishCorridor:UIFurnishCorridor(ui, objects, edit_dialog)
 
   self:addPanel(235, 146, 0) -- List top
   self:addPanel(236, 146, 223) -- List bottom
-  self:addPanel(237, 154, 238):makeButton(0, 0, 197, 28, 238, self.confirm):setTooltip(_S.tooltip.buy_objects_window.confirm)
+  self:addPanel(237, 154, 238):makeButton(0, 0, 197, 28, 238, self.confirm):setTooltip(_S.tooltip.buy_objects_window.confirm):setSound("selectx.wav")
   local i = 1
   local function item_callback(index, qty)
     local is_negative_quantity = qty < 0
@@ -244,6 +244,7 @@ function UIFurnishCorridor:onMouseMove(x, y, dx, dy)
       local obj = self.objects[hover_idx].object
       self.item_price = self.ui.hospital:getObjectBuildCost(obj.id)
       self.preview_anim:setAnimation(self.anims, obj.build_preview_animation)
+      TheApp.audio:playSound("HLIGHT5.wav")
     end
     self.list_hover_index = hover_idx
     repaint = true

--- a/CorsixTH/Lua/dialogs/information.lua
+++ b/CorsixTH/Lua/dialogs/information.lua
@@ -127,16 +127,6 @@ end
 
 function UIInformation:onMouseMove(x, y, dx, dy)
   self.active_hover = self:hoverTest(self.active_hover, x, y, self.width - 29, self.width - 10, self.height - 29, self.height - 10)
-  --[[
-  local current_hover = x > self.width - 29 and x < self.width - 10 and y > self.height - 29 and y < self.height - 10
-  if current_hover and not self.active_hover then
-    self.active_hover = true
-    self.ui:playSound("Hlight5.wav")
-  else
-    if not current_hover then
-      self.active_hover = false
-    end
-  end]]
   return Window:onMouseMove(x, y, dx, dy)
 end
 

--- a/CorsixTH/Lua/dialogs/information.lua
+++ b/CorsixTH/Lua/dialogs/information.lua
@@ -39,7 +39,7 @@ function UIInformation:UIInformation(ui, text, use_built_in_font)
   self.on_top = true
   self.ui = ui
   self.panel_sprites = app.gfx:loadSpriteTable("Data", "PulldV", true)
-  self.hover = false
+  self.active_hover = false
   if not use_built_in_font then
     self.black_font = app.gfx:loadFontAndSpriteTable("QData", "Font00V")
   else
@@ -107,7 +107,7 @@ function UIInformation:onChangeLanguage()
       x = x + panel.x
       y = y + panel.y
       panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y)
-      if self.hover then
+      if self.active_hover then
         self.panel_sprites:draw(canvas, 20, x, y)
       end
     end
@@ -126,16 +126,17 @@ function UIInformation:draw(canvas, x, y)
 end
 
 function UIInformation:onMouseMove(x, y, dx, dy)
+  self.active_hover = self:hoverTest(self.active_hover, x, y, self.width - 29, self.width - 10, self.height - 29, self.height - 10)
+  --[[
   local current_hover = x > self.width - 29 and x < self.width - 10 and y > self.height - 29 and y < self.height - 10
-
-  if current_hover and not self.hover then
-    self.hover = true
+  if current_hover and not self.active_hover then
+    self.active_hover = true
     self.ui:playSound("Hlight5.wav")
   else
     if not current_hover then
-      self.hover = false
+      self.active_hover = false
     end
-  end
+  end]]
   return Window:onMouseMove(x, y, dx, dy)
 end
 

--- a/CorsixTH/Lua/dialogs/information.lua
+++ b/CorsixTH/Lua/dialogs/information.lua
@@ -39,6 +39,7 @@ function UIInformation:UIInformation(ui, text, use_built_in_font)
   self.on_top = true
   self.ui = ui
   self.panel_sprites = app.gfx:loadSpriteTable("Data", "PulldV", true)
+  self.hover = false
   if not use_built_in_font then
     self.black_font = app.gfx:loadFontAndSpriteTable("QData", "Font00V")
   else
@@ -102,6 +103,14 @@ function UIInformation:onChangeLanguage()
 
   -- Close button
   self:addPanel(19, self.width - 28, self.height - 28):makeButton(0, 0, 18, 18, 20, self.close):setTooltip(_S.tooltip.information.close)
+  .panel_for_sprite.custom_draw = function(panel, canvas, x, y)
+      x = x + panel.x
+      y = y + panel.y
+      panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y)
+      if self.hover then
+        self.panel_sprites:draw(canvas, 20, x, y)
+      end
+    end
 end
 
 function UIInformation:draw(canvas, x, y)
@@ -114,6 +123,20 @@ function UIInformation:draw(canvas, x, y)
   end
 
   Window.draw(self, canvas, x, y)
+end
+
+function UIInformation:onMouseMove(x, y, dx, dy)
+  local current_hover = x > self.width - 29 and x < self.width - 10 and y > self.height - 29 and y < self.height - 10
+
+  if current_hover and not self.hover then
+    self.hover = true
+    self.ui:playSound("Hlight5.wav")
+  else
+    if not current_hover then
+      self.hover = false
+    end
+  end
+  return Window:onMouseMove(x, y, dx, dy)
 end
 
 function UIInformation:hitTest(x, y)

--- a/CorsixTH/Lua/dialogs/information.lua
+++ b/CorsixTH/Lua/dialogs/information.lua
@@ -103,7 +103,7 @@ function UIInformation:onChangeLanguage()
 
   -- Close button
   self:addPanel(19, self.width - 28, self.height - 28):makeButton(0, 0, 18, 18, 20, self.close):setTooltip(_S.tooltip.information.close)
-  .panel_for_sprite.custom_draw = function(panel, canvas, x, y)
+  .panel_for_sprite.custom_draw = --[[persistable:information_close_button]] function(panel, canvas, x, y)
       x = x + panel.x
       y = y + panel.y
       panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y)

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -262,7 +262,11 @@ function UIMenuBar:onMouseMove(x, y, dx, dy)
         toparent = false
         visible = true
         if hit ~= true then
+          if hit ~= menu.prev_hover_index then
+            self.ui:playSound("HLight5.wav")
+          end
           menu.hover_index = hit
+          menu.prev_hover_index = menu.hover_index
         else
           menu.hover_index = 0
           if menu.parent and menu.parent:hitTest(x, y, 0) then
@@ -474,6 +478,7 @@ function UIMenu:UIMenu()
   self.items = {}
   self.parent = false
   self.hover_index = 0
+  self.prev_hover_index = nil
   self.has_size = false
 end
 

--- a/CorsixTH/Lua/dialogs/patient.lua
+++ b/CorsixTH/Lua/dialogs/patient.lua
@@ -52,7 +52,7 @@ function UIPatient:UIPatient(ui, patient)
   self.history_panel = self:addColourPanel(36, 22, 99, 88, 223, 223, 223) -- Treatment history background
   self.history_panel:makeButton(0, 0, 99, 88, nil, --[[persistable:patient_toggle_history]] function()
     self.history_panel.visible = not self.history_panel.visible
-  end):setTooltip(_S.tooltip.patient_window.graph) -- Treatment history toggle
+  end):setTooltip(_S.tooltip.patient_window.graph):setSound("selectx.wav") -- Treatment history toggle
   self.history_panel.visible = false -- Hide the treatment history at start
 
   self:addPanel(322,  15, 126) -- Happiness / thirst / temperature sliders

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -93,13 +93,13 @@ function UIStaff:UIStaff(ui, staff)
     end
     self:addPanel(302,   5, 205) -- View circle top/Wage
     self:addPanel(313,  15, 189) -- Tasks bottom
-    self:addPanel(314,  37, 145):makeRepeatButton(0, 0, 49, 48, 315, self.doMoreCleaning):setTooltip(_S.tooltip.handyman_window.prio_litter)
-    self:addPanel(316,  92, 145):makeRepeatButton(0, 0, 49, 48, 317, self.doMoreWatering):setTooltip(_S.tooltip.handyman_window.prio_plants)
-    self:addPanel(318, 148, 145):makeRepeatButton(0, 0, 49, 48, 319, self.doMoreRepairing):setTooltip(_S.tooltip.handyman_window.prio_machines)
-    self:addPanel(240,  21, 210):makeButton(0, 0, 73, 30, 240, self.changeParcel):setTooltip(_S.tooltip.handyman_window.parcel_select)
+    self:addPanel(314,  37, 145):makeRepeatButton(0, 0, 49, 48, 315, self.doMoreCleaning):setTooltip(_S.tooltip.handyman_window.prio_litter):setSound("selectx.wav")
+    self:addPanel(316,  92, 145):makeRepeatButton(0, 0, 49, 48, 317, self.doMoreWatering):setTooltip(_S.tooltip.handyman_window.prio_plants):setSound("selectx.wav")
+    self:addPanel(318, 148, 145):makeRepeatButton(0, 0, 49, 48, 319, self.doMoreRepairing):setTooltip(_S.tooltip.handyman_window.prio_machines):setSound("selectx.wav")
+    self:addPanel(240,  21, 210):makeButton(0, 0, 73, 30, 240, self.changeParcel):setTooltip(_S.tooltip.handyman_window.parcel_select):setSound("selectx.wav")
   self:addPanel(303,   0, 253) -- View circle midpiece
     self:addPanel(304,   6, 302) -- View circle bottom
-    self:addPanel(307, 106, 253):makeButton(0, 0, 50, 50, 308, self.fireStaff):setTooltip(_S.tooltip.staff_window.sack)
+    self:addPanel(307, 106, 253):makeButton(0, 0, 50, 50, 308, self.fireStaff):setTooltip(_S.tooltip.staff_window.sack):setSound("selectx.wav")
     self:addPanel(309, 164, 253):makeButton(0, 0, 37, 50, 310, self.pickupStaff):setTooltip(_S.tooltip.staff_window.pick_up)
   else
     self:addPanel(302,   5, 178) -- View circle top/Wage
@@ -108,7 +108,7 @@ function UIStaff:UIStaff(ui, staff)
     if profile.humanoid_class ~= "Doctor" then
       self:addColourPanel(32, 141, 171, 39, 85, 202, 219)  -- Hides Skills
     end
-    self:addPanel(307, 106, 226):makeButton(0, 0, 50, 50, 308, self.fireStaff):setTooltip(_S.tooltip.staff_window.sack)
+    self:addPanel(307, 106, 226):makeButton(0, 0, 50, 50, 308, self.fireStaff):setTooltip(_S.tooltip.staff_window.sack):setSound("selectx.wav")
     self:addPanel(309, 164, 226):makeButton(0, 0, 37, 50, 310, self.pickupStaff):setTooltip(_S.tooltip.staff_window.pick_up)
   end
 

--- a/CorsixTH/Lua/dialogs/watch.lua
+++ b/CorsixTH/Lua/dialogs/watch.lua
@@ -74,7 +74,7 @@ function UIWatch:UIWatch(ui, count_type)
     :setTooltip(tooltips[count_type])
 
     self:addPanel(end_sprite, 4, 0)
-    .custom_draw = function(panel, canvas, x, y)
+    .custom_draw = --[[persistable:epidemic_timer_button]] function(panel, canvas, x, y)
       x = x + panel.x
       y = y + panel.y
       panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y)
@@ -97,7 +97,7 @@ function UIWatch:UIWatch(ui, count_type)
         self.scrollToTimerEventPatient, nil, self.cycleTimerEventPatient)
   else
     self:addPanel(timer_sprite, 0, 28):setTooltip(tooltips[count_type])
-    .custom_draw = function(panel, canvas, x, y)
+    .custom_draw = --[[persistable:open_hospital_timer_button]] function(panel, canvas, x, y)
       x = x + panel.x
       y = y + panel.y
       panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y)

--- a/CorsixTH/Lua/dialogs/watch.lua
+++ b/CorsixTH/Lua/dialogs/watch.lua
@@ -53,7 +53,7 @@ function UIWatch:UIWatch(ui, count_type)
   self.panel_sprites = app.gfx:loadSpriteTable("Data", "Watch01V", true)
   self.epidemic = false
   self.count_type = count_type
-  self.hover = false
+  self.active_hover = false
   -- For cycling the list of epidemic/emergency patients which index to use
   self.current_index = nil
   -- The last patient whose dialog was opened by clicking the timer
@@ -78,7 +78,7 @@ function UIWatch:UIWatch(ui, count_type)
       x = x + panel.x
       y = y + panel.y
       panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y)
-      if self.hover then
+      if self.active_hover then
         self.panel_sprites:draw(canvas, 15, x, y)
       end
     end
@@ -101,7 +101,7 @@ function UIWatch:UIWatch(ui, count_type)
       x = x + panel.x
       y = y + panel.y
       panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y)
-      if self.hover then
+      if self.active_hover then
         self.panel_sprites:draw(canvas, 17, x+4, y-28)
       end
     end
@@ -125,15 +125,7 @@ function UIWatch:onCountdownEnd()
 end
 
 function UIWatch:onMouseMove(x, y, dx, dy)
-  local current_hover = x > 4 and x < 31 and y > 0 and y < 29
-  if current_hover and not self.hover then
-    self.hover = true
-    self.ui:playSound("Hlight5.wav")
-  else
-    if not current_hover then
-      self.hover = false
-    end
-  end
+  self.active_hover = self:hoverTest(self.active_hover, x, y, 4, 31, 0, 29)
   return Window:onMouseMove(x, y, dx, dy)
 end
 

--- a/CorsixTH/Lua/dialogs/watch.lua
+++ b/CorsixTH/Lua/dialogs/watch.lua
@@ -53,12 +53,14 @@ function UIWatch:UIWatch(ui, count_type)
   self.panel_sprites = app.gfx:loadSpriteTable("Data", "Watch01V", true)
   self.epidemic = false
   self.count_type = count_type
+  self.hover = false
   -- For cycling the list of epidemic/emergency patients which index to use
   self.current_index = nil
   -- The last patient whose dialog was opened by clicking the timer
   self.lastCycledPatient = nil
 
   local end_sprite = (count_type == "epidemic") and 14 or 16
+  self.end_sprite = end_sprite
 
   local tooltips = {
     ["initial_opening"] = _S.tooltip.watch.hospital_opening,
@@ -70,6 +72,17 @@ function UIWatch:UIWatch(ui, count_type)
     self.end_button = self:addPanel(end_sprite, 4, 0)
     :makeButton(4, 0, 27, 28, end_sprite + 1, self.toggleVaccinationMode)
     :setTooltip(tooltips[count_type])
+
+    self:addPanel(end_sprite, 4, 0)
+    .custom_draw = function(panel, canvas, x, y)
+      x = x + panel.x
+      y = y + panel.y
+      panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y)
+      if self.hover then
+        self.panel_sprites:draw(canvas, 15, x, y)
+      end
+    end
+
   elseif count_type ~= "emergency" then
     self.end_button = self:addPanel(end_sprite, 4, 0)
       :makeButton(4, 0, 27, 28, end_sprite + 1, self.onCountdownEnd)
@@ -84,6 +97,14 @@ function UIWatch:UIWatch(ui, count_type)
         self.scrollToTimerEventPatient, nil, self.cycleTimerEventPatient)
   else
     self:addPanel(timer_sprite, 0, 28):setTooltip(tooltips[count_type])
+    .custom_draw = function(panel, canvas, x, y)
+      x = x + panel.x
+      y = y + panel.y
+      panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y)
+      if self.hover then
+        self.panel_sprites:draw(canvas, 17, x+4, y-28)
+      end
+    end
   end
   self:addPanel(1, 2, 47)
 end
@@ -101,6 +122,19 @@ function UIWatch:onCountdownEnd()
     self.hospital:open()
     self.ui:playSound("fanfare.wav")
   end
+end
+
+function UIWatch:onMouseMove(x, y, dx, dy)
+  local current_hover = x > 4 and x < 31 and y > 0 and y < 29
+  if current_hover and not self.hover then
+    self.hover = true
+    self.ui:playSound("Hlight5.wav")
+  else
+    if not current_hover then
+      self.hover = false
+    end
+  end
+  return Window:onMouseMove(x, y, dx, dy)
 end
 
 function UIWatch:onWorldTick()

--- a/CorsixTH/Lua/dialogs/watch.lua
+++ b/CorsixTH/Lua/dialogs/watch.lua
@@ -102,7 +102,7 @@ function UIWatch:UIWatch(ui, count_type)
       y = y + panel.y
       panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y)
       if self.active_hover then
-        self.panel_sprites:draw(canvas, 17, x+4, y-28)
+        self.panel_sprites:draw(canvas, 17, x + 4, y - 28)
       end
     end
   end

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -94,6 +94,7 @@ function GameUI:GameUI(app, local_hospital, map_editor)
   self.recallpositions = {}
 
   self.speed_up_key_pressed = false
+  self.last_hovered_entity = nil
 
   -- The currently specified intensity value for earthquakes. To abstract
   -- the effect from the implementation this value is a number between 0
@@ -509,6 +510,9 @@ function GameUI:onCursorWorldPositionChange()
     -- Set queue mood for patients queueing the new room
     if room then
       local queue = room.door.queue
+      if #queue > 0 then
+        TheApp.audio:playSound("HLIGHTP2.wav")
+      end
       if queue then
         for _, humanoid in ipairs(queue) do
           humanoid:setMood("queue", "activate")
@@ -518,16 +522,24 @@ function GameUI:onCursorWorldPositionChange()
     self.cursor_room = room
   end
 
-  -- Any hoverable mood should be displayed on the new entity
   if class.is(entity, Humanoid) then
     for _, value in pairs(entity.active_moods) do
       if value.on_hover then
-        entity:setMoodInfo(value)
+        if not self.mood_info then
+          if self.last_hovered_entity ~= entity then
+            TheApp.audio:playSound("HLIGHTP2.wav")
+            self.last_hovered_entity = entity
+          end
+          entity:setMoodInfo(value)
+        end
         break
       end
     end
+  else
+    self.last_hovered_entity = nil
   end
-  -- Dynamic info
+
+  -- Dynamic Info
   if entity and self.bottom_panel then
     self.bottom_panel:setDynamicInfo(entity:getDynamicInfo())
   end

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -522,6 +522,7 @@ function GameUI:onCursorWorldPositionChange()
     self.cursor_room = room
   end
 
+  -- Any hoverable mood should be displayed on the new entity
   if class.is(entity, Humanoid) then
     for _, value in pairs(entity.active_moods) do
       if value.on_hover then
@@ -977,15 +978,11 @@ function GameUI:scrollMap(dx, dy)
   self.screen_offset_y = floor(dy + 0.5)
 end
 
---! Start shaking the screen, e.g. an earthquake effect (unless disabled in config)
+--! Start shaking the screen, e.g. an earthquake effect
 --!param intensity (number) The magnitude of the effect, between 0 for no
 -- movement to 1 for significant shaking.
 function GameUI:beginShakeScreen(intensity)
-  if self.app.config.enable_screen_shake then
-    self.shake_screen_intensity = intensity
-  else
-    self.shake_screen_intensity = 0
-  end
+  self.shake_screen_intensity = intensity
 end
 
 --! Stop the screen from shaking after beginShakeScreen is called.

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -978,11 +978,15 @@ function GameUI:scrollMap(dx, dy)
   self.screen_offset_y = floor(dy + 0.5)
 end
 
---! Start shaking the screen, e.g. an earthquake effect
+--! Start shaking the screen, e.g. an earthquake effect (unless disabled in config)
 --!param intensity (number) The magnitude of the effect, between 0 for no
 -- movement to 1 for significant shaking.
 function GameUI:beginShakeScreen(intensity)
-  self.shake_screen_intensity = intensity
+  if self.app.config.enable_screen_shake then
+    self.shake_screen_intensity = intensity
+  else
+    self.shake_screen_intensity = 0
+  end
 end
 
 --! Stop the screen from shaking after beginShakeScreen is called.

--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -1538,15 +1538,13 @@ end
 ]]
 function Window:hoverTest(active_hover, mouse_x, mouse_y, min_x, max_x, min_y, max_y)
   local is_currently_hovering = mouse_x > min_x and mouse_x < max_x and mouse_y > min_y and mouse_y < max_y
-  if is_currently_hovering and not active_hover then
-    self.ui:playSound("HLight5.wav")
-    return true
-  else
-    if not is_currently_hovering then
-      return false
+  if is_currently_hovering then
+    if not active_hover then
+      self.ui:playSound("HLight5.wav")
     end
     return true
   end
+  return false
 end
 
 --[[ Used to test if the window has a (non-transparent) pixel at the given position.

--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -1532,9 +1532,13 @@ function Window:hitTestPanel(x, y, panel)
 end
 
 --[[ Used to test if cursor is currently hovering over certain area in dialog.
-!param active_hover (bool) Is cursor is already hovering over it?
-!params mouse_x, mouse_y (integers) Mouse X and Y coordinate
-!params min_x, max_x, min_y, max_y (integers) Coordinates of the area.
+!param active_hover (bool) Is cursor already hovers over it?
+!param mouse_x (integer) Mouse X coordinate
+!param mouse_y (integer) Mouse Y coordinate
+!param min_x (integer) Minimum X area
+!param max_x (integer) Maximum X area
+!param min_y (integer) Minimum Y area
+!param max_y (integer) Maximum Y area
 ]]
 function Window:hoverTest(active_hover, mouse_x, mouse_y, min_x, max_x, min_y, max_y)
   local is_currently_hovering = mouse_x > min_x and mouse_x < max_x and mouse_y > min_y and mouse_y < max_y

--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -1531,6 +1531,24 @@ function Window:hitTestPanel(x, y, panel)
   return false
 end
 
+--[[ Used to test if cursor is currently hovering over certain area in dialog.
+!param active_hover (bool) Is cursor is already hovering over it?
+!params mouse_x, mouse_y (integers) Mouse X and Y coordinate
+!params min_x, max_x, min_y, max_y (integers) Coordinates of the area.
+]]
+function Window:hoverTest(active_hover, mouse_x, mouse_y, min_x, max_x, min_y, max_y)
+  local is_currently_hovering = mouse_x > min_x and mouse_x < max_x and mouse_y > min_y and mouse_y < max_y
+  if is_currently_hovering and not active_hover then
+    self.ui:playSound("HLight5.wav")
+    return true
+  else
+    if not is_currently_hovering then
+      return false
+    end
+    return true
+  end
+end
+
 --[[ Used to test if the window has a (non-transparent) pixel at the given position.
 !param x (integer) The X coordinate of the pixel to test, relative to the
 top-left corner of the window.


### PR DESCRIPTION
Fixes 
* #3025 
* #3018 

**Describe what the proposed change does**
- Lots "ding!" sounds (HLight5.wav and HLightP2.wav) are implemented, in these situations:
  - Build room (switched from HLightP2.wav to HLight5.wav which TH uses in this dialog)
  - Furnish corridor / Furnish room
  - Top menu
  - Timer buttons
  - UIInformation close button
  - Hovering over humanoid with cold/hot mood
  - Hovering over room/door with queue
  - Hovering over object list in place objects dialog
 
- Lots select sounds (Selectx.wav) are implemented, in these situations:
  - Switch between treatment history / graph in patient dialog
  - Fire staff button
  - Handymen priorities change
  - Handymen plot change
  - Selecting staff in staff management panel
  - Toggle buttons in policy dialog
  - Furnish room and move items buttons
  - Buy items button

- Makes behavior of timer button and UIInformation button as it was in TH; Now it turns red on hover instead of on click.
- Improves behavior of place_dialog.lua making it closer to TH:

<img alt="place_objects.lua updated dialog" src="https://media.discordapp.net/attachments/1139530684956954644/1419777998067994705/2766BC99-47F3-420D-8779-87094591A985.png?ex=68d2fecc&is=68d1ad4c&hm=87fba016c746e94eeca8cceae1e054b2551c7a1ad410107eee7af98c2e989861&=&format=webp&quality=lossless"/>

- Improves staff management panel (select sfx plays when you select a doctor; hovering cursor over name makes it blue and ding sfx plays;

<img width="674" height="506" alt="{7C72566A-2884-4AC9-AD33-F1843C5290A7}" src="https://github.com/user-attachments/assets/70657ba0-26f9-403e-9b46-a2b1eeb3e16f" />

