### PR TITLE
Improving patients dying

### DIFF
--- a/CorsixTH/Lua/dialogs/patient.lua
+++ b/CorsixTH/Lua/dialogs/patient.lua
@@ -285,7 +285,7 @@ function UIPatient:updateInformation()
   self.disease_blanker.visible = not show_dis_btn
 
   -- Show go home?
-  local show_home_btn = not patient.going_home
+  local show_home_btn = not patient.going_home and not patient.going_die
   self.home_button.enabled = show_home_btn
   self.home_button.visible = show_home_btn
   self.home_blanker.visible = not show_home_btn
@@ -294,6 +294,7 @@ function UIPatient:updateInformation()
   local show_guess_btn = not (patient.is_debug or
       patient.diagnosis_progress == 0 or
       patient.diagnosed or
+      patient.going_die or
       patient.going_home)
   self.guess_button.enabled = show_guess_btn
   self.guess_button.visible = show_guess_btn
@@ -330,7 +331,7 @@ function UIPatient:guessDisease()
   local patient = self.patient
   -- NB: the first line of conditions should already be ruled out by button being disabled, but just in case
   if patient.is_debug or patient.diagnosis_progress == 0 or patient.diagnosed or
-      patient.going_home or patient:getRoom() or
+      patient.going_home or patient.going_die or patient:getRoom() or
       not patient.hospital.disease_casebook[patient.disease.id].discovered then
     self.ui:playSound("wrong2.wav")
     return

--- a/CorsixTH/Lua/dialogs/patient.lua
+++ b/CorsixTH/Lua/dialogs/patient.lua
@@ -285,7 +285,7 @@ function UIPatient:updateInformation()
   self.disease_blanker.visible = not show_dis_btn
 
   -- Show go home?
-  local show_home_btn = not patient.going_home and not patient.going_die
+  local show_home_btn = not patient.going_home and not patient.going_to_die
   self.home_button.enabled = show_home_btn
   self.home_button.visible = show_home_btn
   self.home_blanker.visible = not show_home_btn
@@ -294,7 +294,7 @@ function UIPatient:updateInformation()
   local show_guess_btn = not (patient.is_debug or
       patient.diagnosis_progress == 0 or
       patient.diagnosed or
-      patient.going_die or
+      patient.going_to_die or
       patient.going_home)
   self.guess_button.enabled = show_guess_btn
   self.guess_button.visible = show_guess_btn
@@ -331,7 +331,7 @@ function UIPatient:guessDisease()
   local patient = self.patient
   -- NB: the first line of conditions should already be ruled out by button being disabled, but just in case
   if patient.is_debug or patient.diagnosis_progress == 0 or patient.diagnosed or
-      patient.going_home or patient.going_die or patient:getRoom() or
+      patient.going_home or patient.going_to_die or patient:getRoom() or
       not patient.hospital.disease_casebook[patient.disease.id].discovered then
     self.ui:playSound("wrong2.wav")
     return

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -700,9 +700,9 @@ function Humanoid:isLeaving()
   return self.action_queue[1].is_leaving and true or false
 end
 
--- Check if the humanoid is knocking door
+-- Check if the humanoid is knocking on a door
 function Humanoid:isKnockingDoor()
-  return class.is(self.action_queue[1], KnockDoorAction)
+  return class.is(self:getCurrentAction(), KnockDoorAction)
 end
 
 -- Check if the humanoid is entering room
@@ -906,7 +906,7 @@ end
 -- feeling of warmth accordingly. Returns whether the calling function should proceed.
 function Humanoid:tickDay()
   -- No use doing anything if we're going home/fired (or dead)
-  if self.going_home or self.going_die or self.dead then
+  if self.going_home or self.going_to_die or self.dead then
     return false
   end
 

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -700,6 +700,19 @@ function Humanoid:isLeaving()
   return self.action_queue[1].is_leaving and true or false
 end
 
+-- Check if the humanoid is knocking door
+function Humanoid:isKnockingDoor()
+  return class.is(self.action_queue[1], KnockDoorAction)
+end
+
+-- Check if the humanoid is entering room
+function Humanoid:isEnteringRoom()
+  if self.user_of and self.user_of.object_type.id == "door" then
+    return true
+  end
+  return false
+end
+
 -- Check if there is "is_leaving" action in the action queue
 function Humanoid:hasLeavingAction()
   for _, action in ipairs(self.action_queue) do
