### PR TITLE
Fix patient stuck to bench cuz saved_must_happen

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -430,7 +430,7 @@ local function action_walk_start(action, humanoid)
   if not action.no_truncate then
     action.on_interrupt = action_walk_interrupt
   end
-  if action.action_on_restart ~= nil then
+  if action.on_restart ~= nil then
     action.saved_must_happen = action.must_happen
   end
   action.on_restart = action_walk_start


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2947*
*Fixes #2562*

**Describe what the proposed change does**
- Minor change in `saved_must_happen` logic to prevent set `action.saved_must_happen` in cases when `action.action_on_restart` is nil.

Read #2947 to get more context.
