### PR TITLE
World: apply level_config StartPrice to cure_price (init + afterLoad)

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -249,20 +249,26 @@ function World:initLevel(app, avail_rooms)
     end
   end
   -- Apply level-defined pricing to diseases on new game:
-  if level_config and level_config.expertise and #self.available_diseases > 0 then
-    for _, dis in ipairs(self.available_diseases) do
-      local ex = dis.expertise_id and level_config.expertise[dis.expertise_id]
-      if ex and ex.StartPrice then
-        dis.cure_price = ex.StartPrice
-      end
-    end
-  end
+  self:applyLevelStartPrices()
   if #self.available_diseases == 0 and self.map.level_number ~= "MAP EDITOR" then
     -- No diseases are needed if we're actually in the map editor!
     print("Warning: This level does not contain any diseases")
   end
 
   self:determineWinningConditions()
+end
+
+-- Apply level-defined pricing to all available diseases.
+function World:applyLevelStartPrices()
+  local lc = self.map and self.map.level_config
+  if not (lc and lc.expertise and self.available_diseases) then return end
+
+  for _, dis in ipairs(self.available_diseases) do
+    local ex = dis.expertise_id and lc.expertise[dis.expertise_id]
+    if ex and ex.StartPrice then
+      dis.cure_price = ex.StartPrice
+    end
+  end
 end
 
 function World:toggleInformation()
@@ -2212,17 +2218,7 @@ end
 function World:afterLoad(old, new)
   self:setUI(self.ui)
   -- Re-apply level-defined pricing when loading saves:
-  do
-    local lc = self.map and self.map.level_config
-    if lc and lc.expertise and self.available_diseases then
-      for _, dis in ipairs(self.available_diseases) do
-        local ex = dis.expertise_id and lc.expertise[dis.expertise_id]
-        if ex and ex.StartPrice then
-          dis.cure_price = ex.StartPrice
-        end
-      end
-    end
-  end
+  self:applyLevelStartPrices()
   -- insert global compatibility code here
   if old < 4 then
     self.room_built = {}


### PR DESCRIPTION
### Summary
- On new game (`World:initLevel`), set each `disease.cure_price` from `level_config.expertise[expertise_id].StartPrice` .
- On save load (`World:afterLoad`), re-apply the same so updated level data also affect existing saves.
- Uses `~= nil` so `StartPrice = 0` is respected.

### Testing
- **Init:** Verified in logs that `bloaty_head` follows `expertise[2].StartPrice`.
- **Load:** Temporarily modified `StartPrice` in `Map:afterLoad` for a save; logs show `AFTERLOAD` updating `cure_price`.
- **UI:** Drug Casebook reflects the StartPrice (with Hospital Policy multiplier at default).

Fixes #2602 