### PR TITLE
Position settings window on scale/resize

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -482,6 +482,7 @@ end
 
 function UIOptions:onChangeResolution()
   self:processWindowResizeEvent()
+  self:setDefaultPosition(0.5, 0.25)
 end
 
 -- Handle required button changes from a window resize event from the user (via UI


### PR DESCRIPTION
With this change the settings window will stay in the visible area when the scale or resolution is changed. If it is on the right edge of the screen it will stay on the right edge of the screen but won't go out of the screen.

Fixes #3243