### PR TITLE
Cleanly exit the sprite viewer

### DIFF
--- a/CorsixTH/Lua/sprite_viewer.lua
+++ b/CorsixTH/Lua/sprite_viewer.lua
@@ -149,9 +149,6 @@ local function DoKey(_, rawchar)
   elseif key == "s" then
     sdown = true
     need_draw = true
-  elseif key == "q" then
-    TheApp.eventHandlers = old_event_handlers
-    need_draw = false
   elseif key == "-" then
     if scale > 1 then
       scale = scale - 1
@@ -171,6 +168,10 @@ end
 
 local function DoKeyUp(_, rawchar)
     local key = rawchar:lower()
+    if key == "q" then -- Exit sprite viewer
+      TheApp.eventHandlers = old_event_handlers
+      return
+    end
     if key == "w" then
         wdown = false
     end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3297*

**Describe what the proposed change does**
- Prevents a crash when exiting sprite viewer on a new game 
- I do not understand why loading an existing save does not crash this.


Preferably check I haven't now made it crash in other cases on q where it did work (the textinput handler)