### PR TITLE
Fix Task reassignment error with dead handyman

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
@@ -37,7 +37,7 @@ end
 
 function Handyman:die()
   Staff.die(self)
-  self.hospital:onHandymanDeath(self)
+  self.hospital:unassignHandymanTasks(self)
 end
 
 function Handyman:dump()

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1616,7 +1616,7 @@ end
 
 --! Handyman has died. Remove all tasks assigned to this staff
 --!param handyman The handyman deceased
-function Hospital:onHandymanDeath(handyman)
+function Hospital:unassignHandymanTasks(handyman)
   local tasks = self:findAssignedTasksToHandyman(handyman)
   for _, task in ipairs(tasks) do
     task.assignedHandyman = nil


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->
### Description
*Fixes #2918*

**Describe what the proposed change does**
The hospital is notified when a handyman die in order to clean the current Tasks,
Fixes path finding error when trying to reassign task to dead handyman referenced in tables `Hospital:handymanTasks`.
New method to search for tasks assigned to a Handyman.
 
### Note:
After discussion and more investigation :
This PR is a "hotfix" and does not fix the root issue of multiple tasks assigned to one Handyman.
This fix avoid crash for game saves with Handymans having multiple tasks assigned.
This PR can be closed if #3136 is accepted.

### Test :

This fix cannot be tested on issue's game save ( Handyman already dead ).

To reproduce / test the PR :
- Download the save [ScannerExplodeHandymanDie.zip](https://github.com/user-attachments/files/23109835/ScannerExplodeHandymanDie.zip)
- Keep the only handyman into the scanner room
- Wait for the scanner to explode
- Recruit another handyman ( can be done before explosion )
- Wait few days for the error to happen ( or not if patched )
