### PR TITLE
Bump vcpkg dependencies:

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "a67ae9b9f7afc153767a5c33607266252ff9d088",
+    "baseline": "0e39c10736341cc8135b560438229bbda3d3219a",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [
@@ -13,7 +13,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/CorsixTH/vcpkg-registry",
-      "baseline": "1cc12bb832d6b04a22a91d3641b4860c241e6646",
+      "baseline": "e908a2af2d20e68a674dfecd29d062e85d77fbee",
       "packages": [ "ffmpeg" ]
     }
   ]


### PR DESCRIPTION
ffmpeg 7.1.2
fluidsynth 2.5.0
freetype 2.13.3
lpeg 1.1.0#1
lua 5.4.8
luafilesystem 1.8.0#7
sdl2-mixer 2.8.1#2
sdl2 2.32.10
zlib 1.3.1
zstd 1.5.7

Mostly I wanted fluidsynth 2.5.0 so we could try out the glib-less version on the mac.