@@ -893,7 +906,7 @@ end
 -- feeling of warmth accordingly. Returns whether the calling function should proceed.
 function Humanoid:tickDay()
   -- No use doing anything if we're going home/fired (or dead)
-  if self.going_home or self.dead then
+  if self.going_home or self.going_die or self.dead then
     return false
   end
 

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -39,13 +39,13 @@ function Patient:Patient(...)
   self.pay_amount = 0
   -- To distinguish between actually being dead and having a nil hospital
   self.dead = false
-  -- Indicates that the patient is being put on death. Patient may be busy,
-  -- But as soon as he is deoccupy he will start the dying scenario based on this flag
-  -- Except cases are when he is cured or sent home while being busy
+  -- Indicates that the patient is being marked for death. The patient may be busy,
+  -- But as soon as the patient is unoccupied he will start the dying scenario based
+  -- on this flag, except the cases when he is cured or sent home while being busy.
   self.set_to_die = false
   -- Indicates that the patient on the dying scenario
   -- Cure should not happen at this state. Patient can't be sent home
-  self.going_die = false
+  self.going_to_die = false
   -- Is the patient reserved for a particular nurse when being vaccinated
   self.reserved_for = false
   self.vaccinated = false
@@ -100,7 +100,7 @@ function Patient:onClick(ui, button)
     self.user_of:onClick(ui, button)
   elseif button == "right" then
     -- Attempt to push patient over
-    if not self.world:isPaused() and not (self.cured or self.going_die or self.dead or self.going_home)
+    if not self.world:isPaused() and not (self.cured or self.going_to_die or self.dead or self.going_home)
          and math.random(1, 2) == 2 then
       self:falling(true)
     end
@@ -373,7 +373,7 @@ function Patient:die()
   -- Remove any messages and/or callbacks related to the patient.
   self:unregisterCallbacks()
 
-  self.going_die = true
+  self.going_to_die = true
   if self:getRoom() then
     self:queueAction(MeanderAction():setCount(1))
   else
@@ -392,7 +392,7 @@ local good_actions = {walk=true, idle=true, seek_room=true, queue=true}
 --!return Whether the tile can be used for inserting an action.
 function Patient:atFullyEmptyTile(cur_action)
   if not good_actions[cur_action.name] then return false end
-  if self.going_home or self.going_die then return false end
+  if self.going_home or self.going_to_die then return false end
 
   local th = self.world.map.th
   local cell_flags = th:getCellFlags(self.tile_x, self.tile_y)
@@ -582,7 +582,7 @@ end
 
 function Patient:setToDying()
   -- Check that the patient is in a later state of dying
-  if self.going_die or self.dead then return end
+  if self.going_to_die or self.dead then return end
 
   self.set_to_die = true
 end
@@ -912,7 +912,7 @@ function Patient:setTile(x, y)
       self.litter_countdown = math.random(20, 100)
     end
 
-  elseif self.hospital and not self.going_die and not self.going_home then
+  elseif self.hospital and not self.going_to_die and not self.going_home then
     self.litter_countdown = self.litter_countdown - 1
 
     -- Is the patient about to drop some litter?

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -990,7 +990,7 @@ end
 function Patient:updateDynamicInfo()
   local action_string = self.action_string or ""
   local info = ""
-  if self.going_home or self.going_die then
+  if self.going_home or self.going_to_die then
     self:setDynamicInfo('progress', nil)
   elseif self.diagnosed then
     if self.diagnosis_progress < 1.0 then

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -39,6 +39,13 @@ function Patient:Patient(...)
   self.pay_amount = 0
   -- To distinguish between actually being dead and having a nil hospital
   self.dead = false
+  -- Indicates that the patient is being put on death. Patient may be busy,
+  -- But as soon as he is deoccupy he will start the dying scenario based on this flag
+  -- Except cases are when he is cured or sent home while being busy
+  self.set_to_die = false
+  -- Indicates that the patient on the dying scenario
+  -- Cure should not happen at this state. Patient can't be sent home
+  self.going_die = false
   -- Is the patient reserved for a particular nurse when being vaccinated
   self.reserved_for = false
   self.vaccinated = false
@@ -93,7 +100,7 @@ function Patient:onClick(ui, button)
     self.user_of:onClick(ui, button)
   elseif button == "right" then
     -- Attempt to push patient over
-    if not self.world:isPaused() and not (self.cured or self.dead or self.going_home)
+    if not self.world:isPaused() and not (self.cured or self.going_die or self.dead or self.going_home)
          and math.random(1, 2) == 2 then
       self:falling(true)
     end
