### PR TITLE
RFC: Code to extract palette from smacker video as rgb32

### DIFF
--- a/CorsixTH/Src/th_movie.h
+++ b/CorsixTH/Src/th_movie.h
@@ -137,12 +137,16 @@ class movie_picture {
   //! Delete the buffer
   void deallocate();
 
-  uint8_t* buffer;                   ///< Pixel data in #m_pixelFormat
-  const AVPixelFormat pixel_format;  ///< The format of pixels to output
-  int width;                         ///< Picture width
-  int height;                        ///< Picture height
-  double pts;                        ///< Presentation time stamp
-  std::mutex mutex;                  ///< Mutex protecting this picture
+  uint8_t* buffer;                    ///< Pixel data in pixel_format
+  const AVPixelFormat pixel_format;   ///< The format of pixels to output
+  int width;                          ///< Picture width
+  int height;                         ///< Picture height
+  double pts;                         ///< Presentation time stamp
+  std::mutex mutex;                   ///< Mutex protecting this picture
+  std::array<uint8_t, 1024> palette;  ///< Palette data for smacker videos. The
+                                      ///< buffer is already converted to
+                                      ///< pixel_format, this is just for
+                                      ///< reference/debugging.
 };
 
 //! A buffer for holding movie pictures and drawing them to the renderer
@@ -207,7 +211,7 @@ class movie_picture_buffer {
   //! \retval 0 Success
   //! \retval -1 Abort is in progress
   //! \retval 1 An error writing the frame
-  int write(AVFrame* pFrame, double dPts);
+  int write(AVFrame* pFrame, double dPts, AVCodecID codecId);
 
  private:
   //! Return whether there is space to add any more frame data to the queue


### PR DESCRIPTION
I do NOT want this code merged as is, and I'm probably ok if it is never merged in any state; I added the smacker_palette_extract branch to CorsixTH/CorsixTH.

That said, if anyone does come up with a notion to clean it up and add it to master in a safe way - power to you.

If you want to reference it in a wiki - that's probably reasonable.
