### PR TITLE
Remember/select the casebook disease selection

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/drug_casebook.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/drug_casebook.lua
@@ -86,6 +86,8 @@ function UICasebook:UICasebook(ui, disease_selection)
 
   if disease_selection then
     self:selectDisease(disease_selection)
+  elseif self.ui.casebook_selected_disease then
+    self:selectDisease(self.ui.casebook_selected_disease)
   else
     self.selected_index = #self.names_sorted
     self.selected_disease = self.names_sorted[self.selected_index]
@@ -198,6 +200,7 @@ function UICasebook:updateIcons()
 
   self.ui:updateTooltip() -- for the case that mouse is hovering over icon while player scrolls through list with keys
   self.percentage_counter = 50
+  self.ui.casebook_selected_disease = disease
 end
 
 function UICasebook:draw(canvas, x, y)

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -193,9 +193,8 @@ function UI:UI(app, minimal)
   end
 
   self:setCursor(self.default_cursor)
-
-
   self:setupGlobalKeyHandlers()
+  self.casebook_selected_disease = false
 end
 
 function UI:runDebugScript()


### PR DESCRIPTION

*Fixes #3220*

**Describe what the proposed change does**
- Save any selection of a disease
- Return to that selection on opening, if appropriate
