### PR TITLE
[RFC] Add IDs to adviser message strings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -30,7 +30,7 @@ globals = { -- Globals
             "permanent", "print_table", "rangeMapLookup", "rnc",
             "strict_declare_global", "table_length", "unpermanent", "values",
             "serialize", "array_join", "shallow_clone", "staff_initials_cache",
-            "hasBit", "bitOr", "inspect",
+            "hasBit", "bitOr", "inspect", "AdviserStringIds",
 
             -- Game classes
             "AIHospital", "AnimationManager", "AnimationEffect", "App", "Audio",

--- a/CorsixTH/Lua/calls_dispatcher.lua
+++ b/CorsixTH/Lua/calls_dispatcher.lua
@@ -19,6 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 corsixth.require("announcer")
+require("languages.string_ids")
 
 local AnnouncementPriority = _G["AnnouncementPriority"]
 
@@ -115,10 +116,20 @@ function CallsDispatcher:callForRepair(object, urgent, manual, lock_room)
   object:setRepairingMode(lock_room and true or false, true)
 
   if not manual and urgent then
-    object.hospital:giveAdvice({_A.warnings.machines_falling_apart})
+    object.hospital:giveAdvice({
+      {
+        text = _A.warnings.machines_falling_apart,
+        speech_id = AdviserStringIds.warnings.machines_falling_apart
+      }
+    })
   elseif object.hospital:countStaffOfCategory("Handyman", 1) == 0 then
     -- Advise about hiring Handyman
-    object.hospital:giveAdvice({_A.warnings.machinery_damaged2})
+    object.hospital:giveAdvice({
+      {
+        text = _A.warnings.machinery_damaged2,
+        speech_id = AdviserStringIds.warnings.machinery_damaged2
+      }
+    })
   end
 
   if not self.call_queue[object] then

--- a/CorsixTH/Lua/cheats.lua
+++ b/CorsixTH/Lua/cheats.lua
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 corsixth.require("announcer")
+require("languages.string_ids")
 
 local AnnouncementPriority = _G["AnnouncementPriority"]
 
@@ -78,7 +79,7 @@ function Cheats:announceCheat(speech)
     ui:playAnnouncement(announcements[math.random(1, #announcements)], AnnouncementPriority.Critical)
   end
   if speech then
-    ui.adviser:say(speech)
+    ui.adviser:say(speech.text, speech.id)
   end
   self.hospital.cheated = true
 end
@@ -268,16 +269,28 @@ local toggle_cheats = {
     ["spawn_rate_cheat"] = {
     enable = Cheats.roujinOn,
     disable = Cheats.roujinOff,
-    enableAnnouncement = _A.cheats.roujin_on_cheat,
-    disableAnnouncement = _A.cheats.roujin_off_cheat,
+    enableAnnouncement = {
+      text = _A.cheats.roujin_on_cheat,
+      speech_id = AdviserStringIds.cheats.roujin_on_cheat,
+    },
+    disableAnnouncement = {
+      text = _A.cheats.roujin_off_cheat,
+      speech_id = AdviserStringIds.cheats.roujin_off_cheat,
+    },
     lower = 27868.3,
     upper = 27868.4,
   },
   ["no_rest_cheat"] = {
     enable = Cheats.noRestOn,
     disable = Cheats.noRestOff,
-    enableAnnouncement = _A.cheats.norest_on_cheat,
-    disableAnnouncement = _A.cheats.norest_off_cheat,
+    enableAnnouncement = {
+      text = _A.cheats.norest_on_cheat,
+      speech_id = AdviserStringIds.cheats.norest_on_cheat,
+    },
+    disableAnnouncement = {
+      text = _A.cheats.norest_off_cheat,
+      speech_id = AdviserStringIds.cheats.norest_off_cheat,
+    },
     lower = 185.5,
     upper = 185.6,
   },

--- a/CorsixTH/Lua/dialogs/adviser.lua
+++ b/CorsixTH/Lua/dialogs/adviser.lua
@@ -126,13 +126,12 @@ function UIAdviser:hide()
 end
 
 --! Function checks if the adviser has been asked to say something already queued
---!param speech (string) Text to check
+--!param speech (int) Id of the adviser string to check
 --!return (boolean) true if duplicate found
-function UIAdviser:checkForDuplicates(speech)
-  local speech_to_check = speech.text -- Humanise for clarity
+function UIAdviser:checkForDuplicates(speech_id)
   for _, text in ipairs(self.queued_messages) do
-    local speech_to_compare = text.speech -- Humanise for clarity
-    if speech_to_compare == speech_to_check then return true end
+    local queued_speech_id = text.speech_id
+    if queued_speech_id == speech_id then return true end
   end
 end
 
@@ -142,14 +141,15 @@ end
 -- until the next say() call is made. Useful for the tutorial.
 --!param override_current Cancels previous messages (if any) immediately
 -- and shows this new one instead.
-function UIAdviser:say(speech, talk_until_next_announce, override_current)
+function UIAdviser:say(speech, speech_id, talk_until_next_announce, override_current)
   assert(type(speech) == "table")
   if not self.ui.app.config.adviser_disabled then
     -- Drop duplicate messages unless overridden
-    if not override_current and self:checkForDuplicates(speech) then return end
+    if not override_current and self:checkForDuplicates(speech_id) then return end
     -- Queue the new message
     self.queued_messages[#self.queued_messages + 1] = {
       speech = speech.text,
+      speech_id = speech_id,
       stay_up = talk_until_next_announce,
       priority = speech.priority
     }

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 --! The multi-purpose panel for launching dialogs / screens and dynamic information.
 class "UIBottomPanel" (Window)
 
@@ -413,7 +415,7 @@ end
 function UIBottomPanel:queueMessage(type, message, owner, timeout, default_choice, callback)
   -- Show a helpful message if there has been no messages before - only in campaign though
   if not self.ui.hospital.message_popup and tonumber(self.world.map.level_number) then
-    self.world.ui.adviser:say(_A.information.fax_received)
+    self.world.ui.adviser:say(_A.information.fax_received, AdviserStringIds.information.fax_received)
     self.ui.hospital.message_popup = true
   end
   local fax = {
@@ -811,8 +813,11 @@ function UIBottomPanel:giveResearchAdvice()
     end
   end
   local msg = can_build_research and _A.warnings.research_screen_open_1 or _A.warnings.research_screen_open_2
+
+  local msg_id = can_build_research and AdviserStringIds.warnings.research_screen_open_1 or AdviserStringIds.warnings.research_screen_open_2
+
   if not TheApp.using_demo_files then
-    self.ui.adviser:say(msg)
+    self.ui.adviser:say(msg, msg_id)
   end
 end
 

--- a/CorsixTH/Lua/dialogs/build_room.lua
+++ b/CorsixTH/Lua/dialogs/build_room.lua
@@ -18,7 +18,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
 local TH = require("TH")
+
 
 class "UIBuildRoom" (Window)
 
@@ -186,7 +188,7 @@ function UIBuildRoom:buildRoom(index)
     self.ui:addWindow(edit_dlg)
   else
     -- give visual warning that player doesn't have enough $ to build
-    self.ui.adviser:say(_A.warnings.money_very_low_take_loan, false, true)
+    self.ui.adviser:say(_A.warnings.money_very_low_take_loan, AdviserStringIds.warnings.money_very_low_take_loan, false, true)
     self.ui:playSound("Wrong2.wav")
   end
 end

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -19,6 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 corsixth.require("dialogs.place_objects")
+require("languages.string_ids")
 
 class "UIEditRoom" (UIPlaceObjects)
 
@@ -955,7 +956,7 @@ function UIEditRoom:enterDoorPhase()
       self.phase = "walls"
       self:returnToWallPhase(true)
       self.ui:playSound("wrong2.wav")
-      self.ui.adviser:say(_A.room_forbidden_non_reachable_parts)
+      self.ui.adviser:say(_A.room_forbidden_non_reachable_parts, AdviserStringIds.room_forbidden_non_reachable_parts)
       return
     end
   end

--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -19,6 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 corsixth.require("announcer")
+require("languages.string_ids")
 
 local AnnouncementPriority = _G["AnnouncementPriority"]
 
@@ -262,7 +263,7 @@ function UIFax:validate()
   print("Code typed on fax:", code)
   if code == "24328" then
     -- Original game cheat code
-    self.ui.adviser:say(_A.cheats.th_cheat)
+    self.ui.adviser:say(_A.cheats.th_cheat, AdviserStringIds.cheats.th_cheat)
     self.ui:addWindow(UICheats(self.ui))
   elseif code == "112" then
     -- simple, unobfuscated cheat for everyone :)

--- a/CorsixTH/Lua/dialogs/furnish_corridor.lua
+++ b/CorsixTH/Lua/dialogs/furnish_corridor.lua
@@ -19,6 +19,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
 local TH = require("TH")
 local math_floor
     = math.floor
@@ -101,7 +102,7 @@ function UIFurnishCorridor:UIFurnishCorridor(ui, objects, edit_dialog)
 
       if quantity == nil and not is_negative_quantity then
         -- give visual warning that player doesn't have enough $ to buy or can't buy more
-        window.ui.adviser:say(error, false, true)
+        window.ui.adviser:say(error.text, error.id, false, true)
         window.ui:playSound("wrong2.wav")
       elseif qty > 0 then
         window.ui:playSound("AddItemJ.wav")
@@ -137,7 +138,7 @@ function UIFurnishCorridor:purchaseItem(index, quantity)
   local is_negative_quantity = quantity < 0
 
   if (quantity > 0 and o.qty >= 99) then
-    return nil, _A.warnings.cannot_buy:format(o.object.name)
+    return nil, { text = _A.warnings.cannot_buy:format(o.object.name), speech_id = AdviserStringIds.warnings.cannot_buy }
   end
 
   if self.ui.app.key_modifiers.ctrl then
@@ -167,7 +168,7 @@ function UIFurnishCorridor:purchaseItem(index, quantity)
       end
     end
   else
-    return nil, _A.warnings.cannot_afford_2
+    return nil, { text = _A.warnings.cannot_afford_2, speech_id = AdviserStringIds.warnings.cannot_afford_2 }
   end
   return quantity
 end

--- a/CorsixTH/Lua/dialogs/hire_staff.lua
+++ b/CorsixTH/Lua/dialogs/hire_staff.lua
@@ -146,8 +146,14 @@ function UIHireStaff:hire()
 end
 function UIHireStaff:cannotAfford()
   local msg = {
-    (_A.warnings.cannot_afford),
-    (_A.warnings.cash_low_consider_loan),
+    {
+      text = _A.warnings.cannot_afford,
+      speech_id = AdviserStringIds.warnings.cannot_afford
+    },
+    {
+      text = _A.warnings.cash_low_consider_loan,
+      speech_id = AdviserStringIds.warnings.cash_low_consider_loan
+    },
   }
   if msg then
     self.world.ui.adviser:say(msg[math.random(1, #msg)])

--- a/CorsixTH/Lua/dialogs/machine_dialog.lua
+++ b/CorsixTH/Lua/dialogs/machine_dialog.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 class "UIMachine" (Window)
 
 ---@type UIMachine
@@ -109,7 +111,8 @@ function UIMachine:replaceMachine()
   if hosp.balance < cost then
     -- give visual warning that player doesn't have enough $ to buy
     local advice = _A.warnings.cannot_afford_machine:format(cost, machine.object_type.name)
-    self.ui.adviser:say(advice, false, true)
+    local advice_id = AdviserStringIds.warnings.cannot_afford_machine
+    self.ui.adviser:say(advice, advice_id, false, true)
     self.ui:playSound("wrong2.wav")
     return
   end

--- a/CorsixTH/Lua/dialogs/place_staff.lua
+++ b/CorsixTH/Lua/dialogs/place_staff.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 local math_floor
     = math.floor
 local TH = require("TH")
@@ -165,7 +167,7 @@ function UIPlaceStaff:onMouseUp(button, x, y)
         self:close()
         return true
       else
-        self.ui.adviser:say(_A.placement_info.staff_cannot_place)
+        self.ui.adviser:say(_A.placement_info.staff_cannot_place, AdviserStringIds.placement_info.staff_cannot_place)
         return true
       end
     end

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 -- Test for hit within the view circle
 local --[[persistable:staff_dialog_is_in_view_circle]] function is_in_view_circle(x, y, is_handyman)
   local circle_center_y = is_handyman and 276 or 248
@@ -334,7 +336,7 @@ function UIStaff:changeHandymanAttributes(increased)
 
   -- Show a helpful message if this dialog hasn't been opened yet
   if not self.ui.hospital.handyman_popup then
-    self.ui.adviser:say(_A.information.handyman_adjust)
+    self.ui.adviser:say(_A.information.handyman_adjust, AdviserStringIds.information.handyman_adjust)
     self.ui.hospital.handyman_popup = true
   end
 

--- a/CorsixTH/Lua/earthquake.lua
+++ b/CorsixTH/Lua/earthquake.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 --! Manages all earthquakes in the world
 class "Earthquake"
 
@@ -79,7 +81,12 @@ function Earthquake:tick()
     hosp:tickEarthquake("end")
     -- If the earthquake measured more than 7 on the richter scale, tell the user about it
     if self.size > 7 then
-      hosp:giveAdvice({_A.earthquake.ended:format(math.floor(self.size))})
+      hosp:giveAdvice({
+        {
+          text = _A.earthquake.ended:format(math.floor(self.size)),
+          speech_id = AdviserStringIds.earthquake.ended
+        }
+      })
     end
 
     -- Set up the next earthquake date

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 --! A `Humanoid` who is in the hospital for diagnosis and/or treatment.
 class "Patient" (Humanoid)
 
@@ -405,12 +407,30 @@ end
 
 function Patient:fallingAnnounce()
   local msg = {
-  (_A.warnings.falling_1),
-  (_A.warnings.falling_2),
-  (_A.warnings.falling_3),
-  (_A.warnings.falling_4),
-  (_A.warnings.falling_5),
-  (_A.warnings.falling_6),
+    {
+      text = _A.warnings.falling_1,
+      speech_id = AdviserStringIds.warnings.falling_1,
+    },
+    {
+      text = _A.warnings.falling_2,
+      speech_id = AdviserStringIds.warnings.falling_2,
+    },
+    {
+      text = _A.warnings.falling_3,
+      speech_id = AdviserStringIds.warnings.falling_3,
+    },
+    {
+      text = _A.warnings.falling_4,
+      speech_id = AdviserStringIds.warnings.falling_4,
+    },
+    {
+      text = _A.warnings.falling_5,
+      speech_id = AdviserStringIds.warnings.falling_5,
+    },
+    {
+      text = _A.warnings.falling_6,
+      speech_id = AdviserStringIds.warnings.falling_6,
+    },
   }
   self.hospital:giveAdvice(msg)
 end
@@ -438,7 +458,12 @@ function Patient:pee()
     self:changeAttribute("happiness", -0.02) -- not being able to find a loo and doing it in the corridor will make you sad too
     if not self.hospital.did_it_on_floor then
       self.hospital.did_it_on_floor = true
-      self.hospital:giveAdvice({_A.warnings.people_did_it_on_the_floor})
+      self.hospital:giveAdvice({
+        {
+          text = _A.warnings.people_did_it_on_the_floor,
+          speech_id = AdviserStringIds.warnings.people_did_it_on_the_floor
+        }
+      })
     end
   else
     return
@@ -501,7 +526,12 @@ function Patient:goHome(reason, disease_id)
     self:changeAttribute("happiness", -0.5)
 
     local treatment_name = self.hospital.disease_casebook[disease_id].disease.name
-    self.hospital:giveAdvice({_A.warnings.patient_not_paying:format(treatment_name)})
+    self.hospital:giveAdvice({
+      {
+        text = _A.warnings.patient_not_paying:format(treatment_name),
+        speech_id = AdviserStringIds.warnings.patient_not_paying
+      }
+    })
     hosp:updateNotCuredCounts(self, reason)
     self:clearDynamicInfo()
     self:setDynamicInfo('text', {"", _S.dynamic_info.patient.actions.prices_too_high})
@@ -910,7 +940,12 @@ function Patient:setTile(x, y)
 
           -- A callout is only needed if there are no handymen employed
           if self.hospital:countStaffOfCategory("Handyman", 1) == 0 then
-            self.hospital:giveAdvice({_A.staff_advice.need_handyman_litter})
+            self.hospital:giveAdvice({
+              {
+                text = _A.staff_advice.need_handyman_litter,
+                speech_id = AdviserStringIds.staff_advice.need_handyman_litter
+              }
+            })
           end
         end
       end

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -19,6 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 corsixth.require("announcer")
+require("languages.string_ids")
 
 local AnnouncementPriority = _G["AnnouncementPriority"]
 
@@ -496,15 +497,40 @@ function Staff:adviseWrongPersonForThisRoom()
   local required = (room.room_info.maximum_staff or room.room_info.required_staff)
   if required then
     if required.Nurse then
-      self.hospital:giveAdvice({ _A.staff_place_advice.only_nurses_in_room:format(room_name) })
+      self.hospital:giveAdvice({
+        {
+          text = _A.staff_place_advice.only_nurses_in_room:format(room_name),
+          speech_id = AdviserStringIds.staff_place_advice.only_nurses_in_room
+        }
+      })
     elseif required.Surgeon then
-      self.hospital:giveAdvice({ _A.staff_place_advice.only_surgeons })
+      self.hospital:giveAdvice({
+        {
+          text = _A.staff_place_advice.only_surgeons:format(room_name),
+          speech_id = AdviserStringIds.staff_place_advice.only_surgeons
+        }
+      })
     elseif required.Researcher then
-      self.hospital:giveAdvice({ _A.staff_place_advice.only_researchers })
+      self.hospital:giveAdvice({
+        {
+          text = _A.staff_place_advice.only_researchers:format(room_name),
+          speech_id = AdviserStringIds.staff_place_advice.only_researchers
+        }
+      })
     elseif required.Psychiatrist then
-      self.hospital:giveAdvice({ _A.staff_place_advice.only_psychiatrists })
+      self.hospital:giveAdvice({
+        {
+          text = _A.staff_place_advice.only_psychiatrists:format(room_name),
+          speech_id = AdviserStringIds.staff_place_advice.only_psychiatrists
+        }
+      })
     else
-      self.hospital:giveAdvice({ _A.staff_place_advice.only_doctors_in_room:format(room_name) })
+      self.hospital:giveAdvice({
+        {
+          text = _A.staff_place_advice.only_doctors_in_room:format(room_name),
+          speech_id = AdviserStringIds.staff_place_advice.only_doctors_in_room
+        }
+      })
     end
   end
 end

--- a/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/doctor.lua
@@ -20,6 +20,7 @@ SOFTWARE. --]]
 
 corsixth.require("announcer")
 corsixth.require("entities.humanoids.staff")
+require("languages.string_ids")
 
 local AnnouncementPriority = _G["AnnouncementPriority"]
 
@@ -155,7 +156,12 @@ function Doctor:updateSkill(consultant, trait, amount)
     self.profile[trait] = 1.0
     local is = trait:match("^is_(.*)")
     if is == "surgeon" or is == "psychiatrist" or is == "researcher" then
-      self.hospital:giveAdvice({ _A.information.promotion_to_specialist:format(_S.staff_title[is]) })
+      self.hospital:giveAdvice({
+        {
+          text = _A.information.promotion_to_specialist:format(_S.staff_title[is]),
+          speech_id = AdviserStringIds.information.promotion_to_specialist
+        }
+      })
       -- patients might we waiting for a doctor with this skill, notify them
       self.hospital:notifyOfStaffChange(self)
     end
@@ -166,10 +172,20 @@ function Doctor:updateSkill(consultant, trait, amount)
     self.profile:parseSkillLevel()
 
     if old_profile.is_junior and not self.profile.is_junior then
-      self.hospital:giveAdvice({ _A.information.promotion_to_doctor })
+      self.hospital:giveAdvice({
+        {
+          text = _A.information.promotion_to_doctor,
+          speech_id = AdviserStringIds.information.promotion_to_doctor
+        }
+      })
       self:updateStaffTitle()
     elseif not old_profile.is_consultant and self.profile.is_consultant then
-      self.hospital:giveAdvice({ _A.information.promotion_to_consultant })
+      self.hospital:giveAdvice({
+        {
+          text = _A.information.promotion_to_consultant,
+          speech_id = AdviserStringIds.information.promotion_to_consultant
+        }
+      })
       if self:getRoom().room_info.id == "training" then
         self:setNextAction(self:getRoom():createLeaveAction())
         self:queueAction(MeanderAction())
@@ -228,7 +244,12 @@ function Doctor:setCrazy(crazy)
     -- make doctor crazy
     if not self.is_crazy then
       self:setLayer(5, self.profile.layer5 + 4)
-      self.hospital:giveAdvice({_A.warnings.doctor_crazy_overwork})
+      self.hospital:giveAdvice({
+        {
+          text = _A.warnings.doctor_crazy_overwork,
+          speech_id = AdviserStringIds.warnings.doctor_crazy_overwork
+        }
+      })
       self.is_crazy = true
     end
   else
@@ -280,9 +301,19 @@ function Doctor:adviseWrongPersonForThisRoom()
   local room = self:getRoom()
   local room_name = room.room_info.long_name
   if room.room_info.id == "toilets" then
-    self.hospital:giveAdvice({ _A.staff_place_advice.doctors_cannot_work_in_room:format(room_name) })
+    self.hospital:giveAdvice({
+      {
+        text = _A.staff_place_advice.doctors_cannot_work_in_room:format(room_name),
+        speech_id = AdviserStringIds.staff_place_advice.doctors_cannot_work_in_room
+      }
+    })
   elseif room.room_info.id == "training" then
-    self.hospital:giveAdvice({ _A.staff_place_advice.doctors_cannot_work_in_room:format(room_name) })
+    self.hospital:giveAdvice({
+      {
+        text = _A.staff_place_advice.doctors_cannot_work_in_room:format(room_name),
+        speech_id = AdviserStringIds.staff_place_advice.doctors_cannot_work_in_room
+      }
+    })
   else
     Staff.adviseWrongPersonForThisRoom(self)
   end

--- a/CorsixTH/Lua/entities/humanoids/staff/nurse.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/nurse.lua
@@ -20,6 +20,7 @@ SOFTWARE. --]]
 
 corsixth.require("announcer")
 corsixth.require("entities.humanoids.staff")
+require("languages.string_ids")
 
 local AnnouncementPriority = _G["AnnouncementPriority"]
 
@@ -44,7 +45,12 @@ end
 function Nurse:adviseWrongPersonForThisRoom()
   local room = self:getRoom()
   local room_name = room.room_info.long_name
-  self.hospital:giveAdvice({ _A.staff_place_advice.nurses_cannot_work_in_room:format(room_name) })
+  self.hospital:giveAdvice({
+    {
+      text = _A.staff_place_advice.nurses_cannot_work_in_room:format(room_name),
+      speech_id = AdviserStringIds.staff_place_advice.nurses_cannot_work_in_room,
+    }
+  })
 end
 
 function Nurse:afterLoad(old, new)

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -547,7 +547,7 @@ end
 
 --[[ Spawns the inspector who will walk to the reception desk. ]]
 function Epidemic:spawnInspector()
-  self.world.ui.adviser:say(_A.information.epidemic_health_inspector)
+  self.world.ui.adviser:say(_A.information.epidemic_health_inspector, AdviserStringIds.information.epidemic_health_inspector)
   local inspector = self.world:newEntity("Inspector", 2, 2)
   self.inspector = inspector
   inspector:setType("Inspector")
@@ -699,14 +699,14 @@ function Epidemic:showAppropriateAdviceMessages()
     if not self.has_said_hurry_up and self:countInfectedPatients() > 0 and
         -- If only 1/4 of the countdown_intervals remaining on the timer
         self.timer.open_timer == math.floor(self.countdown_intervals * 1 / 4) then
-      self.world.ui.adviser:say(_A.epidemic.hurry_up)
+      self.world.ui.adviser:say(_A.epidemic.hurry_up, AdviserStringIds.epidemic.hurry_up)
       self.has_said_hurry_up = true
 
     -- Wait until at least 1/4 of the countdown_intervals has expired before giving
     -- this warning so it doesn't happen straight away
     elseif self.timer.open_timer <= math.floor(self.countdown_intervals * 3 / 4) and
         not self.has_said_serious and self:countInfectedPatients() > 10 then
-      self.world.ui.adviser:say(_A.epidemic.serious_warning)
+      self.world.ui.adviser:say(_A.epidemic.serious_warning, AdviserStringIds.epidemic.serious_warning)
       self.has_said_serious = true
     end
   end

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -1033,102 +1033,202 @@ local function make_tutorial_phases()
 tutorial_phases = {
   {
     -- 1) build reception
-    { text = _A.tutorial.build_reception,              -- 1
+    {
+      text = _A.tutorial.build_reception,              -- 1
+      speech_id = AdviserStringIds.tutorial.build_reception,
       begin_callback = function() TheApp.ui:getWindow(UIBottomPanel):startButtonBlinking(3) end,
-      end_callback = function() TheApp.ui:getWindow(UIBottomPanel):stopButtonBlinking() end, },
-    { text = _A.tutorial.order_one_reception,          -- 2
+      end_callback = function() TheApp.ui:getWindow(UIBottomPanel):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.order_one_reception,          -- 2
+      speech_id = AdviserStringIds.tutorial.order_one_reception,
       begin_callback = function() TheApp.ui:getWindow(UIFurnishCorridor):startButtonBlinking(3) end,
-      end_callback = function() TheApp.ui:getWindow(UIFurnishCorridor):stopButtonBlinking(3) end, },
-    { text = _A.tutorial.accept_purchase,              -- 3
+      end_callback = function() TheApp.ui:getWindow(UIFurnishCorridor):stopButtonBlinking(3) end,
+    },
+    {
+      text = _A.tutorial.accept_purchase,              -- 3
+      speech_id = AdviserStringIds.tutorial.accept_purchase,
       begin_callback = function() TheApp.ui:getWindow(UIFurnishCorridor):startButtonBlinking(2) end,
-      end_callback = function() TheApp.ui:getWindow(UIFurnishCorridor):stopButtonBlinking(2) end, },
-    _A.tutorial.rotate_and_place_reception,            -- 4
-    _A.tutorial.reception_invalid_position,            -- 5
-                                                       -- 6: object other than reception selected. currently no text for this phase.
+      end_callback = function() TheApp.ui:getWindow(UIFurnishCorridor):stopButtonBlinking(2) end,
+    },
+    {
+      text = _A.tutorial.rotate_and_place_reception,            -- 4
+      speech_id = AdviserStringIds.tutorial.rotate_and_place_reception,
+    },
+    {
+      text = _A.tutorial.reception_invalid_position,            -- 5
+      speech_id = AdviserStringIds.tutorial.reception_invalid_position,
+    }
+    -- 6: object other than reception selected. currently no text for this phase.
   },
 
   {
     -- 2) hire receptionist
-    { text = _A.tutorial.hire_receptionist,            -- 1
+    {
+      text = _A.tutorial.hire_receptionist,            -- 1
+      speech_id = AdviserStringIds.tutorial.hire_receptionist,
       begin_callback = function() TheApp.ui:getWindow(UIBottomPanel):startButtonBlinking(5) end,
-      end_callback = function() TheApp.ui:getWindow(UIBottomPanel):stopButtonBlinking() end, },
-    { text = _A.tutorial.select_receptionists,         -- 2
+      end_callback = function() TheApp.ui:getWindow(UIBottomPanel):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.select_receptionists,         -- 2
+      speech_id = AdviserStringIds.tutorial.select_receptionists,
       begin_callback = function() TheApp.ui:getWindow(UIHireStaff):startButtonBlinking(4) end,
-      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end, },
-    { text = _A.tutorial.next_receptionist,            -- 3
+      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.next_receptionist,            -- 3
+      speech_id = AdviserStringIds.tutorial.next_receptionist,
       begin_callback = function() TheApp.ui:getWindow(UIHireStaff):startButtonBlinking(8) end,
-      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end, },
-    { text = _A.tutorial.prev_receptionist,            -- 4
+      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.prev_receptionist,            -- 4
+      speech_id = AdviserStringIds.tutorial.prev_receptionist,
       begin_callback = function() TheApp.ui:getWindow(UIHireStaff):startButtonBlinking(5) end,
-      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end, },
-    { text = _A.tutorial.choose_receptionist,          -- 5
+      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.choose_receptionist,          -- 5
+      speech_id = AdviserStringIds.tutorial.choose_receptionist,
       begin_callback = function() TheApp.ui:getWindow(UIHireStaff):startButtonBlinking(6) end,
-      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end, },
-    _A.tutorial.place_receptionist,                    -- 6
-    _A.tutorial.receptionist_invalid_position,         -- 7
+      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.place_receptionist,            -- 6
+      speech_id = AdviserStringIds.tutorial.place_receptionist,
+    },
+    {
+      text = _A.tutorial.receptionist_invalid_position,   -- 7
+      speech_id = AdviserStringIds.tutorial.receptionist_invalid_position,
+    }
   },
 
   {
     -- 3) build GP's office
     -- 3.1) room window
-    { text = _A.tutorial.build_gps_office,             -- 1
+    {
+      text = _A.tutorial.build_gps_office,             -- 1
+      speech_id = AdviserStringIds.tutorial.build_gps_office,
       begin_callback = function() TheApp.ui:getWindow(UIBottomPanel):startButtonBlinking(2) end,
-      end_callback = function() TheApp.ui:getWindow(UIBottomPanel):stopButtonBlinking() end, },
-    { text = _A.tutorial.select_diagnosis_rooms,       -- 2
+      end_callback = function() TheApp.ui:getWindow(UIBottomPanel):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.select_diagnosis_rooms,       -- 2
+      speech_id = AdviserStringIds.tutorial.select_diagnosis_rooms,
       begin_callback = function() TheApp.ui:getWindow(UIBuildRoom):startButtonBlinking(1) end,
-      end_callback = function() TheApp.ui:getWindow(UIBuildRoom):stopButtonBlinking() end, },
-    { text = _A.tutorial.click_gps_office,             -- 3
+      end_callback = function() TheApp.ui:getWindow(UIBuildRoom):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.click_gps_office,             -- 3
+      speech_id = AdviserStringIds.tutorial.click_gps_office,
       begin_callback = function() TheApp.ui:getWindow(UIBuildRoom):startButtonBlinking(5) end,
-      end_callback = function() TheApp.ui:getWindow(UIBuildRoom):stopButtonBlinking() end, },
+      end_callback = function() TheApp.ui:getWindow(UIBuildRoom):stopButtonBlinking() end,
+    },
 
     -- 3.2) blueprint
     -- [11][58] was maybe planned to be used in this place, but is not needed.
-    _A.tutorial.click_and_drag_to_build,               -- 4
-    _A.tutorial.room_in_invalid_position,              -- 5
-    _A.tutorial.room_too_small,                        -- 6
-    _A.tutorial.room_too_small_and_invalid,            -- 7
-    { text = _A.tutorial.room_big_enough,              -- 8
+    {
+      text = _A.tutorial.click_and_drag_to_build,               -- 4
+      speech_id = AdviserStringIds.tutorial.click_and_drag_to_build,
+    },
+    {
+      text = _A.tutorial.room_in_invalid_position,              -- 5
+      speech_id = AdviserStringIds.tutorial.room_in_invalid_position,
+    },
+    {
+      text = _A.tutorial.room_too_small,                        -- 6
+      speech_id = AdviserStringIds.tutorial.room_too_small,
+    },
+    {
+      text = _A.tutorial.room_too_small_and_invalid,            -- 7
+      speech_id = AdviserStringIds.tutorial.room_too_small_and_invalid,
+    },
+    {
+      text = _A.tutorial.room_big_enough,              -- 8
+      speech_id = AdviserStringIds.tutorial.room_big_enough,
       begin_callback = function() TheApp.ui:getWindow(UIEditRoom):startButtonBlinking(4) end,
-      end_callback = function() TheApp.ui:getWindow(UIEditRoom):stopButtonBlinking() end, },
+      end_callback = function() TheApp.ui:getWindow(UIEditRoom):stopButtonBlinking() end,
+    },
 
     -- 3.3) door and windows
