### PR TITLE
[WIP] Unassign task of dropped Handyman

### DIFF
--- a/CorsixTH/Lua/dialogs/place_staff.lua
+++ b/CorsixTH/Lua/dialogs/place_staff.lua
@@ -143,7 +143,7 @@ function UIPlaceStaff:onMouseUp(button, x, y)
           -- dropping a handyman should reset the assigned task
           -- as `AnswerCall` action queued later (in `room:onHumanoidEnter`) will reassign him another one.
           if class.is(self.staff, Handyman) then
-            self.staff:unassignTask()
+            self.staff:interruptHandymanTask()
           end
           self.staff:setTile(self.tile_x, self.tile_y)
         else

--- a/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
@@ -99,7 +99,7 @@ function Handyman:interruptHandymanTask()
     self.on_call.assigned = nil
     self.on_call = nil
   end
-  self.task = nil
+  self:unassignTask()
   self:setNextAction(AnswerCallAction())
 end
 

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -341,9 +341,6 @@ function Room:onHumanoidEnter(humanoid)
     -- the handyman didn't arrive as a part of a job
     if humanoid.on_call then
       assert(humanoid.on_call.object:getRoom() == self, "Handyman arrived is on call but not arriving to the designated room")
-    else
-      -- If the handyman was not assigned for the job (e.g. drop by manual pickup), do answer a call
-      humanoid:setNextAction(AnswerCallAction())
     end
     self:tryAdvanceQueue()
     return


### PR DESCRIPTION
**Fixes #2918**

**Description**
- Unassign task of a Handyman when the user move him with right click

This fix avoid multiple tasks assigned for one handyman, this is the source of the crash in the linked issue.
This fix could be reverted if a refactor of the tasks assignment is made.
This PR can be closed if PR #3090 is accepted.

The new task assigned to a moved Handyman doesn't depends only of the distance to unassigned tasks : dropping the Handyman near a broken machine (or even near the first assigned task' object) may have no effects and Handyman could be assigned to another task far away.

To test this PR i used these [utility](https://github.com/CorsixTH/CorsixTH/issues/2918#issuecomment-3536627763) functions dumping assigned tasks per Handyman.

WIP : `unassignTask` does not reset the assigned call (generating an assertion error) 
`interruptHandymanTask` does that but set the next action ( re-assigning a task ). I'm on it.


