### PR TITLE
Shrink the right margin of the fax

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/fax.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/fax.lua
@@ -110,7 +110,7 @@ function UIFax:draw(canvas, x, y)
     local last_y = y + 40
     for _, message in ipairs(self.message) do
       last_y = self.fax_font:drawWrapped(canvas, message.text, x + 190,
-                                         last_y + (message.offset or 0), 330,
+                                         last_y + (message.offset or 0), 360,
                                          "center")
     end
     local choices = self.message.choices


### PR DESCRIPTION
Closer match the left margin and give a little bit more room for the level 12 win message.

Fixes #3058

Let me know what you think.

All 4 messages:

<img width="1360" height="1069" alt="image" src="https://github.com/user-attachments/assets/97986db0-be25-47aa-b5f6-7d4f9024a191" />

<img width="1360" height="1069" alt="image" src="https://github.com/user-attachments/assets/1d36fb9c-871e-4751-87c3-b0d2b438d608" />

<img width="1360" height="1069" alt="image" src="https://github.com/user-attachments/assets/13517143-794d-42c5-a7f7-6ccf3ccedae2" />

<img width="1360" height="1069" alt="image" src="https://github.com/user-attachments/assets/e6ed3801-1ed1-47c4-8756-468bd00d3f5b" />