### PR TITLE
Cache reception desks

### DIFF
--- a/CorsixTH/Lua/announcer.lua
+++ b/CorsixTH/Lua/announcer.lua
@@ -175,7 +175,7 @@ function Announcer:playAnnouncement(name, priority, decay_hours, played_callback
   entry.played_callback = played_callback
   entry.played_callback_delay = played_callback_delay
 
-  if self.app.world:getLocalPlayerHospital():hasStaffedDesk() or priority == AnnouncementPriority.Critical then
+  if self.app.world:getLocalPlayerHospital():hasReceptionDesk(true) or priority == AnnouncementPriority.Critical then
     self.entries:push(new_priority, entry)
   end
 end
@@ -184,7 +184,7 @@ end
 -- Plays the actual sound of the announcements, if available.
 -- Also queues random announcements if no announcements have been played for a while.
 function Announcer:onTick()
-  local staffedDesk = self.app.world:getLocalPlayerHospital():hasStaffedDesk()
+  local staffedDesk = self.app.world:getLocalPlayerHospital():hasReceptionDesk(true)
   local criticalAnnounces = #self.entries.priorities[AnnouncementPriority.Critical]
   if not self.app.world:isCurrentSpeed("Pause") then
     local ticks_since_last_announcement = self.ticks_since_last_announcement

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 242 -- Machine menu enhancements
+local SAVEGAME_VERSION = 243 -- Cache list of reception desks
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -281,6 +281,9 @@ function UIPlaceObjects:removeObject(object, dont_close_if_empty, refund)
   end
   -- Update blueprint
   self:setBlueprintCell(self.object_cell_x, self.object_cell_y)
+  if object.object.id == "reception_desk" then -- Rebuild cache of reception desks
+    self.ui.hospital:buildReceptionDesksCache()
+  end
 end
 
 function UIPlaceObjects:removeAllObjects(refund)
@@ -534,6 +537,9 @@ function UIPlaceObjects:placeObject(dont_close_if_empty)
   self:removeObject(object, dont_close_if_empty)
   object.orientation_before = nil
 
+  if object.object.id == "reception_desk" then -- Rebuild cache of reception desks
+    self.ui.hospital:buildReceptionDesksCache()
+  end
   return real_obj
 end
 

--- a/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/receptionist.lua
@@ -75,6 +75,7 @@ function Receptionist:onPlaceInCorridor()
     local obj = world:getObject(x, y, "reception_desk")
     return obj and obj:occupy(self)
   end)
+  self.hospital:buildReceptionDesksCache() -- Rebuild cache of staffed desks
 end
 
 
@@ -90,6 +91,16 @@ function Receptionist:getDrawingLayer()
     return DrawingLayers.ReceptionistFacingAway
   end
   return DrawingLayers.ReceptionistFacingUser
+end
+
+function Receptionist:onPickup()
+  Staff.onPickup(self)
+  self.hospital:buildReceptionDesksCache() -- Rebuild cache of staffed desks
+end
+
+function Receptionist:fire()
+  Staff.fire(self)
+  self.hospital:buildReceptionDesksCache() -- Rebuild cache of staffed desks
 end
 
 function Receptionist:afterLoad(old, new)

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -658,6 +658,9 @@ function Object:onClick(ui, button, data)
     end
 
     self.picked_up = true
+    if self.object_type.id == "reception_desk" then -- Rebuild cache of reception desks
+      self.hospital:buildReceptionDesksCache()
+    end
     self.world:destroyEntity(self)
     -- NB: the object has to be destroyed before updating/creating the window,
     -- or the blueprint will be wrong

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -513,7 +513,7 @@ end
 --as they leave the reception desks.]]
 function Epidemic:markPatientsAsPassedReception()
   local queuing_patients = {}
-  for _, desk in ipairs(self.hospital:findReceptionDesks()) do
+  for _, desk in ipairs(self.hospital:getReceptionDesks()) do
     for _, patient in ipairs(desk.queue) do
       -- Use patient as map key to speed up lookup
       queuing_patients[patient] = true

--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -120,6 +120,7 @@ function Hospital:Hospital(world, avail_rooms, name)
     bench = 0,
     general = 0,
   }
+  self:buildReceptionDesksCache()
 
   self.num_visitors = 0 -- Counts patients only
   self.num_deaths = 0
@@ -503,6 +504,9 @@ function Hospital:afterLoad(old, new)
     self.hosp_cheats.active_cheats["spawn_rate_cheat"] = self.spawn_rate_cheat
     self.spawn_rate_cheat = nil
   end
