### PR TITLE
Target start menu and desktop icons for all users

### DIFF
--- a/WindowsInstaller/Win32Script.nsi
+++ b/WindowsInstaller/Win32Script.nsi
@@ -53,9 +53,6 @@ InstallDir "$PROGRAMFILES\${PRODUCT_NAME}"
 ; This is needed to be able to install into the program files directory
 RequestExecutionLevel admin
 
-; Also use the all users scope exclusively
-SetShellVarContext all
-
 ; Set installer compression
 SetCompressor lzma
 SetCompressorDictSize 16
@@ -227,6 +224,17 @@ Section "MainSection" SEC01
     File /nonfatal /r x86\*.*
   ${EndIf}
 
+  ; Remove old shortcuts (old installs wrote to APPDATA instead of ProgramData)
+  ; Non-existent files are ignored
+  SetShellVarContext all
+  Delete "$SMPROGRAMS\${PRODUCT_NAME}\*.*"
+
+  RMDir /r "$SMPROGRAMS\${PRODUCT_NAME}"
+  SetShellVarContext current
+  Delete "$SMPROGRAMS\${PRODUCT_NAME}\*.*"
+
+  RMDir /r "$SMPROGRAMS\${PRODUCT_NAME}"
+  
   ; Time to make the configuration file and Saves folder at the correct location
   ${If} $CONFIGAPPDATA == ${BST_CHECKED}
     SetOutPath "$APPDATA\CorsixTH"
@@ -295,10 +303,16 @@ SectionEnd
 
 Section -AdditionalIcons
   !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+  ; Make app shortcuts available for everyone
+  SetShellVarContext all
   CreateDirectory "$SMPROGRAMS\${PRODUCT_NAME}"
   CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME}.lnk" "$INSTDIR\CorsixTH.exe"
   CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
-  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\CorsixTH AppData Folder.lnk" "$APPDATA\CorsixTH"
+  ; Only make AppData shortcut if user told us to use it for saves
+  ${If} $CONFIGAPPDATA == ${BST_CHECKED}
+    ; Use environment variable or it points to ProgramData
+    CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\CorsixTH AppData Folder.lnk" "%APPDATA%\CorsixTH"
+  ${EndIf}
   !insertmacro MUI_STARTMENU_WRITE_END
 SectionEnd
 
@@ -343,9 +357,12 @@ Section Uninstall
 
   Delete "$INSTDIR\*.*"
 
+  ; Our shortcuts are in the all user scope, change the context to remove them.
+  SetShellVarContext all
   Delete "$SMPROGRAMS\${PRODUCT_NAME}\*.*"
 
   RMDir /r "$SMPROGRAMS\${PRODUCT_NAME}"
+  SetShellVarContext current
 
   ; Maybe the user wants to keep saved games?
   MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 "$(remove_saves)" IDYES afterSaves


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3227*

**Describe what the proposed change does**
- Start menu items are written to `C:\ProgramData\Microsoft\Windows\Start Menu`; 
- CorsixTH AppData shortcut is now install aware and won't be made if they chose not to have their saves there.
A possible future TODO is to let this be customisable in the installer between 'Install for everyone' and 'Install for me' (Install for me is by design meant to install CorsixTH to `%APPDATA%` rather than Program Files.

I need to run checks on what this does to the installer via actions to make sure it works as intended.