### PR TITLE
Scrap use of Font01V in loadMenuFont

### DIFF
--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -483,9 +483,11 @@ end
 
 --! Utility function to return preferred font for main menu ui
 function Graphics:loadMenuFont()
-  local font
-  if self:_isLanguageSupportedByTHAssets() then
-    font = self:loadFontAndSpriteTable("QData", "Font01V", nil, nil, { apply_ui_scale = true })
+  -- Use the defined unicode font if set
+  local font = self:hasLanguageFont("unicode")
+  if font then
+    font = self:loadLanguageFont(font, self:loadSpriteTable("QData", "Font01V"), { apply_ui_scale = true })
+  -- Otherwise, fall back to the built in font
   else
     font = self:loadBuiltinFont()
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3278*

**Describe what the proposed change does**
- Prioritise using a defined unicode font if present when loading menu font.
- Fallback to builtin font if not set

The reason we want to prioritise unicode font is for maximum compatibility with OS file paths. The next compatible is builtin, as in `Font01V` it is missing `\` used by Windows and some other symbols.

To note: hotkey_assign has evidence it used this function but it actually doesn't. Instead it falls back to `Font01V` because that's the default set by `Window`. Arguably, it should probably use builtin in that window too.

A second note: Technically the function name is wrong by its current usage, but I don't have any ideas right now on something better fitting. I don't have immediate plans to change it but it can be done, I guess.

Checks required this doesn't break the Russian version more.