### PR TITLE
Add fluidsynth to sdl2_mixer on macos

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,7 +12,6 @@
     "libpng",
     {
        "name": "fluidsynth",
-       "platform": "!osx",
        "features": [
          "sndfile"
        ]
@@ -22,8 +21,7 @@
       "features": [
         "libmodplug",
         {
-          "name": "fluidsynth",
-          "platform": "!osx"
+          "name": "fluidsynth"
         },
         "libflac",
         "mpg123",


### PR DESCRIPTION
**Describe what the proposed change does**
- Fluidsynth and a soundfont will now play MIDI files.