-    _A.tutorial.place_door,                            -- 9
-    _A.tutorial.door_in_invalid_position,              -- 10
-    { text = _A.tutorial.place_windows,                -- 11
+    {
+      text = _A.tutorial.place_door,                            -- 9
+      speech_id = AdviserStringIds.tutorial.place_door,
+    },
+    {
+      text = _A.tutorial.door_in_invalid_position,              -- 10
+      speech_id = AdviserStringIds.tutorial.door_in_invalid_position,
+    },
+    {
+      text = _A.tutorial.place_windows,                -- 11
+      speech_id = AdviserStringIds.tutorial.place_windows,
       begin_callback = function() TheApp.ui:getWindow(UIEditRoom):startButtonBlinking(4) end,
-      end_callback = function() TheApp.ui:getWindow(UIEditRoom):stopButtonBlinking() end, },
-    { text = _A.tutorial.window_in_invalid_position,   -- 12
+      end_callback = function() TheApp.ui:getWindow(UIEditRoom):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.window_in_invalid_position,   -- 12
+      speech_id = AdviserStringIds.tutorial.window_in_invalid_position,
       begin_callback = function() TheApp.ui:getWindow(UIEditRoom):startButtonBlinking(4) end,
-      end_callback = function() TheApp.ui:getWindow(UIEditRoom):stopButtonBlinking() end, },
+      end_callback = function() TheApp.ui:getWindow(UIEditRoom):stopButtonBlinking() end,
+    },
 
     -- 3.4) objects
