### PR TITLE
FIx crash on hovering exploded rooms

### DIFF
--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -510,7 +510,7 @@ function GameUI:onCursorWorldPositionChange()
     -- Set queue mood for patients queueing the new room
     if room then
       local queue = room.door.queue
-      if #queue > 0 then
+      if queue and #queue > 0 then
         TheApp.ui:playSound("HLIGHTP2.wav")
       end
       if queue then


### PR DESCRIPTION
**Describe what the proposed change does**
- Fixes crash that occurs when player hovers over a destroyed room. It is happening because when room destroyed queue is nil, and lua cant get array length from nil