### PR TITLE
automatically dismiss win movie and return to main menu

### DIFF
--- a/CorsixTH/Lua/movie_player.lua
+++ b/CorsixTH/Lua/movie_player.lua
@@ -246,7 +246,7 @@ end
 
 --! Plays the movie for winning the game
 function MoviePlayer:playWinMovie()
-  self:playMovie(self.win_game_movie, true)
+  self:playMovie(self.win_game_movie, false)
 end
 
 --! Play the movie for winning the level


### PR DESCRIPTION
*Fixes #3129*

**Describe what the proposed change does**
- Once the Win Game movie has finished, the player will be automatically returned to the main menu.
- The only change was switching the `wait_for_stop` argument used by `playMovie()` from `true` to `false`, as requested by @lewri.