-    _A.tutorial.place_objects,                         -- 13
-    _A.tutorial.object_in_invalid_position,            -- 14
-    { text = _A.tutorial.confirm_room,                 -- 15
+    {
+      text = _A.tutorial.place_objects,                         -- 13
+      speech_id = AdviserStringIds.tutorial.place_objects,
+    },
+    {
+      text = _A.tutorial.object_in_invalid_position,            -- 14
+      speech_id = AdviserStringIds.tutorial.object_in_invalid_position,
+    },
+    {
+      text = _A.tutorial.confirm_room,                 -- 15
+      speech_id = AdviserStringIds.tutorial.confirm_room,
       begin_callback = function() TheApp.ui:getWindow(UIEditRoom):startButtonBlinking(4) end,
-      end_callback = function() TheApp.ui:getWindow(UIEditRoom):stopButtonBlinking() end, },
-    { text = _A.tutorial.information_window,           -- 16
+      end_callback = function() TheApp.ui:getWindow(UIEditRoom):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.information_window,           -- 16
+      speech_id = AdviserStringIds.tutorial.information_window,
       begin_callback = function() TheApp.ui:getWindow(UIInformation):startButtonBlinking(1) end,
-      end_callback = function() TheApp.ui:getWindow(UIInformation):stopButtonBlinking() end, },
+      end_callback = function() TheApp.ui:getWindow(UIInformation):stopButtonBlinking() end,
+    },
   },
 
   {
     -- 4) hire doctor
