### PR TITLE
Overcharge payment rejection improvement

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -321,13 +321,22 @@ end
 function Patient:agreesToPay(disease_id)
   local hosp = self.hospital
   local casebook = hosp.disease_casebook[disease_id]
-  local price_distortion = self:getPriceDistortion(casebook)
-  local is_over_priced = price_distortion > hosp.over_priced_threshold
-
-  if is_over_priced and math.random(1, 5) == 1 then return false end
-  self.pay_amount = hosp:getTreatmentPrice(disease_id)
-
-  return true
+  local agrees_to_pay = true
+  local price = casebook.price
+  local is_over_priced = price > 1.0
+  if is_over_priced then
+    local overprice_size = price - 1.0
+    -- payment chance modificator was chosen experimentally to match the chance in the original game.
+    -- check github issue 2428 for details.
+    local payment_chance_modificator = 4
+    local payment_chance = math.exp(-1 * payment_chance_modificator * overprice_size)
+    agrees_to_pay = math.random() <= payment_chance
+  end
+  if agrees_to_pay then
+    -- save the price the patient agrees to
+    self.pay_amount = hosp:getTreatmentPrice(disease_id)
+  end
+  return agrees_to_pay
 end
 
 --! Either the patient is cured, or he/she dies.

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -322,12 +322,11 @@ function Patient:agreesToPay(disease_id)
   local hosp = self.hospital
   local casebook = hosp.disease_casebook[disease_id]
   local agrees_to_pay = true
-  local price = casebook.price
-  local is_over_priced = price > 1.0
+  local price_multiplier = casebook.price
+  local is_over_priced = price_multiplier > 1.0
   if is_over_priced then
-    local overprice_size = price - 1.0
+    local overprice_size = price_multiplier - 1.0
     -- payment chance modificator was chosen experimentally to match the chance in the original game.
-    -- check github issue 2428 for details.
     local payment_chance_modificator = 4
     local payment_chance = math.exp(-1 * payment_chance_modificator * overprice_size)
     agrees_to_pay = math.random() <= payment_chance


### PR DESCRIPTION
![screenshot from 2014-09-27 18 24 12](https://cloud.githubusercontent.com/assets/8626080/4431351/c5927eae-4662-11e4-9fb0-e7b72894b9ca.png) 

**Describe what the proposed change does**

The change makes the probability of patients refusing to pay be pretty similar to the original game.
By formula suggested here https://github.com/CorsixTH/CorsixTH/discussions/2428#discussioncomment-15526798

----

### Describe the issue

Currently payment refuse probability does not align with original game.

When the price of procedures increased by the player, the probability of patients refusing to pay does not align with the probability in the original game.

Read this topic for more details:
https://github.com/CorsixTH/CorsixTH/discussions/2428 

----

### Save Game

https://www.dropbox.com/sh/zfb57sosk92nbc9/AABcO6Q2Q70WDp1BORASEB9Sa/prices_impact?dl=0 

----

### CorsixTH Version

0.69.2

----

### Expected Behaviour

The probability should be similar to the original game.

----

