### PR TITLE
Cut down on hover chime

### DIFF
--- a/CorsixTH/Lua/dialogs/build_room.lua
+++ b/CorsixTH/Lua/dialogs/build_room.lua
@@ -41,6 +41,7 @@ function UIBuildRoom:UIBuildRoom(ui)
   self.blue_font = app.gfx:loadFontAndSpriteTable("QData", "Font02V", nil, nil, {ttf_color = selected_label_color})
   self.category_index = 0
   self.list_hover_index = 0
+  self.hover_sound = nil
   self.preview_anim = false
   self.default_button_sound = "selectx.wav"
 
@@ -206,7 +207,10 @@ function UIBuildRoom:onMouseMove(x, y, dx, dy)
   end
 
   if hover_idx ~= self.list_hover_index then
-    self.ui:playSound("HLight5.wav")
+    if self.hover_sound then
+      self.ui:stopSound(self.hover_sound)
+    end
+    self.hover_sound = self.ui:playSound("HLight5.wav")
     if hover_idx == 0 then
       self.cost_box = _S.build_room_window.cost .. "0"
       self.preview_anim = false

--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -52,6 +52,8 @@ function UIStaffManagement:UIStaffManagement(ui)
   self.default_button_sound = "selectx.wav"
   self.hover_id = 0
   self.visual_hover_id = 0
+  self.hover_sound = nil;
+
 
   -- Close button
   self:addPanel(0, 603, 443):makeButton(0, 0, 26, 26, 10, self.close):setTooltip(_S.tooltip.staff_list.close)
@@ -462,7 +464,10 @@ function UIStaffManagement:onMouseMove(x, y, dx, dy)
     if #self.staff_members[self.category] - (self.page - 1)*10 > active_hover_id then
       current_hover_id = active_hover_id + 1 + (self.page - 1)*10
       if self.hover_id ~= current_hover_id then
-        self.ui:playSound("Hlight5.wav")
+        if self.hover_sound then
+          self.ui:stopSound(self.hover_sound)
+        end
+        self.hover_sound = self.ui:playSound("Hlight5.wav")
         self.hover_id = current_hover_id
         self.visual_hover_id = current_hover_id
       end

--- a/CorsixTH/Lua/dialogs/furnish_corridor.lua
+++ b/CorsixTH/Lua/dialogs/furnish_corridor.lua
@@ -56,6 +56,7 @@ function UIFurnishCorridor:UIFurnishCorridor(ui, objects, edit_dialog)
   self.total_price = 0
 
   self.list_hover_index = 0
+  self.hover_sound = nil
   self.preview_anim = TH.animation()
 
   self.objects = {
@@ -244,7 +245,10 @@ function UIFurnishCorridor:onMouseMove(x, y, dx, dy)
       local obj = self.objects[hover_idx].object
       self.item_price = self.ui.hospital:getObjectBuildCost(obj.id)
       self.preview_anim:setAnimation(self.anims, obj.build_preview_animation)
-      self.ui:playSound("HLight5.wav")
+      if self.hover_sound then
+        self.ui:stopSound(self.hover_sound)
+      end
+      self.hover_sound = self.ui:playSound("HLight5.wav")
     end
     self.list_hover_index = hover_idx
     repaint = true

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -263,7 +263,10 @@ function UIMenuBar:onMouseMove(x, y, dx, dy)
         visible = true
         if hit ~= true then
           if hit ~= menu.prev_hover_index then
-            self.ui:playSound("HLight5.wav")
+            if menu.hover_sound then
+              self.ui:stopSound(menu.hover_sound)
+            end
+            menu.hover_sound = self.ui:playSound("HLight5.wav")
           end
           menu.hover_index = hit
           menu.prev_hover_index = menu.hover_index
@@ -479,6 +482,7 @@ function UIMenu:UIMenu()
   self.parent = false
   self.hover_index = 0
   self.prev_hover_index = nil
+  self.hover_sound = nil
   self.has_size = false
 end
 

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -234,6 +234,7 @@ function UIPlaceObjects:addObjects(object_list, pay_for)
 
   self.active_index = 0 -- avoid case of index changing from 1 to 1
   self.active_hover_index = 0
+  self.hover_sound = nil
   self:setActiveIndex(1)
   self:onCursorWorldPositionChange(self.ui:getCursorPosition(self))
 end
@@ -596,7 +597,10 @@ function UIPlaceObjects:onMouseMove(x, y, dx, dy)
     if (header_height+y) % bar_height < 21 then
       current_hover_id = math_floor((y - header_height)/bar_height) + 1
       if self.active_hover_index ~= current_hover_id then
-        self.ui:playSound("Hlight5.wav")
+        if self.hover_sound then
+          self.ui:stopSound(self.hover_sound)
+        end
+        self.hover_sound = self.ui:playSound("Hlight5.wav")
         self.active_hover_index = current_hover_id
       end
     else

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -228,8 +228,15 @@ end
 -- Used for everything except music and announcements
 function UI:playSound(name, played_callback, played_callback_delay)
   if self.app.config.play_sounds then
-    self.app.audio:playSound(name, nil, false, played_callback, played_callback_delay)
+    return self.app.audio:playSound(name, nil, false, played_callback, played_callback_delay)
   end
+end
+
+--! Stop the given sound
+-- see Audio:stopSound
+--!param sound (table) sound to stop
+function UI:stopSound(sound)
+  self.app.audio:stopSound(sound)
 end
 
 -- Stub with args for subclass GameUI.


### PR DESCRIPTION
Only play one hover sound at a time in various dialogs. This keeps the hover noise from escalating when moving the mouse quickly over a list of items.
