### PR TITLE
Optimization for slow frames on large saves

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,6 +31,20 @@
       }
     },
     {
+      "name": "linux-tracy",
+      "binaryDir": "${sourceDir}/build/tracy",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "USE_SOURCE_DATADIRS": "ON",
+        "ENABLE_UNIT_TESTS": "ON",
+        "BUILD_TOOLS": "ON",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "WITH_TRACY": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
       "name": "win-dev",
       "binaryDir": "${sourceDir}/build/dev",
       "generator": "Visual Studio 17 2022",

--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2709;
+return 2710;

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -552,7 +552,8 @@ function Humanoid:findObjectsInSquare(size, object_spec)
   end
 
   local world_map = self.world.map
-  local self_room_id = world_map:getRoomId(self.tile_x, self.tile_y)
+  local th_map = world_map.th
+  local self_room_id = th_map:getRoomId(self.tile_x, self.tile_y)
 
   -- Search the rectangle for as far as it is within the world.
   local width, height = world_map.th:size()
@@ -562,7 +563,7 @@ function Humanoid:findObjectsInSquare(size, object_spec)
   for x = self.tile_x - size, self.tile_x + size do
     if x >= 1 and x <= width then
       for y = self.tile_y - size, self.tile_y + size do
-        if y >= 1 and y <= height and world_map:getRoomId(x, y) == self_room_id then
+        if y >= 1 and y <= height and th_map:getRoomId(x, y) == self_room_id then
           for _, obj in ipairs(entity_map:getObjectsAtCoordinate(x, y)) do
             local entry = objs_table[obj.id]
             if entry then entry[#entry + 1] = obj end

--- a/CorsixTH/Lua/map.lua
+++ b/CorsixTH/Lua/map.lua
@@ -60,7 +60,7 @@ end
 --!param x (int) Vertical position of the tile to query in the map.
 --!return ID of the room at the queried tile.
 function Map:getRoomId(x, y)
-  return self.th:getCellFlags(math.floor(x), math.floor(y)).roomId
+  return self.th:getRoomId(math.floor(x), math.floor(y))
 end
 
 function Map:setPlayerCount(count)

--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -543,6 +543,31 @@ void add_cellint(lua_State* L, const int value, const std::string_view name) {
 }
 
 /**
+ * Get the room id at the given position
+ * @param L Lua context.
+ *   [1] - The world map object
+ *   [2] - The X coordinate
+ *   [3] - The Y coordinate
+ * @return Number of results of the call. The roomId is pushed onto L.
+ */
+int l_map_get_room_id(lua_State* L) {
+  ZoneScoped;
+
+  level_map* pMap = luaT_testuserdata<level_map>(L);
+  int iX = static_cast<int>(luaL_checkinteger(L, 2) -
+                            1);  // Lua arrays start at 1 - pretend
+  int iY = static_cast<int>(luaL_checkinteger(L, 3) - 1);  // the map does too.
+
+  map_tile* pNode = pMap->get_tile(iX, iY);
+  if (pNode == nullptr) {
+    return luaL_argerror(L, 2, "Map coordinates out of bounds");
+  }
+
+  lua_pushinteger(L, pNode->iRoomId);
+  return 1;
+}
+
+/**
  * Get the value of all cell flags at a position.
  * @param L Lua context.
  * @return Number of results of the call.
@@ -1069,6 +1094,7 @@ void lua_register_map(const lua_register_state* pState) {
     lcb.add_function(l_map_set_player_heliport, "setHeliportTile");
     lcb.add_function(l_map_getcell, "getCell");
     lcb.add_function(l_map_gettemperature, "getCellTemperature");
+    lcb.add_function(l_map_get_room_id, "getRoomId");
     lcb.add_function(l_map_getcellflags, "getCellFlags");
     lcb.add_function(l_map_setcellflags, "setCellFlags");
     lcb.add_function(l_map_getcellraw, "getCellRaw");


### PR DESCRIPTION
On large hospitals we spend a lot of time on
Humanoid:findObjectsInSquare. That function calls map:getRoomId repeatedly but gets the rest of the object information from the entity map. map:getRoomId was using the l_getcellflags c++ function which included a lot of cell information that was simply thrown away.

This specializes a version that just returns the roomId for this case. In my tests it improved frame time by about 50%.

Should help with #3277 - system specs matter. Looking for additional verification.

The new linux tracy profile applies compiler optimizations doesn't apply sanitizer hooks for a 'close' to release view.
