### PR TITLE
Avoid emergency patients vomit, drink and use toilet

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -709,6 +709,12 @@ function Patient:tickDay()
     self.health_history["last"] = last
   end
 
+  -- Avoid vomiting, urinating in the hallway, going to the toilet,
+  -- or using vending machines on emergency patients.
+  if self.is_emergency then
+    return
+  end
+
   -- Vomitings.
   if self.vomit_anim and not self:getRoom() and not self:getCurrentAction().is_leaving and not self:getCurrentAction().is_entering then
     --Nausea level is based on health then proximity to vomit is used as a multiplier.


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3067*

I also ran an experiment in the original TH and did not register any emergency patients vomiting or urinating in the hallway.

**Describe what the proposed change does**
- Avoid vomiting, urinating in the hallway, going to the toilet, or using vending machines on emergency patients.