-    { text = _A.tutorial.hire_doctor,                  -- 1
+    {
+      text = _A.tutorial.hire_doctor,                  -- 1
+      speech_id = AdviserStringIds.tutorial.hire_doctor,
       begin_callback = function() TheApp.ui:getWindow(UIBottomPanel):startButtonBlinking(5) end,
-      end_callback = function() TheApp.ui:getWindow(UIBottomPanel):stopButtonBlinking() end, },
-    { text = _A.tutorial.select_doctors,               -- 2
+      end_callback = function() TheApp.ui:getWindow(UIBottomPanel):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.select_doctors,               -- 2
+      speech_id = AdviserStringIds.tutorial.select_doctors,
       begin_callback = function() TheApp.ui:getWindow(UIHireStaff):startButtonBlinking(1) end,
-      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end, },
-    { text = _A.tutorial.choose_doctor,                -- 3
+      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.choose_doctor,                -- 3
+      speech_id = AdviserStringIds.tutorial.choose_doctor,
       begin_callback = function() TheApp.ui:getWindow(UIHireStaff):startButtonBlinking(6) end,
-      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end, },
-    _A.tutorial.place_doctor,                          -- 4
-    _A.tutorial.doctor_in_invalid_position,            -- 5
+      end_callback = function() TheApp.ui:getWindow(UIHireStaff):stopButtonBlinking() end,
+    },
+    {
+      text = _A.tutorial.place_doctor,                          -- 4
+      speech_id = AdviserStringIds.tutorial.place_doctor,
+    },
+    {
+      text = _A.tutorial.doctor_in_invalid_position,            -- 5
+      speech_id = AdviserStringIds.tutorial.doctor_in_invalid_position,
+    },
   },
   {
-    -- 5) end of tutorial
-    { begin_callback = function()
+    -- 5) end of tutorial - Adviser does not say anything else, so properties "text" and "speech_id" are not present
+    {
+      begin_callback = function()
         -- The demo uses a single string for the post-tutorial info while
         -- the real game uses three.
         local texts = TheApp.using_demo_files and {
@@ -1193,15 +1293,18 @@ function GameUI:tutorialStep(chapter, phase_from, phase_to, ...)
 
   if TheApp.config.debug then print("Tutorial: Now in " .. self.tutorial.chapter .. ", " .. self.tutorial.phase) end
   local new_phase = tutorial_phases[self.tutorial.chapter][self.tutorial.phase]
-  local str, callback
-  if (type(new_phase) == "table" and type(new_phase.text) == "table") or not new_phase.text then
-    str = new_phase.text
-    callback = new_phase.begin_callback
-  else
-    str = new_phase
+  local speech, speech_id, callback
+
+  if new_phase then
+    speech = new_phase.text
+    speech_id = new_phase.speech_id
+
+    if new_phase.begin_callback and type(new_phase.begin_callback) == "function" then
+      callback = new_phase.begin_callback
+    end
   end
-  if str and str.text then
-    self.adviser:say(str, true, true)
+  if speech and speech.text and speech_id then
+    self.adviser:say(speech, speech_id, true, true)
   else
     self.adviser.stay_up = nil
   end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -865,7 +865,12 @@ function Hospital:_fixBoiler()
     heat_vars.heating_broke = false
     if num_radiators > 0 then
       -- Only tell the player about fix if there is at least one radiator.
-      self:giveAdvice({_A.boiler_issue.resolved})
+      self:giveAdvice({
+        {
+          speech = _A.boiler_issue.resolved,
+          speech_id = AdviserStringIds.boiler_issue_resolved,
+        }
+      })
     end
   end
 end

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -19,6 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 corsixth.require("announcer")
+require("languages.string_ids")
 
 local AnnouncementPriority = _G["AnnouncementPriority"]
 
@@ -79,7 +80,12 @@ function PlayerHospital:dailyAdviceChecks()
   end
   -- Make players more aware of the need for radiators
   if day == 5 and self:countRadiators() == 0 then
-    self:giveAdvice({_A.information.initial_general_advice.place_radiators})
+    self:giveAdvice({
+      {
+        text = _A.information.initial_general_advice.place_radiators,
+        speech_id = AdviserStringIds.information.initial_general_advice.place_radiators
+      }
+    })
   end
   if day == 8 then
     self:_adviseToilets()
@@ -120,17 +126,37 @@ function PlayerHospital:_adviseMoney()
   if not self.world.free_build_mode then
     if self.balance < 2000 and self.balance >= -500 then
       local cashlow_advice = {
-        _A.warnings.money_low, _A.warnings.money_very_low_take_loan,
-        _A.warnings.cash_low_consider_loan,
+        {
+          text = _A.warnings.money_low,
+          speech_id = AdviserStringIds.warnings.money_low
+        },
+        {
+          text = _A.warnings.money_very_low_take_loan,
+          speech_id = AdviserStringIds.warnings.money_very_low_take_loan
+        },
+        {
+          text = _A.warnings.cash_low_consider_loan,
+          speech_id = AdviserStringIds.warnings.cash_low_consider_loan
+        }
       }
       self:giveAdvice(cashlow_advice)
 
     elseif self.balance < -2000 and current_month > 8 then
       -- TODO: Ideally this should be linked to the lose criteria for balance.
-      self:giveAdvice({_A.warnings.bankruptcy_imminent})
+      self:giveAdvice({
+        {
+          text = _A.warnings.bankruptcy_imminent,
+          speech_id = AdviserStringIds.warnings.bankruptcy_imminent
+        }
+      })
 
     elseif self.balance > 6000 and self.loan > 0 then
-      self:giveAdvice({_A.warnings.pay_back_loan})
+      self:giveAdvice({
+        {
+          text = _A.warnings.pay_back_loan,
+          speech_id = AdviserStringIds.warnings.pay_back_loan
+        }
+      })
     end
   end
 end
@@ -139,8 +165,22 @@ end
 function PlayerHospital:_adviseStaffRoom()
   if self:countRoomOfType("staff_room", 1) > 0 then return end
   local staffroom_advice = {
-    _A.warnings.build_staffroom, _A.warnings.need_staffroom,
-    _A.warnings.staff_overworked, _A.warnings.staff_tired,
+    {
+      text = _A.warnings.build_staffroom,
+      speech_id = AdviserStringIds.warnings.build_staffroom
+    },
+    {
+      text = _A.warnings.need_staffroom,
+      speech_id = AdviserStringIds.warnings.need_staffroom
+    },
+    {
+      text = _A.warnings.staff_overworked,
+      speech_id = AdviserStringIds.warnings.staff_overworked
+    },
+    {
+      text = _A.warnings.staff_tired,
+      speech_id = AdviserStringIds.warnings.staff_tired
+    },
   }
   self:giveAdvice(staffroom_advice)
 end
@@ -149,8 +189,18 @@ end
 function PlayerHospital:_adviseToilets()
   if self:countRoomOfType("toilets", 1) > 0 then return end
   local toilet_advice = {
-    _A.warnings.need_toilets, _A.warnings.build_toilets,
-    _A.warnings.build_toilet_now,
+    {
+      text = _A.warnings.need_toilets,
+      speech_id = AdviserStringIds.warnings.need_toilets
+    },
+    {
+      text = _A.warnings.build_toilets,
+      speech_id = AdviserStringIds.warnings.build_toilets
+    },
+    {
+      text = _A.warnings.build_toilet_now,
+      speech_id = AdviserStringIds.warnings.build_toilet_now
+    },
   }
   self:giveAdvice(toilet_advice)
 end
@@ -176,15 +226,32 @@ function PlayerHospital:_adviseBenches()
     local ratio = sum_ratios / num_sitting_ratios
     if ratio < 0.7 then -- At least 30% standing.
       local bench_advice = {
-        _A.warnings.more_benches, _A.warnings.people_have_to_stand,
+        {
+          text = _A.warnings.more_benches,
+          speech_id = AdviserStringIds.warnings.more_benches
+        },
+        {
+          text = _A.warnings.people_have_to_stand,
+          speech_id = AdviserStringIds.warnings.people_have_to_stand
+        }
       }
       self:giveAdvice(bench_advice)
 
     elseif ratio > 0.9 then
       -- Praise having enough well placed seats about once a year.
       local bench_advice = {
-        _A.praise.many_benches, _A.praise.plenty_of_benches,
-        _A.praise.few_have_to_stand,
+        {
+          text = _A.praise.many_benches,
+          speech_id = AdviserStringIds.praise.many_benches
+        },
+        {
+          text = _A.praise.plenty_of_benches,
+          speech_id = AdviserStringIds.praise.plenty_of_benches
+        },
+        {
+          text = _A.praise.few_have_to_stand,
+          speech_id = AdviserStringIds.praise.few_have_to_stand
+        },
       }
       self:giveAdvice(bench_advice, 1 / 12)
     end
@@ -199,16 +266,36 @@ function PlayerHospital:_adviseHeatingForPatients()
   local warmth = self:getAveragePatientAttribute("warmth", 0.3)
   if warmth < 0.22 then
     local cold_advice = {
-      _A.information.initial_general_advice.increase_heating,
-      _A.warnings.patients_very_cold, _A.warnings.people_freezing,
+      {
+        text = _A.information.initial_general_advice.increase_heating,
+        speech_id = AdviserStringIds.information.initial_general_advice.increase_heating
+      },
+      {
+        text = _A.warnings.patients_very_cold,
+        speech_id = AdviserStringIds.warnings.patients_very_cold
+      },
+      {
+        text = _A.warnings.people_freezing,
+        speech_id = AdviserStringIds.warnings.people_freezing
+      },
     }
     self:giveAdvice(cold_advice)
     self.adviser_data.temperature_advice = true
 
   elseif warmth >= 0.36 then
     local hot_advice = {
-      _A.information.initial_general_advice.decrease_heating,
-      _A.warnings.patients_too_hot, _A.warnings.patients_getting_hot,
+      {
+        text = _A.information.initial_general_advice.decrease_heating,
+        speech_id = AdviserStringIds.information.initial_general_advice.decrease_heating
+      },
+      {
+        text = _A.warnings.patients_too_hot,
+        speech_id = AdviserStringIds.warnings.patients_too_hot
+      },
+      {
+        text = _A.warnings.patients_getting_hot,
+        speech_id = AdviserStringIds.warnings.patients_getting_hot
+      }
     }
     self:giveAdvice(hot_advice)
     self.adviser_data.temperature_advice = true
@@ -222,11 +309,21 @@ function PlayerHospital:_adviseHeatingForStaff()
       or self.heating.heating_broke then return end
   local warmth = self:getAverageStaffAttribute("warmth", 0.3)
   if warmth < 0.22 then
-    self:giveAdvice({_A.warnings.staff_very_cold})
+    self:giveAdvice({
+      {
+        text = _A.warnings.staff_very_cold,
+        speech_id = AdviserStringIds.warnings.staff_very_cold
+      }
+    })
     self.adviser_data.temperature_advice = true
 
   elseif warmth >= 0.36 then
-    self:giveAdvice({_A.warnings.staff_too_hot})
+    self:giveAdvice({
+      {
+        text = _A.warnings.staff_too_hot,
+        speech_id = AdviserStringIds.warnings.staff_too_hot
+      }
+    })
     self.adviser_data.temperature_advice = true
   end
 end
@@ -239,10 +336,22 @@ function PlayerHospital:_adviseDrinksMachines()
   -- Increase need after the first year.
   local threshold = current_date:year() == 1 and 0.9 or 0.8
   if thirst > threshold then
-    self:giveAdvice({_A.warnings.patients_very_thirsty})
+    self:giveAdvice({
+      {
+        text = _A.warnings.patients_very_thirsty,
+        speech_id = AdviserStringIds.warnings.patients_very_thirsty
+      }
+    })
   elseif thirst > 0.6 then
     local thirst_advice = {
-      _A.warnings.patients_thirsty, _A.warnings.patients_thirsty2,
+      {
+        text = _A.warnings.patients_thirsty,
+        speech_id = AdviserStringIds.warnings.patients_thirsty
+      },
+      {
+        text = _A.warnings.patients_thirsty2,
+        speech_id = AdviserStringIds.warnings.patients_thirsty2
+      }
     }
     self:giveAdvice(thirst_advice)
   end
@@ -258,12 +367,18 @@ function PlayerHospital:_warnForLongQueues()
   if chosen_room.required_staff and not chosen_room.required_staff["Nurse"]
       and math.random(1, 3) > 1 then
     local warn_msgs = {
-      _A.warnings.queue_too_long_send_doctor:format(chosen_room.name),
-      _A.staff_advice.need_doctors
+      {
+        text = _A.warnings.queue_too_long_send_doctor:format(chosen_room.name),
+        speech_id = AdviserStringIds.warnings.queue_too_long_send_doctor
+      },
+      {
+        text = _A.staff_advice.need_doctors,
+        speech_id = AdviserStringIds.staff_advice.need_doctors
+      }
     }
     self:giveAdvice(warn_msgs)
   else
-    self.world.ui.adviser:say(_A.warnings.queues_too_long)
+    self.world.ui.adviser:say(_A.warnings.queues_too_long, AdviserStringIds.warnings.queues_too_long)
   end
 end
 
@@ -274,7 +389,12 @@ function PlayerHospital:advisePlants(placed)
 
   local num_plants = self:countPlants()
   if num_plants == 0 or (placed and num_plants > 1) then return end
-  self:giveAdvice({_A.staff_advice.need_handyman_plants})
+  self:giveAdvice({
+    {
+      text = _A.staff_advice.need_handyman_plants,
+      speech_id = AdviserStringIds.staff_advice.need_handyman_plants
+    }
+  })
 end
 
 --! Give advice to the player at the end of a month.
@@ -298,23 +418,53 @@ function PlayerHospital:checkReceptionAdvice(current_month, current_year)
 
   local num_receptionists = self:countStaffOfCategory("Receptionist", 1)
   if num_receptionists ~= 0 and current_month > 2 and not self.adviser_data.reception_advice then
-    self:giveAdvice({_A.warnings.no_desk_6})
+    self:giveAdvice({
+      {
+        text = _A.warnings.no_desk_6,
+        speech_id = AdviserStringIds.warnings.no_desk_6
+      }
+    })
     self.adviser_data.reception_advice = true
 
   elseif num_receptionists == 0 and current_month > 2 and self:countReceptionDesks() ~= 0  then
-    self:giveAdvice({_A.warnings.no_desk_7})
+    self:giveAdvice({
+      {
+        text = _A.warnings.no_desk_7,
+        speech_id = AdviserStringIds.warnings.no_desk_7
+      }
+    })
 
   elseif current_month == 3 then
-    self:giveAdvice({_A.warnings.no_desk}, 1, true)
+    self:giveAdvice({
+      {
+        text = _A.warnings.no_desk,
+        speech_id = AdviserStringIds.warnings.no_desk
+      }
+    }, 1, true)
 
   elseif current_month == 8 then
-    self:giveAdvice({_A.warnings.no_desk_1}, 1, true)
+    self:giveAdvice({
+      {
+        text = _A.warnings.no_desk_1,
+        speech_id = AdviserStringIds.warnings.no_desk_1
+      }
+    }, 1, true)
 
   elseif current_month == 11 then
     if self.visitors == 0 then
-      self:giveAdvice({_A.warnings.no_desk_2}, 1, true)
+      self:giveAdvice({
+        {
+          text = _A.warnings.no_desk_2,
+          speech_id = AdviserStringIds.warnings.no_desk_2
+        }
+      }, 1, true)
     else
-      self:giveAdvice({_A.warnings.no_desk_3}, 1, true)
+      self:giveAdvice({
+        {
+          text = _A.warnings.no_desk_3,
+          speech_id = AdviserStringIds.warnings.no_desk_3
+        }
+      }, 1, true)
     end
   end
 end
@@ -324,7 +474,7 @@ function PlayerHospital:msgNeedFirstReceptionDesk()
   if self.adviser_data.reception_advice then return end
 
   if self:countReceptionDesks() == 0 then
-    self.world.ui.adviser:say(_A.warnings.no_desk_4)
+    self.world.ui.adviser:say(_A.warnings.no_desk_4, AdviserStringIds.warnings.no_desk_4)
     self.adviser_data.reception_advice = true
   end
 end
@@ -334,10 +484,20 @@ function PlayerHospital:msgReceptionDesk()
   local num_receptionists = self:countStaffOfCategory("Receptionist", 1)
 
   if not self.world.ui.start_tutorial and num_receptionists == 0 then
-    self:giveAdvice({_A.room_requirements.reception_need_receptionist})
+    self:giveAdvice({
+      {
+        text = _A.room_requirements.reception_need_receptionist,
+        speech_id = AdviserStringIds.room_requirements.reception_need_receptionist
+      }
+    })
   elseif num_receptionists > 0 and self:countReceptionDesks() == 1 and
       not self.adviser_data.reception_advice and self.world:date():monthOfGame() > 3 then
-    self:giveAdvice({_A.warnings.no_desk_5})
+    self:giveAdvice({
+      {
+        text = _A.warnings.no_desk_5,
+        speech_id = AdviserStringIds.warnings.no_desk_5
+      }
+    })
     self.adviser_data.reception_advice = true
   end
 end
@@ -358,11 +518,11 @@ function PlayerHospital:msgMultiReceptionDesks()
   if (receptionists > 1 and num_desks > 0) or (receptionists > 0 and num_desks > 1) then
     local queue_avg = math.floor(queue_total / num_desks)
     if receptionists < num_desks and queue_avg > 5 then
-      self.world.ui.adviser:say(_A.warnings.reception_bottleneck)
+      self.world.ui.adviser:say(_A.warnings.reception_bottleneck, AdviserStringIds.warnings.reception_bottleneck)
     elseif queue_avg > 4 then
-      self.world.ui.adviser:say(_A.warnings.queue_too_long_at_reception)
+      self.world.ui.adviser:say(_A.warnings.queue_too_long_at_reception, AdviserStringIds.warnings.queue_too_long_at_reception)
     elseif receptionists > num_desks then
-      self.world.ui.adviser:say(_A.warnings.another_desk)
+      self.world.ui.adviser:say(_A.warnings.another_desk, AdviserStringIds.warnings.another_desk)
     end
   end
 end
@@ -382,7 +542,7 @@ function PlayerHospital:showGatesToHell(entity)
 end
 
 --! Advises the player.
---!param msgs (array of string) Messages to select from.
+--!param msgs (array of table) Messages to select from.
 --!param rnd_frac (optional float in range (0, 1]) Fraction of times that the
 --    call actually says something.
 --!param stay_up (bool) If true, let the adviser remain visible afterwards.
@@ -396,7 +556,8 @@ function PlayerHospital:giveAdvice(msgs, rnd_frac, stay_up)
 
   local index = (max_rnd == 1) and 1 or math.random(1, max_rnd)
   if index <= #msgs then
-    self.world.ui.adviser:say(msgs[index], stay_up)
+    --msgs = { {text = <adviserMessage>, speech_id = <adviserMessageId>}, ... }
+    self.world.ui.adviser:say(msgs[index].text, msgs[index].speech_id, stay_up)
     return true
   end
   return false
@@ -407,12 +568,23 @@ function PlayerHospital:msgCured()
   self.world.ui:playSound("cheer.wav") -- This sound is always heard
 
   if self.num_cured < 1 then -- First cure is always reported.
-    self:giveAdvice({_A.information.first_cure})
+    self:giveAdvice({
+      {
+        text = _A.information.first_cure,
+        speech_id = AdviserStringIds.information.first_cure
+      }
+    })
 
   elseif self.num_cured > 1 and not self.adviser_data.cured_died_message then
     local cured_msgs = {
-      _A.level_progress.another_patient_cured:format(self.num_cured),
-      _A.praise.patients_cured:format(self.num_cured)
+      {
+        text = _A.level_progress.another_patient_cured:format(self.num_cured),
+        speech_id = AdviserStringIds.level_progress.another_patient_cured
+      },
+      {
+        text = _A.praise.patients_cured:format(self.num_cured),
+        speech_id = AdviserStringIds.praise.patients_cured
+      }
     }
     self.adviser_data.cured_died_message = self:giveAdvice(cured_msgs, 2/15)
   end
@@ -423,12 +595,22 @@ function PlayerHospital:msgKilled()
   self.world.ui:playSound("boo.wav") -- this sound is always heard
 
   if self.num_deaths < 1 then -- First death is always reported.
-    self:giveAdvice({_A.information.first_death})
-
+    self:giveAdvice({
+      {
+        text = _A.information.first_death,
+        speech_id = AdviserStringIds.information.first_death
+      }
+    })
   elseif self.num_deaths > 1 and not self.adviser_data.cured_died_message then
     local died_msgs = {
-      _A.warnings.many_killed:format(self.num_deaths),
-      _A.level_progress.another_patient_killed:format(self.num_deaths)
+      {
+        text = _A.warnings.many_killed:format(self.num_deaths),
+        speech_id = AdviserStringIds.warnings.many_killed
+      },
+      {
+        text = _A.level_progress.another_patient_killed:format(self.num_deaths),
+        speech_id = AdviserStringIds.level_progress.another_patient_killed
+      }
     }
     self.adviser_data.cured_died_message = self:giveAdvice(died_msgs, 6/10)
   end
@@ -459,10 +641,10 @@ end
 function PlayerHospital:adviseBoilerBreakdown(broken_heat)
   local ui = self.world.ui
   if broken_heat == 0 then
-    ui.adviser:say(_A.boiler_issue.minimum_heat)
+    ui.adviser:say(_A.boiler_issue.minimum_heat, AdviserStringIds.boiler_issue.minimum_heat)
     ui:playRandomAnnouncement({ "sorry002.wav", "sorry004.wav" })
   else
-    ui.adviser:say(_A.boiler_issue.maximum_heat)
+    ui.adviser:say(_A.boiler_issue.maximum_heat, AdviserStringIds.boiler_issue.maximum_heat)
     ui:playRandomAnnouncement({ "sorry003.wav", "sorry004.wav" })
   end
 end
@@ -508,9 +690,9 @@ function PlayerHospital:onEndDay()
         ui:playRandomAnnouncement({ "vip001.wav", "vip002.wav", "vip003.wav",
             "vip004.wav", "vip005.wav" }, AnnouncementPriority.High)
         if self.num_vips < 1 then
-          ui.adviser:say(_A.information.initial_general_advice.first_VIP)
+          ui.adviser:say(_A.information.initial_general_advice.first_VIP, AdviserStringIds.information.initial_general_advice.first_VIP)
         else
-          ui.adviser:say(_A.information.vip_arrived:format(e.name))
+          ui.adviser:say(_A.information.vip_arrived:format(e.name), AdviserStringIds.information.vip_arrived)
         end
         e.announced = true
         self.announce_vip = self.announce_vip - 1
@@ -552,7 +734,7 @@ end
 --! Give visual warning that player doesn't have enough $ to build
 -- Let the message remain until cancelled by the player as it is being displayed behind the town map
 function PlayerHospital:adviseCannotAffordPlot()
-  self.world.ui.adviser:say(_A.warnings.cannot_afford_2, true, true)
+  self.world.ui.adviser:say(_A.warnings.cannot_afford_2, AdviserStringIds.warnings.cannot_afford_2, true, true)
 end
 
 --! Tell the player, through the advisor, about the impact of casebook prices
@@ -560,16 +742,19 @@ end
 -- from Hospital:computePriceLevelImpact
 --!param name (string) The name of the casebook entry of the diagnosis or disease
 function PlayerHospital:advisePriceLevelImpact(judgment, name)
-  local message
+  local message, message_id
   if judgment == "under" then
     message = _A.warnings.low_prices:format(name)
+    message_id = AdviserStringIds.warnings.low_prices
   elseif judgment == "over" then
     message = _A.warnings.high_prices:format(name)
+    message_id = AdviserStringIds.warnings.high_prices
   else
     assert(judgment == "fair", "Price level impact judgements must be under, over or fair")
     message = _A.warnings.fair_prices:format(name)
+    message_id = AdviserStringIds.warnings.fair_prices
   end
-  self.world.ui.adviser:say(message)
+  self.world.ui.adviser:say(message, message_id)
 end
 
 --! Makes the raise request for a staff member
@@ -580,7 +765,7 @@ function PlayerHospital:makeRaiseRequest(amount, staff)
   -- a staff member requesting a raise.
   -- Only show the help if the player is playing the campaign.
   if not self.has_seen_pay_rise and tonumber(self.world.map.level_number) then
-    self.world.ui.adviser:say(_A.information.pay_rise)
+    self.world.ui.adviser:say(_A.information.pay_rise, AdviserStringIds.information.pay_rise)
     self.has_seen_pay_rise = true
   end
   self.world.ui.bottom_panel:queueMessage("strike", amount, staff)
@@ -831,12 +1016,12 @@ end
 function PlayerHospital:adviseNoGPOffice()
   if self:countStaffOfCategory("Doctor", 1) > 0 then -- Doctor without a room
     if not self.adviser_data.no_gp_office then
-      self.world.ui.adviser:say(_A.warnings.no_gp_office)
+      self.world.ui.adviser:say(_A.warnings.no_gp_office, AdviserStringIds.warnings.no_gp_office)
       self.adviser_data.no_gp_office = true
     end
   else -- No room or doctor
     if not self.adviser_data.no_doctor_no_gp_office then
-      self.world.ui.adviser:say(_A.warnings.no_doctor_no_gp_office)
+      self.world.ui.adviser:say(_A.warnings.no_doctor_no_gp_office, AdviserStringIds.warnings.no_doctor_no_gp_office)
       self.adviser_data.no_doctor_no_gp_office = true
     end
   end

--- a/CorsixTH/Lua/languages/string_ids.lua
+++ b/CorsixTH/Lua/languages/string_ids.lua
@@ -1,0 +1,414 @@
+AdviserStringIds = {
+    boiler_issue = {
+        maximum_heat                  = 1,
+        minimum_heat                  = 2,
+        resolved                      = 3,
+    },
+
+    build_advice = {
+        blueprint_invalid             = 4,
+        blueprint_would_block         = 5,
+        door_not_reachable            = 6,
+        placing_object_blocks_door    = 7,
+    },
+
+    cheats = {
+        th_cheat                      = 8,
+        roujin_on_cheat               = 9,
+        roujin_off_cheat              = 10,
+        norest_on_cheat               = 11,
+        norest_off_cheat              = 12,
+    },
+
+    competitors = {
+        hospital_opened               = 13,
+        land_purchased                = 14,
+        staff_poached                 = 15,
+    },
+
+    earthquake = {
+        alert                         = 16,
+        damage                        = 17,
+        ended                         = 18,
+    },
+
+    epidemic = {
+
+        serious_warning               = 19,
+        hurry_up                      = 20,
+        multiple_epidemies            = 21,
+    },
+
+    goals = {
+        win = {
+            money                       = 22,
+            reputation                  = 23,
+            value                       = 24,
+            cure                        = 25,
+        },
+        lose = {
+            kill                        = 26,
+        },
+    },
+
+    information = {
+        epidemic                      = 27,
+        emergency                     = 28,
+        promotion_to_doctor           = 29,
+        promotion_to_specialist       = 30,
+        promotion_to_consultant       = 31,
+
+        first_death                   = 32,
+        first_cure                    = 33,
+
+        place_windows                 = 34,
+        larger_rooms                  = 35,
+        extra_items                   = 36,
+
+        patient_abducted              = 37,
+        patient_leaving_too_expensive = 38,
+
+        pay_rise                      = 39,
+        handyman_adjust               = 40,
+        fax_received                  = 41,
+
+        vip_arrived                   = 42,
+        epidemic_health_inspector     = 43,
+
+        initial_general_advice = {
+            research_now_available      = 44,
+            research_symbol             = 45,
+            surgeon_symbol              = 46,
+            psychiatric_symbol          = 47,
+            rats_have_arrived           = 48,
+            autopsy_available           = 49,
+            first_epidemic              = 50,
+            first_VIP                   = 51,
+            taking_your_staff           = 52,
+            machine_needs_repair        = 53,
+            epidemic_spreading          = 54,
+            increase_heating            = 55,
+            place_radiators             = 56,
+            decrease_heating            = 57,
+            first_patients_thirsty      = 58,
+            first_emergency             = 59,
+        },
+    },
+
+    level_progress = {
+        nearly_won                    = 60,
+        three_quarters_won            = 61,
+        halfway_won                   = 62,
+        nearly_lost                   = 63,
+        three_quarters_lost           = 64,
+        halfway_lost                  = 65,
+
+        another_patient_cured         = 66,
+        another_patient_killed        = 67,
+
+        financial_criteria_met        = 68,
+        cured_enough_patients         = 69,
+        dont_kill_more_patients       = 70,
+        reputation_good_enough        = 71,
+        improve_reputation            = 72,
+        hospital_value_enough         = 73,
+        close_to_win_increase_value   = 74,
+
+    },
+
+    multiplayer = {
+
+        everyone_failed               = 75,
+        players_failed                = 76,
+
+        poaching = {
+            already_poached_by_someone  = 77,
+            not_interested              = 78,
+            in_progress                 = 79,
+        },
+
+        objective_completed           = 80,
+        objective_failed              = 81,
+    },
+
+    placement_info = {
+
+        room_cannot_place             = 82,
+        room_cannot_place_2           = 83,
+        reception_can_place           = 84,
+        reception_cannot_place        = 85,
+        door_can_place                = 86,
+        door_cannot_place             = 87,
+        window_can_place              = 88,
+        window_cannot_place           = 89,
+        staff_can_place               = 90,
+        staff_cannot_place            = 91,
+        object_can_place              = 92,
+        object_cannot_place           = 93,
+    },
+
+    praise = {
+        many_plants                   = 94,
+        plants_are_well               = 95,
+        plants_thriving               = 96,
+
+        many_benches                  = 97,
+        plenty_of_benches             = 98,
+        few_have_to_stand             = 99,
+
+        patients_cured                = 100,
+    },
+
+    research = {
+        new_machine_researched        = 101,
+        new_drug_researched           = 102,
+        drug_improved                 = 103,
+        drug_improved_1               = 104,
+        machine_improved              = 105,
+        new_available                 = 106,
+        drug_fully_researched         = 107,
+        autopsy_discovered_rep_loss   = 108,
+    },
+
+    room_forbidden_non_reachable_parts = 109,
+
+    room_requirements = {
+        psychiatry_need_psychiatrist  = 110,
+        pharmacy_need_nurse           = 111,
+        training_room_need_consultant = 112,
+        research_room_need_researcher = 113,
+        op_need_two_surgeons          = 114,
+        op_need_another_surgeon       = 115,
+        op_need_ward                  = 116,
+        ward_need_nurse               = 117,
+        gps_office_need_doctor        = 118,
+        reception_need_receptionist   = 119,
+    },
+
+
+    staff_advice = {
+        need_doctors                  = 120,
+        too_many_doctors              = 121,
+        need_handyman_litter          = 122,
+        need_handyman_plants          = 123,
+        need_handyman_machines        = 124,
+        need_nurses                   = 125,
+        too_many_nurses               = 126,
+    },
+
+    staff_place_advice = {
+        only_researchers              = 127,
+        only_surgeons                 = 128,
+        only_psychiatrists            = 129,
+        only_nurses_in_room           = 130,
+        doctors_cannot_work_in_room   = 131,
+        nurses_cannot_work_in_room    = 132,
+        only_doctors_in_room          = 133,
+        receptionists_only_at_desk    = 134,
+        not_enough_lecture_chairs     = 135,
+    },
+
+    surgery_requirements = {
+        need_surgeons_ward_op         = 136,
+        need_surgeon_ward             = 137,
+    },
+
+    tutorial = {
+
+        build_reception               = 138,
+        order_one_reception           = 139,
+        accept_purchase               = 140,
+        rotate_and_place_reception    = 141,
+        reception_invalid_position    = 142,
+
+
+        hire_receptionist             = 143,
+        select_receptionists          = 144,
+        next_receptionist             = 145,
+        prev_receptionist             = 146,
+        choose_receptionist           = 147,
+        place_receptionist            = 148,
+        receptionist_invalid_position = 149,
+
+
+
+        build_gps_office              = 150,
+        select_diagnosis_rooms        = 151,
+        click_gps_office              = 152,
+
+
+
+        click_and_drag_to_build       = 153,
+        room_in_invalid_position      = 154,
+        room_too_small                = 155,
+        room_too_small_and_invalid    = 156,
+        room_big_enough               = 157,
+
+
+        place_door                    = 158,
+        door_in_invalid_position      = 159,
+        place_windows                 = 160,
+        window_in_invalid_position    = 161,
+
+
+        place_objects                 = 162,
+        object_in_invalid_position    = 163,
+        confirm_room                  = 164,
+        information_window            = 165,
+
+
+        hire_doctor                   = 166,
+        select_doctors                = 167,
+        choose_doctor                 = 168,
+        place_doctor                  = 169,
+        doctor_in_invalid_position    = 170,
+
+
+        start_tutorial                = 171,
+        build_pharmacy                = 172,
+    },
+
+    vomit_wave = {
+        started                       = 173,
+        ended                         = 174,
+    },
+
+    warnings = {
+        money_low                     = 175,
+        money_very_low_take_loan      = 176,
+        cash_low_consider_loan        = 177,
+        bankruptcy_imminent           = 178,
+        financial_trouble             = 179,
+        finanical_trouble2            = 180,
+        financial_trouble3            = 181,
+
+        pay_back_loan                 = 182,
+
+        machines_falling_apart        = 183,
+        no_patients_last_month        = 184,
+        nobody_cured_last_month       = 185,
+        queues_too_long               = 186,
+        patient_stuck                 = 187,
+
+        patients_unhappy              = 188,
+        patient_leaving               = 189,
+        patients_leaving              = 190,
+        patients_really_thirsty       = 191,
+        patients_annoyed              = 192,
+
+        patients_thirsty              = 193,
+        patients_thirsty2             = 194,
+        patients_very_thirsty         = 195,
+
+        patients_too_hot              = 196,
+        patients_getting_hot          = 197,
+        patients_very_cold            = 198,
+        people_freezing               = 199,
+
+        staff_overworked              = 200,
+        staff_tired                   = 201,
+
+        staff_too_hot                 = 202,
+        staff_very_cold               = 203,
+        staff_unhappy                 = 204,
+        staff_unhappy2                = 205,
+        doctor_crazy_overwork         = 206,
+
+        reduce_staff_rest_threshold   = 207,
+        nurses_tired                  = 208,
+        doctors_tired                 = 209,
+        handymen_tired                = 210,
+        receptionists_tired           = 211,
+
+        nurses_tired2                 = 212,
+        doctors_tired2                = 213,
+        handymen_tired2               = 214,
+        receptionists_tired2          = 215,
+
+        need_toilets                  = 216,
+        build_toilets                 = 217,
+        build_toilet_now              = 218,
+        more_toilets                  = 219,
+        people_did_it_on_the_floor    = 220,
+
+        need_staffroom                = 221,
+        build_staffroom               = 222,
+
+        many_killed                   = 223,
+
+        plants_thirsty                = 224,
+        too_many_plants               = 225,
+
+        charges_too_high              = 226,
+        charges_too_low               = 227,
+
+        machine_severely_damaged      = 228,
+        machinery_slightly_damaged    = 229,
+        machinery_damaged             = 230,
+        machinery_damaged2            = 231,
+        machinery_very_damaged        = 232,
+        machinery_deteriorating       = 233,
+
+        queue_too_long_send_doctor    = 234,
+        queue_too_long_at_reception   = 235,
+        reception_bottleneck          = 236,
+
+        epidemic_getting_serious      = 237,
+        deal_with_epidemic_now        = 238,
+        many_epidemics                = 239,
+
+        hospital_is_rubbish           = 240,
+
+        more_benches                  = 241,
+        people_have_to_stand          = 242,
+
+        too_much_litter               = 243,
+        litter_everywhere             = 244,
+        litter_catastrophy            = 245,
+        some_litter                   = 246,
+
+        place_plants_to_keep_people   = 247,
+        place_plants2                 = 248,
+        place_plants3                 = 249,
+        place_plants4                 = 250,
+
+        desperate_need_for_watering   = 251,
+        change_priorities_to_plants   = 252,
+        plants_dying                  = 253,
+
+        no_desk                       = 254,
+        no_desk_1                     = 255,
+        no_desk_2                     = 256,
+        no_desk_3                     = 257,
+        no_desk_4                     = 258,
+        no_desk_5                     = 259,
+        no_desk_6                     = 260,
+        no_desk_7                     = 261,
+        another_desk                  = 262,
+        cannot_buy                    = 263,
+        cannot_afford                 = 264,
+        cannot_afford_2               = 265,
+        cannot_afford_machine         = 266,
+        falling_1                     = 267,
+        falling_2                     = 268,
+        falling_3                     = 269,
+        falling_4                     = 270,
+        falling_5                     = 271,
+        falling_6                     = 272,
+        research_screen_open_1        = 273,
+        research_screen_open_2        = 274,
+        researcher_needs_desk_1       = 275,
+        researcher_needs_desk_2       = 276,
+        researcher_needs_desk_3       = 277,
+        nurse_needs_desk_1            = 278,
+        nurse_needs_desk_2            = 279,
+        low_prices                    = 280,
+        high_prices                   = 281,
+        fair_prices                   = 282,
+        patient_not_paying            = 283,
+        no_doctor_no_gp_office        = 284,
+        no_gp_office                  = 285,
+    },
+}
+
+--_G["AdviserStringIds"] = AdviserStringIds

--- a/CorsixTH/Lua/objects/helicopter.lua
+++ b/CorsixTH/Lua/objects/helicopter.lua
@@ -19,6 +19,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
 corsixth.require("announcer")
+require("languages.string_ids")
+
 local AnnouncementPriority = _G["AnnouncementPriority"]
 
 local object = {}
@@ -66,7 +68,7 @@ function Helicopter:tick()
   elseif phase == 60 then
     self:setSpeed(0, 0)
     self.spawned_patients = 0
-    ui.adviser:say(_A.information.emergency)
+    ui.adviser:say(_A.information.emergency, AdviserStringIds.information.emergency)
   elseif phase == 85 then
     if self.spawned_patients < self.hospital.emergency.victims then
       self:spawnPatient()

--- a/CorsixTH/Lua/objects/plant.lua
+++ b/CorsixTH/Lua/objects/plant.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 local object = {}
 object.id = "plant"
 object.thob = 45
@@ -186,7 +188,12 @@ function Plant:callForWatering()
 
     -- If very thirsty, make user aware of it.
     if self.current_state > 1 and not self.plant_announced then
-      self.hospital:giveAdvice({ _A.warnings.plants_thirsty })
+      self.hospital:giveAdvice({
+        {
+          text = _A.warnings.plants_thirsty,
+          speech_id = AdviserStringIds.warnings.plants_thirsty,
+        }
+      })
       self.plant_announced = true
     end
   end

--- a/CorsixTH/Lua/research_department.lua
+++ b/CorsixTH/Lua/research_department.lua
@@ -28,6 +28,8 @@ get improved. On the other hand it appears that the research is
 stored for future use anyway.
 --]]
 
