### PR TITLE
Fix smoke machine position

### DIFF
--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -43,8 +43,6 @@ function Machine:Machine(hospital, object_type, x, y, direction, etc)
 
   self.total_usage = 0
   self:setHandymanRepairPosition(direction)
-
-  self.smoke_offset = object_type.orientations[direction].smoke_position
 end
 
 --!param room (object) machine room
@@ -81,10 +79,10 @@ end
 local function getSmokeTile(self)
   local map, _, _ = self.th:getTile()
   local x, y = self.tile_x, self.tile_y
-
-  if self.object_type.orientations[self.direction].smoke_position then
-    x = x + self.object_type.orientations[self.direction].smoke_position[1] -- todo : replace by self.smoke_offset
-    y = y + self.object_type.orientations[self.direction].smoke_position[2]
+  local smoke_position = self.object_type.orientations[self.direction].smoke_position
+  if smoke_position then
+    x = x + smoke_position[1]
+    y = y + smoke_position[2]
   end
 
   return map, x, y

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -45,11 +45,6 @@ function Machine:Machine(hospital, object_type, x, y, direction, etc)
   self:setHandymanRepairPosition(direction)
 
   self.smoke_offset = object_type.orientations[direction].smoke_position
-  if object_type.smoke_animation then
-    self.smoke_animation = object_type.smoke_animation
-  else
-    self.smoke_animation = 3428 -- Default to the (0,0) based animation
-  end
 end
 
 --!param room (object) machine room
@@ -87,7 +82,7 @@ local function getSmokeTile(self)
   local map, _, _ = self.th:getTile()
   local x, y = self.tile_x, self.tile_y
 
-  if self.smoke_offset or self.object_type.orientations[self.direction].smoke_position then
+  if self.object_type.orientations[self.direction].smoke_position then
     x = x + self.object_type.orientations[self.direction].smoke_position[1] -- todo : replace by self.smoke_offset
     y = y + self.object_type.orientations[self.direction].smoke_position[2]
   end
@@ -98,7 +93,7 @@ end
 --! Set whether the smoke animation should be showing
 local function setSmoke(self, isSmoking)
   -- If turning smoke on for this machine
-  if isSmoking then
+  if isSmoking and self.object_type.smoke_animation then
     -- If there is no smoke animation for this machine, make one
     if not self.smokeInfo then
       self.smokeInfo = TH.animation()
@@ -111,9 +106,8 @@ local function setSmoke(self, isSmoking)
       -- tick to animate over all frames
       self.ticks = true
     end
-    -- TODO: select the smoke icon based on the type of machine
     local mirror = self.direction == "east" and 1 or 0
-    self.smokeInfo:setAnimation(self.world.anims, self.smoke_animation or self.object_type.smoke_animation, mirror)
+    self.smokeInfo:setAnimation(self.world.anims, self.object_type.smoke_animation, mirror)
   else -- Otherwise, turning smoke off
     -- If there is currently a smoke animation, remove it
     if self.smokeInfo then
@@ -268,7 +262,7 @@ function Machine:updateSmokeDisplay(room)
   end
 
   -- How many uses this machine has left until it explodes
-  local threshold = self:getRemainingUses()
+  self:getRemainingUses()
 
   -- Machines needing urgent repair show smoke
   if threshold < 4 then

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -74,6 +74,26 @@ function Machine:isMachine()
   return true
 end
 
+--! Return Tile position for smoke animation
+--!return (map, int, int)
+local function getSmokeTile(self)
+  local map, x, y = self.th:getTile()
+  if self.footprint then
+    for _, footprintCell in ipairs(self.footprint) do
+      if footprintCell.smoke_position then
+        x = x + footprintCell[1]
+        y = y + footprintCell[2]
+        break
+      end
+    end
+  end
+
+  -- adjust the offset of the original animation.
+  x = x - 1
+
+  return map, x, y
+end
+
 --! Set whether the smoke animation should be showing
 local function setSmoke(self, isSmoking)
   -- If turning smoke on for this machine
@@ -84,7 +104,7 @@ local function setSmoke(self, isSmoking)
       -- Note: Set the location of the smoke to that of the machine
       -- rather than setting the machine to the parent so that the smoke
       -- doesn't get hidden with the machine during use
