### PR TITLE
Convert base labels to types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,7 +3,7 @@
 name: Bug report
 description: Create a report to help us improve
 title: "[Bug] Give a summary of the problem"
-labels: ["bug"]
+type: Bug
 ### Questions
 # What happened?
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,7 +3,7 @@
 name: Feature request
 description: Suggest an idea for this project
 title: "Give a feature/enhancement summary"
-labels: ["enhancement"]
+type: Enhancement
 ### Questions
 # What is wanted?
 body:


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Contributes to #3137*

**Describe what the proposed change does**
- Changes issue templates to use the Enhancement and Bug type, instead of labels.
