### PR TITLE
Close daughter UIOptions Windows when clicking outside boundary

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -541,6 +541,13 @@ function UIResolution:ok()
   end
 end
 
+function UIResolution:onMouseDown(button, x, y)
+  if not self:hitTest(x, y) then
+    self:close(false)
+  end
+  UIResizable.onMouseDown(self, button, x, y)
+end
+
 --! Closes the resolution dialog
 --!param ok (boolean or nil) whether the resolution entry was confirmed (true) or aborted (false)
 function UIResolution:close(ok)
@@ -597,6 +604,13 @@ end
 
 function UIScrollSpeed:cancel()
   self:close(false)
+end
+
+function UIScrollSpeed:onMouseDown(button, x, y)
+  if not self:hitTest(x, y) then
+    self:close(false)
+  end
+  UIResizable.onMouseDown(self, button, x, y)
 end
 
 --!param ok (boolean or nil) whether the resolution entry was confirmed (true) or aborted (false)
@@ -662,6 +676,13 @@ function UIShiftScrollSpeed:cancel()
   self:close(false)
 end
 
+function UIShiftScrollSpeed:onMouseDown(button, x, y)
+  if not self:hitTest(x, y) then
+    self:close(false)
+  end
+  UIResizable.onMouseDown(self, button, x, y)
+end
+
 --!param ok (boolean or nil) whether the resolution entry was confirmed (true) or aborted (false)
 function UIShiftScrollSpeed:close(ok)
   UIResizable.close(self)
@@ -725,6 +746,13 @@ end
 
 function UIZoomSpeed:cancel()
   self:close(false)
+end
+
+function UIZoomSpeed:onMouseDown(button, x, y)
+  if not self:hitTest(x, y) then
+    self:close(false)
+  end
+  UIResizable.onMouseDown(self, button, x, y)
 end
 
 --!param ok (boolean or nil) whether the resolution entry was confirmed (true) or aborted (false)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3205*

**Describe what the proposed change does**
- Will close the daughter windows from UIOptions if they are clicked off of, treating it as a 'cancel' action.

There is an alternative solution, where `UIResizable` has a variable added called `clickoff_closes`; which instead rewrites UIResizable instead of this patch. (essentially `if self.clickoff_closes and not self:hitTest(x, y) then self:close() end` -- though some windows may do different things on cancel which wouldn't be accounted for here as easy).