+require("languages.string_ids")
+
 --! Manages all things related to research for one hospital.
 class "ResearchDepartment"
 
@@ -273,8 +275,12 @@ function ResearchDepartment:nextResearch(category)
     cat.frac = 0
     self:redistributeResearchPoints()
 
-    self.hospital:giveAdvice({_A.research.drug_fully_researched
-      :format(_S.research.categories[category])})
+    self.hospital:giveAdvice({
+      {
+        text = _A.research.drug_fully_researched:format(_S.research.categories[category]),
+        speech_id = AdviserStringIds.research.drug_fully_researched
+      }
+    })
 
     -- Notify any research window
     local window = self.world.ui:getWindow(UIResearch)
@@ -466,9 +472,19 @@ function ResearchDepartment:improveDrug(drug)
   decideNextResearch()
 
   if drug.disease.id == "the_squits" then
-    self.hospital:giveAdvice({_A.research.drug_improved_1:format(drug.disease.name)})
+    self.hospital:giveAdvice({
+      {
+        text = _A.research.drug_improved_1:format(drug.disease.name),
+        speech_id = AdviserStringIds.research.drug_improved_1
+      }
+    })
   else
-    self.hospital:giveAdvice({_A.research.drug_improved:format(drug.disease.name)})
+    self.hospital:giveAdvice({
+      {
+        text = _A.research.drug_improved:format(drug.disease.name),
+        speech_id = AdviserStringIds.research.drug_improved
+      }
+    })
   end
 end
 
