### PR TITLE
Fix array index out of range bug in map_editor

### DIFF
--- a/CorsixTH/Src/th_map.cpp
+++ b/CorsixTH/Src/th_map.cpp
@@ -1270,7 +1270,8 @@ drawable* level_map::hit_test_drawables(link_list* pListStart, int iXs, int iYs,
 }
 
 int level_map::get_tile_owner(const map_tile* pNode) const {
-  return plot_owner[pNode->iParcelId];
+  uint16_t parcelId = pNode->iParcelId;
+  return get_parcel_owner(parcelId);
 }
 
 int level_map::get_parcel_owner(int iParcel) const {


### PR DESCRIPTION
The blank map has a parcel_count of 1 and only a single entry in plot_owners, so when placing parcels there was an out of bounds access.
