### PR TITLE
Fix flashing issue with Ubuntu 22.04

### DIFF
--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -507,7 +507,13 @@ bool render_target::update(const render_target_creation_params& params) {
     SDL_RenderSetLogicalSize(renderer, width, height);
   }
 
-  SDL_SetWindowMinimumSize(window, params.min_width, params.min_height);
+  int old_min_width;
+  int old_min_height;
+  SDL_GetWindowMinimumSize(window, &old_min_width, &old_min_height);
+  if (old_min_width != params.min_width ||
+      old_min_height != params.min_height) {
+    SDL_SetWindowMinimumSize(window, params.min_width, params.min_height);
+  }
 
   return true;
 }


### PR DESCRIPTION
It seems that the code got into an update loop where every time it called SDL_SetMinimumSize it detected a resolution change and tried to update again.

Work around that by only calling SDL_SetMinimumSize if the new minimum is different from the old one as returned by SDL_GetMinimumSize.

Fixes #3314 