@@ -519,7 +535,12 @@ function ResearchDepartment:improveMachine(machine)
     end
   end
   -- Tell the player that something has been improved
-  self.hospital:giveAdvice({_A.research.machine_improved:format(machine.name)})
+  self.hospital:giveAdvice({
+    {
+      text = _A.research.machine_improved:format(machine.name),
+      speech_id = AdviserStringIds.research.machine_improved
+    }
+  })
 end
 
 --[[ Updates the dynamic info for each matching machine found in the player's
@@ -563,9 +584,19 @@ function ResearchDepartment:discoverObject(object, automatic)
       if unveil_room then
         room_disc.is_discovered = true
         if automatic then
-          self.hospital:giveAdvice({_A.research.new_available:format(object.name)})
+          self.hospital:giveAdvice({
+            {
+              text = _A.research.new_available:format(object.name),
+              speech_id = AdviserStringIds.research.new_available
+            }
+          })
         else
-          self.hospital:giveAdvice({_A.research.new_machine_researched:format(object.name)})
+          self.hospital:giveAdvice({
+            {
+              text = _A.research.new_machine_researched:format(object.name),
+              speech_id = AdviserStringIds.research.new_machine_researched
+            }
+          })
         end
         -- It may now be possible to continue researching machine improvements
         local current_improvement_research = self.research_policy.improvements.current

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 class "Room"
 
 ---@type Room
@@ -346,13 +348,28 @@ function Room:onHumanoidEnter(humanoid)
     return
   end
   local researcher_desks = {
-    (_A.warnings.researcher_needs_desk_1),
-    (_A.warnings.researcher_needs_desk_2),
-    (_A.warnings.researcher_needs_desk_3),
+    {
+      text = _A.warnings.researcher_needs_desk_1,
+      speech_id = AdviserStringIds.warnings.researcher_needs_desk_1
+    },
+    {
+      text = _A.warnings.researcher_needs_desk_2,
+      speech_id = AdviserStringIds.warnings.researcher_needs_desk_2
+    },
+    {
+      text = _A.warnings.researcher_needs_desk_3,
+      speech_id = AdviserStringIds.warnings.researcher_needs_desk_3
+    },
   }
   local nurse_desks = {
-    (_A.warnings.nurse_needs_desk_1),
-    (_A.warnings.nurse_needs_desk_2),
+    {
+      text = _A.warnings.nurse_needs_desk_1,
+      speech_id = AdviserStringIds.warnings.nurse_needs_desk_1
+    },
+    {
+      text = _A.warnings.nurse_needs_desk_2,
+      speech_id = AdviserStringIds.warnings.nurse_needs_desk_2
+    },
   }
   if class.is(humanoid, Staff) then
     -- If the room is already full of staff, or the staff member isn't relevant

--- a/CorsixTH/Lua/rooms/gp.lua
+++ b/CorsixTH/Lua/rooms/gp.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 local room = {}
 room.id = "gp"
 room.vip_must_visit = false
@@ -205,7 +207,12 @@ end
 function GPRoom:roomFinished()
   if self.hospital:countStaffOfCategory("Doctor") == 0 and
       not self.world.ui.start_tutorial then
-    self.hospital:giveAdvice({_A.room_requirements.gps_office_need_doctor})
+    self.hospital:giveAdvice({
+      {
+        text = _A.room_requirements.gps_office_need_doctor,
+        speech_id = AdviserStringIds.room_requirements.gps_office_need_doctor
+      }
+    })
   end
   return Room.roomFinished(self)
 end

--- a/CorsixTH/Lua/rooms/operating_theatre.lua
+++ b/CorsixTH/Lua/rooms/operating_theatre.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 local room = {}
 room.id = "operating_theatre"
 room.vip_must_visit = true
@@ -70,13 +72,28 @@ function OperatingTheatreRoom:roomFinished()
   end
   -- Tell the player what is missing, if anything.
   if self.hospital:countRoomOfType("ward", 1) == 0 then
-    self.hospital:giveAdvice({_A.room_requirements.op_need_ward})
+    self.hospital:giveAdvice({
+      {
+        text = _A.room_requirements.op_need_ward,
+        speech_id = AdviserStringIds.room_requirements.op_need_ward
+      }
+    })
   end
   local numSurgeons = self.hospital:countStaffOfCategory("Surgeon", 2)
   if numSurgeons == 0 then
-    self.hospital:giveAdvice({_A.room_requirements.op_need_two_surgeons})
+    self.hospital:giveAdvice({
+      {
+        text = _A.room_requirements.op_need_two_surgeons,
+        speech_id = AdviserStringIds.room_requirements.op_need_two_surgeons
+      }
+    })
   elseif numSurgeons == 1 then
-    self.hospital:giveAdvice({_A.room_requirements.op_need_another_surgeon})
+    self.hospital:giveAdvice({
+      {
+        text = _A.room_requirements.op_need_another_surgeon,
+        speech_id = AdviserStringIds.room_requirements.op_need_another_surgeon
+      }
+    })
   end
   return Room.roomFinished(self)
 end

--- a/CorsixTH/Lua/rooms/pharmacy.lua
+++ b/CorsixTH/Lua/rooms/pharmacy.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 local room = {}
 room.id = "pharmacy"
 room.vip_must_visit = false
@@ -52,7 +54,12 @@ end
 
 function PharmacyRoom:roomFinished()
   if self.hospital:countStaffOfCategory("Nurse", 1) == 0 then
-    self.hospital:giveAdvice({ _A.room_requirements.pharmacy_need_nurse })
+    self.hospital:giveAdvice({
+      {
+        text = _A.room_requirements.pharmacy_need_nurse,
+        speech_id = AdviserStringIds.room_requirements.pharmacy_need_nurse
+      }
+    })
   end
   return Room.roomFinished(self)
 end

--- a/CorsixTH/Lua/rooms/psych.lua
+++ b/CorsixTH/Lua/rooms/psych.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 local room = {}
 room.id = "psych"
 room.vip_must_visit = false
@@ -53,7 +55,12 @@ end
 
 function PsychRoom:roomFinished()
   if self.hospital:countStaffOfCategory("Psychiatrist", 1) == 0 then
-    self.hospital:giveAdvice({_A.room_requirements.psychiatry_need_psychiatrist})
+    self.hospital:giveAdvice({
+      {
+        text = _A.room_requirements.psychiatry_need_psychiatrist,
+        speech_id = AdviserStringIds.room_requirements.psychiatry_need_psychiatrist
+      }
+    })
   end
   return Room.roomFinished(self)
 end

--- a/CorsixTH/Lua/rooms/research.lua
+++ b/CorsixTH/Lua/rooms/research.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 local room = {}
 room.id = "research"
 room.vip_must_visit = true
@@ -131,12 +133,21 @@ function ResearchRoom:roomFinished()
   -- Is this the first research department built?
   if not self.hospital.research_dep_built and not TheApp.using_demo_files then
     self.hospital.research_dep_built = true
-    self.hospital:giveAdvice({_A.information.initial_general_advice
-      .research_now_available})
+    self.hospital:giveAdvice({
+      {
+        text = _A.information.initial_general_advice.research_now_available,
+        speech_id = AdviserStringIds.information.initial_general_advice.research_now_available
+      }
+    })
   end
   -- Also check if it would be good to hire a researcher.
   if self.hospital:countStaffOfCategory("Researcher", 1) == 0 then
-    self.hospital:giveAdvice({_A.room_requirements.research_room_need_researcher})
+    self.hospital:giveAdvice({
+      {
+        text = _A.room_requirements.research_room_need_researcher,
+        speech_id = AdviserStringIds.room_requirements.research_room_need_researcher
+      }
+    })
   end
   return Room.roomFinished(self)
 end

--- a/CorsixTH/Lua/rooms/training.lua
+++ b/CorsixTH/Lua/rooms/training.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 local room = {}
 room.id = "training"
 room.vip_must_visit = false
@@ -69,7 +71,12 @@ function TrainingRoom:roomFinished()
 
   -- Also tell the player if he/she doesn't have a consultant yet.
   if self.hospital:countStaffOfCategory("Consultant", 1) == 0 then
-    self.hospital:giveAdvice({_A.room_requirements.training_room_need_consultant})
+    self.hospital:giveAdvice({
+      {
+        text = _A.room_requirements.training_room_need_consultant,
+        speech_id = AdviserStringIds.room_requirements.training_room_need_consultant
+      }
+    })
   end
   Room.roomFinished(self)
 end
@@ -206,15 +213,24 @@ function TrainingRoom:commandEnteringStaff(humanoid)
         humanoid:queueAction(UseObjectAction(obj))
         humanoid:queueAction(MeanderAction())
       else
-        self.hospital:giveAdvice({_A.staff_place_advice.not_enough_lecture_chairs})
+        self.hospital:giveAdvice({
+          {
+            text = _A.staff_place_advice.not_enough_lecture_chairs,
+            speech_id = AdviserStringIds.staff_place_advice.not_enough_lecture_chairs
+          }
+        })
         humanoid:setNextAction(self:createLeaveAction())
         humanoid:queueAction(MeanderAction())
         humanoid.last_room = nil -- Prevent Doctor returning to this room automatically
       end
     end
   elseif humanoid.humanoid_class ~= "Handyman" then
-    self.hospital:giveAdvice({_A.staff_place_advice.only_doctors_in_room
-      :format(_S.rooms_long.training_room)})
+    self.hospital:giveAdvice({
+      {
+        text = _A.staff_place_advice.only_doctors_in_room:format(_S.rooms_long.training_room),
+        speech_id = AdviserStringIds.staff_place_advice.only_doctors_in_room
+      }
+    })
     humanoid:setNextAction(self:createLeaveAction())
     humanoid:queueAction(MeanderAction())
     return

--- a/CorsixTH/Lua/rooms/ward.lua
+++ b/CorsixTH/Lua/rooms/ward.lua
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. --]]
 
