### PR TITLE
Fix bottom panel bar offset

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -316,6 +316,9 @@ function UIBottomPanel:drawDynamicInfo(canvas, x, y)
     return
   end
 
+  local info = self.dynamic_info
+  local font = self.white_font
+
   local dynamic_info_panel_x = 364
   local progress_bar_r_offset = 11
   local progress_bar_width = 100


### PR DESCRIPTION

<img width="655" height="305" alt="image" src="https://github.com/user-attachments/assets/8702c8c2-3940-4a43-af7a-f5060dccc57f" />

**Describe what the proposed change does**
- if machine menu button is enabled, then move progress bar to the right side of panel, as it is without button
