### PR TITLE
Don't assume staff_member_set for all rooms

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 234 -- Overhaul training
+local SAVEGAME_VERSION = 235 -- Fix staff_member_set applying to all rooms
 
 class "App"
 

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -1076,6 +1076,14 @@ function Room:afterLoad(old, new)
     self.waiting_staff_member = nil
     self.dealt_patient_callback = nil
   end
+  -- Patch the saves post 233 that labelled all rooms as having a staff_member_set
+  if old >= 233 and old < 235 then
+    local room_name = self.room_info.id
+    if room_name ~= "ward" and room_name ~= "operating_theatre" and
+        room_name ~= "research" then
+      self.staff_member_set = nil
+    end
+  end
 end
 
 --[[ Is the room one of the diagnosis rooms for the patient?


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3094*

**Describe what the proposed change does**
- Staff member set was applying to all rooms at once following #2971 
- Reverts this, adds a note to override in derived class instead (we already do)
- Option commit for afterLoad, if we want it
