### PR TITLE
Add ttf shadow option

### DIFF
--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -421,13 +421,26 @@ local ttf_col_to_cache_key = function(ttf_color)
   end
 end
 
+local shadow_to_cache_key = function(ttf_shadow)
+  if type(ttf_shadow) == "table" then
+    return string.format("sx%d,sy%d,s%s",
+      ttf_shadow.offset_x or 1,
+      ttf_shadow.offset_y or 1,
+      ttf_col_to_cache_key(ttf_shadow.color))
+  elseif ttf_shadow == true then
+    return "sx1,sy1,sa255,r0,g0,b0"
+  end
+  return "nil"
+end
+
 local language_font_cache_key = function(name, font_options)
-  return string.format("%s,%d,%d,%s,%s",
+  return string.format("%s,%d,%d,%s,%s,%s",
     name or "nil",
     font_options.x_sep or 0,
     font_options.y_sep or 0,
     ttf_col_to_cache_key(font_options.ttf_color),
-    font_options.force_bitmap and "T" or "F")
+    font_options.force_bitmap and "T" or "F",
+    shadow_to_cache_key(font_options.ttf_shadow))
 end
 
 --! Load a true type font
@@ -448,6 +461,13 @@ end
 --    width will be detected from the sprite table.
 --  ttf_height (integer) The nominal height of the font, in pixels. If nil, the
 --    height will be detected from the sprite table.
+--  ttf_shadow (table|boolean) table with fields offset_x, offset_y and color.
+--    The color field has the same format as ttf_color. If this field is
+--    present, the font will be drawn with a shadow of the specified colour and
+--    offset. color is optional and defaults to opaque black. offset_x and
+--    offset_y are optional and default to 1. If the field is omitted entirely,
+--    no shadow is drawn. Alternately ttf_shadow can be set to true to draw a
+--    shadow with default parameters, or false to disable any shadow.
 --!param y_sep (int) Deprecated: use font_options.y_sep instead.
 --!param ttf_color (table) Deprecated: use font_options.ttf_color instead.
 --!param force_bitmap (boolean) Deprecated: use font_options.force_bitmap
@@ -510,6 +530,13 @@ end
 --    width will be detected from the sprite table.
 --  ttf_height (integer) The nominal height of the font, in pixels. If nil, the
 --    height will be detected from the sprite table.
+--  ttf_shadow (table|boolean) table with fields offset_x, offset_y and color.
+--    The color field has the same format as ttf_color. If this field is
+--    present, the font will be drawn with a shadow of the specified colour and
+--    offset. color is optional and defaults to opaque black. offset_x and
+--    offset_y are optional and default to 1. If the field is omitted entirely,
+--    no shadow is drawn. Alternately ttf_shadow can be set to true to draw a
+--    shadow with default parameters, or false to disable any shadow.
 function Graphics:loadFontAndSpriteTable(dir, name, complex, palette, font_options)
   local sprite_table = self:loadSpriteTable(dir, name, complex, palette)
 
@@ -536,6 +563,13 @@ end
 --    width will be detected from the sprite table.
 --  ttf_height (integer) The nominal height of the font, in pixels. If nil, the
 --    height will be detected from the sprite table.
+--  ttf_shadow (table|boolean) table with fields offset_x, offset_y and color.
+--    The color field has the same format as ttf_color. If this field is
+--    present, the font will be drawn with a shadow of the specified colour and
+--    offset. color is optional and defaults to opaque black. offset_x and
+--    offset_y are optional and default to 1. If the field is omitted entirely,
+--    no shadow is drawn. Alternately ttf_shadow can be set to true to draw a
+--    shadow with default parameters, or false to disable any shadow.
 function Graphics:loadFont(sprite_table, font_options, y_sep, ttf_color, force_bitmap)
 
   -- afterLoad fix. Saves before 215 would double the y_sep argument, but did not have ttf_col

--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -256,7 +256,7 @@ end
 --!  can be either of "left", "center", "right"
 function Panel:setLabel(label, font, align)
   self.label = label or ""
-  self.label_font = font or self.label_font or TheApp.gfx:loadFontAndSpriteTable("QData", "Font01V")
+  self.label_font = font or self.label_font or TheApp.gfx:loadFontAndSpriteTable("QData", "Font01V", nil, nil, {ttf_shadow = true})
   self.align = align or self.align
   return self
 end

--- a/CorsixTH/Src/th_gfx_font.h
+++ b/CorsixTH/Src/th_gfx_font.h
@@ -62,6 +62,20 @@ struct text_layout {
   int width;
 };
 
+struct font_shadow_options {
+  //! Whether to draw a shadow
+  bool enabled{false};
+
+  //! Horizontal offset of the shadow, in pixels
+  int offset_x{1};
+
+  //! Vertical offset of the shadow, in pixels
+  int offset_y{1};
+
+  //! Colour of the shadow
+  argb_colour color{0xFF000000u};
+};
+
 class font {
  public:
   virtual ~font() = default;
@@ -226,6 +240,8 @@ class freetype_font final : public font {
 
   void set_font_color(argb_colour color);
 
+  void set_shadow_options(const font_shadow_options& options);
+
   text_layout get_text_dimensions(const char* sMessage, size_t iMessageLength,
                                   int iMaxWidth = INT_MAX) const override;
 
@@ -289,6 +305,7 @@ class freetype_font final : public font {
   static constexpr int cache_size_log2{7};
   FT_Face font_face{nullptr};
   argb_colour font_color{0};
+  font_shadow_options shadow_opts{};
   bool is_done_freetype_init{false};
   mutable cached_text cache[1 << cache_size_log2]{};
 
@@ -311,8 +328,12 @@ class freetype_font final : public font {
           an object which can be used by the rendering engine, and store the
           result in the pTexture or iTexture field.
   */
-  void make_texture(render_target* pEventualCanvas,
+  void make_texture(const render_target* pEventualCanvas,
                     cached_text* pCacheEntry) const;
+
+  static void copy_pixel_data(const cached_text* cacheEntry, argb_colour color,
+                              int offsetX, int offsetY,
+                              std::vector<argb_colour>::iterator outIter);
 
   //! Free a previously-made texture of a cache entry.
   /*!


### PR DESCRIPTION
The shadow supports arbitrary pixel offsets and color, and extends the text box accordingly. The default settings match the common shadow used in CorsixTH.

The default UI font now uses the shadow which helps it pop.