-      self.smokeInfo:setTile(self.th:getTile())
+      self.smokeInfo:setTile(getSmokeTile(self))
       -- Always show the first smoke layer
       self.smokeInfo:setLayer(10, 2)
       -- tick to animate over all frames

--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -262,7 +262,7 @@ function Machine:updateSmokeDisplay(room)
   end
 
   -- How many uses this machine has left until it explodes
-  self:getRemainingUses()
+  local threshold = self:getRemainingUses()
 
   -- Machines needing urgent repair show smoke
   if threshold < 4 then

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -831,7 +831,8 @@ function Object.processTypeDefinition(object_type)
         end
         for _, key in ipairs({"use_position_secondary",
                               "finish_use_position",
-                              "finish_use_position_secondary"}) do
+                              "finish_use_position_secondary",
+                              "smoke_position"}) do
           if details[key] then
             details[key][1] = details[key][1] - x
             details[key][2] = details[key][2] - y

--- a/CorsixTH/Lua/objects/machines/blood_machine.lua
+++ b/CorsixTH/Lua/objects/machines/blood_machine.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 5094
 object.default_strength = 12
 object.crashed_animation = 3372
 object.show_in_town_map = true
+object.smoke_animation = 3428 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -99,7 +100,8 @@ object.orientations = {
                   {0, -1, only_passable = true, need_north_side = true},
                   {-2, 0, need_south_side = true, need_north_side = true},
                   {-1, 0}, {0, 0, complete_cell = true}, {1, 0, only_passable = true},
-                  {-1, 1, need_east_side = true, need_west_side = true} }
+                  {-1, 1, need_east_side = true, need_west_side = true} },
+    smoke_position = {0, 0},
   },
   east = {
     handyman_position = {-1, 0},
@@ -108,8 +110,9 @@ object.orientations = {
     footprint = { {0, -2, need_east_side = true, need_west_side = true},
                   {-1, -1, only_passable = true, complete_cell = true}, {0, -1},
                   {1, -1, need_south_side = true, need_north_side = true},
-                  {-1, 0, only_passable = true, need_west_side = true}, {0, 0, complete_cell = true},
-                  {0, 1, only_passable = true} }
+                  {-1, 0, only_passable = true, need_west_side = true},
+                  {0, 0, complete_cell = true}, {0, 1, only_passable = true} },
+    smoke_position = {0, 0},
   },
 }
 local anim_mgr = TheApp.animation_manager

--- a/CorsixTH/Lua/objects/machines/blood_machine.lua
+++ b/CorsixTH/Lua/objects/machines/blood_machine.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 5094
 object.default_strength = 12
 object.crashed_animation = 3372
 object.show_in_town_map = true
-object.smoke_animation = 3452 -- TODO
+object.smoke_animation = 3472
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/blood_machine.lua
+++ b/CorsixTH/Lua/objects/machines/blood_machine.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 5094
 object.default_strength = 12
 object.crashed_animation = 3372
 object.show_in_town_map = true
-object.smoke_animation = 3472
+object.smoke_animation = 3460
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/blood_machine.lua
+++ b/CorsixTH/Lua/objects/machines/blood_machine.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 5094
 object.default_strength = 12
 object.crashed_animation = 3372
 object.show_in_town_map = true
