### PR TITLE
Fix failure to enter fullscreen

### DIFF
--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -689,7 +689,10 @@ function UI:toggleFullscreen()
 
   local success = true
   self.app:prepareVideoUpdate()
-  local error_message = self.app.video:update(self.app.config.width, self.app.config.height, unpack(modes))
+  local error_message = self.app.video:update(self.app.config.width, self.app.config.height,
+      self.app.MIN_WINDOW_WIDTH * self.app.config.ui_scale,
+      self.app.MIN_WINDOW_HEIGHT * self.app.config.ui_scale,
+      unpack(self.app.modes))
   self.app:finishVideoUpdate()
 
   if error_message then


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes bug introduced in 3170*

Lua crashes when switching to fullscreen mode.

```Lua
An error has occurred!
Almost anything can be the cause, but the detailed information below can help the developers find the source of the error.
Running: The buttonup handler.
A stack trace is included below, and the handler has been disconnected.
../Resources/Lua/ui.lua:692: bad argument #3 to 'update' (number expected, got string)
stack traceback:
    [C]: in method 'update'
    ../Resources/Lua/ui.lua:692: in method 'toggleFullscreen'
    ../Resources/Lua/dialogs/resizables/options.lua:388: in local 'callback'
    ../Resources/Lua/window.lua:728: in method 'handleClick'
    ../Resources/Lua/window.lua:1724: in method 'onMouseUp'
    ../Resources/Lua/window.lua:1707: in field 'onMouseUp'
    ../Resources/Lua/ui.lua:893: in function <../Resources/Lua/ui.lua:880>
    (...tail calls...)
    ../Resources/Lua/app.lua:1235: in function <../Resources/Lua/app.lua:1230>
```

**Describe what the proposed change does**
- Include the params now needed by `l_surface_creation_params` in Src/th_lua_gfx.cpp.