### PR TITLE
[WIP] Add proxies for partial rendering of the same animation from multiple tiles.

### DIFF
--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2702;
+return 2703;

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -78,25 +78,27 @@ function Object:initOrientation(direction)
   if footprint and footprint.list_bottom then
     flags = flags + 2048
   end
-  local rap = footprint and footprint.render_attach_position
-  if rap and rap[1] and type(rap[1]) == "table" then
-    self.split_anims = {self.th}
-    self.split_anim_positions = rap
-    self.th:setCrop(rap[1].column)
-    for i = 2, #rap do
-      local point = rap[i]
-      local th = TH.animation()
-      th:setCrop(point.column)
-      th:setHitTestResult(self)
-      th:setPosition(Map:WorldToScreen(1-point[1], 1-point[2]))
-      self.split_anims[i] = th
-    end
-  else
+
+  -- local rap = footprint and footprint.render_attach_position
+  -- if rap and rap[1] and type(rap[1]) == "table" then
+  --   self.split_anims = {self.th}
+  --   self.split_anim_positions = rap
+  --   self.th:setCrop(rap[1].column)
+    -- for i = 2, #rap do
+    --   local point = rap[i]
+    --   local th = TH.animation()
+    --   th:setCrop(point.column)
+    --   th:setHitTestResult(self)
+    --   th:setPosition(Map:WorldToScreen(1-point[1], 1-point[2]))
+    --   self.split_anims[i] = th
+    -- end
+  -- else
     -- Make sure these variables aren't left behind. The object
     -- might just have been moved and rotated.
     self.split_anims = nil
     self.split_anim_positions = nil
-  end
+  -- end
+
   if footprint and footprint.animation_offset then
     self:setPosition(unpack(footprint.animation_offset))
   end

--- a/CorsixTH/Lua/objects/bed.lua
+++ b/CorsixTH/Lua/objects/bed.lua
@@ -90,7 +90,7 @@ object.orientations = {
                   {0, -1, complete_cell = true}, {-1, 0, complete_cell = true},
                   {0, 0, complete_cell = true} },
     use_position = {1, 0},
