### PR TITLE
[WIP] Remove patient from queue on death [BLOCKED]

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -377,6 +377,13 @@ function Patient:die()
   if self:getRoom() then
     self:queueAction(MeanderAction():setCount(1))
   else
+    -- Eject patient from queue, if they are in one.
+    for _, action in ipairs(self.action_queue) do
+      if action.name == "queue" then
+        action.queue:removeValue(self)
+        break
+      end
+    end
     self:setNextAction(MeanderAction():setCount(1))
   end
   self:queueAction(DieAction())


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2562*
*Fixes #2947*

**Describe what the proposed change does**
- If a patient dies outside a room, make sure they are sufficiently kicked from the queue so they can die peacefully

NB: This is WIP because there needs to be additional code to handle the 'send home' and 'send to reception' actions too in the specific scenarios above. At the least, I know the reception one is broken.