### PR TITLE
Fix lua linking for vcpkg

### DIFF
--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -133,8 +133,9 @@ endif()
 
 # Find Lua
 if(VCPKG_TARGET_TRIPLET)
-  find_package(Lua CONFIG REQUIRED)
-  target_link_libraries(CorsixTH_lib PUBLIC lua)
+  find_package(Lua REQUIRED)
+  target_include_directories(CorsixTH_lib PUBLIC ${LUA_INCLUDE_DIRS})
+  target_link_libraries(CorsixTH_lib PUBLIC ${LUA_LIBRARIES})
 else()
   find_package(Lua REQUIRED)
   if(Lua_FOUND OR LUA_FOUND)


### PR DESCRIPTION
Lua was being linked wrong for vcpkg, and it was actually picking up the system lua if available because -llua was being put in the linker options.

See https://github.com/microsoft/vcpkg/blob/b472291f295551b7127359ea38fdd2ca092f6f1b/ports/lua/usage#L5

