### PR TITLE
Support predefined colours in panels

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -23,14 +23,15 @@ self = false
 globals = { -- Globals
             "_A", "_S",
             "corsixth",
-            "class", "compare_tables", "DrawFlags", "DrawingLayers",
-            "destrict", "flag_clear", "flag_isset", "flag_set", "flag_toggle",
-            "lfs", "list_to_set", "loadfile_envcall", "loadstring_envcall",
+            "class", "Colours", "compare_tables", "DrawFlags",
+            "DrawingLayers", "destrict", "flag_clear", "flag_isset",
+            "flag_set", "flag_toggle", "lfs", "list_to_set",
+            "loadfile_envcall", "loadstring_envcall",
             "pause_gc_and_use_weak_keys", "permanent",
-            "rangeMapLookup", "rnc", "strict_declare_global", "table_length",
-            "unpermanent", "values", "serialize", "array_join", "shallow_clone",
-            "staff_initials_cache", "hasBit", "bitOr", "inspect",
-            "getRandomEntryFromArray",
+            "rangeMapLookup", "rnc", "strict_declare_global",
+            "table_length", "unpermanent", "values", "serialize",
+            "array_join", "shallow_clone", "staff_initials_cache",
+            "hasBit", "bitOr", "inspect", "getRandomEntryFromArray",
 
             -- Game classes
             "AIHospital", "AnimationManager", "AnimationEffect", "App", "Audio",

--- a/CorsixTH/Lua/utility.lua
+++ b/CorsixTH/Lua/utility.lua
@@ -249,6 +249,55 @@ AnimationEffect.None = 0
 AnimationEffect.Glowing = 1
 AnimationEffect.Jelly = 2
 
+-- Predefined colours
+Colours = {}
+Colours.PanelDefault = { -- CorsixTH's default panel colour (pale purple)
+  red = 154, green = 146, blue = 198
+}
+Colours.Disabled = { -- Specific grey with purplish aspect
+  red = 127, green = 123, blue = 149
+}
+Colours.Setting = Colours.PanelDefault
+Colours.SettingHover = { -- Slightly darkened from a pale purple
+  red = 133, green = 128, blue = 183,
+}
+Colours.SettingActive = Colours.SettingHover
+Colours.HotkeyBox = { -- Purple
+  red = 081, green = 076, blue = 150,
+}
+Colours.HotkeyBoxActive = { -- Deep purple
+  red = 041, green = 036, blue = 090,
+}
+Colours.Textbox = { -- Black
+  red = 000, green = 000, blue = 000
+}
+Colours.Scrollbar = { -- Purple
+  red = 081, green = 076, blue = 150,
+}
+Colours.Title = { -- Very pale purple
+  red = 174, green = 166, blue = 218
+}
+Colours.Caption = { -- Murky purple
+  red = 134, green = 126, blue = 178
+}
+
+-- Include the standard colours also
+Colours.White = {
+  red = 255, green = 255, blue = 255
+}
+Colours.Black = {
+  red = 000, green = 000, blue = 000
+}
+Colours.Red = {
+  red = 255, green = 000, blue = 000
+}
+Colours.Green = {
+  red = 000, green = 255, blue = 000
+}
+Colours.Blue = {
+  red = 000, green = 000, blue = 255
+}
+
 -- Compare values of two simple (non-nested) tables
 function compare_tables(t1, t2)
   local count1 = 0


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
- **The code currently is unused, it'll be used in further PRs**
- Adds colour by string support to the Window class
- If a string is given that has no definition, it will use the `default` colour.

This originally was going to include the other changes to the dialog files but there's more movement going on at the moment in those files I'll hold off until this is accepted.