### PR TITLE
Revert e1afe68 (PR 2953) (Half couch renders issue)

### DIFF
--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1198,6 +1198,8 @@ animation::animation() { patient_effect_offset = rand(); }
 void animation::draw(render_target* pCanvas, int iDestX, int iDestY) {
   if (are_flags_set(flags, thdf_alpha_50 | thdf_alpha_75)) return;
 
+  iDestX += pixel_offset.x;
+  iDestY += pixel_offset.y;
   if (sound_to_play) {
     sound_player* pSounds = sound_player::get_singleton();
     if (pSounds) pSounds->play_at(sound_to_play, iDestX, iDestY, 0);
@@ -1211,13 +1213,11 @@ void animation::draw(render_target* pCanvas, int iDestX, int iDestY) {
       rcNew.x = iDestX + (crop_column - 1) * 32;
       rcNew.w = 64;
       render_target::scoped_clip clip(pCanvas, &rcNew);
-      manager->draw_frame(pCanvas, frame_index, layers, iDestX + pixel_offset.x,
-                          iDestY + pixel_offset.y, flags, patient_effect,
-                          patient_effect_offset);
+      manager->draw_frame(pCanvas, frame_index, layers, iDestX, iDestY, flags,
+                          patient_effect, patient_effect_offset);
     } else
-      manager->draw_frame(pCanvas, frame_index, layers, iDestX + pixel_offset.x,
-                          iDestY + pixel_offset.y, flags, patient_effect,
-                          patient_effect_offset);
+      manager->draw_frame(pCanvas, frame_index, layers, iDestX, iDestY, flags,
+                          patient_effect, patient_effect_offset);
   }
 }
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
- Reverts e1afe68 (PR 2953) in master (Apply render offset after cropping instead of before.)
- Fixes the trolley and sofa at least in `master` (don't have the scanner nearby for testing).

While the patch is the good direction, it's going to take time before the other needed parts of the patch land in `master`. As such, it seems useful to revert this patch in master, and move it to my render branch instead.