@@ -354,14 +361,19 @@ end
 
 --! Patient died, process the event.
 function Patient:die()
+  self.set_to_die = false
+  if self.cured then return end
+
   -- It may happen that this patient was just cured and then the room blew up.
   self.hospital:humanoidDeath(self)
+
+  self:setMood("dying5", "deactivate")
   self:setMood("dead", "activate")
 
   -- Remove any messages and/or callbacks related to the patient.
   self:unregisterCallbacks()
 
-  self.going_home = true
+  self.going_die = true
   if self:getRoom() then
     self:queueAction(MeanderAction():setCount(1))
   else
@@ -380,7 +392,7 @@ local good_actions = {walk=true, idle=true, seek_room=true, queue=true}
 --!return Whether the tile can be used for inserting an action.
 function Patient:atFullyEmptyTile(cur_action)
   if not good_actions[cur_action.name] then return false end
-  if self.going_home then return false end
+  if self.going_home or self.going_die then return false end
 
   local th = self.world.map.th
   local cell_flags = th:getCellFlags(self.tile_x, self.tile_y)
@@ -568,6 +580,25 @@ function Patient:_checkIfCureRoom(room)
       and self.diagnosed)
 end
 
+function Patient:setToDying()
+  -- Check that the patient is in a later state of dying
+  if self.going_die or self.dead then return end
+
+  self.set_to_die = true
+end
+
+function Patient:tick()
+  Humanoid.tick(self)
+
+  if self.set_to_die and
+    not self:getRoom() and
+    not self:getCurrentAction().is_leaving and
+    not self:isKnockingDoor() and
+    not self:isEnteringRoom() then
+      self:die()
+  end
+end
+
 -- This function handles changing of the different attributes of the patient.
 -- For example if thirst gets over a certain level (now: 0.7), the patient
 -- tries to find a drinks machine nearby.
@@ -648,10 +679,7 @@ function Patient:tickDay()
     self.attributes["health"] = 0.0
   -- is there time to say a prayer
   elseif health == 0.0 then
-    if not self:getRoom() and not self:getCurrentAction().is_leaving then
-      self:setMood("dying5", "deactivate")
-      self:die()
-    end
+    self:setToDying()
     -- Patient died, will die when they leave the room, will be cured, or is leaving
     -- the hospital. Regardless we do not need to adjust any other attribute
     return
@@ -884,7 +912,7 @@ function Patient:setTile(x, y)
       self.litter_countdown = math.random(20, 100)
     end
 
-  elseif self.hospital and not self.going_home then
+  elseif self.hospital and not self.going_die and not self.going_home then
     self.litter_countdown = self.litter_countdown - 1
 
     -- Is the patient about to drop some litter?
@@ -962,7 +990,7 @@ end
 function Patient:updateDynamicInfo()
   local action_string = self.action_string or ""
   local info = ""
-  if self.going_home then
+  if self.going_home or self.going_die then
     self:setDynamicInfo('progress', nil)
   elseif self.diagnosed then
     if self.diagnosis_progress < 1.0 then

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -247,7 +247,7 @@ function Epidemic:checkInfectedLeftHospital()
   for _, infected_patient in ipairs(self.infected_patients) do
     local px, py = infected_patient.tile_x, infected_patient.tile_y
     -- If leaving and no longer in the hospital.
-    if (infected_patient.going_home or infected_patient.going_die) and not infected_patient.cured and
+    if (infected_patient.going_home or infected_patient.going_to_die) and not infected_patient.cured and
         px and py and not self.hospital:isInHospital(px,py) then
       -- Patient escaped from the hospital, discovery is inevitable.
       self:finishCoverUp()
@@ -274,7 +274,7 @@ otherwise a player may never win the epidemic in such a case.]]
 function Epidemic:checkPatientsForRemoval()
   for i = #self.infected_patients, 1, -1 do
     local infected_patient = self.infected_patients[i]
-    if (not self.coverup_selected and (infected_patient.going_home or infected_patient.going_die)) or
+    if (not self.coverup_selected and (infected_patient.going_home or infected_patient.going_to_die)) or
         infected_patient.dead or infected_patient.tile_x == nil then
       table.remove(self.infected_patients,i)
     end
@@ -534,7 +534,7 @@ function Epidemic:evacuateHospital()
   for _, patient in ipairs(self.hospital.patients) do
     if patient.has_passed_reception and
       not patient.going_home and
