### PR TITLE
Support for blocking off areas in rooms

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -30,7 +30,7 @@ globals = { -- Globals
             "pause_gc_and_use_weak_keys", "permanent",
             "rangeMapLookup", "rnc", "strict_declare_global",
             "unpermanent", "values", "serialize",
-            "array_join", "shallow_clone", "staff_initials_cache",
+            "array_join", "table_merge", "shallow_clone", "staff_initials_cache",
             "hasBit", "bitOr", "inspect", "getRandomEntryFromArray", "isTableEmpty",
             "stripTrailingSlashes", "isDirectory", "canOpenDirectory",
 

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -697,9 +697,9 @@ param(config_values, 'room_information_dialogs') .. [=[
 --
 -- 1. Totally forbidden - requires every passable tile in the hospital
 -- to remain reachable from a hospital entrance. This avoids issues that
--- could arise from area blocking, but it also deprived of the opportunity
--- to build rooms in the same layouts which was possible to build in the
--- original TH. Before version 0.70 this was a default option in CorsixTH.
+-- could arise from area blocking, but it also prevents room layouts
+-- which are allowed in Theme Hospital. Before version 0.70 this was
+-- a default option in CorsixTH.
 --
 -- 2. Partially allowed - user is allowed to make dead ended, inaccessible
 -- spaces that are not accessible from the hospital entrance but only if

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -174,7 +174,7 @@ local function new_config_defaults()
     use_new_graphics = false,
     check_for_updates = true,
     room_information_dialogs = true,
-    allow_blocking_off_areas = false,
+    blocking_off_areas = 2,
     direct_zoom = nil,
     new_machine_extra_info = true,
     player_name = [[]],
@@ -691,11 +691,38 @@ param(config_values, 'shift_scroll_speed') .. [=[
 param(config_values, 'room_information_dialogs') .. [=[
 
 -------------------------------------------------------------------------------
--- If true, parts of the hospital can be made inaccessible by blocking the path
--- with rooms or objects. If false, all parts of the hospital must be kept
--- accessible, the game will disallow any attempt to blocking the path.
+-- Possibility to blocking off areas when building and placing objects.
+--
+-- There are 3 possible options:
+--
+-- 1. Totally forbidden - user is not allowed to make any dead ended,
+-- inaccessible spaces that are not accessible from the hospital entrance.
+-- Before version 0.70 this was a default option in CorsixTH.
+-- This avoided issues that could arise from area blocking, but it also
+-- deprived of the opportunity to build rooms in the same layouts which
+-- was possible to build in the original TH. Although this is a safe option,
+-- it is now deprecated but is still available.
+--
+-- 2. Partially allowed - user is allowed to make dead ended, inaccessible
+-- spaces that are not accessible from the hospital entrance but only if
+-- certain conditions are met. The condition is that the rooms themselves
+-- and usable objects inside the room must remain accessible. This ensures
+-- the preservation of the hospital's functionality and ensures the validity
+-- of the path routing in the hospital. This is the style that the blocking
+-- off areas were implemented in the original TH. This is a safe option.
+--
+-- 3. Completely allowed - user is allowed to make any dead ended,
+-- inaccessible spaces that are not accessible from the hospital entrance.
+-- This is a dangerous feature that can lead to game crashes. Use it only
+-- at your own risk and if you fully understand why you enabling it.
+--
+-- Recommended option is '2. Partially allowed'.
+--
+-- Set '1' for '1. Totally forbidden',
+-- Set '2' for '2. Partially allowed',
+-- Set '3' for '3. Completely allowed'.
 --]=] .. '\n' ..
-param(config_values, 'allow_blocking_off_areas') .. [=[
+param(config_values, 'blocking_off_areas') .. [=[
 
 -------------------------------------------------------------------------------
 -- Direct Zoom: Avoid rendering to an intermediate texture when zooming.

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -691,27 +691,25 @@ param(config_values, 'shift_scroll_speed') .. [=[
 param(config_values, 'room_information_dialogs') .. [=[
 
 -------------------------------------------------------------------------------
--- Possibility to blocking off areas when building and placing objects.
+-- Ability to block off areas when building and placing objects.
 --
 -- There are 3 possible options:
 --
--- 1. Totally forbidden - user is not allowed to make any dead ended,
--- inaccessible spaces that are not accessible from the hospital entrance.
--- Before version 0.70 this was a default option in CorsixTH.
--- This avoided issues that could arise from area blocking, but it also
--- deprived of the opportunity to build rooms in the same layouts which
--- was possible to build in the original TH. Although this is a safe option,
--- it is now deprecated but is still available.
+-- 1. Totally forbidden - requires every passable tile in the hospital
+-- to remain reachable from a hospital entrance. This avoids issues that
+-- could arise from area blocking, but it also deprived of the opportunity
+-- to build rooms in the same layouts which was possible to build in the
+-- original TH. Before version 0.70 this was a default option in CorsixTH.
 --
 -- 2. Partially allowed - user is allowed to make dead ended, inaccessible
 -- spaces that are not accessible from the hospital entrance but only if
 -- certain conditions are met. The condition is that the rooms themselves
 -- and usable objects inside the room must remain accessible. This ensures
 -- the preservation of the hospital's functionality and ensures the validity
--- of the path routing in the hospital. This is the style that the blocking
--- off areas were implemented in the original TH. This is a safe option.
+-- of the path routing in the hospital. This allows user to build rooms with
+-- the same layout as in the original TH. This is a safe option.
 --
--- 3. Completely allowed - user is allowed to make any dead ended,
+-- 3. Completely allowed - user is allowed to make dead ended,
 -- inaccessible spaces that are not accessible from the hospital entrance.
 -- This is a dangerous feature that can lead to game crashes. Use it only
 -- at your own risk and if you fully understand why you enabling it.

--- a/CorsixTH/Lua/config_finder.lua
+++ b/CorsixTH/Lua/config_finder.lua
@@ -714,10 +714,8 @@ param(config_values, 'room_information_dialogs') .. [=[
 -- This is a dangerous feature that can lead to game crashes. Use it only
 -- at your own risk and if you fully understand why you enabling it.
 --
--- Recommended option is '2. Partially allowed'.
---
 -- Set '1' for '1. Totally forbidden',
--- Set '2' for '2. Partially allowed',
+-- Set '2' for '2. Partially allowed' (Default),
 -- Set '3' for '3. Completely allowed'.
 --]=] .. '\n' ..
 param(config_values, 'blocking_off_areas') .. [=[

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -951,7 +951,7 @@ function UIEditRoom:enterDoorPhase()
     if self.ui.app.config.blocking_off_areas == 3 then
       -- all-permissive placing approach ('blocking off areas enabled')
       -- This could lead to crashes, so we'll record this in the log so that during investigation
-      -- we'll be able to get know that safe placement was disabled.
+      -- we'll be able to know that safe placement was disabled.
       TheApp.world:gameLog("Blocking off areas is allowed with room " .. self.blueprint_rect.x .. ", " .. self.blueprint_rect.y .. ".")
     else
       -- undo passable flags and go back to walls phase

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -948,8 +948,11 @@ function UIEditRoom:enterDoorPhase()
 
   -- check if all adjacent tiles of the rooms are still connected
   if not self:checkReachability() then
-    if self.ui.app.config.allow_blocking_off_areas then
-      print("Blocking off areas is allowed with room " .. self.blueprint_rect.x .. ", " .. self.blueprint_rect.y .. ".")
+    if self.ui.app.config.blocking_off_areas == 3 then
+      -- all-permissive placing approach ('blocking off areas enabled')
+      -- This could lead to crashes, so we'll record this in the log so that during investigation
+      -- we'll be able to get know that safe placement was disabled.
+      TheApp.world:gameLog("Blocking off areas is allowed with room " .. self.blueprint_rect.x .. ", " .. self.blueprint_rect.y .. ".")
     else
       -- undo passable flags and go back to walls phase
       self.phase = "walls"

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -949,7 +949,7 @@ function UIEditRoom:enterDoorPhase()
   -- check if all adjacent tiles of the rooms are still connected
   if not self:checkReachability() then
     if self.ui.app.config.blocking_off_areas == 3 then
-      -- all-permissive placing approach ('blocking off areas enabled')
+      -- all-permissive placing approach
       -- This could lead to crashes, so we'll record this in the log so that during investigation
       -- we'll be able to know that safe placement was disabled.
       TheApp.world:gameLog("Blocking off areas is allowed with room " .. self.blueprint_rect.x .. ", " .. self.blueprint_rect.y .. ".")

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -820,14 +820,18 @@ function UIMenuBar:makeGameMenu(app)
     :appendItem(_S.menu_charts.briefing, function() self.ui:showBriefing() end)
   )
 
+  local function allowBlockingAreas(option)
+    return option == 2, function()
+      app.config.blocking_off_areas = option
+    end, "", function ()
+      return app.config.blocking_off_areas == option
+    end
+  end
   local function limit_camera(item)
     app.ui:limitCamera(item.checked)
   end
   local function disable_salary_raise(item)
     app.world:debugDisableSalaryRaise(item.checked)
-  end
-  local function allowBlockingAreas(item)
-    app.config.allow_blocking_off_areas = item.checked
   end
   local levels_menu = UIMenu()
   for L = 1, 12 do
@@ -840,9 +844,13 @@ function UIMenuBar:makeGameMenu(app)
   if self.ui.app.config.debug then
     self:addMenu(_S.menu.debug, UIMenu() -- Debug
       :appendMenu(_S.menu_debug.jump_to_level, levels_menu)
+      :appendMenu(_S.menu_debug.allow_blocking_off_areas, UIMenu()
+        :appendCheckItem(_S.menu_debug_overlay_blocking_off_areas.choice_1, allowBlockingAreas(1))
+        :appendCheckItem(_S.menu_debug_overlay_blocking_off_areas.choice_2, allowBlockingAreas(2))
+        :appendCheckItem(_S.menu_debug_overlay_blocking_off_areas.choice_3, allowBlockingAreas(3))
+      )
       :appendCheckItem(_S.menu_debug.limit_camera,         true, limit_camera, nil, function() return self.ui.limit_to_visible_diamond end)
       :appendCheckItem(_S.menu_debug.disable_salary_raise, false, disable_salary_raise, nil, function() return self.ui.app.world.debug_disable_salary_raise end)
-      :appendCheckItem(_S.menu_debug.allow_blocking_off_areas, false, allowBlockingAreas, nil, function() return self.ui.app.config.allow_blocking_off_areas end)
       :appendItem(_S.menu_debug.make_debug_fax,     function() self.ui:makeDebugFax() end)
       :appendItem(_S.menu_debug.make_debug_patient, function() self.ui:addWindow(UIMakeDebugPatient(self.ui)) end)
       :appendItem(_S.menu_debug.cheats:format(hotkey_value_label("ingame_showCheatWindow", hotkeys)),             function() self.ui:addWindow(UICheats(self.ui)) end)

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -745,9 +745,9 @@ function UIPlaceObjects:setBlueprintCell(x, y)
       self.object_footprint[i][2] = ypos
     end
 
-    local function _setPartialFlags(x_, f_, map_, flag_altpal_, allgood_)
+    local function _setPartialFlags(x_, y_, map_, flag_altpal_, allgood_)
       if ATTACH_BLUEPRINT_TO_TILE then
-        self.object_anim:setTile(map_, x_, f_, 0)
+        self.object_anim:setTile(map_, x_, y_, 0)
       end
       self.object_anim:setPartialFlag(flag_altpal_, not allgood_)
       self.object_slave_anim:setPartialFlag(flag_altpal_, not allgood_)
@@ -893,9 +893,7 @@ function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag
           invalid_placement = not_along_wall and hasNoConnectingPath(x, y, to_check_x, to_check_y)
         end
       else
-        -- self.ui.app.config.blocking_off_areas == 1 or 3
-        -- soft placing approach disabled ('safe blocking off areas disabled').
-        -- in thas case follow strict placing approach ('blocking off areas disabled').
+        -- follow strict placing approach ('blocking off areas disabled').
         invalid_placement = not_along_wall and hasNoConnectingPath(x, y, to_check_x, to_check_y)
       end
     else

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -633,6 +633,10 @@ end
 local flag_alpha75 = 256 * 8
 local flag_altpal = 16
 
+--! Method for displaying a blueprint when placing object by coordinates under the user cursor.
+--! Draws a blueprint and determines its color depending on whether the object can be placed
+--! at the given coordinates or not. A gray blueprint means placement is prohibited.
+--! A colored blueprint means placement is permitted.
 function UIPlaceObjects:setBlueprintCell(x, y)
   self:clearBlueprint()
   self.object_cell_x = x
@@ -740,59 +744,174 @@ function UIPlaceObjects:setBlueprintCell(x, y)
       self.object_footprint[i][1] = xpos
       self.object_footprint[i][2] = ypos
     end
-    if self.object_anim and object.class ~= "SideObject" then
-      if allgood then
-        if world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, self.object_orientation, roomId) then
-          if self.ui.app.config.allow_blocking_off_areas then
-            print("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
-          else
-            allgood = false
-          end
-        end
-      end
-      if ATTACH_BLUEPRINT_TO_TILE then
-        self.object_anim:setTile(map, x, y)
-      end
-      self.object_anim:setPartialFlag(flag_altpal, not allgood)
-      self.object_slave_anim:setPartialFlag(flag_altpal, not allgood)
-      self.object_blueprint_good = allgood
-      self.ui:tutorialStep(1, allgood and 5 or 4, allgood and 4 or 5)
-    elseif object.class == "SideObject" then
-      if map:getCellFlags(x, y)[passable_flag] == true then
-        local checked_x, checked_y = x, y
-        if passable_flag == "travelNorth" or passable_flag == "travelSouth" then
-          checked_y =  checked_y + (passable_flag == "travelNorth" and -1 or 1)
-        else
-          checked_x = checked_x + (passable_flag == "travelEast" and 1 or -1)
-        end
 
-        flags = {}
-        flags[passable_flag] = false
-        map:setCellFlags(x, y, flags)
-        if not world.pathfinder:findDistance(x, y, checked_x, checked_y) then
-          --we need to check if the failure to get the distance is due to the presence of an object in the adjacent tile
-          if map:getCellFlags(checked_x, checked_y)["passable"] then
-            if self.ui.app.config.allow_blocking_off_areas then
-              print("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
-            else
-              allgood = false
-            end
-          end
-        end
-        flags[passable_flag] = true
-        map:setCellFlags(x, y, flags)
-      end
+    local function _setPartialFlags(x_, f_, map_, flag_altpal_, allgood_)
       if ATTACH_BLUEPRINT_TO_TILE then
-        self.object_anim:setTile(map, x, y)
+        self.object_anim:setTile(map_, x_, f_, 0)
       end
-      self.object_anim:setPartialFlag(flag_altpal, not allgood)
-      self.object_slave_anim:setPartialFlag(flag_altpal, not allgood)
-      self.object_blueprint_good = allgood
-      self.ui:tutorialStep(1, allgood and 5 or 4, allgood and 4 or 5)
+      self.object_anim:setPartialFlag(flag_altpal_, not allgood_)
+      self.object_slave_anim:setPartialFlag(flag_altpal_, not allgood_)
+      self.object_blueprint_good = allgood_
+      self.ui:tutorialStep(1, allgood_ and 5 or 4, allgood_ and 4 or 5)
     end
 
+    if self.object_anim and object.class ~= "SideObject" then
+      -- Not SideObject - an object that occupies the whole title or several of them
+      -- (Drinks machine, plant, reception desk, room machines and etc).
+      allgood = allgood and self:_isNonSideObjectValidPlacement(x, y, object, self.object_orientation, roomId, world)
+      _setPartialFlags(x, y, map, flag_altpal, allgood)
+    elseif object.class == "SideObject" then
+      -- SideObject - an object that lives on the edge of a tile (radiator, bin, extinguisher).
+      if map:getCellFlags(x, y)[passable_flag] == true then
+        allgood = allgood and self:_isSideObjectValidPlacement(x, y, roomId, passable_flag, map, world)
+      end
+      _setPartialFlags(x, y, map, flag_altpal, allgood)
+    end
   else
     self.object_footprint = {}
+  end
+end
+
+function UIPlaceObjects:_isNonSideObjectValidPlacement(x, y, object, object_orientation, roomId, world)
+  local invalid_placement
+  if self.ui.app.config.blocking_off_areas == 2 then
+    -- soft placing approach ('safe blocking off areas enabled')
+    if roomId > 0 and x and y then
+      -- placing an object in a room
+      local room = world:getRoom(x, y)
+      if room and room.door and room.door.tile_x and room.door.tile_y then
+        -- a valid room with a door
+        if not room.is_active then
+          -- user in a room editing mode
+          local object_layout = object.orientations[object_orientation]
+          invalid_placement = world:wouldNonSideObjectDontHaveAccessToTheRoomDoor(x, y, room, object_layout)
+          if not invalid_placement then
+            -- also check that after placing the object, all usage titles of objects already placed in the room
+            -- will remain accessible from the door room tile.
+            invalid_placement = world:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(x, y, room, object_layout, false)
+          end
+        else
+          -- user not in a room editing mode.
+          -- as we are not in a room editing mode, then there possbile be humanoids in the room.
+          -- this means that placing object can block a humanoid's passage to the door.
+          -- to prevent that case we fallback to strict placing approach ('blocking off areas disabled').
+          invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, roomId)
+        end
+      else
+        -- not a valid room with a door. corner case like a transition state.
+        invalid_placement = true
+      end
+    else
+      -- placing an object outside of any room.
+      -- fallback to strict placing approach ('blocking off areas disabled').
+      invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, roomId)
+    end
+  else
+    -- self.ui.app.config.blocking_off_areas == 1 or 3
+    -- soft placing approach disabled ('safe blocking off areas disabled').
+    -- in thas case follow strict placing approach ('blocking off areas disabled').
+    invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, roomId)
+  end
+
+  if invalid_placement then
+    if self.ui.app.config.blocking_off_areas == 3 then
+      -- all-permissive placing approach ('blocking off areas enabled')
+      -- This could lead to crashes, so we'll record this in the log so that during investigation
+      -- we'll be able to get know that safe placement was disabled.
+      TheApp.world:gameLog("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
+      return true
+    else
+      return false
+    end
+  else
+    return true
+  end
+end
+
+function UIPlaceObjects:_isSideObjectValidPlacement(x, y, roomId, passable_flag, map, world)
+  local invalid_placement
+  -- Depending on the orientation of the side object, we will check the accessibility of the cell
+  -- that is located just behind the edge that this side object creates with its placement
+  local to_check_x, to_check_y = x, y
+  if passable_flag == "travelNorth" or passable_flag == "travelSouth" then
+    to_check_y = to_check_y + (passable_flag == "travelNorth" and -1 or 1)
+  else
+    to_check_x = to_check_x + (passable_flag == "travelEast" and 1 or -1)
+  end
+  local opposite_passable_flag = Object:getComplementaryPassableFlag(passable_flag)
+
+  local function _isNoConnectingPathBetween(x1, y1, x2, y2)
+    if not world.pathfinder:findDistance(x1, y1, x2, y2) then
+      -- we need to check if the failure to get the distance is due to the presence of an object in the adjacent tile
+      if map:getCellFlags(x2, y2)["passable"] then
+        return true
+      end
+    end
+    return false
+  end
+
+  -- 1. Let's simulate it as if we've already placed the object and make tile edge unpassable
+  -- SideObject cell
+  local flags_main = {}
+  flags_main[passable_flag] = false
+  map:setCellFlags(x, y, flags_main)
+  -- adjacent cell to SideObject
+  local flags_adjacent = {}
+  flags_adjacent[opposite_passable_flag] = false
+  map:setCellFlags(to_check_x, to_check_y, flags_adjacent)
+
+  if self.ui.app.config.blocking_off_areas == 2 then
+    -- soft placing approach ('safe blocking off areas enabled')
+    -- 2. Check if the passability to objects is broken.
+    if roomId > 0 and x and y then
+      -- placing an object in a room
+      local room = world:getRoom(x, y)
+      if room and room.door and room.door.tile_x and room.door.tile_y then
+        -- a valid room with a door
+        if not room.is_active then
+          -- user in a room editing mode
+          invalid_placement = world:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(x, y, room, nil, true)
+        else
+          -- user not in a room editing mode.
+          -- as we are not in a room editing mode, then there possbile be humanoids in the room.
+          -- this means that placing object can block a humanoid's passage to the door.
+          -- to prevent that case we fallback to strict placing approach ('blocking off areas disabled').
+          invalid_placement = _isNoConnectingPathBetween(x, y, to_check_x, to_check_y)
+        end
+      else
+        -- not a valid room with a door. corner case like a transition state.
+        invalid_placement = true
+      end
+    else
+      -- placing an object outside of any room.
+      -- fallback to strict placing approach ('blocking off areas disabled').
+      invalid_placement = _isNoConnectingPathBetween(x, y, to_check_x, to_check_y)
+    end
+  else
+    -- self.ui.app.config.blocking_off_areas == 1 or 3
+    -- soft placing approach disabled ('safe blocking off areas disabled').
+    -- in thas case follow strict placing approach ('blocking off areas disabled').
+    invalid_placement = _isNoConnectingPathBetween(x, y, to_check_x, to_check_y)
+  end
+
+  -- 3. Make tiles sides passable back
+  flags_main[passable_flag] = true
+  map:setCellFlags(x, y, flags_main)
+  flags_adjacent[opposite_passable_flag] = true
+  map:setCellFlags(to_check_x, to_check_y, flags_adjacent)
+
+  if invalid_placement then
+    if self.ui.app.config.blocking_off_areas == 3 then
+      -- all-permissive placing approach ('blocking off areas enabled')
+      -- This could lead to crashes, so we'll record this in the log so that during investigation
+      -- we'll be able to get know that safe placement was disabled.
+      TheApp.world:gameLog("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
+      return true
+    else
+      return false
+    end
+  else
+    return true
   end
 end
 

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -662,7 +662,7 @@ function UIPlaceObjects:setBlueprintCell(x, y)
     local opt_tiles_blocked = 0
     local world = self.ui.app.world
     local player_id = self.ui.hospital:getPlayerIndex()
-    local roomId = self.room and self.room.id
+    local room_id = self.room and self.room.id
     local passable_flag
     local direction = self.object_orientation
     local direction_parameters =  {
@@ -709,9 +709,9 @@ function UIPlaceObjects:setBlueprintCell(x, y)
         end
 
         -- Check 2: Is the tile in the object's allowed room?:
-        local result = world:willObjectsFootprintTileBeWithinItsAllowedRoomIfLocatedAt(xpos, ypos, object, roomId)
+        local result = world:willObjectsFootprintTileBeWithinItsAllowedRoomIfLocatedAt(xpos, ypos, object, room_id)
         local is_object_allowed = result.within_room
-        roomId = result.roomId
+        room_id = result.roomId
 
         -- Check 3: The footprint tile should either be buildable or passable, is it?:
         if not tile.only_side and is_object_allowed then
@@ -758,13 +758,11 @@ function UIPlaceObjects:setBlueprintCell(x, y)
     if self.object_anim and object.class ~= "SideObject" then
       -- Not SideObject - an object that occupies the whole title or several of them
       -- (Drinks machine, plant, reception desk, room machines and etc).
-      allgood = allgood and self:_isNonSideObjectValidPlacement(x, y, object, self.object_orientation, roomId, world)
+      allgood = allgood and self:_isNonSideObjectPlacementValid(x, y, object, self.object_orientation, room_id, world)
       _setPartialFlags(x, y, map, flag_altpal, allgood)
     elseif object.class == "SideObject" then
       -- SideObject - an object that lives on the edge of a tile (radiator, bin, extinguisher).
-      if map:getCellFlags(x, y)[passable_flag] == true then
-        allgood = allgood and self:_isSideObjectValidPlacement(x, y, roomId, passable_flag, map, world)
-      end
+      allgood = allgood and self:_isSideObjectPlacementValid(x, y, room_id, passable_flag, map, world)
       _setPartialFlags(x, y, map, flag_altpal, allgood)
     end
   else
@@ -772,19 +770,27 @@ function UIPlaceObjects:setBlueprintCell(x, y)
   end
 end
 
-function UIPlaceObjects:_isNonSideObjectValidPlacement(x, y, object, object_orientation, roomId, world)
+--! Function for checking the valid placement of "SideObject".
+--! param x (integer) target tile x coordinate.
+--! param y (integer) target tile y coordinate.
+--! param object (object) target SideObject.
+--! param object_orientation (string) footprint orientation name.
+--! param room_id (integer) room id if we in a build mode.
+--! param world (object) target world object.
+--! return (bool) is such placement will not break pathfinding.
+function UIPlaceObjects:_isNonSideObjectPlacementValid(x, y, object, object_orientation, room_id, world)
   local invalid_placement
-  if self.ui.app.config.blocking_off_areas == 2 then
-    -- soft placing approach ('safe blocking off areas enabled')
-    if roomId > 0 and x and y then
-      -- placing an object in a room
-      local room = world:getRoom(x, y)
-      if room and room.door and room.door.tile_x and room.door.tile_y then
-        -- a valid room with a door
+  if room_id > 0 and x and y then
+    -- placing an object in a room
+    local room = world:getRoom(x, y)
+    if room and not room.crashed and room.door and room.door.tile_x and room.door.tile_y then
+      -- a valid room with a door
+      if self.ui.app.config.blocking_off_areas == 2 then
+        -- soft placing approach ('safe blocking off areas enabled')
         if not room.is_active then
           -- user in a room editing mode
           local object_layout = object.orientations[object_orientation]
-          invalid_placement = world:wouldNonSideObjectDontHaveAccessToTheRoomDoor(x, y, room, object_layout)
+          invalid_placement = world:wouldNonSideObjectsNotHaveAccessToRoomDoor(x, y, room, object_layout)
           if not invalid_placement then
             -- also check that after placing the object, all usage titles of objects already placed in the room
             -- will remain accessible from the door room tile.
@@ -795,29 +801,28 @@ function UIPlaceObjects:_isNonSideObjectValidPlacement(x, y, object, object_orie
           -- as we are not in a room editing mode, then there possbile be humanoids in the room.
           -- this means that placing object can block a humanoid's passage to the door.
           -- to prevent that case we fallback to strict placing approach ('blocking off areas disabled').
-          invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, roomId)
+          invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, room_id)
         end
       else
-        -- not a valid room with a door. corner case like a transition state.
-        invalid_placement = true
+        -- soft placing approach disabled ('safe blocking off areas disabled').
+        -- in that case follow strict placing approach ('blocking off areas disabled').
+        invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, room_id)
       end
     else
-      -- placing an object outside of any room.
-      -- fallback to strict placing approach ('blocking off areas disabled').
-      invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, roomId)
+      -- not a valid room with a door. corner case like a transition state.
+      invalid_placement = true
     end
   else
-    -- self.ui.app.config.blocking_off_areas == 1 or 3
-    -- soft placing approach disabled ('safe blocking off areas disabled').
-    -- in thas case follow strict placing approach ('blocking off areas disabled').
-    invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, roomId)
+    -- placing an object outside of any room.
+    -- fallback to strict placing approach ('blocking off areas disabled').
+    invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, room_id)
   end
 
   if invalid_placement then
     if self.ui.app.config.blocking_off_areas == 3 then
       -- all-permissive placing approach ('blocking off areas enabled')
       -- This could lead to crashes, so we'll record this in the log so that during investigation
-      -- we'll be able to get know that safe placement was disabled.
+      -- we'll be able to know that safe placement was disabled.
       TheApp.world:gameLog("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
       return true
     else
@@ -828,7 +833,15 @@ function UIPlaceObjects:_isNonSideObjectValidPlacement(x, y, object, object_orie
   end
 end
 
-function UIPlaceObjects:_isSideObjectValidPlacement(x, y, roomId, passable_flag, map, world)
+--! Function for checking the valid placement of "SideObject".
+--! param x (integer) target tile x coordinate.
+--! param y (integer) target tile y coordinate.
+--! param room_id (integer) room id if we in a build mode.
+--! param passable_flag (string) passable flag name. orientation of an object relative to the cardinal directions.
+--! param map (object) target map object.
+--! param world (object) target world object.
+--! return (bool) is such placement will not break pathfinding.
+function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag, map, world)
   local invalid_placement
   -- Depending on the orientation of the side object, we will check the accessibility of the cell
   -- that is located just behind the edge that this side object creates with its placement
@@ -839,8 +852,9 @@ function UIPlaceObjects:_isSideObjectValidPlacement(x, y, roomId, passable_flag,
     to_check_x = to_check_x + (passable_flag == "travelEast" and 1 or -1)
   end
   local opposite_passable_flag = Object:getComplementaryPassableFlag(passable_flag)
+  local not_along_wall = map:getCellFlags(x, y)[passable_flag] == true
 
-  local function _isNoConnectingPathBetween(x1, y1, x2, y2)
+  local function hasNoConnectingPath(x1, y1, x2, y2)
     if not world.pathfinder:findDistance(x1, y1, x2, y2) then
       -- we need to check if the failure to get the distance is due to the presence of an object in the adjacent tile
       if map:getCellFlags(x2, y2)["passable"] then
@@ -860,41 +874,41 @@ function UIPlaceObjects:_isSideObjectValidPlacement(x, y, roomId, passable_flag,
   flags_adjacent[opposite_passable_flag] = false
   map:setCellFlags(to_check_x, to_check_y, flags_adjacent)
 
-  if self.ui.app.config.blocking_off_areas == 2 then
-    -- soft placing approach ('safe blocking off areas enabled')
-    -- 2. Check if the passability to objects is broken.
-    if roomId > 0 and x and y then
-      -- placing an object in a room
-      local room = world:getRoom(x, y)
-      if room and room.door and room.door.tile_x and room.door.tile_y then
-        -- a valid room with a door
+  -- 2. Check if the passability to objects is broken.
+  if room_id > 0 and x and y then
+    -- placing an object in a room
+    local room = world:getRoom(x, y)
+    if room and not room.crashed and room.door and room.door.tile_x and room.door.tile_y then
+      -- a valid room with a door
+      if self.ui.app.config.blocking_off_areas == 2 then
+        -- soft placing approach ('safe blocking off areas enabled')
         if not room.is_active then
           -- user in a room editing mode
-          invalid_placement = world:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(x, y, room, nil, true)
+          invalid_placement = not_along_wall and world:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(x, y, room, nil, true)
         else
           -- user not in a room editing mode.
           -- as we are not in a room editing mode, then there possbile be humanoids in the room.
           -- this means that placing object can block a humanoid's passage to the door.
           -- to prevent that case we fallback to strict placing approach ('blocking off areas disabled').
-          invalid_placement = _isNoConnectingPathBetween(x, y, to_check_x, to_check_y)
+          invalid_placement = not_along_wall and hasNoConnectingPath(x, y, to_check_x, to_check_y)
         end
       else
-        -- not a valid room with a door. corner case like a transition state.
-        invalid_placement = true
+        -- self.ui.app.config.blocking_off_areas == 1 or 3
+        -- soft placing approach disabled ('safe blocking off areas disabled').
+        -- in thas case follow strict placing approach ('blocking off areas disabled').
+        invalid_placement = not_along_wall and hasNoConnectingPath(x, y, to_check_x, to_check_y)
       end
     else
-      -- placing an object outside of any room.
-      -- fallback to strict placing approach ('blocking off areas disabled').
-      invalid_placement = _isNoConnectingPathBetween(x, y, to_check_x, to_check_y)
+      -- not a valid room with a door. corner case like a transition state.
+      invalid_placement = true
     end
   else
-    -- self.ui.app.config.blocking_off_areas == 1 or 3
-    -- soft placing approach disabled ('safe blocking off areas disabled').
-    -- in thas case follow strict placing approach ('blocking off areas disabled').
-    invalid_placement = _isNoConnectingPathBetween(x, y, to_check_x, to_check_y)
+    -- placing an object outside of any room.
+    -- fallback to strict placing approach ('blocking off areas disabled').
+    invalid_placement = not_along_wall and hasNoConnectingPath(x, y, to_check_x, to_check_y)
   end
 
-  -- 3. Make tiles sides passable back
+  -- 3. Restore the original tile's passable properties, thus undoing the actions taken in step 1.
   flags_main[passable_flag] = true
   map:setCellFlags(x, y, flags_main)
   flags_adjacent[opposite_passable_flag] = true
@@ -904,7 +918,7 @@ function UIPlaceObjects:_isSideObjectValidPlacement(x, y, roomId, passable_flag,
     if self.ui.app.config.blocking_off_areas == 3 then
       -- all-permissive placing approach ('blocking off areas enabled')
       -- This could lead to crashes, so we'll record this in the log so that during investigation
-      -- we'll be able to get know that safe placement was disabled.
+      -- we'll be able to know that safe placement was disabled.
       TheApp.world:gameLog("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
       return true
     else

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -777,7 +777,7 @@ end
 --! param object_orientation (string) footprint orientation name.
 --! param room_id (integer) room id if we in a build mode.
 --! param world (object) target world object.
---! return (bool) is such placement will not break pathfinding.
+--! return (bool) is this placement not going to break path finding.
 function UIPlaceObjects:_isNonSideObjectPlacementValid(x, y, object, object_orientation, room_id, world)
   local invalid_placement
   if room_id > 0 and x and y then
@@ -840,7 +840,7 @@ end
 --! param passable_flag (string) passable flag name. orientation of an object relative to the cardinal directions.
 --! param map (object) target map object.
 --! param world (object) target world object.
---! return (bool) is such placement will not break pathfinding.
+--! return (bool) is this placement not going to break path finding.
 function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag, map, world)
   local invalid_placement
   -- Depending on the orientation of the side object, we will check the accessibility of the cell

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -756,7 +756,7 @@ function UIPlaceObjects:setBlueprintCell(x, y)
     end
 
     if self.object_anim and object.class ~= "SideObject" then
-      -- Not SideObject - an object that occupies the whole title or several of them
+      -- Not SideObject - object is occupying one or more tiles entirely
       -- (Drinks machine, plant, reception desk, room machines and etc).
       allgood = allgood and self:_isNonSideObjectPlacementValid(x, y, object, self.object_orientation, room_id, world)
       _setPartialFlags(x, y, map, flag_altpal, allgood)
@@ -770,13 +770,13 @@ function UIPlaceObjects:setBlueprintCell(x, y)
   end
 end
 
---! Function for checking the valid placement of "SideObject".
+--! Function for checking the valid placement of "NonSideObject".
 --! param x (integer) target tile x coordinate.
 --! param y (integer) target tile y coordinate.
 --! param object (object) target SideObject.
 --! param object_orientation (string) footprint orientation name.
 --! param room_id (integer) room id if we in a build mode.
---! param world (object) target world object.
+--! param world (object) world class instance
 --! return (bool) is this placement not going to break path finding.
 function UIPlaceObjects:_isNonSideObjectPlacementValid(x, y, object, object_orientation, room_id, world)
   local invalid_placement
@@ -786,7 +786,7 @@ function UIPlaceObjects:_isNonSideObjectPlacementValid(x, y, object, object_orie
     if room and not room.crashed and room.door and room.door.tile_x and room.door.tile_y then
       -- a valid room with a door
       if self.ui.app.config.blocking_off_areas == 2 then
-        -- soft placing approach ('safe blocking off areas enabled')
+        -- soft placing approach
         if not room.is_active then
           -- user in a room editing mode
           local object_layout = object.orientations[object_orientation]
@@ -800,28 +800,27 @@ function UIPlaceObjects:_isNonSideObjectPlacementValid(x, y, object, object_orie
           -- user not in a room editing mode.
           -- as we are not in a room editing mode, then there possbile be humanoids in the room.
           -- this means that placing object can block a humanoid's passage to the door.
-          -- to prevent that case we fallback to strict placing approach ('blocking off areas disabled').
+          -- To prevent that case we fallback to strict placing approach.
           invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, room_id)
         end
       else
-        -- soft placing approach disabled ('safe blocking off areas disabled').
-        -- in that case follow strict placing approach ('blocking off areas disabled').
+        -- soft placing approach disabled. So follow strict placing approach.
         invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, room_id)
       end
     else
-      -- not a valid room with a door. corner case like a transition state.
+      -- not a valid room with a door. Possible corner case like a transition state.
       invalid_placement = true
     end
   else
     -- placing an object outside of any room.
-    -- fallback to strict placing approach ('blocking off areas disabled').
+    -- Fallback to strict placing approach.
     invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, room_id)
   end
 
   if not invalid_placement then
     return true
   elseif self.ui.app.config.blocking_off_areas == 3 then
-    -- all-permissive placing approach ('blocking off areas enabled')
+    -- all-permissive placing approach.
     -- This could lead to crashes, so we'll record this in the log so that during investigation
     -- we'll be able to know that safe placement was disabled.
     TheApp.world:gameLog("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
@@ -835,8 +834,8 @@ end
 --! param y (integer) target tile y coordinate.
 --! param room_id (integer) room id if we in a build mode.
 --! param passable_flag (string) passable flag name. orientation of an object relative to the cardinal directions.
---! param map (object) target map object.
---! param world (object) target world object.
+--! param map (object) map class instance
+--! param world (object) world class instance
 --! return (bool) is this placement not going to break path finding.
 function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag, map, world)
   -- if we consider to place a SideObject against a wall, it is always a valid placement.
@@ -854,7 +853,7 @@ function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag
   else
     to_check_x = to_check_x + (passable_flag == "travelEast" and 1 or -1)
   end
-  local opposite_passable_flag = Object:getComplementaryPassableFlag(passable_flag)
+  local opposite_passable_flag = Object.getComplementaryPassableFlag(passable_flag)
 
   local function hasNoConnectingPath(x1, y1, x2, y2)
     if not world.pathfinder:findDistance(x1, y1, x2, y2) then
@@ -883,7 +882,7 @@ function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag
     if room and not room.crashed and room.door and room.door.tile_x and room.door.tile_y then
       -- a valid room with a door
       if self.ui.app.config.blocking_off_areas == 2 then
-        -- soft placing approach ('safe blocking off areas enabled')
+        -- soft placing approach
         if not room.is_active then
           -- user in a room editing mode
           invalid_placement = world:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(x, y, room, nil, true)
@@ -891,20 +890,20 @@ function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag
           -- user not in a room editing mode.
           -- as we are not in a room editing mode, then there could be humanoids in the room.
           -- this means that placing object can block a humanoid's passage to the door.
-          -- to prevent that case we fallback to strict placing approach ('blocking off areas disabled').
+          -- to prevent that case we fallback to strict placing approach.
           invalid_placement = hasNoConnectingPath(x, y, to_check_x, to_check_y)
         end
       else
-        -- follow strict placing approach ('blocking off areas disabled').
+        -- follow strict placing approach.
         invalid_placement = hasNoConnectingPath(x, y, to_check_x, to_check_y)
       end
     else
-      -- not a valid room with a door. corner case like a transition state.
+      -- not a valid room with a door. Possible corner case like a transition state.
       invalid_placement = true
     end
   else
     -- placing an object outside of any room.
-    -- fallback to strict placing approach ('blocking off areas disabled').
+    -- Fallback to strict placing approach.
     invalid_placement = hasNoConnectingPath(x, y, to_check_x, to_check_y)
   end
 
@@ -917,7 +916,7 @@ function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag
   if not invalid_placement then
     return true
   elseif self.ui.app.config.blocking_off_areas == 3 then
-    -- all-permissive placing approach ('blocking off areas enabled')
+    -- all-permissive placing approach.
     -- This could lead to crashes, so we'll record this in the log so that during investigation
     -- we'll be able to know that safe placement was disabled.
     TheApp.world:gameLog("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -887,7 +887,7 @@ function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag
           invalid_placement = not_along_wall and world:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(x, y, room, nil, true)
         else
           -- user not in a room editing mode.
-          -- as we are not in a room editing mode, then there possbile be humanoids in the room.
+          -- as we are not in a room editing mode, then there could be humanoids in the room.
           -- this means that placing object can block a humanoid's passage to the door.
           -- to prevent that case we fallback to strict placing approach ('blocking off areas disabled').
           invalid_placement = not_along_wall and hasNoConnectingPath(x, y, to_check_x, to_check_y)

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -842,6 +842,12 @@ end
 --! param world (object) target world object.
 --! return (bool) is this placement not going to break path finding.
 function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag, map, world)
+  -- if we consider to place a SideObject against a wall, it is always a valid placement.
+  -- also, for SideObject, do not change 'passable_flag according to the algorithm below in 1.,
+  -- as this will make the wall passable through.
+  local along_wall = map:getCellFlags(x, y)[passable_flag] == false
+  if along_wall then return true end
+
   local invalid_placement
   -- Depending on the orientation of the side object, we will check the accessibility of the cell
   -- that is located just behind the edge that this side object creates with its placement
@@ -852,7 +858,6 @@ function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag
     to_check_x = to_check_x + (passable_flag == "travelEast" and 1 or -1)
   end
   local opposite_passable_flag = Object:getComplementaryPassableFlag(passable_flag)
-  local not_along_wall = map:getCellFlags(x, y)[passable_flag] == true
 
   local function hasNoConnectingPath(x1, y1, x2, y2)
     if not world.pathfinder:findDistance(x1, y1, x2, y2) then
@@ -884,17 +889,17 @@ function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag
         -- soft placing approach ('safe blocking off areas enabled')
         if not room.is_active then
           -- user in a room editing mode
-          invalid_placement = not_along_wall and world:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(x, y, room, nil, true)
+          invalid_placement = world:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(x, y, room, nil, true)
         else
           -- user not in a room editing mode.
           -- as we are not in a room editing mode, then there could be humanoids in the room.
           -- this means that placing object can block a humanoid's passage to the door.
           -- to prevent that case we fallback to strict placing approach ('blocking off areas disabled').
-          invalid_placement = not_along_wall and hasNoConnectingPath(x, y, to_check_x, to_check_y)
+          invalid_placement = hasNoConnectingPath(x, y, to_check_x, to_check_y)
         end
       else
         -- follow strict placing approach ('blocking off areas disabled').
-        invalid_placement = not_along_wall and hasNoConnectingPath(x, y, to_check_x, to_check_y)
+        invalid_placement = hasNoConnectingPath(x, y, to_check_x, to_check_y)
       end
     else
       -- not a valid room with a door. corner case like a transition state.
@@ -903,7 +908,7 @@ function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag
   else
     -- placing an object outside of any room.
     -- fallback to strict placing approach ('blocking off areas disabled').
-    invalid_placement = not_along_wall and hasNoConnectingPath(x, y, to_check_x, to_check_y)
+    invalid_placement = hasNoConnectingPath(x, y, to_check_x, to_check_y)
   end
 
   -- 3. Restore the original tile's passable properties, thus undoing the actions taken in step 1.

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -818,19 +818,16 @@ function UIPlaceObjects:_isNonSideObjectPlacementValid(x, y, object, object_orie
     invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, room_id)
   end
 
-  if invalid_placement then
-    if self.ui.app.config.blocking_off_areas == 3 then
-      -- all-permissive placing approach ('blocking off areas enabled')
-      -- This could lead to crashes, so we'll record this in the log so that during investigation
-      -- we'll be able to know that safe placement was disabled.
-      TheApp.world:gameLog("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
-      return true
-    else
-      return false
-    end
-  else
+  if not invalid_placement then
+    return true
+  elseif self.ui.app.config.blocking_off_areas == 3 then
+    -- all-permissive placing approach ('blocking off areas enabled')
+    -- This could lead to crashes, so we'll record this in the log so that during investigation
+    -- we'll be able to know that safe placement was disabled.
+    TheApp.world:gameLog("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
     return true
   end
+  return false
 end
 
 --! Function for checking the valid placement of "SideObject".
@@ -917,19 +914,16 @@ function UIPlaceObjects:_isSideObjectPlacementValid(x, y, room_id, passable_flag
   flags_adjacent[opposite_passable_flag] = true
   map:setCellFlags(to_check_x, to_check_y, flags_adjacent)
 
-  if invalid_placement then
-    if self.ui.app.config.blocking_off_areas == 3 then
-      -- all-permissive placing approach ('blocking off areas enabled')
-      -- This could lead to crashes, so we'll record this in the log so that during investigation
-      -- we'll be able to know that safe placement was disabled.
-      TheApp.world:gameLog("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
-      return true
-    else
-      return false
-    end
-  else
+  if not invalid_placement then
+    return true
+  elseif self.ui.app.config.blocking_off_areas == 3 then
+    -- all-permissive placing approach ('blocking off areas enabled')
+    -- This could lead to crashes, so we'll record this in the log so that during investigation
+    -- we'll be able to know that safe placement was disabled.
+    TheApp.world:gameLog("Blocking off areas is allowed at " .. x .. ", " .. y .. ".")
     return true
   end
+  return false
 end
 
 local function NearestPointOnLine(lx1, ly1, lx2, ly2, px, py)

--- a/CorsixTH/Lua/dialogs/place_staff.lua
+++ b/CorsixTH/Lua/dialogs/place_staff.lua
@@ -101,7 +101,16 @@ function UIPlaceStaff:_isValidStaffPlacement()
   end
   local room = world:getRoom(x, y)
   -- On a tile humanoids can walk on?
-  local walkable = flag_cache.passable and (not room and true or not room.crashed)
+  local walkable = flag_cache.passable
+  if room then
+    if room.door and room.door.tile_x and room.door.tile_y then
+      -- Check that the door is accessible from this tile. Otherwise, forbid placement.
+      local reachable = world.pathfinder:findDistance(x, y, room.door.tile_x, room.door.tile_y)
+      walkable = walkable and not room.crashed and reachable
+    else
+      walkable = false
+    end
+  end
   -- and in an area the regular staff (doctors, nurses and handymen) can go?
   local staffable = (self.allow_in_rooms or flag_cache.roomId == 0)
   -- Or is it a receptionist placed on an unstaffed reception desk?

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -366,18 +366,19 @@ function Object:getWalkableTiles()
   return tiles
 end
 
+local opposite_flags = {
+  travelNorth = "travelSouth",
+  travelSouth = "travelNorth",
+  travelEast = "travelWest",
+  travelWest = "travelEast"
+}
 --! The function returns the direction opposite to the one passed as a parameter.
 --! For North, it returns South, and so on.
 --! param passable_flag (string) 'passable_flag' that we want to invert.
 --! return (string) inverted 'passable_flag'.
 function Object:getComplementaryPassableFlag(passable_flag)
-  if passable_flag == "travelNorth" or passable_flag == "travelSouth" then
-    return passable_flag == "travelNorth" and "travelSouth" or "travelNorth"
-  else
-    return passable_flag == "travelEast" and "travelWest" or "travelEast"
-  end
+  return opposite_flags[passable_flag]
 end
-
 function Object:setTile(x, y)
   local function coordinatesAreInFootprint(object_footprint, xpos, ypos)
     for _, xy in ipairs(object_footprint) do

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -288,7 +288,7 @@ function Object:_getUsageTile(usage_position_name)
   end
 end
 
---! This function returns an absolete world coordinates for use position.
+--! This function returns an absolute world coordinates for use position.
 --! param object_x (integer) world tile x coordinate.
 --! param object_y (integer) world tile y coordinate.
 --! param object_layout (table) object orientation description with footprint.

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -377,7 +377,7 @@ local opposite_flags = {
 --! For North, it returns South, and so on.
 --! param passable_flag (string) 'passable_flag' that we want to invert.
 --! return (string) inverted 'passable_flag'.
-function Object:getComplementaryPassableFlag(passable_flag)
+function Object.getComplementaryPassableFlag(passable_flag)
   return opposite_flags[passable_flag]
 end
 
@@ -396,7 +396,7 @@ function Object:setTile(x, y)
     flags1[passable_flag] = value
     self.world.map.th:setCellFlags(xpos, ypos, flags1)
     local flags2 = {}
-    flags2[Object:getComplementaryPassableFlag(passable_flag)] = value
+    flags2[Object.getComplementaryPassableFlag(passable_flag)] = value
     self.world.map.th:setCellFlags(next_x, next_y, flags2)
   end
 

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -273,15 +273,85 @@ function Object:updateDynamicInfo()
   end
 end
 
-function Object:getSecondaryUsageTile()
-  local x, y = self.tile_x, self.tile_y
-  local offset = self.object_type.orientations
-  if offset then
-    offset = offset[self.direction].use_position_secondary
-    x = x + offset[1]
-    y = y + offset[2]
+--! This function returns a tiles offset coordinates for
+--! object use position
+--! param usage_position_name (string) usage position name
+--! return (table) table with {x, y, usage_position_name} table
+function Object:_getUsageTile(usage_position_name)
+  local object_x, object_y = self.tile_x, self.tile_y
+  local orientations = self.object_type.orientations
+  if orientations then
+    local object_layout = orientations[self.direction]
+    return Object:getXYforUsePosition(object_x, object_y, object_layout, usage_position_name)
+  else
+    return nil
   end
-  return x, y
+end
+
+--! This function returns an absolete world coordinates for use position.
+--! param object_x (integer) world tile x coordinate.
+--! param object_y (integer) world tile y coordinate.
+--! param object_layout (table) object orientation description with footprint.
+--! param usage_position_name (string) usage position name.
+--! return (array) array with '{x, y, usage_position_name}' tables inside.
+function Object:getXYforUsePosition(object_x, object_y, object_layout, usage_position_name)
+  local usage_tile_offset = object_layout[usage_position_name]
+  if usage_tile_offset then
+    local first = usage_tile_offset[1]
+    local second = usage_tile_offset[2]
+    if type(first) == "table" then -- for 'handyman_position' in 'cast_remover' case as it store table
+      local result = {}
+      for _, xy in ipairs(usage_tile_offset) do
+        local x = object_x + xy[1]
+        local y = object_y + xy[2]
+        table.insert(result, {x, y, usage_position_name})
+      end
+      return result
+    else -- for other regular cases
+      local x = object_x + first
+      local y = object_y + second
+      return {{x, y, usage_position_name}}
+    end
+  else
+    return nil
+  end
+end
+
+--! This function returns an array with use positions names
+--! return (array) use positions names
+function Object:usePositionNames()
+  return {
+    "use_position",
+    "use_position_secondary",
+    "finish_use_position",
+    "finish_use_position_secondary",
+    "handyman_position",
+  }
+end
+
+--! This function returns a table with tiles offset coordinates for
+--! object use positions
+--! return (table) use positions offsets
+function Object:getAllUsageTiles()
+  local result_table = {}
+  local object_use_positions_names = Object:usePositionNames()
+  for key, use_position_name in pairs(object_use_positions_names) do
+    local usage_tile = self:_getUsageTile(use_position_name)
+    result_table = table_merge(result_table, usage_tile)
+  end
+  return result_table
+end
+
+--! This function returns tile offset coordinate for "use_position_secondary"
+--! return (int, int) x, y tile offset
+function Object:getSecondaryUsageTile()
+  local secondary_usage_tile = self:_getUsageTile("use_position_secondary")
+  if secondary_usage_tile then
+    local xy = secondary_usage_tile[1]
+    return xy[1], xy[2]
+  else
+    return nil, nil
+  end
 end
 
 -- This function returns a list of all "only_passable" tiles belonging to an object.
@@ -296,6 +366,18 @@ function Object:getWalkableTiles()
   return tiles
 end
 
+--! The function returns the direction opposite to the one passed as a parameter.
+--! For North, it returns South, and so on.
+--! param passable_flag (string) 'passable_flag' that we want to invert.
+--! return (string) inverted 'passable_flag'.
+function Object:getComplementaryPassableFlag(passable_flag)
+  if passable_flag == "travelNorth" or passable_flag == "travelSouth" then
+    return passable_flag == "travelNorth" and "travelSouth" or "travelNorth"
+  else
+    return passable_flag == "travelEast" and "travelWest" or "travelEast"
+  end
+end
+
 function Object:setTile(x, y)
   local function coordinatesAreInFootprint(object_footprint, xpos, ypos)
     for _, xy in ipairs(object_footprint) do
@@ -306,20 +388,12 @@ function Object:setTile(x, y)
     return false
   end
 
-  local function getComplementaryPassableFlag(passable_flag)
-    if passable_flag == "travelNorth" or passable_flag == "travelSouth" then
-      return passable_flag == "travelNorth" and "travelSouth" or "travelNorth"
-    else
-      return passable_flag == "travelEast" and "travelWest" or "travelEast"
-    end
-  end
-
   local function setPassableFlags(passable_flag, xpos, ypos, next_x, next_y, value)
     local flags1 = {}
     flags1[passable_flag] = value
     self.world.map.th:setCellFlags(xpos, ypos, flags1)
     local flags2 = {}
-    flags2[getComplementaryPassableFlag(passable_flag)] = value
+    flags2[Object:getComplementaryPassableFlag(passable_flag)] = value
     self.world.map.th:setCellFlags(next_x, next_y, flags2)
   end
 

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -372,6 +372,7 @@ local opposite_flags = {
   travelEast = "travelWest",
   travelWest = "travelEast"
 }
+
 --! The function returns the direction opposite to the one passed as a parameter.
 --! For North, it returns South, and so on.
 --! param passable_flag (string) 'passable_flag' that we want to invert.
@@ -379,6 +380,7 @@ local opposite_flags = {
 function Object:getComplementaryPassableFlag(passable_flag)
   return opposite_flags[passable_flag]
 end
+
 function Object:setTile(x, y)
   local function coordinatesAreInFootprint(object_footprint, xpos, ypos)
     for _, xy in ipairs(object_footprint) do

--- a/CorsixTH/Lua/languages/english.lua
+++ b/CorsixTH/Lua/languages/english.lua
@@ -228,6 +228,11 @@ menu_debug = {
   map_overlay                 = "  MAP OVERLAY  ",
   sprite_viewer               = "  SPRITE VIEWER  ",
 }
+menu_debug_overlay_blocking_off_areas = {
+  choice_1 = "  TOTALLY FORBIDDEN  ",
+  choice_2 = "  PARTIALLY ALLOWED  ",
+  choice_3 = "  COMPLETELY ALLOWED  ",
+}
 menu_debug_overlay = {
   none                        = "  NONE  ",
   flags                       = "  FLAGS  ",

--- a/CorsixTH/Lua/objects/plant.lua
+++ b/CorsixTH/Lua/objects/plant.lua
@@ -47,22 +47,18 @@ object.usage_animations = {
 object.orientations = {
   north = {
     footprint = { {0, 0, complete_cell = true} },
-    use_position = {0, -1},
     use_animate_from_use_position = true
   },
   east = {
     footprint = { {0, 0, complete_cell = true} },
-    use_position = {-1, 0},
     use_animate_from_use_position = true
   },
   south = {
     footprint = { {0, 0, complete_cell = true} },
-    use_position = {0, -1},
     use_animate_from_use_position = true
   },
   west = {
     footprint = { {0, 0, complete_cell = true} },
-    use_position = {-1, 0},
     use_animate_from_use_position = true
   },
 }

--- a/CorsixTH/Lua/utility.lua
+++ b/CorsixTH/Lua/utility.lua
@@ -399,6 +399,17 @@ function array_join(array, separator)
   return result
 end
 
+--! Merge tables in one table
+function table_merge(...)
+  local result = {}
+   for _, t in ipairs({...}) do
+      for _, v in ipairs(t) do
+        table.insert(result, v)
+      end
+  end
+  return result
+end
+
 local function serialize_string(val, options)
   local level = options and options.long_bracket_level_start or 0
   while string.find(val, ']' .. string.rep('=', level) .. ']') do

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1883,7 +1883,6 @@ function World:isFootprintTileBuildableOrPassable(x, y, tile, footprint, require
   end
 end
 
---! Strict placing approach ('blocking off areas disabled') function.
 --! Check that pathfinding still works, i.e. that placing the object
 --! wouldn't disconnect one part of the hospital from another. To do
 --! this, we provisionally mark the footprint as unpassable (as it will
@@ -1964,7 +1963,6 @@ function World:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, objec
   return not pathfinding_fine
 end
 
---! Soft placing approach ('safe blocking off areas enabled') function.
 --! Check that pathfinding between object and room door still works,
 --! i.e. that placing the object wouldn't disconnect it from the world.
 --! For that it mark the footprint as unpassable (as it will
@@ -1975,7 +1973,7 @@ end
 --!param room (object) target room for placing the object.
 --!param object_layout (table) object orientation description with footprint.
 --!return (bool) is such placement will break pathfinding.
-function World:wouldNonSideObjectDontHaveAccessToTheRoomDoor(object_x, object_y, room, object_layout)
+function World:wouldNonSideObjectsNotHaveAccessToRoomDoor(object_x, object_y, room, object_layout)
   if not room.door or not room.door.tile_x or not room.door.tile_y then return true end
 
   local door_x, door_y = room:getEntranceXY(true)
@@ -1983,7 +1981,7 @@ function World:wouldNonSideObjectDontHaveAccessToTheRoomDoor(object_x, object_y,
   local map = self.map.th
 
   -- To switch the tiles passability
-  local function _setFootprintTilesPassable(passable)
+  local function setFootprintTilesPassable(passable)
     for _, tile in ipairs(object_footprint) do
       if not tile.only_passable then
         map:setCellFlags(object_x + tile[1], object_y + tile[2], {passable = passable})
@@ -1993,10 +1991,10 @@ function World:wouldNonSideObjectDontHaveAccessToTheRoomDoor(object_x, object_y,
 
   local function _isIsolated(tile_x, tile_y, poi_x, poi_y)
     -- Make footprint tiles unpassable except only_passable ones
-    _setFootprintTilesPassable(false)
+    setFootprintTilesPassable(false)
     -- And check is there is a valid path
     local getPathDistance = self:getPathDistance(tile_x, tile_y, poi_x, poi_y)
-    _setFootprintTilesPassable(true)
+    setFootprintTilesPassable(true)
 
     -- Let's also check that there is a path even without the footprint apply.
     -- This will help to avoid cases where the path starts on an inaccessible tile.
@@ -2036,7 +2034,6 @@ function World:wouldNonSideObjectDontHaveAccessToTheRoomDoor(object_x, object_y,
   return not pathfinding_fine
 end
 
---! Soft placing approach ('safe blocking off areas enabled') function.
 --! Check that pathfinding between already placed in the room objects
 --! and room door still works. i.e. that placing the target object
 --! wouldn't disconnect the existing objects from the world.
@@ -2063,7 +2060,7 @@ function World:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(object_x, object_y
   end
 
   -- To switch the tiles passability
-  local function _setFootprintTilesPassable(passable) -- don't used for SideObjects
+  local function setFootprintTilesPassable(passable) -- not used for SideObjects
     for _, tile in ipairs(object_footprint) do
       if not tile.only_passable then
         map:setCellFlags(object_x + tile[1], object_y + tile[2], {passable = passable})
@@ -2087,7 +2084,7 @@ function World:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(object_x, object_y
 
   --2. Make footprint tiles unpassable except only_passable ones
   if not is_side_object then
-    _setFootprintTilesPassable(false)
+    setFootprintTilesPassable(false)
   end
 
   --3. Find out which use position tiles would become isolated:
@@ -2114,7 +2111,7 @@ function World:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(object_x, object_y
 
   -- 4. For each footprint tile passable flag set to false by step 2 undo this change:
   if not is_side_object then
-    _setFootprintTilesPassable(true)
+    setFootprintTilesPassable(true)
     for tiles_index, tile in ipairs(object_footprint) do
       map:setCellFlags(object_x + tile[1], object_y + tile[2], {passable = tiles_passable_flags[tiles_index]})
     end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1783,6 +1783,9 @@ function World:newObject(id, x, y, flags, name)
   return entity
 end
 
+-- Checks whether object can be spawned at some coordinates.
+-- For example, when searching for a suitable placement for "gates_to_hell".
+-- 'NonSideObject' is a object that do occupy the tile entirely, not only one side of it.
 function World:canNonSideObjectBeSpawnedAt(x, y, objects_id, orientation, spawn_rooms_id, player_id)
   local object = self.object_types[objects_id]
   local objects_footprint = object.orientations[orientation].footprint
@@ -1880,14 +1883,19 @@ function World:isFootprintTileBuildableOrPassable(x, y, tile, footprint, require
   end
 end
 
----
--- Check that pathfinding still works, i.e. that placing the object
--- wouldn't disconnect one part of the hospital from another. To do
--- this, we provisionally mark the footprint as unpassable (as it will
--- become when the object is placed), and then check that the cells
--- surrounding the footprint have not had their connectedness changed.
----
-function World:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, objects_orientation, spawn_rooms_id)
+--! Strict placing approach ('blocking off areas disabled') function.
+--! Check that pathfinding still works, i.e. that placing the object
+--! wouldn't disconnect one part of the hospital from another. To do
+--! this, we provisionally mark the footprint as unpassable (as it will
+--! become when the object is placed), and then check that the cells
+--! surrounding the footprint have not had their connectedness changed.
+--!param x (integer) target tile x coordinate.
+--!param y (integer) target tile y coordinate.
+--!param object (object) target object for placing.
+--!param objects_orientation (table) object orientations description with footprints.
+--!param room_id (integer) target room for placing the object.
+--!return (bool) is such placement will break pathfinding.
+function World:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, objects_orientation, room_id)
   local objects_footprint = object.orientations[objects_orientation].footprint
   local map = self.map.th
 
@@ -1906,7 +1914,7 @@ function World:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, objec
     return result
   end
 
-  local all_good = true
+  local pathfinding_fine = true
 
   --1. Find out which footprint tiles are passable now before this function makes some unpassable
   --during its test:
@@ -1922,7 +1930,7 @@ function World:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, objec
     local xpos = x + tile[1]
     local ypos = y + tile[2]
     local flags = {}
-    if map:getCellFlags(xpos, ypos, flags).roomId == spawn_rooms_id and flags.passable then
+    if map:getCellFlags(xpos, ypos, flags).roomId == room_id and flags.passable then
       if prev_x then
         if not self.pathfinder:findDistance(xpos, ypos, prev_x, prev_y) then
           -- There is no route between the two map nodes. In most cases,
@@ -1934,7 +1942,7 @@ function World:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, objec
           -- connected before.
           if not isIsolated(xpos, ypos) then
             if not isIsolated(prev_x, prev_y) then
-              all_good = false
+              pathfinding_fine = false
               break
             end
           else
@@ -1953,7 +1961,166 @@ function World:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, objec
     map:setCellFlags(x + tile[1], y + tile[2], {passable = tiles_passable_flags[tiles_index]})
   end
 
-  return not all_good
+  return not pathfinding_fine
+end
+
+--! Soft placing approach ('safe blocking off areas enabled') function.
+--! Check that pathfinding between object and room door still works,
+--! i.e. that placing the object wouldn't disconnect it from the world.
+--! For that it mark the footprint as unpassable (as it will
+--! become when the object is placed), and then check that the
+--! "use_position" cells have path to the room door.
+--!param object_x (integer) target tile x coordinate.
+--!param object_y (integer) target tile y coordinate.
+--!param room (object) target room for placing the object.
+--!param object_layout (table) object orientation description with footprint.
+--!return (bool) is such placement will break pathfinding.
+function World:wouldNonSideObjectDontHaveAccessToTheRoomDoor(object_x, object_y, room, object_layout)
+  if not room.door or not room.door.tile_x or not room.door.tile_y then return true end
+
+  local door_x, door_y = room:getEntranceXY(true)
+  local object_footprint = object_layout.footprint
+  local map = self.map.th
+
+  -- To switch the tiles passability
+  local function _setFootprintTilesPassable(passable)
+    for _, tile in ipairs(object_footprint) do
+      if not tile.only_passable then
+        map:setCellFlags(object_x + tile[1], object_y + tile[2], {passable = passable})
+      end
+    end
+  end
+
+  local function _isIsolated(tile_x, tile_y, poi_x, poi_y)
+    -- Make footprint tiles unpassable except only_passable ones
+    _setFootprintTilesPassable(false)
+    -- And check is there is a valid path
+    local getPathDistance = self:getPathDistance(tile_x, tile_y, poi_x, poi_y)
+    _setFootprintTilesPassable(true)
+
+    -- Let's also check that there is a path even without the footprint apply.
+    -- This will help to avoid cases where the path starts on an inaccessible tile.
+    -- For some reason, "getPathDistance" successfully constructs a path from inaccessible tiles.
+    -- So filtering such cases there.
+    getPathDistance = getPathDistance and self:getPathDistance(tile_x, tile_y, poi_x, poi_y)
+    return not getPathDistance
+  end
+
+  -- 1. Let's simulate it as if we've already placed the object and make some tiles unpassable.
+  -- Find out which footprint tiles are passable now before this function makes some unpassable
+  -- during its test:
+  local tiles_passable_flags = {}
+  for _, tile in ipairs(object_footprint) do
+    table.insert(tiles_passable_flags, map:getCellFlags(object_x + tile[1], object_y + tile[2], {}).passable)
+  end
+
+  -- 2. Find out which use position tiles would become isolated:
+  local pathfinding_fine = true
+  local usage_tiles = {}
+  local object_use_positions_names = Object:usePositionNames()
+  for _, usage_position_type in ipairs(object_use_positions_names) do
+    local more_usage_tiles = Object:getXYforUsePosition(object_x, object_y, object_layout, usage_position_type)
+    usage_tiles = table_merge(usage_tiles, more_usage_tiles)
+  end
+
+  for _, usage_tile in ipairs(usage_tiles) do
+    pathfinding_fine = pathfinding_fine and not _isIsolated(usage_tile[1], usage_tile[2], door_x, door_y)
+    if not pathfinding_fine then break end
+  end
+
+  -- 3. For each footprint tile passable flag set to false by step 2 undo this change:
+  for tiles_index, tile in ipairs(object_footprint) do
+    map:setCellFlags(object_x + tile[1], object_y + tile[2], {passable = tiles_passable_flags[tiles_index]})
+  end
+
+  return not pathfinding_fine
+end
+
+--! Soft placing approach ('safe blocking off areas enabled') function.
+--! Check that pathfinding between already placed in the room objects
+--! and room door still works. i.e. that placing the target object
+--! wouldn't disconnect the existing objects from the world.
+--! For 'NonSideObject' it mark the footprint as unpassable
+--! (as it will become when the object is placed).
+--! For 'SideObject' this function expects that mark the footprint
+--! as unpassable will be executed outside of this function.
+--! And then this function check that the "use_position" cells
+--! of existing objects have path to the room door.
+--!param object_x (integer) target tile x coordinate.
+--!param object_y (integer) target tile y coordinate.
+--!param room (object) target room for placing the object.
+--!param object_layout (table) object orientation description with footprint.
+--!param is_side_object (bool) is that object is side object.
+--!return (bool) is such placement will break pathfinding.
+function World:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(object_x, object_y, room, object_layout, is_side_object)
+  if not room.door or not room.door.tile_x or not room.door.tile_y then return true end
+
+  local object_footprint
+  local door_x, door_y = room:getEntranceXY(true)
+  local map = self.map.th
+  if not is_side_object then
+    object_footprint = object_layout.footprint
+  end
+
+  -- To switch the tiles passability
+  local function _setFootprintTilesPassable(passable) -- don't used for SideObjects
+    for _, tile in ipairs(object_footprint) do
+      if not tile.only_passable then
+        map:setCellFlags(object_x + tile[1], object_y + tile[2], {passable = passable})
+      end
+    end
+  end
+
+  local function _isIsolated(tile_x, tile_y, poi_x, poi_y)
+    local getPathDistance = self:getPathDistance(tile_x, tile_y, poi_x, poi_y)
+    return not getPathDistance
+  end
+
+  --1. Find out which footprint tiles are passable now before this function makes some unpassable
+  --during its test:
+  local tiles_passable_flags = {}
+  if not is_side_object then
+    for _, tile in ipairs(object_footprint) do
+      table.insert(tiles_passable_flags, map:getCellFlags(object_x + tile[1], object_y + tile[2], {}).passable)
+    end
+  end
+
+  --2. Make footprint tiles unpassable except only_passable ones
+  if not is_side_object then
+    _setFootprintTilesPassable(false)
+  end
+
+  --3. Find out which use position tiles would become isolated:
+  local pathfinding_fine = true
+  for room_object, _ in pairs(room.objects) do
+    -- check that for each already placed object there is a valid path to the door
+    local object_usage_tiles = room_object:getAllUsageTiles()
+    for _, usage_tile in pairs(object_usage_tiles) do
+      local use_x, use_y = usage_tile[1], usage_tile[2]
+      -- 'SideObject' somehow has 'use_position', even though they don't have it in the footprint.
+      -- We don't need to check that 'use_position' for 'SideObjects',
+      -- because these 'use_position' are not actually used in the game, so skip them.
+      if (room_object.object_type.class ~= "SideObject") and use_x and use_y then
+        -- check that the placing object itself does not occupy 'use_position'
+        local the_same_title = (object_x == use_x) and (object_y == use_y)
+        pathfinding_fine = pathfinding_fine and not the_same_title
+        -- also check that the placing object does not break the path from 'use_position' to the room door.
+        pathfinding_fine = pathfinding_fine and not _isIsolated(use_x, use_y, door_x, door_y)
+      end
+      if not pathfinding_fine then break end
+    end
+    if not pathfinding_fine then break end
+  end
+
+  -- 4. For each footprint tile passable flag set to false by step 2 undo this change:
+  if not is_side_object then
+    _setFootprintTilesPassable(true)
+    for tiles_index, tile in ipairs(object_footprint) do
+      map:setCellFlags(object_x + tile[1], object_y + tile[2], {passable = tiles_passable_flags[tiles_index]})
+    end
+  end
+
+  return not pathfinding_fine
 end
 
 --! Notifies the world that an object has been placed, notifying

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1893,7 +1893,7 @@ end
 --!param object (object) target object for placing.
 --!param objects_orientation (table) object orientations description with footprints.
 --!param room_id (integer) target room for placing the object.
---!return (bool) is such placement will break pathfinding.
+--!return (bool) will this placement break path finding.
 function World:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, objects_orientation, room_id)
   local objects_footprint = object.orientations[objects_orientation].footprint
   local map = self.map.th
@@ -1972,7 +1972,7 @@ end
 --!param object_y (integer) target tile y coordinate.
 --!param room (object) target room for placing the object.
 --!param object_layout (table) object orientation description with footprint.
---!return (bool) is such placement will break pathfinding.
+--!return (bool) will this placement break path finding.
 function World:wouldNonSideObjectsNotHaveAccessToRoomDoor(object_x, object_y, room, object_layout)
   if not room.door or not room.door.tile_x or not room.door.tile_y then return true end
 
@@ -2048,7 +2048,7 @@ end
 --!param room (object) target room for placing the object.
 --!param object_layout (table) object orientation description with footprint.
 --!param is_side_object (bool) is that object is side object.
---!return (bool) is such placement will break pathfinding.
+--!return (bool) will this placement break path finding.
 function World:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(object_x, object_y, room, object_layout, is_side_object)
   if not room.door or not room.door.tile_x or not room.door.tile_y then return true end
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1913,7 +1913,7 @@ function World:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, objec
     return result
   end
 
-  local pathfinding_fine = true
+  local pathfinding_success = true
 
   --1. Find out which footprint tiles are passable now before this function makes some unpassable
   --during its test:
@@ -1941,7 +1941,7 @@ function World:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, objec
           -- connected before.
           if not isIsolated(xpos, ypos) then
             if not isIsolated(prev_x, prev_y) then
-              pathfinding_fine = false
+              pathfinding_success = false
               break
             end
           else
@@ -1960,7 +1960,7 @@ function World:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, objec
     map:setCellFlags(x + tile[1], y + tile[2], {passable = tiles_passable_flags[tiles_index]})
   end
 
-  return not pathfinding_fine
+  return not pathfinding_success
 end
 
 --! Check that pathfinding between object and room door still works,
@@ -2013,7 +2013,7 @@ function World:wouldNonSideObjectsNotHaveAccessToRoomDoor(object_x, object_y, ro
   end
 
   -- 2. Find out which use position tiles would become isolated:
-  local pathfinding_fine = true
+  local pathfinding_success = true
   local usage_tiles = {}
   local object_use_positions_names = Object:usePositionNames()
   for _, usage_position_type in ipairs(object_use_positions_names) do
@@ -2022,8 +2022,8 @@ function World:wouldNonSideObjectsNotHaveAccessToRoomDoor(object_x, object_y, ro
   end
 
   for _, usage_tile in ipairs(usage_tiles) do
-    pathfinding_fine = pathfinding_fine and not _isIsolated(usage_tile[1], usage_tile[2], door_x, door_y)
-    if not pathfinding_fine then break end
+    pathfinding_success = pathfinding_success and not _isIsolated(usage_tile[1], usage_tile[2], door_x, door_y)
+    if not pathfinding_success then break end
   end
 
   -- 3. For each footprint tile passable flag set to false by step 2 undo this change:
@@ -2031,7 +2031,7 @@ function World:wouldNonSideObjectsNotHaveAccessToRoomDoor(object_x, object_y, ro
     map:setCellFlags(object_x + tile[1], object_y + tile[2], {passable = tiles_passable_flags[tiles_index]})
   end
 
-  return not pathfinding_fine
+  return not pathfinding_success
 end
 
 --! Check that pathfinding between already placed in the room objects
@@ -2088,7 +2088,7 @@ function World:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(object_x, object_y
   end
 
   --3. Find out which use position tiles would become isolated:
-  local pathfinding_fine = true
+  local pathfinding_success = true
   for room_object, _ in pairs(room.objects) do
     -- check that for each already placed object there is a valid path to the door
     local object_usage_tiles = room_object:getAllUsageTiles()
@@ -2100,13 +2100,13 @@ function World:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(object_x, object_y
       if (room_object.object_type.class ~= "SideObject") and use_x and use_y then
         -- check that the placing object itself does not occupy 'use_position'
         local tile_overlap = (object_x == use_x) and (object_y == use_y)
-        pathfinding_fine = pathfinding_fine and not tile_overlap
+        pathfinding_success = pathfinding_success and not tile_overlap
         -- also check that the placing object does not break the path from 'use_position' to the room door.
-        pathfinding_fine = pathfinding_fine and not _isIsolated(use_x, use_y, door_x, door_y)
+        pathfinding_success = pathfinding_success and not _isIsolated(use_x, use_y, door_x, door_y)
       end
-      if not pathfinding_fine then break end
+      if not pathfinding_success then break end
     end
-    if not pathfinding_fine then break end
+    if not pathfinding_success then break end
   end
 
   -- 4. For each footprint tile passable flag set to false by step 2 undo this change:
@@ -2117,7 +2117,7 @@ function World:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(object_x, object_y
     end
   end
 
-  return not pathfinding_fine
+  return not pathfinding_success
 end
 
 --! Notifies the world that an object has been placed, notifying

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2099,8 +2099,8 @@ function World:wouldObjectBreakRoomObjectsAccessToTheRoomDoor(object_x, object_y
       -- because these 'use_position' are not actually used in the game, so skip them.
       if (room_object.object_type.class ~= "SideObject") and use_x and use_y then
         -- check that the placing object itself does not occupy 'use_position'
-        local the_same_title = (object_x == use_x) and (object_y == use_y)
-        pathfinding_fine = pathfinding_fine and not the_same_title
+        local tile_overlap = (object_x == use_x) and (object_y == use_y)
+        pathfinding_fine = pathfinding_fine and not tile_overlap
         -- also check that the placing object does not break the path from 'use_position' to the room door.
         pathfinding_fine = pathfinding_fine and not _isIsolated(use_x, use_y, door_x, door_y)
       end

--- a/WindowsInstaller/config_template.txt
+++ b/WindowsInstaller/config_template.txt
@@ -394,11 +394,38 @@ shift_scroll_speed = 4
 room_information_dialogs = true
 
 -------------------------------------------------------------------------------
--- If true, parts of the hospital can be made inaccessible by blocking the path
--- with rooms or objects. If false, all parts of the hospital must be kept
--- accessible, the game will disallow any attempt to blocking the path.
+-- Possibility to blocking off areas when building and placing objects.
 --
-allow_blocking_off_areas = false
+-- There are 3 possible options:
+--
+-- 1. Totally forbidden - user is not allowed to make any dead ended,
+-- inaccessible spaces that are not accessible from the hospital entrance.
+-- Before version 0.70 this was a default option in CorsixTH.
+-- This avoided issues that could arise from area blocking, but it also
+-- deprived of the opportunity to build rooms in the same layouts which
+-- was possible to build in the original TH. Although this is a safe option,
+-- it is now deprecated but is still available.
+--
+-- 2. Partially allowed - user is allowed to make dead ended, inaccessible
+-- spaces that are not accessible from the hospital entrance but only if
+-- certain conditions are met. The condition is that the rooms themselves
+-- and usable objects inside the room must remain accessible. This ensures
+-- the preservation of the hospital's functionality and ensures the validity
+-- of the path routing in the hospital. This is the style that the blocking
+-- off areas were implemented in the original TH. This is a safe option.
+--
+-- 3. Completely allowed - user is allowed to make any dead ended,
+-- inaccessible spaces that are not accessible from the hospital entrance.
+-- This is a dangerous feature that can lead to game crashes. Use it only
+-- at your own risk and if you fully understand why you enabling it.
+--
+-- Recommended option is '2. Partially allowed'.
+--
+-- Set '1' for '1. Totally forbidden',
+-- Set '2' for '2. Partially allowed',
+-- Set '3' for '3. Completely allowed'.
+--
+blocking_off_areas = 2
 
 -------------------------------------------------------------------------------
 -- Direct Zoom: Avoid rendering to an intermediate texture when zooming.

--- a/WindowsInstaller/config_template.txt
+++ b/WindowsInstaller/config_template.txt
@@ -400,9 +400,9 @@ room_information_dialogs = true
 --
 -- 1. Totally forbidden - requires every passable tile in the hospital
 -- to remain reachable from a hospital entrance. This avoids issues that
--- could arise from area blocking, but it also deprived of the opportunity
--- to build rooms in the same layouts which was possible to build in the
--- original TH. Before version 0.70 this was a default option in CorsixTH.
+-- could arise from area blocking, but it also prevents room layouts
+-- which are allowed in Theme Hospital. Before version 0.70 this was
+-- a default option in CorsixTH.
 --
 -- 2. Partially allowed - user is allowed to make dead ended, inaccessible
 -- spaces that are not accessible from the hospital entrance but only if

--- a/WindowsInstaller/config_template.txt
+++ b/WindowsInstaller/config_template.txt
@@ -417,10 +417,8 @@ room_information_dialogs = true
 -- This is a dangerous feature that can lead to game crashes. Use it only
 -- at your own risk and if you fully understand why you enabling it.
 --
--- Recommended option is '2. Partially allowed'.
---
 -- Set '1' for '1. Totally forbidden',
--- Set '2' for '2. Partially allowed',
+-- Set '2' for '2. Partially allowed' (Default),
 -- Set '3' for '3. Completely allowed'.
 --
 blocking_off_areas = 2

--- a/WindowsInstaller/config_template.txt
+++ b/WindowsInstaller/config_template.txt
@@ -394,27 +394,25 @@ shift_scroll_speed = 4
 room_information_dialogs = true
 
 -------------------------------------------------------------------------------
--- Possibility to blocking off areas when building and placing objects.
+-- Ability to block off areas when building and placing objects.
 --
 -- There are 3 possible options:
 --
--- 1. Totally forbidden - user is not allowed to make any dead ended,
--- inaccessible spaces that are not accessible from the hospital entrance.
--- Before version 0.70 this was a default option in CorsixTH.
--- This avoided issues that could arise from area blocking, but it also
--- deprived of the opportunity to build rooms in the same layouts which
--- was possible to build in the original TH. Although this is a safe option,
--- it is now deprecated but is still available.
+-- 1. Totally forbidden - requires every passable tile in the hospital
+-- to remain reachable from a hospital entrance. This avoids issues that
+-- could arise from area blocking, but it also deprived of the opportunity
+-- to build rooms in the same layouts which was possible to build in the
+-- original TH. Before version 0.70 this was a default option in CorsixTH.
 --
 -- 2. Partially allowed - user is allowed to make dead ended, inaccessible
 -- spaces that are not accessible from the hospital entrance but only if
 -- certain conditions are met. The condition is that the rooms themselves
 -- and usable objects inside the room must remain accessible. This ensures
 -- the preservation of the hospital's functionality and ensures the validity
--- of the path routing in the hospital. This is the style that the blocking
--- off areas were implemented in the original TH. This is a safe option.
+-- of the path routing in the hospital. This allows user to build rooms with
+-- the same layout as in the original TH. This is a safe option.
 --
--- 3. Completely allowed - user is allowed to make any dead ended,
+-- 3. Completely allowed - user is allowed to make dead ended,
 -- inaccessible spaces that are not accessible from the hospital entrance.
 -- This is a dangerous feature that can lead to game crashes. Use it only
 -- at your own risk and if you fully understand why you enabling it.


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #465*
*Fixes #602*
*Fixes #1963*
*Fixes #2021*
*Fixes #2072*

--------------

This PR implements functionality that allows the player to block tiles and areas within a room. #826
However, only blocks that don't block access to objects that are involved in the room's operation are allowed.
This way, users can block off areas without encountering any inaccessible objects: the game won't crash with errors about being unable to build a route, and humanoids won't teleport themselves or teleport objects.
Just like it was in the original TH.
This behavior is set as the default behavior because this is the behavior implemented in the original TH.

--------------

<details>
  <summary>Before. CorsixTH  0.69.2. Press here 👈</summary>

.
CorsixTH  0.69.2.
`allow_blocking_off_areas` `false`.
Radiation Shield is gray.
Unable to build an X-ray in such layout.
  
<img width="474" height="314" alt="Screenshot 2026-03-19 at 16 31 45_2" src="https://github.com/user-attachments/assets/01b498e7-3d16-4272-8b73-553fcb735036" />

</details>

--------------

<details>
  <summary>After. CorsixTH  0.70.0. Press here 👈</summary>

 .
This PR.
`blocking_off_areas` `2`.
Radiation Shield is colored.
Able to build X-ray in such layout.
The top corner of the room is blocked. But the room functions perfectly.
  
<img width="472" height="308" alt="Screenshot 2026-03-19 at 16 31 44_3" src="https://github.com/user-attachments/assets/d3a8cf77-9abe-4838-8a16-e7e36060668c" />

</details>

--------------

**Describe what the proposed change does**
- Besides `allow_blocking_off_areas` `true` and `allow_blocking_off_areas` `false` which were implemented before, this PR introduces the new third intermediate approach.

--------------

<img width="388" height="80" alt="Screenshot 2026-03-20 at 15 22 54" src="https://github.com/user-attachments/assets/88c6e825-2a85-4929-bd00-611f24bfad1a" />

--------------

<details>
  <summary>Relative freedom graph of these 3 settings</summary>

<img width="451" height="531" alt="Image" src="https://github.com/user-attachments/assets/b86828f0-ff52-4696-99bd-33b51dac7dbb" />

</details>

--------------

**Describe what the proposed change does**
- `allow_blocking_off_areas` config param renamed to `blocking_off_areas` and now have 3 possible states:
``` Lua
-- Possibility of blocking off areas when building and placing objects.
--
-- There are 3 possible options:
--
-- 1. Totally forbidden - user is not allowed to make any dead ended,
-- inaccessible spaces that are not accessible from the hospital entrance.
-- Before version 0.70 this was a default option in CorsixTH.
-- This avoided issues that could arise from area blocking, but it also
-- deprived of the opportunity to build rooms in the same layouts which
-- was possible to build in the original TH. Although this is a safe option,
-- it is now deprecated but is still available.
-- (previously `allow_blocking_off_areas false`)
--
-- 2. Partially allowed - user is allowed to make dead ended, inaccessible
-- spaces that are not accessible from the hospital entrance but only if
-- certain conditions are met. The condition is that the rooms themselves
-- and usable objects inside the room must remain accessible. This ensures
-- the preservation of the hospital's functionality and ensures the validity
-- of the path routing in the hospital. This is the style that the blocking
-- off areas were implemented in the original TH. This is a safe option.
--
-- 3. Completely allowed - user is allowed to make any dead ended,
-- inaccessible spaces that are not accessible from the hospital entrance.
-- This is a dangerous feature that can lead to game crashes. Use it only
-- at your own risk and if you fully understand why you enable it.
-- (previously `allow_blocking_off_areas true`).
--
-- Recommended option is '2. Partially allowed'.
```
- Implements `3.1.` and `3.2.` and `4.1.2.` of https://github.com/CorsixTH/CorsixTH/issues/826#issuecomment-3214374270
- As a result, this will allow the building of rooms in layouts which were available in the original TH. Currently, with the `allow_blocking_off_areas` `false` the number of available layouts in CorsixTH is smaller than in the original TH. This creates difficulties when building some rooms, especially X-ray room.
- Since this new logic for corridors is not yet implemented, in corridors the new approach will make a safe fallback to `allow_blocking_off_areas` `false` ("Totally forbidden").

**Where we are and where to go next with the blocking off areas:**
- Checks for placements outside of rooms, in corridors, have not yet been implemented. So, in the corridors, everything remains as before for this PR.
- To implement this mechanism for corridors, we need functionality that could determine whether there are humanoids or rooms in the area accessible from any given cell.
- After implementing checks for corridors, the `allow_blocking_off_areas true` functionality can be successfully removed from the game, as it completely loses any meaning after that. At least it shouldn't be possible to enable it from the menu or from the config.
- After that #826 and all dependent issues can be considered as completed.
