### PR TITLE
Make sprite viewer reopenable

### DIFF
--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -873,7 +873,7 @@ function UIMenuBar:makeGameMenu(app)
         :appendCheckItem(_S.menu_debug_overlay.byte_7,      false, overlay(7, 7, true), "")
         :appendCheckItem(_S.menu_debug_overlay.parcel,      false, overlay("parcel"), "")
       )
-      :appendItem(_S.menu_debug.sprite_viewer, function() corsixth.require("sprite_viewer") end)
+      :appendItem(_S.menu_debug.sprite_viewer, function() corsixth.require("sprite_viewer")() end)
     )
   end
 end

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -873,7 +873,7 @@ function UIMenuBar:makeGameMenu(app)
         :appendCheckItem(_S.menu_debug_overlay.byte_7,      false, overlay(7, 7, true), "")
         :appendCheckItem(_S.menu_debug_overlay.parcel,      false, overlay("parcel"), "")
       )
-      :appendItem(_S.menu_debug.sprite_viewer, corsixth.require("sprite_viewer"))
+      :appendItem(_S.menu_debug.sprite_viewer, function() corsixth.require("sprite_viewer")() end)
     )
   end
 end

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -873,7 +873,7 @@ function UIMenuBar:makeGameMenu(app)
         :appendCheckItem(_S.menu_debug_overlay.byte_7,      false, overlay(7, 7, true), "")
         :appendCheckItem(_S.menu_debug_overlay.parcel,      false, overlay("parcel"), "")
       )
-      :appendItem(_S.menu_debug.sprite_viewer, function() corsixth.require("sprite_viewer")() end)
+      :appendItem(_S.menu_debug.sprite_viewer, corsixth.require("sprite_viewer"))
     )
   end
 end

--- a/CorsixTH/Lua/sprite_viewer.lua
+++ b/CorsixTH/Lua/sprite_viewer.lua
@@ -22,6 +22,9 @@ SOFTWARE. --]]
 -- when you don't have a copy of AnimView, or the means to compile it, then a
 -- crude sprite viewer is better than no sprite viewer.
 
+local SpriteViewer = {}
+local is_open = false
+
 local gfx = TheApp.gfx
 gfx.cache.tabled = {}
 local font = gfx:loadFontAndSpriteTable("QData", "Font00V")
@@ -170,6 +173,7 @@ local function DoKeyUp(_, rawchar)
     local key = rawchar:lower()
     if key == "q" then -- Exit sprite viewer
       TheApp.eventHandlers = old_event_handlers
+      is_open = false
       return
     end
     if key == "w" then
@@ -245,10 +249,23 @@ local function DoTimer()
   return need_draw
 end
 
-old_event_handlers = TheApp.eventHandlers
-TheApp.eventHandlers = {
-  frame = DoFrame,
-  keydown = DoKey,
-  keyup = DoKeyUp,
-  timer = DoTimer,
-}
+function SpriteViewer.open()
+  if is_open then
+    return
+  end
+  is_open = true
+
+  old_event_handlers = TheApp.eventHandlers
+  TheApp.eventHandlers = {
+    frame = DoFrame,
+    keydown = DoKey,
+    keyup = DoKeyUp,
+    timer = DoTimer,
+  }
+
+  need_draw = true
+end
+
+return function()
+  SpriteViewer.open()
+end

--- a/CorsixTH/Lua/sprite_viewer.lua
+++ b/CorsixTH/Lua/sprite_viewer.lua
@@ -22,12 +22,9 @@ SOFTWARE. --]]
 -- when you don't have a copy of AnimView, or the means to compile it, then a
 -- crude sprite viewer is better than no sprite viewer.
 
-local SpriteViewer = {}
 local is_open = false
-
 local gfx = TheApp.gfx
-gfx.cache.tabled = {}
-local font = gfx:loadFontAndSpriteTable("QData", "Font00V")
+local font -- Set on open
 local need_draw = true
 local sprite_table_paths = {}
 local palettes = {}
@@ -184,6 +181,10 @@ local function DoKeyUp(_, rawchar)
     end
 end
 
+local function DoTextInput()
+  return false
+end
+
 local function Render(canvas)
   local encoding = is_complex and " (Complex) " or " (Simple) "
   local msg = table.concat(sprite_table_paths[sprite_table_index], package.config:sub(1, 1)) .. encoding .. palette_name
@@ -249,11 +250,13 @@ local function DoTimer()
   return need_draw
 end
 
-function SpriteViewer.open()
+local function open()
   if is_open then
     return
   end
   is_open = true
+  gfx.cache.tabled = {}
+  font = gfx:loadFontAndSpriteTable("QData", "Font00V")
 
   old_event_handlers = TheApp.eventHandlers
   TheApp.eventHandlers = {
@@ -261,11 +264,10 @@ function SpriteViewer.open()
     keydown = DoKey,
     keyup = DoKeyUp,
     timer = DoTimer,
+    textinput = DoTextInput
   }
 
   need_draw = true
 end
 
-return function()
-  SpriteViewer.open()
-end
+return open

--- a/CorsixTH/Lua/sprite_viewer.lua
+++ b/CorsixTH/Lua/sprite_viewer.lua
@@ -39,6 +39,8 @@ local scale = 1
 local bg_colour_index = 1
 local y_off
 local old_event_handlers
+local old_gfx_cache = {}
+local sprite_viewer_gfx_cache = {}
 local mpalette_index
 
 local background_colours = {
@@ -170,6 +172,8 @@ local function DoKeyUp(_, rawchar)
     local key = rawchar:lower()
     if key == "q" then -- Exit sprite viewer
       TheApp.eventHandlers = old_event_handlers
+      sprite_viewer_gfx_cache = gfx.cache.tabled
+      gfx.cache.tabled = old_gfx_cache
       is_open = false
       return
     end
@@ -255,7 +259,8 @@ local function open()
     return
   end
   is_open = true
-  gfx.cache.tabled = {}
+  old_gfx_cache = gfx.cache.tabled
+  gfx.cache.tabled = sprite_viewer_gfx_cache
   font = gfx:loadFontAndSpriteTable("QData", "Font00V")
 
   old_event_handlers = TheApp.eventHandlers


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #1785*
*Fixes #2308*

**Describe what the proposed change does**
- Make spriteviewer reopenable in the same session. It resumes where you left off (which is I assume what it already did previously anyway, you just couldn't access it).

Please could we get some additional checks this doesn't break saves or to the best of our ability any other part of the game handlers. I've tested myself and seems ok.