### PR TITLE
Fix xmi write when called with an empty buffer

### DIFF
--- a/CorsixTH/Src/xmi2mid.cpp
+++ b/CorsixTH/Src/xmi2mid.cpp
@@ -135,6 +135,9 @@ class memory_buffer {
 
   template <class T>
   bool write(const T* values, size_t count) {
+    if (count == 0) {
+      return true;
+    }
     if (!skip(static_cast<std::ptrdiff_t>(sizeof(T) * count))) return false;
     std::memcpy(pointer - sizeof(T) * count, values, sizeof(T) * count);
     return true;


### PR DESCRIPTION
Spotted this regression from my xmi refactor.

The data() of a vector can be anything including a nullptr when the vector is empty. This can lead to invalid arguments being passed to memcpy. I avoid the potential UB by gating on count which will be zero for the empty vector.