### PR TITLE
Fix debug patients lock-up Operating Theatre room

### DIFF
--- a/CorsixTH/Lua/rooms/operating_theatre.lua
+++ b/CorsixTH/Lua/rooms/operating_theatre.lua
@@ -239,7 +239,7 @@ function OperatingTheatreRoom:commandEnteringPatient(patient)
 
   local screen, sx, sy = self.world:findObjectNear(patient, "surgeon_screen")
   -- Patient walk to surgeon screen
-  patient:queueAction(WalkAction(sx, sy)
+  patient:setNextAction(WalkAction(sx, sy)
     :setMustHappen(true)
     :disableTruncate())
   -- Patient changes into surgical gown


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2862*

**Describe what the proposed change does**
- Looks like bedug patients have another actions queue state when joining the OP. So this change will handle both regular and debug patients.