-      not patient.going_die then
+      not patient.going_to_die then
         patient:goHome("evacuated")
     end
   end

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -247,7 +247,7 @@ function Epidemic:checkInfectedLeftHospital()
   for _, infected_patient in ipairs(self.infected_patients) do
     local px, py = infected_patient.tile_x, infected_patient.tile_y
     -- If leaving and no longer in the hospital.
-    if infected_patient.going_home and not infected_patient.cured and
+    if (infected_patient.going_home or infected_patient.going_die) and not infected_patient.cured and
         px and py and not self.hospital:isInHospital(px,py) then
       -- Patient escaped from the hospital, discovery is inevitable.
       self:finishCoverUp()
@@ -274,7 +274,7 @@ otherwise a player may never win the epidemic in such a case.]]
 function Epidemic:checkPatientsForRemoval()
   for i = #self.infected_patients, 1, -1 do
     local infected_patient = self.infected_patients[i]
-    if (not self.coverup_selected and infected_patient.going_home) or
+    if (not self.coverup_selected and (infected_patient.going_home or infected_patient.going_die)) or
         infected_patient.dead or infected_patient.tile_x == nil then
       table.remove(self.infected_patients,i)
     end
@@ -532,8 +532,10 @@ end
 --[[ Forces evacuation of the hospital - it makes ALL patients leave and storm out. ]]
 function Epidemic:evacuateHospital()
   for _, patient in ipairs(self.hospital.patients) do
-    if patient.has_passed_reception and not patient.going_home then
-      patient:goHome("evacuated")
+    if patient.has_passed_reception and
+      not patient.going_home and
+      not patient.going_die then
+        patient:goHome("evacuated")
     end
   end
 end

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1136,8 +1136,8 @@ function Hospital:resolveEmergency()
   local rescued_patients = emer.cured_emergency_patients
   for _, patient in ipairs(self.emergency_patients) do
     if patient and not patient.cured and not patient.dead
-        and not patient.going_home and not patient:getRoom() then
-      patient:die()
+        and not patient.going_home then
+      patient:setToDying()
     end
   end
   local total = emer.victims

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -753,7 +753,7 @@ local function tryMovePatient(old_room, new_room, patient)
 
   local px, py = patient.tile_x, patient.tile_y
   -- Don't reroute the patient if he just decided to go to the toilet or is going home
-  if patient.going_to_toilet ~= "no" or patient.going_home then
+  if patient.going_to_toilet ~= "no" or patient.going_home or patient.going_die then
     return false
   end
 

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -753,7 +753,7 @@ local function tryMovePatient(old_room, new_room, patient)
 
   local px, py = patient.tile_x, patient.tile_y
   -- Don't reroute the patient if he just decided to go to the toilet or is going home
-  if patient.going_to_toilet ~= "no" or patient.going_home or patient.going_die then
+  if patient.going_to_toilet ~= "no" or patient.going_home or patient.going_to_die then
     return false
   end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3055*
*Fixes #1584*

**Describe what the proposed change does**
- Now if it's time for a patient to die by the timer, instead of trying to kill him instantly, he is transferred to a state `set_to_die`.
- `patient.set_to_die = true` a more transparent and understandable state name instead of `patient.attributes["health"] = 0.0`.
- Each tick `going_to_die` is being checked. If it is true and all other conditions and situation are suitable, only then the dying scenario is launched.
- Added checks for the patient knocking on the door or opening the door as inappropriate moments for running the dying scenario.
- The scenario of dying after unsuccessful treatment does not fall under this category, since there is no delay and the patient's situation is known in advance at treatment end phase.
- Previously when the patient's dying scenario was triggered, the `patient.going_home` flag was set to true (If patient goes to heaven, this is this how patient goes home?...), which is logically incorrect and created traps in other places. Instead there is new a `patient.going_to_die`.

```lua
  -- Indicates that the patient is being put on death. Patient may be busy,
  -- But as soon as he is deoccupy he will start the dying scenario based on this flag
  -- Except cases are when he is cured or sent home while being busy
  self.set_to_die = false
  -- Indicates that the patient on the dying scenario
  -- Cure should not happen at this state. Patient can't be sent home
  self.going_to_die = false
    -- To distinguish between actually being dead and having a nil hospital
  self.dead = false
  ```
  
  Perhaps more understandable names could be thought up for these flags.