### PR TITLE
Make UI Scale & Resolution option button aware

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -339,7 +339,6 @@ function UIOptions:selectResolution(number)
       local err = {_S.errors.unavailable_screen_size}
       self.ui:addWindow(UIInformation(self.ui, err))
     end
-    self:processWindowResizeEvent()
   end
 
   if res.custom then
@@ -479,6 +478,10 @@ function UIOptions:buttonZoomSpeed()
   end
 
   self.ui:addWindow( UIZoomSpeed(self.ui, callback) )
+end
+
+function UIOptions:onChangeResolution()
+  self:processWindowResizeEvent()
 end
 
 -- Handle required button changes from a window resize event from the user (via UI

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -975,12 +975,8 @@ end
 --!param width (integer) New window width
 --!param height (integer) New window height
 function UI:onWindowResize(width, height)
-  if not self.app.config.fullscreen and self:changeResolution(width, height) then
-    -- Update the Options window, if open
-    local window = self:getWindow(UIOptions)
-    if window then
-      window:processWindowResizeEvent()
-    end
+  if not self.app.config.fullscreen then
+    self:changeResolution(width, height)
   end
 end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
- Disables the UI Scale button if no scale other than 100% can be selected
- Also updates the tooltip with a hint.

<img width="451" height="72" alt="image" src="https://github.com/user-attachments/assets/964101b8-e1e0-458a-bca7-4853e6452c04" /> \
(string has the word 'first' at the end, and replaces UI with 'user interface' at the start: this screenshot was before that).

Link into #3188 