### PR TITLE
Preventing handyman orphaning tasks on pickup

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
@@ -93,13 +93,18 @@ function Handyman:afterLoad(old, new)
   Staff.afterLoad(self, old, new)
 end
 
+function Handyman:onPickup()
+  self:interruptHandymanTask()
+  Staff.onPickup(self)
+end
+
 function Handyman:interruptHandymanTask()
   self:setDynamicInfoText("")
   if self.on_call then
     self.on_call.assigned = nil
     self.on_call = nil
   end
-  self.task = nil
+  self:unassignTask()
   self:setNextAction(AnswerCallAction())
 end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2134*
*Fixes #2642*

**Describe what the proposed change does**
- Release handyman task on grab

The described in issue test case can be tested in this save.

[handyman_xray_experiments_v0.65.sav.zip](https://github.com/user-attachments/files/25525791/handyman_xray_experiments_v0.65.sav.zip)

Thanks @marcassin92 for the #3136. 
I used #3136 as a base for this PR.