-object.smoke_animation = 3428 -- TODO
+object.smoke_animation = 3452 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/cardio.lua
+++ b/CorsixTH/Lua/objects/machines/cardio.lua
@@ -137,7 +137,7 @@ object.multi_usage_animations = {
 }
 object.orientations = {
   north = {
-    footprint = { {-1, -1, complete_cell = true}, {-1, 0, complete_cell = true}, {1, -1, only_passable = true},
+    footprint = { {-1, -1, complete_cell = true}, {-1, 0, complete_cell = true}, {1, -1, only_passable = true , smoke_position = true},
                   {0, -1, need_north_side = true}, {0, 0, only_passable = true} },
     render_attach_position = {-1, 0},
     use_position = {1, -1},
@@ -146,7 +146,7 @@ object.orientations = {
   },
   east = {
     footprint = { {-1, -1, complete_cell = true}, {-1, 0}, {0, -1, complete_cell = true},
-                  {0, 0, only_passable = true}, {-1, 1, only_passable = true} },
+                  {0, 0, only_passable = true}, {-1, 1, only_passable = true, smoke_position = true} },
     render_attach_position = {0, -1},
     use_position = {-1, 1},
     use_position_secondary = {0, 0},

--- a/CorsixTH/Lua/objects/machines/cardio.lua
+++ b/CorsixTH/Lua/objects/machines/cardio.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 918
 object.default_strength = 12
 object.crashed_animation = 3308
 object.show_in_town_map = true
+object.smoke_animation = 3432
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -137,20 +138,22 @@ object.multi_usage_animations = {
 }
 object.orientations = {
   north = {
-    footprint = { {-1, -1, complete_cell = true}, {-1, 0, complete_cell = true}, {1, -1, only_passable = true , smoke_position = true},
+    footprint = { {-1, -1, complete_cell = true}, {-1, 0, complete_cell = true}, {1, -1, only_passable = true},
                   {0, -1, need_north_side = true}, {0, 0, only_passable = true} },
     render_attach_position = {-1, 0},
     use_position = {1, -1},
     use_position_secondary = {0, 0},
     added_handyman_animate_offset_while_in_use = {1, -1},
+    smoke_position = {0, 0},
   },
   east = {
     footprint = { {-1, -1, complete_cell = true}, {-1, 0}, {0, -1, complete_cell = true},
-                  {0, 0, only_passable = true}, {-1, 1, only_passable = true, smoke_position = true} },
+                  {0, 0, only_passable = true}, {-1, 1, only_passable = true} },
     render_attach_position = {0, -1},
     use_position = {-1, 1},
     use_position_secondary = {0, 0},
     added_handyman_animate_offset_while_in_use = {-1, 1},
+    smoke_position = {0, 0},
   },
 }
 local anim_mgr = TheApp.animation_manager

--- a/CorsixTH/Lua/objects/machines/cast_remover.lua
+++ b/CorsixTH/Lua/objects/machines/cast_remover.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 5072
 object.default_strength = 10
 object.crashed_animation = 3388
 object.show_in_town_map = true
+object.smoke_animation = 3468
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -130,6 +131,7 @@ object.orientations = {
                   {-2, -1, only_passable = true, invisible = true, optional = true} },
     list_bottom = true,
     render_attach_position = {-1, 1},
+    smoke_position = {0, 0},
   },
   east = {
     use_position = {0, 0},
@@ -144,6 +146,7 @@ object.orientations = {
                   {-1, -2, only_passable = true, invisible = true, optional = true} },
     early_list = true,
     list_bottom = true,
+    smoke_position = {0, 0},
   },
 }
 anim_mgr:setPatientMarker(object.idle_animations.north, {-1.6, -0.8})

--- a/CorsixTH/Lua/objects/machines/dna_fixer.lua
+++ b/CorsixTH/Lua/objects/machines/dna_fixer.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 5070
 object.default_strength = 7
 object.crashed_animation = 3376 -- TODO correct?
 object.show_in_town_map = true
+object.smoke_animation = 3428 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -66,6 +67,7 @@ object.orientations = {
                   {-1,  1, only_passable = true} },
     use_position = "passable",
     early_list = true,
+    smoke_position = {0, 0},
   },
   east = {
     footprint = { {-1,  -2, complete_cell = true}, {0,  -2, complete_cell = true},
@@ -73,6 +75,7 @@ object.orientations = {
                   {-1,  0}, {0,  0},
                   {1,  -1, only_passable = true} },
     use_position = "passable",
+    smoke_position = {0, 0},
   },
 }
 

--- a/CorsixTH/Lua/objects/machines/dna_fixer.lua
+++ b/CorsixTH/Lua/objects/machines/dna_fixer.lua
@@ -30,7 +30,6 @@ object.build_preview_animation = 5070
 object.default_strength = 7
 object.crashed_animation = 3376 -- TODO correct?
 object.show_in_town_map = true
-object.smoke_animation = 3428 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -67,7 +66,6 @@ object.orientations = {
                   {-1,  1, only_passable = true} },
     use_position = "passable",
     early_list = true,
-    smoke_position = {0, 0},
   },
   east = {
     footprint = { {-1,  -2, complete_cell = true}, {0,  -2, complete_cell = true},
@@ -75,7 +73,6 @@ object.orientations = {
                   {-1,  0}, {0,  0},
                   {1,  -1, only_passable = true} },
     use_position = "passable",
-    smoke_position = {0, 0},
   },
 }
 

