### PR TITLE
Fix advisor priority check

### DIFF
--- a/CorsixTH/Lua/dialogs/adviser.lua
+++ b/CorsixTH/Lua/dialogs/adviser.lua
@@ -83,7 +83,8 @@ function UIAdviser:talk()
   local best = 1
   if self.queued_messages[1].priority then
     for i = 1, #self.queued_messages do
-      if best ~= i and self.queued_messages[best].priority < self.queued_messages[i].priority then
+      if best ~= i and self.queued_messages[i].priority and
+          self.queued_messages[best].priority < self.queued_messages[i].priority then
         best = i
       end
     end


### PR DESCRIPTION


**Describe what the proposed change does**
- Check for advisor priority before comparing it. This fixes an error I've had in several savegames, with the full error message below.
<details><summary>CorsixTH/Lua/dialogs/adviser.lua:87: attempt to compare number with nil</summary>
An error has occurred!
Almost anything can be the cause, but the detailed information below can help the developers find the source of the error.
Running: The timer handler.
A stack trace is included below, and the handler has been disconnected.
CorsixTH/CorsixTH/Lua/dialogs/adviser.lua:87: attempt to compare number with nil
stack traceback:
	CorsixTH/CorsixTH/Lua/dialogs/adviser.lua:87: in method 'talk'
	CorsixTH/CorsixTH/Lua/dialogs/adviser.lua:260: in method 'onTick'
	CorsixTH/CorsixTH/Lua/window.lua:1912: in field 'onTick'
	CorsixTH/CorsixTH/Lua/dialogs/bottom_panel.lua:638: in method 'onTick'
	CorsixTH/CorsixTH/Lua/window.lua:1912: in field 'onTick'
	CorsixTH/CorsixTH/Lua/ui.lua:1015: in field 'onTick'
	CorsixTH/CorsixTH/Lua/game_ui.lua:839: in method 'onTick'
	CorsixTH/CorsixTH/Lua/app.lua:1337: in function <CorsixTH/CorsixTH/Lua/app.lua:1332>
	(...tail calls...)
	CorsixTH/CorsixTH/Lua/app.lua:1235: in function <CorsixTH/CorsixTH/Lua/app.lua:1230>

Error in timer handler: 
CorsixTH/CorsixTH/Lua/dialogs/adviser.lua:87: attempt to compare number with nil
stack traceback:
	CorsixTH/CorsixTH/Lua/dialogs/adviser.lua:87: in method 'talk'
	CorsixTH/CorsixTH/Lua/dialogs/adviser.lua:260: in method 'onTick'
	CorsixTH/CorsixTH/Lua/window.lua:1912: in field 'onTick'
	CorsixTH/CorsixTH/Lua/dialogs/bottom_panel.lua:638: in method 'onTick'
	CorsixTH/CorsixTH/Lua/window.lua:1912: in field 'onTick'
	CorsixTH/CorsixTH/Lua/ui.lua:1015: in field 'onTick'
	CorsixTH/CorsixTH/Lua/game_ui.lua:839: in method 'onTick'
	CorsixTH/CorsixTH/Lua/app.lua:1337: in function <CorsixTH/CorsixTH/Lua/app.lua:1332>
	(...tail calls...)
	CorsixTH/CorsixTH/Lua/app.lua:1235: in function <CorsixTH/CorsixTH/Lua/app.lua:1230>
Warning: No event handler for timer
An error has occurred!
Almost anything can be the cause, but the detailed information below can help the developers find the source of the error.
Running: The frame handler.
A stack trace is included below, and the handler has been disconnected.
CorsixTH/CorsixTH/Lua/graphics.lua:368: bad argument #2 to 'drawWrapped' (string expected, got nil)
stack traceback:
	[C]: in method 'drawWrapped'
	CorsixTH/CorsixTH/Lua/graphics.lua:368: in method 'drawWrapped'
	CorsixTH/CorsixTH/Lua/dialogs/adviser.lua:206: in method 'draw'
	CorsixTH/CorsixTH/Lua/window.lua:1523: in field 'draw'
	CorsixTH/CorsixTH/Lua/dialogs/bottom_panel.lua:238: in method 'draw'
	CorsixTH/CorsixTH/Lua/window.lua:1523: in field 'draw'
	CorsixTH/CorsixTH/Lua/game_ui.lua:262: in method 'draw'
	CorsixTH/CorsixTH/Lua/app.lua:1379: in function <CorsixTH/CorsixTH/Lua/app.lua:1372>
	(...tail calls...)
	CorsixTH/CorsixTH/Lua/app.lua:1235: in function <CorsixTH/CorsixTH/Lua/app.lua:1230>

Error in frame handler: 
CorsixTH/CorsixTH/Lua/graphics.lua:368: bad argument #2 to 'drawWrapped' (string expected, got nil)
stack traceback:
	[C]: in method 'drawWrapped'
	CorsixTH/CorsixTH/Lua/graphics.lua:368: in method 'drawWrapped'
	CorsixTH/CorsixTH/Lua/dialogs/adviser.lua:206: in method 'draw'
	CorsixTH/CorsixTH/Lua/window.lua:1523: in field 'draw'
	CorsixTH/CorsixTH/Lua/dialogs/bottom_panel.lua:238: in method 'draw'
	CorsixTH/CorsixTH/Lua/window.lua:1523: in field 'draw'
	CorsixTH/CorsixTH/Lua/game_ui.lua:262: in method 'draw'
	CorsixTH/CorsixTH/Lua/app.lua:1379: in function <CorsixTH/CorsixTH/Lua/app.lua:1372>
	(...tail calls...)
	CorsixTH/CorsixTH/Lua/app.lua:1235: in function <CorsixTH/CorsixTH/Lua/app.lua:1230>
Warning: No event handler for frame
</details>