### PR TITLE
Drop WX stringimpl.h header include

### DIFF
--- a/AnimView/frmMain.cpp
+++ b/AnimView/frmMain.cpp
@@ -47,7 +47,6 @@ SOFTWARE.
 #include <wx/spinbutt.h>
 #include <wx/spinctrl.h>
 #include <wx/stattext.h>
-#include <wx/stringimpl.h>
 #include <wx/textctrl.h>
 #include <wx/tokenzr.h>
 #include <wx/unichar.h>


### PR DESCRIPTION
*Fixes Compile problem with AnimView

**Describe what the proposed change does**
- Does not include "wx/strimpl.h" in AnimView/frmMain.cpp anymore, as it doesn't seem to exist in newer wx versions.