--- a/CorsixTH/Lua/objects/machines/dna_fixer.lua
+++ b/CorsixTH/Lua/objects/machines/dna_fixer.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 5070
 object.default_strength = 7
 object.crashed_animation = 3376 -- TODO correct?
 object.show_in_town_map = true
+object.smoke_animation = 3444
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -66,6 +67,7 @@ object.orientations = {
                   {-1,  1, only_passable = true} },
     use_position = "passable",
     early_list = true,
+    smoke_position = {0, 0}
   },
   east = {
     footprint = { {-1,  -2, complete_cell = true}, {0,  -2, complete_cell = true},
@@ -73,6 +75,7 @@ object.orientations = {
                   {-1,  0}, {0,  0},
                   {1,  -1, only_passable = true} },
     use_position = "passable",
+    smoke_position = {0, 0}
   },
 }
 

--- a/CorsixTH/Lua/objects/machines/electrolyser.lua
+++ b/CorsixTH/Lua/objects/machines/electrolyser.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 930
 object.default_strength = 10
 object.crashed_animation = 3300
 object.show_in_town_map = true
-object.smoke_animation = 3428 -- TODO
+object.smoke_animation = 3456
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/electrolyser.lua
+++ b/CorsixTH/Lua/objects/machines/electrolyser.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 930
 object.default_strength = 10
 object.crashed_animation = 3300
 object.show_in_town_map = true
+object.smoke_animation = 3428 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -72,7 +73,8 @@ object.orientations = {
                   {-2, -1, complete_cell = true}, {-1, -1}, {0, -1, complete_cell = true},
                   {-2,  0, complete_cell = true}, {-1,  0}, {0,  0, complete_cell = true},
                   {-1, 1, only_passable = true, need_south_side = true} },
-    use_position = "passable"
+    use_position = "passable",
+    smoke_position = {0, 0},
   },
   east = {
     render_attach_position = {-1, -1},
@@ -80,7 +82,8 @@ object.orientations = {
                   {-2, -1}, {-1, -1}, {0, -1, complete_cell = true},
                   {-2,  0, need_south_side = true}, {-1,  0}, {0,  0, complete_cell = true},
                   {1, -1, only_passable = true, need_east_side = true} },
-    use_position = "passable"
+    use_position = "passable",
+    smoke_position = {0, 0},
   },
 }
 local anim_mgr = TheApp.animation_manager

--- a/CorsixTH/Lua/objects/machines/hair_restorer.lua
+++ b/CorsixTH/Lua/objects/machines/hair_restorer.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 5074
 object.default_strength = 8
 object.crashed_animation = 5116
 object.show_in_town_map = true
-object.smoke_animation = 3460 -- TODO
+object.smoke_animation = 3472
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/hair_restorer.lua
+++ b/CorsixTH/Lua/objects/machines/hair_restorer.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 5074
 object.default_strength = 8
 object.crashed_animation = 5116
 object.show_in_town_map = true
+object.smoke_animation = 3460 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -64,6 +65,7 @@ object.orientations = {
     finish_use_position = {0, 1},
     footprint = { {0, -1, only_passable = true}, {0, 0, complete_cell = true}, {0, 1, only_passable = true} },
     use_animate_from_use_position = true,
+    smoke_position = {0, 0},
   },
   east = {
     use_position = {1, 0},
@@ -72,6 +74,7 @@ object.orientations = {
     finish_use_position = {1, 0},
     footprint = { {-1, 0, only_passable = true}, {0, 0, complete_cell = true}, {1, 0, only_passable = true} },
     use_animate_from_use_position = true,
+    smoke_position = {0, 0},
   },
 }
 local anim_mgr = TheApp.animation_manager

--- a/CorsixTH/Lua/objects/machines/hair_restorer.lua
+++ b/CorsixTH/Lua/objects/machines/hair_restorer.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 5074
 object.default_strength = 8
 object.crashed_animation = 5116
 object.show_in_town_map = true
-object.smoke_animation = 3472
+object.smoke_animation = 3460
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/inflator.lua
+++ b/CorsixTH/Lua/objects/machines/inflator.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 908
 object.default_strength = 10
 object.crashed_animation = 3362
 object.show_in_town_map = true
