### PR TITLE
Right click in build mode remove window

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1122,7 +1122,9 @@ function UIEditRoom:onLeftButtonDown(x, y)
   end
 end
 
--- Remove window
+--! Attempt to remove a window placed on the room blueprints
+--!param x co-ordinate
+--!param y co-ordinate
 function UIEditRoom:tryRemoveWindowFromWall(x, y)
   local cell_x, cell_y, wall_dir = self:screenToWall(self.x + x, self.y + y)
   if not cell_x then


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2682*

**Changes :**
- In "Window" phase, the right click remove the window from the wall and reset to the default transparent wall.
- Move right and left click logic in dedicated method.

Note : 
As the cursor is above a wall in "window" phase, after right click, the window is still there because the `blueprint_window` is still valid and we're in build mode. Move the cursor outside this cell to see the window disappear. 
Should we hide the blueprint/window in this case ?

Wall selection to delete is the same as wall construction (Test: Try delete a window with the cursor in the room corner)