+require("languages.string_ids")
+
 local room = {}
 room.id = "ward"
 room.vip_must_visit = true
@@ -78,7 +80,12 @@ function WardRoom:roomFinished()
   }
   self.maximum_patients = beds
   if self.hospital:countStaffOfCategory("Nurse", 1) == 0 then
-    self.hospital:giveAdvice({_A.room_requirements.ward_need_nurse})
+    self.hospital:giveAdvice({
+      {
+        text = _A.room_requirements.ward_need_nurse,
+        speech_id = AdviserStringIds.room_requirements.ward_need_nurse
+      }
+    })
   end
   Room.roomFinished(self)
 end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -43,6 +43,7 @@ corsixth.require("date")
 corsixth.require("announcer")
 corsixth.require("endconditions")
 corsixth.require("earthquake")
+require("languages.string_ids")
 
 --! Manages entities, rooms, and the date.
 class "World"
@@ -1734,7 +1735,12 @@ function World:newObject(id, x, y, flags, name)
     entity = Machine(hospital, object_type, x, y, flags, name)
     -- Tell the player if there is no handyman to take care of the new machinery.
     if hospital:countStaffOfCategory("Handyman", 1) == 0 then
-      hospital:giveAdvice({_A.staff_advice.need_handyman_machines})
+      hospital:giveAdvice({
+        {
+          text = _A.staff_advice.need_handyman_machines,
+          speech_id = AdviserStringIds.staff_advice.need_handyman_machines,
+        }
+      })
     end
   else
     entity = Object(hospital, object_type, x, y, flags, name)


### PR DESCRIPTION
*Fixes #3037 *

**Describe what the proposed change does**
- Refactors the adviser messages system so the lang strings can have an ID and are easier to filter. 
- As a result, the existing "Adviser:checkForDuplicates" no longer compares whole strings. Instead it only compares integer IDs, which should be faster
