### PR TITLE
Fix bundled font detection in Windows

### DIFF
--- a/CorsixTH/Lua/graphics.lua
+++ b/CorsixTH/Lua/graphics.lua
@@ -179,27 +179,30 @@ function Graphics:loadFontFile()
 
   local function getFontPath()
     local config_err, compile_err = "", ""
+    -- Check for font specified in config file
     if config_path then
       if check(config_path) then return config_path
       else config_err = "Configured font set but not found. Check path " .. config_path
       end
     end
+    -- Check for font specified in compile options
     if compile_path then
       if check(compile_path) then return compile_path
       else compile_err = " Compiled font path set but not found. Check path " .. compile_path
       end
     end
-    local path = self.app:getFullPath({})
-    for file in lfs.dir(path) do
-      for _, ext in pairs({"%.ttc$", "%.ttf$", "%.otc$", "%.otf$"}) do
-        if file:match(ext) then
-          return path .. file
-        end
+    -- Check the CorsixTH directory for our unicode font
+    local path = self.app:getFullPath()
+    local font_names = { "CorsixTHUnicode.ttf", "GoNotoKurrent-Regular.ttf" }
+    for _, name in ipairs(font_names) do
+      if check(path .. name) then
+        return path .. name
       end
     end
     return nil, config_err .. compile_err
   end
   local font_file, err = getFontPath()
+
   if not font_file then
     print("Unicode font not found, no fallback available.", err)
     return


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2936*

It turns out giving lfs an empty string is a bad idea. Giving it a blank string causes it to assume you want to look in `C:\`. However, lfs on windows seems to default to its own current directory (where `CorsixTH.lua` lives) when its path isn't overridden. Giving it a pure file or extended directory, however also works because it knows where to start from.

**Describe what the proposed change does**
-  Remove scraping of font files from the CorsixTH install, instead define files to look for and lfs will find them if they exist in the CorsixTH.lua folder

Tested on Windows, briefly on Linux


You can verify on Linux by dumping a validly named font file in `/usr/share/corsix-th` (for arch based) and seeing if CorsixTH detects it (remove any font specified in the config first).
Similarly with Windows, but where CorsixTH.lua lives (with CorsixTH.exe)
I am not sure on Mac, but it seems to be `../Resources/` inside the .app from Argus' comments on discord.