### PR TITLE
[RFC] Revert bracket support in filenames

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1084,7 +1084,7 @@ function App:saveConfig()
           handled_ids[identifier] = true
           if value ~= tostring(self.config[identifier]) then
             lines[#lines] = string.format("%s = %s", identifier,
-                serialize(self.config[identifier], { long_bracket_level_start = 1 } ))
+                serialize(self.config[identifier], { long_bracket_level_start = 0 } ))
           end
         end
       end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3224*
*Fixes #3034*

**Describe what the proposed change does**
- Revert #2391 but leaves the utility function change intact for now.

Asking @tobylane to review if he's got any alternatives (bar changing config file format) before we break support for square brackets in config values.

This is in prep in case we don't manage to agree on changes to the config file system before next release. The other reason is sometimes I've found cases where the `[=[` format is incompatible with itself.

@ARGAMX it looks like this change will convert `[=[ ]=]` formatted strings back to `[[ ]]`, but won't crash on reading them.