### PR TITLE
Build ffmpeg with openssl on macos

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -61,7 +61,11 @@
             "avcodec",
             "avformat",
             "swresample",
-            "swscale"
+            "swscale",
+            {
+              "name": "openssl",
+              "platform": "osx, ios"
+            }
           ]
         }
       ]


### PR DESCRIPTION
**Describe what the proposed change does**
- Vcpkg's ffmpeg uses securetransport on macos and ios, which Apple deprecated and curl dropped earlier this year. As Apple hasn't made a replacement, this adds openssl to ffmpeg. Outside of vcpkg this isn't needed, just build without securetransport or openssl. I include ios because it has the same fault, but there's another issue before ios can be a build platform.