### PR TITLE
Set emergency patient health to 0 after emergency timer expires

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1136,8 +1136,13 @@ function Hospital:resolveEmergency()
   local rescued_patients = emer.cured_emergency_patients
   for _, patient in ipairs(self.emergency_patients) do
     if patient and not patient.cured and not patient.dead
-        and not patient.going_home and not patient:getRoom() then
-      patient:die()
+        and not patient.going_home then
+      if not patient:getRoom() then
+        patient:die()
+      else
+        -- Patient is considered dead, unless cured by staff, will die after leaving the room.
+        patient.attributes["health"] = 0.0
+      end
     end
   end
   local total = emer.victims


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3055*

At the end of Emergency time : `patient:die()` method is not call because the patient is in a room, and it's not possible to know if the patient is surely going to be cured.
Setting the `health` attributes to 0.0 will make the patient died next time he's out of a room, and the day [end](https://github.com/CorsixTH/CorsixTH/blob/afdec16eb78837ea931f08f30d35d6d9286831a1/CorsixTH/Lua/entities/humanoids/patient.lua#L650-L654). Unless the patient is [cured](https://github.com/CorsixTH/CorsixTH/blob/afdec16eb78837ea931f08f30d35d6d9286831a1/CorsixTH/Lua/entities/humanoids/patient.lua#L349-L352) before leaving the room and then the `health` is set to 1, so no death.