+object.smoke_animation = 3424
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -62,6 +63,7 @@ object.orientations = {
     footprint = { {-1, -1}, {0, -1, need_north_side = true}, {1, -1, only_passable = true},
                   {-1, 0}, {0, 0}, {1, 0, only_passable = true},
                   {-1, 1, only_passable = true}, {0, 1, only_passable = true}, {1, 1, only_passable = true} },
+    smoke_position = {0, 0},
   },
   east = {
     handyman_position = {-1, 1},
@@ -72,6 +74,7 @@ object.orientations = {
     footprint = { {-1, -1}, {0, -1}, {1, -1, only_passable = true},
                   {-1, 0, need_west_side = true}, {0, 0}, {1, 0, only_passable = true},
                   {-1, 1, only_passable = true}, {0, 1, only_passable = true}, {1, 1, only_passable = true} },
+    smoke_position = {0, 0},
   },
 }
 local anim_mgr = TheApp.animation_manager

--- a/CorsixTH/Lua/objects/machines/jelly_moulder.lua
+++ b/CorsixTH/Lua/objects/machines/jelly_moulder.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 928
 object.default_strength = 7
 object.crashed_animation = 3312
 object.show_in_town_map = true
+object.smoke_animation = 3428 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -113,6 +114,7 @@ object.orientations = {
                   {-1, 0}, {0, 0, complete_cell = true}, {1, 0, only_passable = true},
                   {-1, 1, only_passable = true, need_east_side = true}, },
     render_attach_position = {0, -1},
+    smoke_position = {0, 0},
   },
   east = {
     handyman_position = {-1, 2},
@@ -126,6 +128,7 @@ object.orientations = {
                   {-1, 0}, {0, 0, complete_cell = true},
                   {-1, 1, only_passable = true}, {0, 1, only_passable = true}, },
     render_attach_position = {-1, 0},
+    smoke_position = {0, 0},
   },
 }
 

--- a/CorsixTH/Lua/objects/machines/jelly_moulder.lua
+++ b/CorsixTH/Lua/objects/machines/jelly_moulder.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 928
 object.default_strength = 7
 object.crashed_animation = 3312
 object.show_in_town_map = true
-object.smoke_animation = 3460 -- TODO
+object.smoke_animation = 3440
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/jelly_moulder.lua
+++ b/CorsixTH/Lua/objects/machines/jelly_moulder.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 928
 object.default_strength = 7
 object.crashed_animation = 3312
 object.show_in_town_map = true
-object.smoke_animation = 3428 -- TODO
+object.smoke_animation = 3460 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/operating_table.lua
+++ b/CorsixTH/Lua/objects/machines/operating_table.lua
@@ -32,6 +32,7 @@ object.build_preview_animation = 5080
 object.default_strength = 8
 object.crashed_animation = 3392
 object.show_in_town_map = true
+object.smoke_animation = 3472
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -97,11 +98,12 @@ object.orientations = {
     footprint = {
       {-2, -1, only_passable = true},
       {-1, -1, complete_cell = true}, {-1, -2, only_passable = true},
-      {0, -1, complete_cell = true, smoke_position = true}, {0, -2, complete_cell = true},
+      {0, -1, complete_cell = true}, {0, -2, complete_cell = true},
       {1, 0, complete_cell = true}, {1, -2, complete_cell = true},  {1, -1, only_passable = true},
     },
     render_attach_position = {0, -1},
     slave_position = {1, -1},
+    smoke_position = {0, 0},
   },
   east = {
     use_position = {-2, -1},
@@ -109,11 +111,12 @@ object.orientations = {
     footprint = {
       {-1, -2, only_passable = true},
       {-1, -1, complete_cell = true}, {-2, -1, only_passable = true},
-      {-1, 0, complete_cell = true, smoke_position = true}, {-2, 0, complete_cell = true},
-      {0, 1, complete_cell = true}, {-2, 1, complete_cell = true},  {-1, 1, only_passable = true},
+      {-1, 0, complete_cell = true}, {-2, 0, complete_cell = true},
+      {0, 1, complete_cell = true}, {-2, 1, complete_cell = true},  {-1, 1, only_passable = true}, {0, 0}
     },
     slave_position = {-1, 1},
     render_attach_position = {-1, 0},
+    smoke_position = {0, 0},
   },
 }
 

