### PR TITLE
Adjust overall machine decrease when earthquake

### DIFF
--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -126,11 +126,10 @@ end
 
 --! Call on machine use.
 --!param room (object) machine room
+--!param earthquake_activated (boolean) If true, machine was damaged by an active earthquake
 --!return (bool) is room exploding after this use
 function Machine:machineUsed(room, earthquake_activated)
-  if type(earthquake_activated) ~= "boolean" then
-      earthquake_activated = false
-  end
+  earthquake_activated = not not earthquake_activated
   -- Do nothing if the room has already crashed
   if room.crashed then
     return
@@ -157,7 +156,6 @@ end
 
 --! Call after use of the machine.
 function Machine:incrementUsageCounts(total_usage_only, is_earthquake)
-  total_usage_only = total_usage_only or false
   if not is_earthquake then
       self.total_usage = self.total_usage + 1
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3123*

**Describe what the proposed change does**
When the function *Machine:earthquakeImpact(room)* is called, a local boolean attribut named *earthquake_activated* in machine.lua will change to *true*. And when the incrementUsageCounts is called, there is a verification to know if the reason of the increment came from a earthquake.
