### PR TITLE
Fix deadlock on sound

### DIFF
--- a/CorsixTH/Src/th_sound.cpp
+++ b/CorsixTH/Src/th_sound.cpp
@@ -296,7 +296,6 @@ uint32_t sound_player::play_at(size_t iIndex, double dVolume, int iX, int iY,
 }
 
 sound_player::toggle_pause_result sound_player::toggle_pause(uint32_t handle) {
-  std::scoped_lock lock(channel_mutex);
   int channel = playing_channel_for_handle(handle);
   if (channel < 0) {
     return toggle_pause_result::error;
@@ -311,7 +310,6 @@ sound_player::toggle_pause_result sound_player::toggle_pause(uint32_t handle) {
 }
 
 void sound_player::stop(uint32_t handle) {
-  std::scoped_lock lock(channel_mutex);
   int channel = playing_channel_for_handle(handle);
   if (channel < 0) {
     return;
@@ -354,7 +352,6 @@ void sound_player::release_channel(int iChannel) {
 }
 
 uint32_t sound_player::play_raw(size_t iIndex, int iVolume, int loops) {
-  std::scoped_lock lock(channel_mutex);
   int iChannel = reserve_channel();
   if (iChannel < 0) {
     return null_handle;

--- a/CorsixTH/Src/th_sound.h
+++ b/CorsixTH/Src/th_sound.h
@@ -174,6 +174,12 @@ class sound_player {
   //! if it is free.
   std::array<uint32_t, number_of_channels> channels{};
   uint32_t next_playing_track_handle{0};
+
+  /// Mutex to protect access to channels array and next_playing_track_handle.
+  ///
+  /// \remark Do not hold this mutex while calling any SDL_mixer (Mix_*)
+  /// functions as SDL_mixer has its own internal lock which is held while
+  /// calling on_channel_finished and could lead to deadlocks.
   std::recursive_mutex channel_mutex{};
 };
 


### PR DESCRIPTION
SDL_Mixer holds a lock for performing almost all operations, internally Mix_LockAudio. This lock is not available to code outside of SDL_Mixer and while there are ways around it they are hacky at best.

Notably that lock is held while calling
sound_player::on_channel_finished. This could lead to a deadlock if we are already holding channel_mutex and call a Mix_* operation (on_channel_finished can't get the channel_mutex and Mix_* can't get the Mix_AudioLock).

With the current SDL_Mixer API I don't see any way to guarantee that the handle is not obsolete when the operation is called; however that should be a rare and relatively benign race condition so for now I'll accept it.

In case a future developer comes across this, my concern is:

* Thread 1 calls play, assigns handle A to channel 1.
* Thread 1 calls pause with handle A
* After getting the channel from playing_channel_for_handle but before calling Mix_Paused the channel finishes, on_channel_finished is called and the channel is released.
* Then thread 2 called play, assigns handle B to channel 1.
* Thread 1 continues and pause action happens on channel 1 sound B.

I have not been able to come up with a scenario where it causes any problems with only one main thread playing/stopping/pausing audio which is the case today.