-    render_attach_position = {{-2,0},{-1,0},{0,0},{0,-1,}},
+    -- render_attach_position = {{-2,0},{-1,0},{0,0},{0,-1,}},
   },
   west = {
     footprint = { {-1, 1, only_passable = true}, {-1, -1, complete_cell = true},

--- a/CorsixTH/Lua/objects/bench.lua
+++ b/CorsixTH/Lua/objects/bench.lua
@@ -125,7 +125,7 @@ object.usage_animations = {
 }
 object.orientations = {
   north = {
-    render_attach_position = { {0, 0}, {-1, 0}, {0, -1} },
+    -- render_attach_position = { {0, 0}, {-1, 0}, {0, -1} },
     footprint = { {0, 0, complete_cell = true}, {0, -1, only_passable = true, invisible = true, shareable = true} },
     use_position = "passable",
   },

--- a/CorsixTH/Lua/objects/crash_trolley.lua
+++ b/CorsixTH/Lua/objects/crash_trolley.lua
@@ -83,7 +83,7 @@ object.multi_usage_animations = {
 }
 object.orientations = {
   north = {
-    render_attach_position = { {0, 0}, {-1, 1} },
+    -- render_attach_position = { {0, 0}, {-1, 1} },
     footprint = { {-1, 0, complete_cell = true}, {-1, 1, only_passable = true},
       {0, 0, only_passable = true}, {0, 1, only_passable = true} },
     use_position = {-1, 1},
@@ -91,7 +91,7 @@ object.orientations = {
     list_bottom = true,
   },
   east = {
-    render_attach_position = { {0, 0}, {1, -1} },
+    -- render_attach_position = { {0, 0}, {1, -1} },
     footprint = { {0, -1, complete_cell = true}, {0, 0, only_passable = true},
       {1, -1, only_passable = true}, {1, 0, only_passable = true} },
     use_position = {1, -1},

--- a/CorsixTH/Lua/objects/machines/ultrascanner.lua
+++ b/CorsixTH/Lua/objects/machines/ultrascanner.lua
@@ -79,7 +79,7 @@ object.orientations = {
     smoke_position = {0, 0},
   },
   east = {
-    render_attach_position = { {0, 0}, {1, 0}, {-1, 1} },
+    -- render_attach_position = { {0, 0}, {1, 0}, {-1, 1} },
     footprint = { {-1, -1, complete_cell = true}, {0, -1, only_passable = true, need_north_side = true},
                   {1, -1, only_passable = true, need_north_side = true},
                   {-1, 0, complete_cell = true}, {0, 0}, {1, 0, only_passable = true},

--- a/CorsixTH/Lua/objects/sofa.lua
+++ b/CorsixTH/Lua/objects/sofa.lua
@@ -105,7 +105,7 @@ object.orientations = {
     use_position = "passable",
   },
   south = {
-    render_attach_position = { {0, 0}, {-1, 1} },
+    -- render_attach_position = { {0, 0}, {-1, 1} },
     footprint = { {-1, 0, complete_cell = true}, {0, 0, complete_cell = true}, {-1, 1, only_passable = true} },
     use_position = "passable",
   },

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1042,9 +1042,7 @@ void animation_manager::get_frame_extent(size_t iFrame, const ::layers& oLayers,
 
 chunk_renderer::chunk_renderer(const int width, const int height,
                                std::vector<uint8_t>::iterator start)
-    : ptr(start),
-      end(start + (width * height)),
-      width(width) {}
+    : ptr(start), end(start + (width * height)), width(width) {}
 
 void chunk_renderer::chunk_fill_to_end_of_line(uint8_t value) {
   if (x != 0 || !skip_eol) {
@@ -1182,23 +1180,21 @@ void animation_base::set_layer(int iLayer, int iId) {
   }
 }
 
-
 animation_proxy::animation_proxy(animation* const parent_anim, int8_t dx,
-                                 int8_t dy, int8_t crop_base,
-                                 int8_t crop_width)
+                                 int8_t dy, int8_t crop_base, int8_t crop_width)
     : parent_anim(parent_anim),
       dx(dx),
       dy(dy),
       crop_base(crop_base),
-      crop_width(crop_width) { }
+      crop_width(crop_width) {}
 
 void animation_proxy::attach_to_map(level_map* game_map, int x, int y,
                                     int layer) {
-    throw std::runtime_error("Unexpected attach_to_map call.");
+  throw std::runtime_error("Unexpected attach_to_map call.");
 }
 
 void animation_proxy::remove_from_tile() {
-  remove_self_from_tile(); // Better be safe than sorry.
+  remove_self_from_tile();  // Better be safe than sorry.
   parent_anim->remove_from_tile();
 }
 
@@ -1212,19 +1208,19 @@ void animation_proxy::draw_fn(render_target* canvas, int dest_x, int dest_y) {
   int delta_y = (dx + dy) * 16;
 
   if (crop_width > 0) {
-      clip_rect new_clipt_rectangle;
-      new_clipt_rectangle.y = 0;
-      new_clipt_rectangle.h = canvas->get_height();
-      new_clipt_rectangle.x = delta_x + crop_base * 32;
-      new_clipt_rectangle.w = crop_width * 32;
+    clip_rect new_clipt_rectangle;
+    new_clipt_rectangle.y = 0;
+    new_clipt_rectangle.h = canvas->get_height();
+    new_clipt_rectangle.x = delta_x + crop_base * 32;
+    new_clipt_rectangle.w = crop_width * 32;
 
-      parent_anim->draw_fn(canvas, dest_x - delta_x, dest_y - delta_y);
+    parent_anim->draw_fn(canvas, dest_x - delta_x, dest_y - delta_y);
   } else {
     parent_anim->draw_fn(canvas, dest_x - delta_x, dest_y - delta_y);
   }
 }
 bool animation_proxy::hit_test_fn(int dest_x, int dest_y, int test_x,
-                                  int test_y)  {
+                                  int test_y) {
   // Compute offset of the xy position of the proxy wrt the animation.
   int delta_x = (dx - dy) * 32;
   int delta_y = (dx + dy) * 16;
@@ -1236,7 +1232,6 @@ bool animation_proxy::is_multiple_frame_animation_fn() {
   return parent_anim->is_multiple_frame_animation_fn();
 }
 
-
 namespace {
 
 bool are_flags_set(uint32_t val, uint32_t flags) {
@@ -1247,9 +1242,7 @@ bool are_flags_set(uint32_t val, uint32_t flags) {
 
 animation::animation() { patient_effect_offset = rand(); }
 
-animation::~animation() {
-  animation::remove_from_tile();
-}
+animation::~animation() { animation::remove_from_tile(); }
 
 void animation::attach_to_map(level_map* game_map, int x, int y, int layer) {
   map_tile* node = game_map->get_tile(x, y);
@@ -1785,7 +1778,7 @@ void animation::add_proxy(int8_t dx, int8_t dy, int8_t crop_base,
 }
 
 void animation::remove_all_proxies_from_tile() {
-  for (auto &proxy: proxies) {
+  for (auto& proxy : proxies) {
     proxy.remove_self_from_tile();
   }
 }

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1156,12 +1156,7 @@ void animation_base::remove_from_tile() {
 
 void animation_base::attach_to_tile(int x, int y, map_tile* node, int layer) {
   remove_from_tile();
-  link_list* pList;
-  if (flags & thdf_early_list) {
-    pList = &node->oEarlyEntities;
-  } else {
-    pList = &node->entities;
-  }
+  link_list* pList = &node->entities;
 
   this->set_drawing_layer(layer);
   this->set_tile(x, y);

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -142,12 +142,12 @@ class memory_reader {
 
 animation_manager::animation_manager()
     : sheet(nullptr),
+      canvas(nullptr),
       animation_count(0),
       frame_count(0),
       element_list_count(0),
       element_count(0),
-      game_ticks(0),
-      canvas(nullptr) {}
+      game_ticks(0) {}
 
 void animation_manager::set_sprite_sheet(sprite_sheet* pSpriteSheet) {
   sheet = pSpriteSheet;
@@ -1042,7 +1042,9 @@ void animation_manager::get_frame_extent(size_t iFrame, const ::layers& oLayers,
 
 chunk_renderer::chunk_renderer(const int width, const int height,
                                std::vector<uint8_t>::iterator start)
-    : width(width), height(height), ptr(start), end(start + (width * height)) {}
+    : ptr(start),
+      end(start + (width * height)),
+      width(width) {}
 
 void chunk_renderer::chunk_fill_to_end_of_line(uint8_t value) {
   if (x != 0 || !skip_eol) {
@@ -1185,6 +1187,61 @@ void animation_base::set_layer(int iLayer, int iId) {
   }
 }
 
+
+animation_proxy::animation_proxy(animation* const parent_anim, int8_t dx,
+                                 int8_t dy, int8_t crop_base,
+                                 int8_t crop_width)
+    : parent_anim(parent_anim),
+      dx(dx),
+      dy(dy),
+      crop_base(crop_base),
+      crop_width(crop_width) { }
+
+void animation_proxy::attach_to_map(level_map* game_map, int x, int y,
+                                    int layer) {
+    throw std::runtime_error("Unexpected attach_to_map call.");
+}
+
+void animation_proxy::remove_from_tile() {
+  remove_self_from_tile(); // Better be safe than sorry.
+  parent_anim->remove_from_tile();
+}
+
+void animation_proxy::remove_self_from_tile() {
+  animation_base::remove_from_tile();
+}
+
+void animation_proxy::draw_fn(render_target* canvas, int dest_x, int dest_y) {
+  // Compute offset of the xy position of the proxy wrt the animation.
+  int delta_x = (dx - dy) * 32;
+  int delta_y = (dx + dy) * 16;
+
+  if (crop_width > 0) {
+      clip_rect new_clipt_rectangle;
+      new_clipt_rectangle.y = 0;
+      new_clipt_rectangle.h = canvas->get_height();
+      new_clipt_rectangle.x = delta_x + crop_base * 32;
+      new_clipt_rectangle.w = crop_width * 32;
+
+      parent_anim->draw_fn(canvas, dest_x - delta_x, dest_y - delta_y);
+  } else {
+    parent_anim->draw_fn(canvas, dest_x - delta_x, dest_y - delta_y);
+  }
+}
+bool animation_proxy::hit_test_fn(int dest_x, int dest_y, int test_x,
+                                  int test_y)  {
+  // Compute offset of the xy position of the proxy wrt the animation.
+  int delta_x = (dx - dy) * 32;
+  int delta_y = (dx + dy) * 16;
+
+  return parent_anim->hit_test_fn(dest_x - delta_x, dest_y - delta_y, test_x,
+                                  test_y);
+}
+bool animation_proxy::is_multiple_frame_animation_fn() {
+  return parent_anim->is_multiple_frame_animation_fn();
+}
+
+
 namespace {
 
 bool are_flags_set(uint32_t val, uint32_t flags) {
@@ -1194,6 +1251,21 @@ bool are_flags_set(uint32_t val, uint32_t flags) {
 }  // namespace
 
 animation::animation() { patient_effect_offset = rand(); }
+
+animation::~animation() {
+  animation::remove_from_tile();
+}
+
+void animation::attach_to_map(level_map* game_map, int x, int y, int layer) {
+  map_tile* node = game_map->get_tile(x, y);
+  attach_to_tile(x, y, node, layer);
+  // XXX Attach proxies as well.
+}
+
+void animation::remove_from_tile() {
+  animation_base::remove_from_tile();
+  remove_all_proxies_from_tile();
+}
 
 void animation::draw(render_target* pCanvas, int iDestX, int iDestY) {
   if (are_flags_set(flags, thdf_alpha_50 | thdf_alpha_75)) return;
@@ -1712,6 +1784,22 @@ void animation::set_morph_target(animation* pMorphTarget, int iDurationFactor) {
 
 void animation::set_frame(size_t iFrame) { frame_index = iFrame; }
 
+void animation::add_proxy(int8_t dx, int8_t dy, int8_t crop_base,
+                          int8_t crop_width) {
+  proxies.emplace_back(this, dx, dy, crop_base, crop_width);
+}
+
+void animation::remove_all_proxies_from_tile() {
+  for (auto &proxy: proxies) {
+    proxy.remove_self_from_tile();
+  }
+}
+
+void animation::remove_all_proxies() {
+  remove_all_proxies_from_tile();
+  proxies.clear();
+}
+
 void sprite_render_list::tick() {
   pixel_offset.x += dx_per_tick;
   pixel_offset.y += dy_per_tick;
@@ -1756,6 +1844,12 @@ bool sprite_render_list::hit_test(int iDestX, int iDestY, int iTestX,
                                   int iTestY) {
   // TODO
   return false;
+}
+
+void sprite_render_list::attach_to_map(level_map* game_map, int x, int y,
+                                       int layer) {
+  map_tile* node = game_map->get_tile(x, y);
+  attach_to_tile(x, y, node, layer);
 }
 
 void sprite_render_list::set_lifetime(int iLifetime) {

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -56,9 +56,11 @@ enum draw_flags : uint32_t {
   thdf_flip_horizontal = 1 << 0,
   //! Draw with the top becoming the bottom and vice versa
   thdf_flip_vertical = 1 << 1,
-  //! Draw with 50% transparency. If set together with thdf_alpha_75, don't draw at all.
+  //! Draw with 50% transparency. If set together with thdf_alpha_75, don't draw
+  //! at all.
   thdf_alpha_50 = 1 << 2,
-  //! Draw with 75% transparency. If set together with thdf_alpha_50, don't draw at all.
+  //! Draw with 75% transparency. If set together with thdf_alpha_50, don't draw
+  //! at all.
   thdf_alpha_75 = 1 << 3,
   //! Draw using a remapped palette
   thdf_alt_palette = 1 << 4,
@@ -497,7 +499,7 @@ class animation_base : public drawable {
   ::layers layers{};
 };
 
-class animation_proxy: public animation_base {
+class animation_proxy : public animation_base {
  public:
   animation_proxy(animation* const parent_anim, int8_t dx, int8_t dy,
                   int8_t crop_base, int8_t crop_width);
@@ -628,7 +630,7 @@ class animation : public animation_base {
 
  private:
   animation_manager* manager{nullptr};
-  std::vector<animation_proxy> proxies{}; ///< Proxies of the animation.
+  std::vector<animation_proxy> proxies{};  ///< Proxies of the animation.
   animation* morph_target{nullptr};
   size_t animation_index{};  ///< Animation number.
   size_t frame_index{};      ///< Frame number.

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -40,6 +40,7 @@ SOFTWARE.
 class lua_persist_reader;
 class lua_persist_writer;
 class memory_reader;
+class level_map;
 struct map_tile;
 
 enum class scaled_items { none, sprite_sheets, bitmaps, all };
@@ -173,7 +174,7 @@ class chunk_renderer {
 
   std::vector<uint8_t>::iterator ptr, end;
   int x{0}, y{0};
-  int width, height;
+  int width;
   bool skip_eol{false};
 };
 
@@ -466,8 +467,9 @@ class animation_base : public drawable {
  public:
   animation_base();
 
-  void remove_from_tile();
+  virtual void remove_from_tile();
   void attach_to_tile(int x, int y, map_tile* node, int layer);
+  virtual void attach_to_map(level_map* game_map, int x, int y, int layer) = 0;
 
   uint32_t get_flags() const { return flags; }
   const xy_pair& get_pixel_offset() const { return pixel_offset; }
@@ -495,12 +497,41 @@ class animation_base : public drawable {
   ::layers layers{};
 };
 
+class animation_proxy: public animation_base {
+ public:
+  animation_proxy(animation* const parent_anim, int8_t dx, int8_t dy,
+                  int8_t crop_base, int8_t crop_width);
+
+  void attach_to_map(level_map* game_map, int x, int y, int layer) override;
+
+  void draw_fn(render_target* canvas, int dest_x, int dest_y) override;
+  bool hit_test_fn(int dest_x, int dest_y, int test_x, int test_y) override;
+  bool is_multiple_frame_animation_fn() override;
+  void remove_from_tile() override;
+
+  link_list* get_previous() { return prev; }
+
+  //! Removes itself from its tile.
+  void remove_self_from_tile();
+
+ private:
+  animation* const parent_anim;
+  const int8_t dx;
+  const int8_t dy;
+  const int8_t crop_base;
+  const int8_t crop_width;
+};
+
 //! The kind of animation.
 enum class animation_kind { primary_child, secondary_child, normal, morph };
 
 class animation : public animation_base {
  public:
   animation();
+  ~animation() override;
+
+  void attach_to_map(level_map* game_map, int x, int y, int layer) override;
+  void remove_from_tile() override;
 
   void set_parent(animation* pParent, bool use_primary);
 
@@ -576,8 +607,28 @@ class animation : public animation_base {
 
   animation_manager* get_animation_manager() { return manager; }
 
+  //! Add a proxy to the animation.
+  /*!
+   * @param dx X tiles shift relative to the map position of the animation.
+   * @param dy Y tiles shift relative to the map position of the animation.
+   * @param crop_base Base-position of the cropped area that is rendered
+   *    through the proxy. Number of half-tiles in positive X direction with
+   *    respect to the center of the base tile of the proxy.
+   * @param crop_width Width of the crop area in number of half tiles to the
+   *    right of the crop base. If less than 1, no cropping is applied.
+   */
+  void add_proxy(int8_t dx, int8_t dy, int8_t crop_base, int8_t crop_width);
+
+  //! Remove all proxies of the animation.
+  void remove_all_proxies();
+
+  //! Remove all proxies from their map tile. The proxies themselves are kept.
+  //! The method is safe to use even if proxies are not attach to a tile.
+  void remove_all_proxies_from_tile();
+
  private:
   animation_manager* manager{nullptr};
+  std::vector<animation_proxy> proxies{}; ///< Proxies of the animation.
   animation* morph_target{nullptr};
   size_t animation_index{};  ///< Animation number.
   size_t frame_index{};      ///< Frame number.
@@ -589,10 +640,14 @@ class animation : public animation_base {
     animation* parent;
   };
 
+  //! The number of the sound to play, or \c 0.
+  //! Is set on tick() and cleared to \c 0 directly after starting the sound.
   size_t sound_to_play{};
+
   int crop_column{};
   animation_kind anim_kind{animation_kind::normal};
   animation_effect patient_effect{animation_effect::none};
+
   //! Number of game_ticks to offset animation by so they aren't all
   //! running in sync.
   size_t patient_effect_offset;
@@ -623,6 +678,8 @@ class sprite_render_list : public animation_base {
   }
 
   bool is_multiple_frame_animation_fn() override { return false; }
+
+  void attach_to_map(level_map* game_map, int x, int y, int layer) override;
 
  private:
   struct sprite {

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -55,9 +55,9 @@ enum draw_flags : uint32_t {
   thdf_flip_horizontal = 1 << 0,
   //! Draw with the top becoming the bottom and vice versa
   thdf_flip_vertical = 1 << 1,
-  //! Draw with 50% transparency
+  //! Draw with 50% transparency. If set together with thdf_alpha_75, don't draw at all.
   thdf_alpha_50 = 1 << 2,
-  //! Draw with 75% transparency
+  //! Draw with 75% transparency. If set together with thdf_alpha_50, don't draw at all.
   thdf_alpha_75 = 1 << 3,
   //! Draw using a remapped palette
   thdf_alt_palette = 1 << 4,

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -55,7 +55,7 @@ int l_anims_set_spritesheet(lua_State* L) {
 
 //! Set the video target for the sprites.
 /*!
-    setCanvas(<video-surface>)
+ *  setCanvas(<video-surface>)
  */
 int l_anims_set_canvas(lua_State* L) {
   animation_manager* pAnims = luaT_testuserdata<animation_manager>(L);
@@ -89,7 +89,7 @@ int l_anims_load(lua_State* L) {
 
 //! Load custom animations.
 /*!
-    loadCustom(<data-of-an-animation-file>) -> true/false
+ *  Anims:loadCustom(<data-of-an-animation-file>) -> true/false
  */
 int l_anims_loadcustom(lua_State* L) {
   animation_manager* pAnims = luaT_testuserdata<animation_manager>(L);
@@ -108,8 +108,8 @@ int l_anims_loadcustom(lua_State* L) {
 //! Lua interface for getting a set of animations by name and tile size (one for
 //! each view direction, 'nil' if no animation is available for a direction).
 /*!
-    getAnimations(<tile-size>, <animation-name>) -> (<anim-north>, <anim-east>,
-   <anim-south>, <anim-west>)
+ *  Anims:getAnimations(<tile-size>, <animation-name>)
+ *      -> (<anim-north>, <anim-east>, <anim-south>, <anim-west>)
  */
 int l_anims_getanims(lua_State* L) {
   animation_manager* pAnims = luaT_testuserdata<animation_manager>(L);
@@ -141,6 +141,10 @@ int l_anims_getanims(lua_State* L) {
   return 4;
 }
 
+//! Get the first frame of an animation.
+/*!
+ *  Anims:getFirstFrame(<anim-number>) -> <frame-number>
+ */
 int l_anims_getfirst(lua_State* L) {
   animation_manager* pAnims = luaT_testuserdata<animation_manager>(L);
   int iAnim = static_cast<int>(luaL_checkinteger(L, 2));
@@ -149,6 +153,10 @@ int l_anims_getfirst(lua_State* L) {
   return 1;
 }
 
+//! Get the next frame of an animation.
+/*!
+ *  Anims:getNextFrame(<frame-number>) -> <frame-number>
+ */
 int l_anims_getnext(lua_State* L) {
   animation_manager* pAnims = luaT_testuserdata<animation_manager>(L);
   int iFrame = static_cast<int>(luaL_checkinteger(L, 2));
@@ -177,6 +185,11 @@ int l_anims_set_alt_pal(lua_State* L) {
   return 1;
 }
 
+//! Set the primary (often patient) marker of an animation.
+/*!
+ *  Anims:setFramePrimaryMarker(<frame-num>, <x-pos>, <y-pos>) -> Anims
+ *  with x and y positions in pixels relative to tile-centre at floor level.
+ */
 int l_anims_set_primary_marker(lua_State* L) {
   animation_manager* pAnims = luaT_testuserdata<animation_manager>(L);
   lua_pushboolean(
@@ -188,12 +201,11 @@ int l_anims_set_primary_marker(lua_State* L) {
   return 1;
 }
 
-int l_anims_tick(lua_State* L) {
-  animation_manager* pAnims = luaT_testuserdata<animation_manager>(L);
-  pAnims->tick();
-  return 0;
-}
-
+//! Set the secondary (often staff) marker of an animation.
+/*!
+ *  Anims:setFrameSecondaryMarker(<frame-num>, <x-pos>, <y-pos>) -> Anims
+ *  with x and y positions in pixels relative to tile-centre at floor level.
+ */
 int l_anims_set_secondary_marker(lua_State* L) {
   animation_manager* pAnims = luaT_testuserdata<animation_manager>(L);
   lua_pushboolean(
@@ -203,6 +215,16 @@ int l_anims_set_secondary_marker(lua_State* L) {
              ? 1
              : 0);
   return 1;
+}
+
+//! Update the global patients effects counter for the next frame.
+/*!
+ * Anims:tick()
+ */
+int l_anims_tick(lua_State* L) {
+  animation_manager* pAnims = luaT_testuserdata<animation_manager>(L);
+  pAnims->tick();
+  return 0;
 }
 
 int l_anims_draw(lua_State* L) {
@@ -301,6 +323,10 @@ int l_anim_set_hitresult(lua_State* L) {
   return 1;
 }
 
+//! Set the frame of an animation.
+/*!
+ *  Animation:setFrame(<frame number>) -> Animation
+ */
 int l_anim_set_frame(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   pAnimation->set_frame(luaL_checkinteger(L, 2));
@@ -308,12 +334,25 @@ int l_anim_set_frame(lua_State* L) {
   return 1;
 }
 
+//! Get the current frame of an animation.
+/*!
+ *  Animation:getFrame(<frame number>) -> <current-frame-num>
+ */
 int l_anim_get_frame(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   lua_pushinteger(L, pAnimation->get_frame());
   return 1;
 }
 
+//! Set the tile column to draw.
+/*!
+ *  Anim:setCrop(<half-tile-offsets>) -> Anim
+ *
+ *  Tile column is specified as number of half-tile offsets relative to the
+ *  center of the center tile of the animation. Width of the column is always a
+ *  full tile.
+ *  Enabling cropping is controlled by the \c thdf_crop draw flag.
+ */
 int l_anim_set_crop(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   pAnimation->set_crop_column(static_cast<int>(luaL_checkinteger(L, 2)));
@@ -321,6 +360,15 @@ int l_anim_set_crop(lua_State* L) {
   return 1;
 }
 
+//! Get the tile column to draw.
+/*!
+ *  Anim:getCrop(<half-tile-offsets>) -> <column>
+ *
+ *  Tile column is specified as number of half-tile offsets relative to the
+ *  center of the center tile of the animation. Width of the column is always a
+ *  full tile.
+ *  Enabling cropping is controlled by the \c thdf_crop draw flag.
+ */
 int l_anim_get_crop(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   lua_pushinteger(L, pAnimation->get_crop_column());
@@ -367,6 +415,10 @@ int l_anim_set_morph(lua_State* L) {
   return 1;
 }
 
+//! Get the current animation.
+/*!
+ * Anim:getAnimation() -> <animation-number>
+ */
 int l_anim_get_anim(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   lua_pushinteger(L, pAnimation->get_animation());
@@ -374,8 +426,11 @@ int l_anim_get_anim(lua_State* L) {
   return 1;
 }
 
-// setTile(anim/spr_list, map, x, y, drawing_layer).
-// If map is 'nil', remove animation from tile.
+//! Set the base tile of the animation.
+/*!
+ * <animation/sprite-render-list>:setTile(<map>, <x>, <y>, <drawing_layer>)
+ * If map is 'nil', remove the animation from the tile.
+ */
 template <typename T>
 int l_anim_set_tile(lua_State* L) {
   T* pAnimation = luaT_testuserdata<T>(L);
@@ -391,9 +446,8 @@ int l_anim_set_tile(lua_State* L) {
     int y = static_cast<int>(luaL_checkinteger(L, 4));
     int drawing_layer = static_cast<int>(luaL_checkinteger(L, 5));
 
-    map_tile* node = pMap->get_tile(x - 1, y - 1);
-    if (node) {
-      pAnimation->attach_to_tile(x - 1, y - 1, node, drawing_layer);
+    if (pMap->is_on_map(x - 1, y - 1)) {
+      pAnimation->attach_to_map(pMap, x - 1, y - 1, drawing_layer);
     } else {
       // Off-map, report an error.
       std::string msg = "Map index out of bounds (" + std::to_string(x) + ", " +
@@ -552,6 +606,10 @@ int l_anim_set_layers_from(lua_State* L) {
   return 1;
 }
 
+//! Add a description to an animation.
+/*!
+ * Anim:setTag(<string/nil>) -> Anim
+ */
 int l_anim_set_tag(lua_State* L) {
   luaT_testuserdata<animation>(L);
   lua_settop(L, 2);
@@ -559,6 +617,10 @@ int l_anim_set_tag(lua_State* L) {
   return 1;
 }
 
+//! Get a description from an animation.
+/*!
+ * Anim:getTag() -> <string>
+ */
 int l_anim_get_tag(lua_State* L) {
   luaT_testuserdata<animation>(L);
   lua_settop(L, 1);
@@ -567,6 +629,10 @@ int l_anim_get_tag(lua_State* L) {
   return 1;
 }
 
+//! Get the position of the primary marker (often for patients).
+/*!
+ * Anim:getPrimaryMarker() -> x, y
+ */
 int l_anim_get_primary_marker(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   int iX = 0;
@@ -577,6 +643,10 @@ int l_anim_get_primary_marker(lua_State* L) {
   return 2;
 }
 
+//! Get the position of the secondary marker (often for staff).
+/*!
+ * Anim:getSecondaryMarker() -> x, y
+ */
 int l_anim_get_secondary_marker(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   int iX = 0;
@@ -587,6 +657,10 @@ int l_anim_get_secondary_marker(lua_State* L) {
   return 2;
 }
 
+//! Advance the animation to the next frame.
+/*!
+ * Anim/SpriteRenderList:tick() -> Anim/SpriteRenderList
+ */
 template <typename T>
 int l_anim_tick(lua_State* L) {
   T* pAnimation = luaT_testuserdata<T>(L);
@@ -595,6 +669,10 @@ int l_anim_tick(lua_State* L) {
   return 1;
 }
 
+//! Draw the animation.
+/*!
+ * Anim/SpriteRenderList:draw() -> Anim/SpriteRenderList
+ */
 template <typename T>
 int l_anim_draw(lua_State* L) {
   T* pAnimation = luaT_testuserdata<T>(L);
@@ -605,11 +683,47 @@ int l_anim_draw(lua_State* L) {
   return 1;
 }
 
+//! Add a proxy to an animation.
+/*!
+ * Anim:addProxy(<dx>, <dy>, opt-crop-column>, <opt-crop-width>)
+ */
+int l_anim_add_proxy(lua_State* L) {
+  animation* pAnimation = luaT_testuserdata<animation>(L);
+  std::int8_t dx = static_cast<std::int8_t>(luaL_checkinteger(L, 2));
+  std::int8_t dy = static_cast<std::int8_t>(luaL_checkinteger(L, 3));
+  if (lua_isnoneornil(L, 4) || lua_isnoneornil(L, 5)) {
+    pAnimation->add_proxy(dx, dy, 0, -1);
+  } else {
+    std::int8_t crop_base = static_cast<std::int8_t>(luaL_checkinteger(L, 4));
+    std::int8_t crop_width = static_cast<std::int8_t>(luaL_checkinteger(L, 5));
+    if (crop_width <= 0) {
+      return luaL_argerror(L, 5, "Crop width must be at least 1");
+    }
+    pAnimation->add_proxy(dx, dy, crop_base, crop_width);
+  }
+
+  lua_settop(L, 1);
+  return 1;
+}
+
+//! Remove all proxies from the animation.
+/*!
+ * Anim:removeAllProxies() -> Anim
+ */
+int l_anim_remove_all_proxies(lua_State* L) {
+  animation* pAnimation = luaT_testuserdata<animation>(L);
+  pAnimation->remove_all_proxies();
+
+  lua_settop(L, 1);
+  return 1;
+}
+
 int l_anim_set_patient_effect(lua_State* L) {
   animation* pAnimation = luaT_testuserdata<animation>(L);
   animation_effect flags =
       static_cast<animation_effect>(luaL_checkinteger(L, 2));
   pAnimation->set_patient_effect(flags);
+
   lua_settop(L, 1);
   return 1;
 }
@@ -730,6 +844,8 @@ void lua_register_anims(const lua_register_state* pState) {
     lcb.add_function(l_anim_get_secondary_marker, "getSecondaryMarker");
     lcb.add_function(l_anim_tick<animation>, "tick");
     lcb.add_function(l_anim_draw<animation>, "draw", lua_metatable::surface);
+    lcb.add_function(l_anim_add_proxy, "addProxy");
+    lcb.add_function(l_anim_remove_all_proxies, "removeAllProxies");
     lcb.add_function(l_anim_set_patient_effect, "setPatientEffect");
   }
 

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -249,12 +249,12 @@ map_tile_flags::operator uint32_t() const {
 }
 
 map_tile::map_tile()
-    : iParcelId(0),
+    : tile_layers{},
+      iParcelId(0),
       iRoomId(0),
+      aiTemperature{8192, 8192},
       flags({}),
-      raw{},
-      tile_layers{},
-      aiTemperature{8192, 8192} {}
+      raw{} { }
 
 level_map::level_map() = default;
 

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1061,149 +1061,32 @@ void level_map::draw(render_target* pCanvas, int iScreenX, int iScreenY,
 
   draw_floor(pCanvas, iScreenX, iScreenY, iWidth, iHeight, iCanvasX, iCanvasY);
 
-  bool bFirst = true;
-  map_scanline_iterator formerIterator;
-  for (map_tile_iterator itrNode1(this, iScreenX, iScreenY, iWidth, iHeight);
-       itrNode1; ++itrNode1) {
-    if (!itrNode1.is_last_on_scanline()) {
-      continue;
-    }
+  for (int y_tile = 0; y_tile < height; y_tile++) {
+    for (int x_tile = 0; x_tile < width; x_tile++) {
+      int x = iCanvasX - iScreenX + (x_tile - y_tile) * 32;
+      int y = iCanvasY - iScreenY + (x_tile + y_tile) * 16;
+      const map_tile* tile = get_tile_unchecked(x_tile, y_tile);
 
-    for (map_scanline_iterator itrNode(
-             itrNode1, map_scanline_iterator_direction::backward, iCanvasX,
-             iCanvasY);
-         itrNode; ++itrNode) {
-      draw_north_wall(itrNode.get_tile(), itrNode.x(), itrNode.y(), pCanvas);
+      draw_north_wall(tile, x, y, pCanvas);
+      draw_layer(tile, x, y, tile_layer::west_wall, pCanvas);
+      draw_layer(tile, x, y, tile_layer::ui, pCanvas);
 
-      // Draw early entities.
-      drawable* pItem = static_cast<drawable*>(itrNode->oEarlyEntities.next);
-      while (pItem) {
-        pItem->draw_fn(pCanvas, itrNode.x(), itrNode.y());
-        pItem = static_cast<drawable*>(pItem->next);
+      drawable* item = static_cast<drawable*>(tile->entities.next);
+      while (item) {
+        item->draw_fn(pCanvas, x, y);
+        item = static_cast<drawable*>(item->next);
       }
     }
-
-    map_scanline_iterator itrNode(
-        itrNode1, map_scanline_iterator_direction::forward, iCanvasX, iCanvasY);
-    if (!bFirst) {
-      // since the scanline count from one THMapScanlineIterator to
-      // another can differ synchronization between the current iterator
-      // and the former one is needed
-      if (itrNode.x() < -64) {
-        ++itrNode;
-      }
-      while (formerIterator.x() < itrNode.x()) {
-        ++formerIterator;
-      }
-    }
-    bool bPreviousTileNeedsRedraw = false;
-    for (; itrNode; ++itrNode) {
-      bool bNeedsRedraw = false;
-
-      // Draw the west wall and ui layers.
-      draw_layer(itrNode.get_tile(), itrNode.x(), itrNode.y(),
-                 tile_layer::west_wall, pCanvas);
-      draw_layer(itrNode.get_tile(), itrNode.x(), itrNode.y(), tile_layer::ui,
-                 pCanvas);
-
-      int height;
-      uint16_t layer = itrNode->tile_layers[tile_layer::north_wall];
-      if (layer_exists(layer, height)) {
-        bNeedsRedraw = true;
-      }
-      if (itrNode->oEarlyEntities.next) {
-        bNeedsRedraw = true;
-      }
-
-      bool bRedrawAnimations = false;
-
-      drawable* pItem = static_cast<drawable*>(itrNode->entities.next);
-      while (pItem) {
-        pItem->draw_fn(pCanvas, itrNode.x(), itrNode.y());
-        if (pItem->is_multiple_frame_animation_fn()) {
-          bRedrawAnimations = true;
-        }
-        if (pItem->get_drawing_layer() == 1) {
-          bNeedsRedraw = true;
-        }
-        pItem = static_cast<drawable*>(pItem->next);
-      }
-
-      // if the current tile contained a multiple frame animation (e.g. a
-      // doctor walking) check to see if in the tile to its left and above
-      // it there are items that need to be redrawn (i.e. in the tile to
-      // its left side objects to the south of the tile and in the tile
-      // above it side objects to the east of the tile).
-      if (bRedrawAnimations && !bFirst) {
-        bool bTileNeedsRedraw = bPreviousTileNeedsRedraw;
-
-        // check if an object in the adjacent tile to the left of the
-        // current tile needs to be redrawn and if necessary draw it
-        pItem = static_cast<drawable*>(
-            formerIterator.get_previous_tile()->entities.next);
-        while (pItem) {
-          if (pItem->get_drawing_layer() == 9) {
-            pItem->draw_fn(pCanvas, formerIterator.x() - 64,
-                           formerIterator.y());
-            bTileNeedsRedraw = true;
-          }
-          pItem = static_cast<drawable*>(pItem->next);
-        }
-
-        // check if an object in the adjacent tile above the current
-        // tile needs to be redrawn and if necessary draw it
-        pItem = formerIterator
-                    ? static_cast<drawable*>(formerIterator->entities.next)
-                    : nullptr;
-        while (pItem) {
-          if (pItem->get_drawing_layer() == 8) {
-            pItem->draw_fn(pCanvas, formerIterator.x(), formerIterator.y());
-          }
-          pItem = static_cast<drawable*>(pItem->next);
-        }
-
-        // If an object was redrawn in the tile to the left of the
-        // current tile, or if the tile below it had an object in the
-        // north side or a wall to the north, then redraw that tile.
-        if (bTileNeedsRedraw) {
-          const map_tile* prev_tile = itrNode.get_previous_tile();
-          int prev_tile_x = itrNode.x() - 64;
-          int prev_tile_y = itrNode.y();
-
-          // Redraw the north wall of the previous tile.
-          draw_north_wall(prev_tile, prev_tile_x, prev_tile_y, pCanvas);
-
-          // Redraw early entities of previous tile.
-          pItem = static_cast<drawable*>(prev_tile->oEarlyEntities.next);
-          for (; pItem; pItem = static_cast<drawable*>(pItem->next)) {
-            pItem->draw_fn(pCanvas, prev_tile_x, prev_tile_y);
-          }
-
-          // Redraw entities of previous tile.
-          pItem = static_cast<drawable*>(prev_tile->entities.next);
-          for (; pItem; pItem = static_cast<drawable*>(pItem->next)) {
-            pItem->draw_fn(pCanvas, prev_tile_x, prev_tile_y);
-          }
-        }
-      }
-      bPreviousTileNeedsRedraw = bNeedsRedraw;
-      if (!bFirst) {
-        ++formerIterator;
-      }
-    }
-
-    formerIterator = itrNode;
-    bFirst = false;
   }
 
   // Draw map overlay if active.
   if (overlay) {
-    for (map_tile_iterator itrNode(this, iScreenX, iScreenY, iWidth, iHeight);
-         itrNode; ++itrNode) {
-      overlay->draw_cell(pCanvas,
-                         itrNode.tile_x_position_on_screen() + iCanvasX - 32,
-                         itrNode.tile_y_position_on_screen() + iCanvasY, this,
-                         itrNode.tile_x(), itrNode.tile_y());
+    for (int y_tile = 0; y_tile < height; y_tile++) {
+      for (int x_tile = 0; x_tile < width; x_tile++) {
+        // XXX Changing iCanvasX and iCanvasY doesn't seem to do anything.
+        // Not sure why.
+        overlay->draw_cell(pCanvas, iCanvasX, iCanvasY, this, x_tile, y_tile);
+      }
     }
   }
 }

--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -254,7 +254,7 @@ map_tile::map_tile()
       iRoomId(0),
       aiTemperature{8192, 8192},
       flags({}),
-      raw{} { }
+      raw{} {}
 
 level_map::level_map() = default;
 

--- a/CorsixTH/Src/th_map.h
+++ b/CorsixTH/Src/th_map.h
@@ -285,6 +285,10 @@ class level_map {
   void update_temperatures(uint16_t iAirTemperature,
                            uint16_t iRadiatorTemperature);
 
+  bool is_on_map(int x, int y) {
+    return x >= 0 && x < get_width() && y >= 0 && y < get_height();
+  }
+
   //! Get the map width (in tiles)
   inline int get_width() const { return width; }
 


### PR DESCRIPTION
*Fixes #*

**Describe what the proposed change does**
- Adds animation proxy objects at tiles with possible cropping.
- The proxy objects are like the `render_attach_points` in Lua, except they are in cpp.
- Also, unlike in Lua, the animation is not duplicated. Instead the same animation is painted once for each proxy object. By setting cropping limits at the proxies, duplicate painting of the same parts can be avoided.

Much of the cpp code seems to be there. Things to do:
- [ ] Actually attach proxies to their tile.
- [x] Test if it does anything useful.
  - Render code is a simple double loop to draw in positive X direction now, without any early entities or multiple `rap`s.
  - Graphics are at the expected place for the simple case that I tried (since loading a save is not feasible is my guess).
- [ ] Extend the cpp persistance save and load code in some way.
- [ ] Take out the render attach code.
  - Disabled it by commenting it away for now.
- [ ] Add proxies to animations that need it.