+  if old < 243 then
+    self:buildReceptionDesksCache()
+  end
 
   -- Update other objects in the hospital (added in version 106).
   if self.epidemic then self.epidemic:afterLoad(old, new) end
@@ -861,38 +865,36 @@ function Hospital:isPlayerHospital()
   return self == self.world:getLocalPlayerHospital()
 end
 
---! Does the hospital have a working reception?
---!return (bool) Whether there is a working reception in the hospital.
-function Hospital:hasStaffedDesk()
-  for _, desk in ipairs(self:findReceptionDesks()) do
-    if desk.receptionist or desk.reserved_for then return true end
-  end
-  return false
+--! Does the hospital have a reception desk
+--!param is_staffed (bool) Does the desk need to be staffed
+--!return (bool) Whether there is a reception desk in the hospital.
+function Hospital:hasReceptionDesk(is_staffed)
+  return not not self:getReceptionDesks(is_staffed)[1]
 end
 
---! Returns a list of all reception desks that are staffed
-function Hospital:getStaffedDesks()
-  local staffed_desks = {}
-  for _, desk in ipairs(self:findReceptionDesks()) do
-    if desk.receptionist or desk.reserved_for then
-      staffed_desks[#staffed_desks + 1] = desk
-    end
-  end
-  return staffed_desks
+--! Fetches a list of all reception desks
+--!param is_staffed (bool) Do the desks need to be staffed
+--!return (table) A list of relevant desks
+function Hospital:getReceptionDesks(is_staffed)
+  return is_staffed and self.staffed_reception_desks or self.reception_desks
 end
 
---! Collect the reception desks in the hospital.
---!return (list) The reception desks in the hospital.
-function Hospital:findReceptionDesks()
-  local reception_desks = {}
+--! Collect the reception desks in the hospital into a list for the above function
+function Hospital:buildReceptionDesksCache()
+  local reception_desks, staffed_desks = {}, {}
   for _, obj_list in pairs(self.world.objects) do
     for _, obj in ipairs(obj_list) do
-      if obj.hospital == self and obj.object_type.id == "reception_desk" then
+      if obj.hospital == self and obj.object_type.id == "reception_desk" and
+          not obj.picked_up then
         reception_desks[#reception_desks + 1] = obj
+        if obj.receptionist or obj.reserved_for then
+          staffed_desks[#staffed_desks + 1] = obj
+        end
       end
     end
   end
-  return reception_desks
+  self.staffed_reception_desks = staffed_desks
+  self.reception_desks = reception_desks
 end
 
 --! Called at the end of each year
@@ -924,7 +926,7 @@ function Hospital:createEmergency(emergency)
   local random_disease = self.world.available_diseases[math.random(1, #self.world.available_diseases)]
   local disease = TheApp.diseases[random_disease.id]
   local number = math.random(2, disease.emergency_number)
-  if self:getHeliportSpawnPosition() and self:hasStaffedDesk() then
+  if self:getHeliportSpawnPosition() and self:hasReceptionDesk(true) then
     if not emergency then
       -- Create a random emergency if parameters are not specified already.
       emergency = {
@@ -1010,7 +1012,7 @@ function Hospital:spawnContagiousPatient()
     return contagious
   end
 
-  if self:hasStaffedDesk() then
+  if self:hasReceptionDesk(true) then
     local patient = self.world:newEntity("Patient", 2, 1)
     local contagious_diseases = get_available_contagious_diseases()
     if #contagious_diseases > 0 then
@@ -2320,7 +2322,7 @@ end
 
 --! Check if the hospital is ready to accept patients
 function Hospital:canAcceptPatients()
-  return self.opened and self:hasStaffedDesk()
+  return self.opened and self:hasReceptionDesk(true)
 end
 
 --! Has this hospital received any patients yet?

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -283,7 +283,7 @@ function PlayerHospital:monthlyAdviceChecks()
   local current_month = today:monthOfYear()
   local current_year = today:year()
 
-  if not self:hasStaffedDesk() then
+  if not self:hasReceptionDesk(true) then
     self:checkReceptionAdvice(current_month, current_year)
     -- No other checks should happen in this month
     return
@@ -344,14 +344,11 @@ end
 
 --! Give advice about having more desks.
 function PlayerHospital:msgMultiReceptionDesks()
+  local num_desks = #self:getReceptionDesks()
   -- Compute total queue length at staffed receptions.
-  local num_desks = 0
   local queue_total = 0
-  for _, desk in ipairs(self:findReceptionDesks()) do
-    num_desks = num_desks + 1
-    if desk.receptionist or desk.reserved_for then
-      queue_total = queue_total + #desk.queue
-    end
+  for _, desk in ipairs(self:getReceptionDesks(true)) do
+    queue_total = queue_total + #desk.queue
   end
 
   local receptionists = self:countStaffOfCategory("Receptionist")

--- a/CorsixTH/Lua/humanoid_actions/seek_reception.lua
+++ b/CorsixTH/Lua/humanoid_actions/seek_reception.lua
@@ -70,25 +70,23 @@ local function action_seek_reception_start(action, humanoid)
   assert(humanoid.hospital, "humanoid must be associated with a hospital to seek reception")
 
   -- Go through all receptions desks.
-  for _, desk in ipairs(humanoid.hospital:findReceptionDesks()) do
-    if desk.receptionist or desk.reserved_for then
-      -- Ok, so we found one with staff at it or on the way.
-      -- Is this one better than the last one?
-      -- A lower score is better.
-      -- First find out where the usage tile is.
-      local orientation = desk.object_type.orientations[desk.direction]
-      local x = desk.tile_x + orientation.use_position[1]
-      local y = desk.tile_y + orientation.use_position[2]
+  for _, desk in ipairs(humanoid.hospital:getReceptionDesks(true)) do
+    -- Ok, so we found one with staff at it or on the way.
+    -- Is this one better than the last one?
+    -- A lower score is better.
+    -- First find out where the usage tile is.
+    local orientation = desk.object_type.orientations[desk.direction]
+    local x = desk.tile_x + orientation.use_position[1]
+    local y = desk.tile_y + orientation.use_position[2]
 
-      local distance_from_desk = humanoid.world:getPathDistance(humanoid.tile_x, humanoid.tile_y, x, y)
-      if distance_from_desk then
-        local this_score = distance_from_desk + desk:getUsageScore()
-        if not score or this_score < score then
-          -- It is better, or the first one!
-          score = this_score
-          best_desk = desk
-          best_distance_from_desk = distance_from_desk
-        end
+    local distance_from_desk = humanoid.world:getPathDistance(humanoid.tile_x, humanoid.tile_y, x, y)
+    if distance_from_desk then
+      local this_score = distance_from_desk + desk:getUsageScore()
+      if not score or this_score < score then
+        -- It is better, or the first one!
+        score = this_score
+        best_desk = desk
+        best_distance_from_desk = distance_from_desk
       end
     end
   end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -440,7 +440,7 @@ function World:spawnPatient(hospital)
     return
   end
 
-  if not hospital:hasStaffedDesk() then return nil end
+  if not hospital:hasReceptionDesk(true) then return nil end
 
   -- Construct disease, take a random guess first, as a quick clear-sky attempt.
   local disease = self.available_diseases[math.random(1, #self.available_diseases)]
@@ -462,7 +462,7 @@ function World:spawnPatient(hospital)
   local spawns = self.spawn_points
   -- Let the first patient to the player use the shortest path to a reception desk
   local spawn_point = hospital:isPlayerHospital() and not hospital:hadPatients() and
-      self:_findClosestSpawnToDesk(hospital:getStaffedDesks(), spawns) or
+      self:_findClosestSpawnToDesk(hospital:getReceptionDesks(true), spawns) or
       spawns[math.random(1, #spawns)]
 
   local patient = self:newEntity("Patient", 2, 1)
@@ -1004,7 +1004,7 @@ function World:onEndDay()
 
   --check if it's time for a VIP visit
   if self.game_date:isSameDay(self.next_vip_date) then
-    if #self.rooms > 0 and local_hospital:hasStaffedDesk() then
+    if #self.rooms > 0 and local_hospital:hasReceptionDesk(true) then
       local_hospital:createVip()
     else
       self.next_vip_date = self:_generateNextVipDate()

--- a/CorsixTH/Luatest/spec/announcer_spec.lua
+++ b/CorsixTH/Luatest/spec/announcer_spec.lua
@@ -49,7 +49,7 @@ local function create_app_mock(speed_set, desk_set)
   world_mock.isCurrentSpeed = function() return speed_set end
   world_mock.getLocalPlayerHospital = function()
     return {
-      hasStaffedDesk = function() return desk_set end
+      hasReceptionDesk = function() return desk_set end
     }
   end
 


### PR DESCRIPTION
**Describe what the proposed change does**
- Cache the sets of all and only staffed reception desks
- Add functions to get the necessary info (eg the existence of a staffed desk)
- Update the cache on a change in receptionists or desks
