### PR TITLE
Show every level's criteria in progress report by сompacting

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
@@ -61,7 +61,7 @@ function UIProgressReport:UIProgressReport(ui)
   local x = 263
   local crit_amount = #crit_data
   -- 30 gap width value is used when there is 5 criterias or less.
-  local gap_width = math.floor(math.min(150/crit_amount, 30))
+  local gap_width = math.floor(math.min(150 / crit_amount, 30))
   for _, crit_table in ipairs(crit_data) do
     crit_table.visible = true
     local crit_name = crit_table.name

--- a/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/progress_report.lua
@@ -57,8 +57,11 @@ function UIProgressReport:UIProgressReport(ui)
 
   -- Collect which criteria to show here, draw columns in draw
   -- Add the icons for the criteria
-  local x = 263
   local crit_data = world.endconditions:generateReportTable(hospital)
+  local x = 263
+  local crit_amount = #crit_data
+  -- 30 gap width value is used when there is 5 criterias or less.
+  local gap_width = math.floor(math.min(150/crit_amount, 30))
   for _, crit_table in ipairs(crit_data) do
     crit_table.visible = true
     local crit_name = crit_table.name
@@ -88,9 +91,10 @@ function UIProgressReport:UIProgressReport(ui)
     if not crit_table.icon_file then -- Icons from QData/Rep02V
       self:addPanel(crit_table.icon, x, 240)
     end
-    self:makeTooltip(tooltip, x, 180, x + 30, 180 + 90)
-    x = x + 30
+    self:makeTooltip(tooltip, x, 180, x + gap_width, 180 + 90)
+    x = x + gap_width
   end
+  self.gap_width = gap_width
   self.crit_data = crit_data
 
   self:addPanel(0, 606, 447):makeButton(0, 0, 26, 26, 8, self.close):setTooltip(_S.tooltip.status.close)
@@ -214,7 +218,7 @@ function UIProgressReport:draw(canvas, x, y)
         local icon_sprites = self.panel_sprites_table[crit_table.icon_file]
         icon_sprites:draw(canvas, crit_table.icon, x + lx, y + 240)
       end
-      lx = lx + 30
+      lx = lx + self.gap_width
     end
   end
 

--- a/CorsixTH/Lua/endconditions.lua
+++ b/CorsixTH/Lua/endconditions.lua
@@ -151,16 +151,9 @@ function EndConditions:generateReportTable(hospital)
     table.insert(report_table, crit_table)
     count = count + 1
   end
-  -- Limit the table to five goals, ordered by progress towards meeting the lose goal
-  if count > 5 then
-    table.sort(report_table, function(a,b) return a.progress > b.progress end)
-    for n = 6, #report_table do report_table[n] = nil end
-  end
-
   -- Fill up the report table with win criteria not already present as lose criteria
   for _, crit in pairs(report_table) do unique_criteria_set[crit.name] = true end
   for i = 1, #local_criteria_variable do
-    if count == 5 then break end
     local name = local_criteria_variable[i].name
     if win_group[name] and not unique_criteria_set[name] then
       count = count + 1


### PR DESCRIPTION
* Fixes #2750 

**Describe what the proposed change does**
- Progress report shows every criteria that is used in level
- Example with six criterias:
<img width="196" height="112" alt="{9EEB944B-0D66-452E-AF4A-E77F1FB4C9AF}" src="https://github.com/user-attachments/assets/03d74908-aee0-41d2-911b-684ecddf393e" />

This is not a perfect solution due to overlapping, it seems that later balance and hospital value icons graphics should be replaced with icons that take less space.