--- a/CorsixTH/Lua/objects/machines/operating_table.lua
+++ b/CorsixTH/Lua/objects/machines/operating_table.lua
@@ -97,7 +97,7 @@ object.orientations = {
     footprint = {
       {-2, -1, only_passable = true},
       {-1, -1, complete_cell = true}, {-1, -2, only_passable = true},
-      {0, -1, complete_cell = true}, {0, -2, complete_cell = true},
+      {0, -1, complete_cell = true, smoke_position = true}, {0, -2, complete_cell = true},
       {1, 0, complete_cell = true}, {1, -2, complete_cell = true},  {1, -1, only_passable = true},
     },
     render_attach_position = {0, -1},
@@ -109,7 +109,7 @@ object.orientations = {
     footprint = {
       {-1, -2, only_passable = true},
       {-1, -1, complete_cell = true}, {-2, -1, only_passable = true},
-      {-1, 0, complete_cell = true}, {-2, 0, complete_cell = true},
+      {-1, 0, complete_cell = true, smoke_position = true}, {-2, 0, complete_cell = true},
       {0, 1, complete_cell = true}, {-2, 1, complete_cell = true},  {-1, 1, only_passable = true},
     },
     slave_position = {-1, 1},

--- a/CorsixTH/Lua/objects/machines/scanner.lua
+++ b/CorsixTH/Lua/objects/machines/scanner.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 920
 object.default_strength = 12
 object.crashed_animation = 3316
 object.show_in_town_map = true
+object.smoke_animation = 3428
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -211,11 +212,13 @@ object.orientations = {
     use_position = {0, 0},
     footprint = { {-2, -1}, {-1, -1}, {0, -1}, {-2, 0}, {-1, 0, need_south_side = true},  {0, 0, complete_cell = true, only_passable = true} },
     render_attach_position = {0, -1},
+    smoke_position = {0, 0},
   },
   east = {
     use_position = {0, 0},
     footprint = { {-1, -2} , {0, -2}, {-1, -1}, {0, -1, need_east_side = true}, {-1, 0}, {0, 0, complete_cell = true, only_passable = true} },
     render_attach_position = {-1, 0},
+    smoke_position = {0, 0},
   },
 }
 local anim_mgr = TheApp.animation_manager

--- a/CorsixTH/Lua/objects/machines/shower.lua
+++ b/CorsixTH/Lua/objects/machines/shower.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 5100
 object.default_strength = 10
 object.crashed_animation = 3380
 object.show_in_town_map = true
-object.smoke_animation = 3428 -- TODO
+object.smoke_animation = 3448
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/shower.lua
+++ b/CorsixTH/Lua/objects/machines/shower.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 5100
 object.default_strength = 10
 object.crashed_animation = 3380
 object.show_in_town_map = true
+object.smoke_animation = 3428 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -67,6 +68,7 @@ object.orientations = {
                   {-2,  0, complete_cell = true}, {-1,  0, complete_cell = true}, {0,  0, complete_cell = true},
                   {-1,  1, only_passable = true}, },
     render_attach_position = {-1, 0},
+    smoke_position = {0, 0},
   },
   east = {
     use_position = {1, -1},
@@ -75,6 +77,7 @@ object.orientations = {
                   {0, -1, complete_cell = true}, {1, -1, only_passable = true},
                   {-2,  0}, {-1,  0, complete_cell = true}, {0,  0, complete_cell = true}, },
     render_attach_position = {-1, 0},
+    smoke_position = {0, 0},
   },
 }
 

--- a/CorsixTH/Lua/objects/machines/slicer.lua
+++ b/CorsixTH/Lua/objects/machines/slicer.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 932
 object.default_strength = 8
 object.crashed_animation = 3400
 object.show_in_town_map = true
-object.smoke_animation = 3428 -- TODO
+object.smoke_animation = 3464
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/slicer.lua
+++ b/CorsixTH/Lua/objects/machines/slicer.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 932
 object.default_strength = 8
 object.crashed_animation = 3400
 object.show_in_town_map = true
