### PR TITLE
Cleanup global variables

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -23,11 +23,10 @@ self = false
 globals = { -- Globals
             "_A", "_S",
             "corsixth",
-            "action_queue_leave_bench", "class", "compare_tables", "DrawFlags",
-            "DrawingLayers",
+            "class", "compare_tables", "DrawFlags", "DrawingLayers",
             "destrict", "flag_clear", "flag_isset", "flag_set", "flag_toggle",
             "lfs", "list_to_set", "loadfile_envcall", "loadstring_envcall",
-            "pause_gc_and_use_weak_keys", "permanent", "print_table",
+            "pause_gc_and_use_weak_keys", "permanent",
             "rangeMapLookup", "rnc", "strict_declare_global", "table_length",
             "unpermanent", "values", "serialize", "array_join", "shallow_clone",
             "staff_initials_cache", "hasBit", "bitOr", "inspect",

--- a/CorsixTH/Lua/humanoid_actions/queue.lua
+++ b/CorsixTH/Lua/humanoid_actions/queue.lua
@@ -136,6 +136,8 @@ local function action_queue_find_drink_action(action, humanoid)
   end
 end
 
+local action_queue_leave_bench -- Defined below the next function.
+
 -- Finish standing includes currently going to the drinks machine.
 local function action_queue_finish_standing(action, humanoid)
   local index = action_queue_find_idle(action, humanoid)
@@ -165,7 +167,7 @@ local function action_queue_finish_standing(action, humanoid)
   error("Queue action not in action_queue")
 end
 
-local function action_queue_leave_bench(action, humanoid)
+action_queue_leave_bench = function(action, humanoid)
   local index
   for i, current_action in ipairs(humanoid.action_queue) do
     -- Check to see that we haven't


### PR DESCRIPTION
Remove two entries from the global variables list in `.luacheckrc`.

- 'action_queue_leave_bench' is now a local function
- 'print_table' was dropped in d1eb8b3946b674d621b5cc454e7517503ae2f8f3 in favour of 'serialize'.

