### PR TITLE
Epidemic. Vaccination cursor does not work fix

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -72,13 +72,18 @@ function Patient:onClick(ui, button)
     else
       local hospital = self.hospital or self.world:getLocalPlayerHospital()
       local epidemic = hospital and hospital.epidemic
-      if not epidemic or
-        (not epidemic.coverup_selected or
-        (not self.infected or self.marked_for_vaccination) and
-        not epidemic.vaccination_mode_active) then
-          ui:addWindow(UIPatient(ui, self))
-      elseif not epidemic.timer.closed then
-        epidemic:markForVaccination(self)
+
+      local function isValidEpidemicTarget(epidemic)
+        return epidemic and epidemic.coverup_selected and
+          (epidemic.vaccination_mode_active or (self.infected and (not self.marked_for_vaccination)))
+      end
+
+      if isValidEpidemicTarget(epidemic) then
+          if not epidemic.timer.closed then
+            epidemic:markForVaccination(self)
+          end
+      else
+        ui:addWindow(UIPatient(ui, self))
       end
     end
   elseif self.user_of then

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -72,10 +72,13 @@ function Patient:onClick(ui, button)
     else
       local hospital = self.hospital or self.world:getLocalPlayerHospital()
       local epidemic = hospital and hospital.epidemic
-      if epidemic and epidemic.vaccination_mode_active then
+      if not epidemic or
+        (not epidemic.coverup_selected or
+        (not self.infected or self.marked_for_vaccination) and
+        not epidemic.vaccination_mode_active) then
+          ui:addWindow(UIPatient(ui, self))
+      elseif not epidemic.timer.closed then
         epidemic:markForVaccination(self)
-      else
-        ui:addWindow(UIPatient(ui, self))
       end
     end
   elseif self.user_of then

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -70,13 +70,13 @@ function Patient:onClick(ui, button)
     if self.message_callback then
       self:message_callback()
     else
-      local hospital = self.hospital or self.world:getLocalPlayerHospital()
-      local epidemic = hospital and hospital.epidemic
-
       local function isValidEpidemicTarget(epidemic)
         return epidemic and epidemic.coverup_selected and
           (epidemic.vaccination_mode_active or (self.infected and (not self.marked_for_vaccination)))
       end
+
+      local hospital = self.hospital or self.world:getLocalPlayerHospital()
+      local epidemic = hospital and hospital.epidemic
 
       if isValidEpidemicTarget(epidemic) then
           if not epidemic.timer.closed then

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -70,14 +70,15 @@ function Patient:onClick(ui, button)
     if self.message_callback then
       self:message_callback()
     else
+
       local function isValidEpidemicTarget(epidemic)
         return epidemic and epidemic.coverup_selected and
-          (epidemic.vaccination_mode_active or (self.infected and (not self.marked_for_vaccination)))
+            (epidemic.vaccination_mode_active or
+            (self.infected and (not self.marked_for_vaccination)))
       end
 
       local hospital = self.hospital or self.world:getLocalPlayerHospital()
       local epidemic = hospital and hospital.epidemic
-
       if isValidEpidemicTarget(epidemic) then
           if not epidemic.timer.closed then
             epidemic:markForVaccination(self)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2736*

**Describe what the proposed change does**
- Restores the functionality of the Epidemiology Cursor to the same UX as in the original game.

Test cases:

```
Clicking with vaccination mode off:
   Epidemic not marked patient - mark.
   Epidemic marked patient - open window.
   Regular patient - open window.

Clicking with vaccination mode on:
   Epidemic not marked patient - mark. 
   Epidemic marked patient - do nothing.
   Regular patient - do nothing.
```