+object.smoke_animation = 3428 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -65,6 +66,7 @@ object.orientations = {
     handyman_position = {1, -1},
     use_position_secondary = {-1, -1},
     list_bottom = true,
+    smoke_position = {0, 0},
   },
   east = {
     footprint = {
@@ -76,6 +78,7 @@ object.orientations = {
     use_position_secondary = {-1, -1},
     early_list = true,
     list_bottom = true,
+    smoke_position = {0, 0},
   },
 }
 local anim_mgr = TheApp.animation_manager

--- a/CorsixTH/Lua/objects/machines/ultrascanner.lua
+++ b/CorsixTH/Lua/objects/machines/ultrascanner.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 5068
 object.default_strength = 12
 object.crashed_animation = 3396
 object.show_in_town_map = true
-object.smoke_animation = 3452 -- TODO
+object.smoke_animation = 3436
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/ultrascanner.lua
+++ b/CorsixTH/Lua/objects/machines/ultrascanner.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 5068
 object.default_strength = 12
 object.crashed_animation = 3396
 object.show_in_town_map = true
+object.smoke_animation = 3428 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -75,6 +76,7 @@ object.orientations = {
     use_position = {-1, 0, need_west_side = true},
     use_position_secondary = {1, -1},
     handyman_position = {2, 0},
+    smoke_position = {0, 0},
   },
   east = {
     render_attach_position = { {0, 0}, {1, 0}, {-1, 1} },
@@ -86,6 +88,7 @@ object.orientations = {
     use_position_secondary = {-1, 1},
     handyman_position = {0, 2},
     list_bottom = true,
+    smoke_position = {0, 0},
   },
 }
 local anim_mgr = TheApp.animation_manager

--- a/CorsixTH/Lua/objects/machines/ultrascanner.lua
+++ b/CorsixTH/Lua/objects/machines/ultrascanner.lua
@@ -30,7 +30,7 @@ object.build_preview_animation = 5068
 object.default_strength = 12
 object.crashed_animation = 3396
 object.show_in_town_map = true
-object.smoke_animation = 3428 -- TODO
+object.smoke_animation = 3452 -- TODO
 local function copy_north_to_south(t)
   t.south = t.north
   return t

--- a/CorsixTH/Lua/objects/machines/x_ray.lua
+++ b/CorsixTH/Lua/objects/machines/x_ray.lua
@@ -30,6 +30,7 @@ object.build_preview_animation = 5076
 object.default_strength = 12
 object.crashed_animation = 3384
 object.show_in_town_map = true
+object.smoke_animation = 3440
 local function copy_north_to_south(t)
   t.south = t.north
   return t
@@ -80,7 +81,8 @@ object.orientations = {
     render_attach_position = {-1, -1},
     footprint = { {-2, -2}, {-1, -2},
                   {-2, -1}, {-1, -1}, {0, -1}, {1, -1, only_passable = true},
-                  {-2, 0}, {-1, 0}, {0, 0} }
+                  {-2, 0}, {-1, 0}, {0, 0} },
+    smoke_position = {0, 0},
   },
   east = {
     use_position = {-1, 1},
@@ -88,7 +90,8 @@ object.orientations = {
     footprint = { {-2, -2}, {-1, -2}, {0, -2},
                   {-2, -1}, {-1, -1}, {0, -1},
                   {-1, 0}, {0, 0},
-                  {-1, 1, only_passable = true} }
+                  {-1, 1, only_passable = true} },
+    smoke_position = {0, 0},
   },
 }
 local anim_mgr = TheApp.animation_manager


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

![xray mp4](https://github.com/user-attachments/assets/2404cb8a-3d4b-4635-a3a1-eec21ff0a4d9)

*Fixes #2872*

- Select the best animation for each machines
- Store the smoke animation position into `object.orientations` of each machine definition
- Apply the object translation to the smoke position, and mirror if necessary the animation

Note : 
- The smoke position isn't part of the footprint definition because some machine ( operating_table ) doesn't have a `(0, 0)` tile.
- An improvment could be to store the `x` and `y` offset/translation instead of applying it to `smoke_position` in _entities/object.lua_, and remove the `smoke_position` for every machines.
- Seeing that some animations are not nice from the Original game, maybe we can choose another better ( if possible ) ?
  - 3 machines (operating, blood, hair) use the same `3472` animation, when `3444` and `3452` arn't used.

Question for reviewers : 
- What's the rule about backward compatibility for saves ? should we try as possible to be non breaking ?
=> In the `getSmokeTile` function, `self.object_type` is used to get the smoke position but it can be found in `self.smoke_offset` (stored in the constructor), i did that (temporarily) to make it work for machines without this info ( ex: from an save without this fix ). 

