### PR TITLE
Set health to 0 on failed emergency patients

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1137,6 +1137,8 @@ function Hospital:resolveEmergency()
   for _, patient in ipairs(self.emergency_patients) do
     if patient and not patient.cured and not patient.dead
         and not patient.going_home then
+      -- Set the patient's health to 0 before we die
+      patient:changeAttribute("health", patient:getAttribute("health") * -1)
       patient:setToDying()
     end
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Implements https://github.com/CorsixTH/CorsixTH/pull/3113/files#r2491630152*

**Describe what the proposed change does**
-  Make sure emergency patients who die get zero health, or they risk triggering additional activities in tickDay()
