### PR TITLE
Fix the tile coordinates of the animations at the east wall.

### DIFF
--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -357,7 +357,7 @@ int l_map_updateblueprint(lua_State* L) {
                           ? 0
                           : thdf_alt_palette));
     pNode = pMap->get_tile_unchecked(iNewX + iNewW, iY);
-    pAnim->attach_to_tile(iNewX + iNewW - 1, iY, pNode, 0);
+    pAnim->attach_to_tile(iNewX + iNewW, iY, pNode, 0);
     pAnim->set_pixel_offset(2, -1);
   }
 


### PR DESCRIPTION

*Fixes #3000

- I made a mistake in PR #2987, in assigning the incorrect coordinates to map tiles at the east wall while changing (and I guess also building) a room.
- Lewri found the bug 🥳 
