### PR TITLE
Add Colours to folders + adjustment

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/folder_settings.lua
+++ b/CorsixTH/Lua/dialogs/resizables/folder_settings.lua
@@ -24,26 +24,31 @@ class "UIFolder" (UIResizable)
 ---@type UIFolder
 local UIFolder = _G["UIFolder"]
 
-local col_bg = {
-  red = 154,
-  green = 146,
-  blue = 198,
+local col = {
+   bg = Colours.PanelDefault,
+   setting = Colours.Setting,
+   title = Colours.Title,
+   caption = Colours.Caption,
+   button = Colours.PanelDefault
 }
 
-local col_shadow = {
-  red = 134,
-  green = 126,
-  blue = 178,
-}
+--- Calculates the Y position for the dialog box in the option menu
+-- and increments along the current position for the next element
+-- @return The Y position to place the element at
+function UIFolder:_getOptionYPos()
+  -- Offset from top of options box
+  local STARTING_Y_POS = 50
+  -- Y Height is 20 for panel size + 5 for spacing
+  local Y_HEIGHT = 25
 
-local col_caption = {
-  red = 174,
-  green = 166,
-  blue = 218,
-}
+  -- Multiply by the index so that index = 1 is at STARTING_Y_POS
+  local calculated_pos = STARTING_Y_POS + Y_HEIGHT * (self._current_option_index - 1)
+  self._current_option_index = self._current_option_index + 1
+  return calculated_pos
+end
 
 function UIFolder:UIFolder(ui, mode)
-  self:UIResizable(ui, 360, 240, col_bg)
+  self:UIResizable(ui, 420, 240, col.bg)
 
   local app = ui.app
   self.mode = mode
@@ -54,94 +59,102 @@ function UIFolder:UIFolder(ui, mode)
   self:setDefaultPosition(0.5, 0.25)
   self.default_button_sound = "selectx.wav"
   self.app = app
+  self._current_option_index = 1
 
   -- Window parts definition
   -- Title
-  self:addBevelPanel(80, 10, 200, 20, col_caption):setLabel(_S.folders_window.caption)
+  self:addBevelPanel(110, 10, 200, 20, col.title):setLabel(_S.folders_window.caption)
     .lowered = true
 
   -- Location of original game
   local built_in = app.gfx:loadMenuFont()
 
-  self:addBevelPanel(20, 50, 130, 20, col_shadow, col_bg, col_bg)
+  local y = self:_getOptionYPos()
+  self:addBevelPanel(20, y, 130, 20, col.caption, col.bg, col.bg)
     :setLabel(_S.folders_window.data_label)
     :setTooltip(_S.tooltip.folders_window.data_location)
     .lowered = true
-  self:addBevelPanel(160, 50, 180, 20, col_bg)
+  self:addBevelPanel(160, y, 240, 20, col.setting)
     :setLabel(app.config.theme_hospital_install, built_in)
     :setAutoClip(true)
-    :makeButton(0, 0, 180, 20, nil, self.buttonBrowseForTHInstall)
+    :makeButton(0, 0, 240, 20, nil, self.buttonBrowseForTHInstall)
     :setTooltip(_S.tooltip.folders_window.browse_data:format(app.config.theme_hospital_install))
 
   -- Location of font file
+  y = self:_getOptionYPos()
   local font_location_label = app.config.unicode_font and app.config.unicode_font or _S.tooltip.folders_window.no_font_specified
   local tooltip_font = app.config.unicode_font and _S.tooltip.folders_window.browse_font:format(app.config.unicode_font) or _S.tooltip.folders_window.no_font_specified
 
-  self:addBevelPanel(20, 75, 130, 20, col_shadow, col_bg, col_bg)
+  self:addBevelPanel(20, y, 130, 20, col.caption, col.bg, col.bg)
     :setLabel(_S.folders_window.font_label)
     :setTooltip(_S.tooltip.folders_window.font_location)
     .lowered = true
-  self.fonts_panel = self:addBevelPanel(160, 75, 180, 20, col_bg)
+  self.fonts_panel = self:addBevelPanel(160, y, 240, 20, col.setting)
     :setLabel(font_location_label, built_in)
     :setAutoClip(true)
-    :makeButton(0, 0, 180, 20, nil, self.buttonBrowseForFont)
+    :makeButton(0, 0, 240, 20, nil, self.buttonBrowseForFont)
     :setTooltip(tooltip_font)
 
   -- Location saves alternative
+  y = self:_getOptionYPos()
   local default_savegame_dir = app:getDefaultSavegameDir()
   local saves_location = app.config.savegames and app.config.savegames or default_savegame_dir
   local tooltip_saves = _S.tooltip.folders_window.browse_saves:format(saves_location)
 
-  self:addBevelPanel(20, 100, 130, 20, col_shadow, col_bg, col_bg)
+  self:addBevelPanel(20, y, 130, 20, col.caption, col.bg, col.bg)
     :setLabel(_S.folders_window.savegames_label):setTooltip(_S.tooltip.folders_window.savegames_location)
     .lowered = true
-  self.saves_panel = self:addBevelPanel(160, 100, 160, 20, col_bg)
+  self.saves_panel = self:addBevelPanel(160, y, 220, 20, col.setting)
     :setLabel(saves_location , built_in)
     :setAutoClip(true)
-    :makeButton(0, 0, 160, 20, nil, self.buttonBrowseForSavegames)
+    :makeButton(0, 0, 220, 20, nil, self.buttonBrowseForSavegames)
     :setTooltip(tooltip_saves)
-  self:addBevelPanel(320, 100, 20, 20, col_bg)
+  self:addBevelPanel(380, 100, 20, 20, col.button)
     :setLabel("X")
     :makeButton(0, 0, 20, 20, nil, self.resetSavegameDir)
     :setTooltip(_S.tooltip.folders_window.reset_to_default:format(default_savegame_dir))
 
   -- location for screenshots
+  y = self:_getOptionYPos()
   local default_screenshots_dir = app:getDefaultScreenshotsDir()
   local screenshots_location = app.config.screenshots and app.config.screenshots or default_screenshots_dir
   local tooltip_screenshots = _S.tooltip.folders_window.browse_screenshots:format(screenshots_location)
 
-  self:addBevelPanel(20, 125, 130, 20, col_shadow, col_bg, col_bg)
+  self:addBevelPanel(20, y, 130, 20, col.caption, col.bg, col.bg)
     :setLabel(_S.folders_window.screenshots_label):setTooltip(_S.tooltip.folders_window.screenshots_location)
     .lowered = true
-  self.screenshots_panel = self:addBevelPanel(160, 125, 160, 20, col_bg)
+  self.screenshots_panel = self:addBevelPanel(160, y, 220, 20, col.setting)
     :setLabel(screenshots_location, built_in)
     :setAutoClip(true)
-    :makeButton(0, 0, 160, 20, nil, self.buttonBrowseForScreenshots)
+    :makeButton(0, 0, 220, 20, nil, self.buttonBrowseForScreenshots)
     :setTooltip(tooltip_screenshots)
-  self:addBevelPanel(320, 125, 20, 20, col_bg)
+  self:addBevelPanel(380, y, 20, 20, col.button)
     :setLabel("X")
     :makeButton(0, 0, 20, 20, nil, self.resetScreenshotDir)
     :setTooltip(_S.tooltip.folders_window.reset_to_default:format(default_screenshots_dir))
 
  -- location for music files
+  y = self:_getOptionYPos()
   local music_location_label = app.config.audio_music and app.config.audio_music or _S.tooltip.folders_window.not_specified
   local tooltip_music = app.config.audio_music and _S.tooltip.folders_window.browse_music:format(app.config.audio_music) or _S.tooltip.folders_window.not_specified
 
-  self:addBevelPanel(20, 150, 130, 20, col_shadow, col_bg, col_bg)
+  self:addBevelPanel(20, y, 130, 20, col.caption, col.bg, col.bg)
     :setLabel(_S.folders_window.music_label):setTooltip(_S.tooltip.folders_window.music_location)
     .lowered = true
-  self.music_panel = self:addBevelPanel(160, 150, 180, 20, col_bg)
+  self.music_panel = self:addBevelPanel(160, y, 220, 20, col.setting)
     :setLabel(music_location_label, built_in)
     :setAutoClip(true)
-    :makeButton(0, 0, 160, 20, nil, self.buttonBrowseForAudio_music)
+    :makeButton(0, 0, 220, 20, nil, self.buttonBrowseForAudio_music)
     :setTooltip(tooltip_music)
-  self:addBevelPanel(320, 150, 20, 20, col_bg)
+  self:addBevelPanel(380, y, 20, 20, col.button)
     :setLabel("X")
     :makeButton(0, 0, 20, 20, nil, self.resetMusicDir)
     :setTooltip(_S.tooltip.folders_window.clear_directory)
 
   -- "Back" button
-  self:addBevelPanel(20, 180, 320, 40, col_bg)
+  -- Give some extra padding to adjust for symmetry
+  y = self:_getOptionYPos() + 15
+  self:addBevelPanel(50, y, 320, 40, col.button)
     :setLabel(_S.folders_window.back)
     :makeButton(0, 0, 320, 40, nil, self.buttonBack)
     :setTooltip(_S.tooltip.folders_window.back)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #*

**Describe what the proposed change does**
- Switches folders window over to Colours.
- Uses the YOptionPos calculations from UOptions.
- Expands width of the folder setting value so the 'No x location specified yet' text is fully visible in English. A bit less helpful now we show the current save/screenshot location instead of a generic message.
<img width="459" height="262" alt="image" src="https://github.com/user-attachments/assets/a7a37635-b163-4f5b-9a75-391fd87466f8" />


Will update if needed ref https://github.com/CorsixTH/CorsixTH/pull/3318#issuecomment-4231490508