### PR TITLE
Inherit from Japanese audio files if present

### DIFF
--- a/CorsixTH/Lua/languages/japanese.lua
+++ b/CorsixTH/Lua/languages/japanese.lua
@@ -21,6 +21,7 @@ SOFTWARE. --]]
 Font("unicode")
 Language("日本語", "Japanese", "ja", "jp")
 Inherit("english")
+Inherit("original_strings", 6)
 Encoding(utf8)
 IsArabicNumerals(false)
 


### PR DESCRIPTION
**Describe what the proposed change does**
- In the Japanese PC release of Theme Hospital, Japanese announcer audio is found in SOUND-6.DAT, which is formatted like and based on the English SOUND-0.DAT. This small change to the Japanese translation file would allow for those audio files to be used if the user has pointed CorsixTH to the Japanese version of the game, otherwise English audio will be used as a fallback.
