### PR TITLE
Add cmake option FETCH_UNICODE_FONT to download GoNoto unicode font

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@
 #   - WITH_LUAROCKS : Install required luarocks in the macOS app (requires luarocks)
 #   - FETCH_CATCH2 : Use FetchContent to obtain Catch2 if ENABLE_UNIT_TESTS=yes
 #   - FETCH_SOUNDFONT : Use FetchContent to download a soundfont to use (no)
+#   - FETCH_UNICODE_FONT: Use FetchContent to download the GoNoto Unicode font (no)
 
 # Tests and debug options
 #   - ENABLE_UNIT_TESTS : Enable Unit Testing Target (requires Catch2) (no)
@@ -42,6 +43,7 @@ option(BUILD_TOOLS "Build additional CLI tools (rnc_decode)" OFF)
 option(ENABLE_SANITIZERS "Build with ASan and UBSan enabled" OFF)
 option(WITH_TRACY "Build with Tracy profiling enabled" OFF)
 option(FETCH_SOUNDFONT "Download soundfont asset" OFF)
+option(FETCH_UNICODE_FONT "Download GoNoto Unicode font" OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -65,7 +65,8 @@
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "VCPKG_TARGET_TRIPLET": "x64-windows-release",
         "ENABLE_UNIT_TESTS": "ON",
-        "FETCH_SOUNDFONT": "ON"
+        "FETCH_SOUNDFONT": "ON",
+        "FETCH_UNICODE_FONT": "ON"
       }
     },
     {
@@ -77,7 +78,8 @@
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "VCPKG_TARGET_TRIPLET": "x86-windows",
         "ENABLE_UNIT_TESTS": "ON",
-        "FETCH_SOUNDFONT": "ON"
+        "FETCH_SOUNDFONT": "ON",
+        "FETCH_UNICODE_FONT": "ON"
       }
     },
     {

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -7,6 +7,10 @@ endif()
 # Project Declaration
 project(CorsixTH)
 
+if(WITH_FONT AND FETCH_UNICODE_FONT)
+  message(WARNING "CorsixTH will attempt to use the WITH_FONT value ${WITH_FONT} before the fetched Unicode font.")
+endif()
+
 if(MSVC)
   # We want to bind against the very latest versions of the MSVC runtimes
   add_definitions(/D "_BIND_TO_CURRENT_VCLIBS_VERSION=1")
@@ -290,6 +294,20 @@ if(FETCH_SOUNDFONT)
   set(FLUIDR3_FILE ${fluidr3_SOURCE_DIR}/FluidR3.sf3)
 endif()
 
+if(FETCH_UNICODE_FONT)
+  include(FetchContent)
+
+  fetchcontent_declare(
+    GoNoto
+    URL https://github.com/satbyy/go-noto-universal/releases/download/v7.0/GoNotoKurrent-Regular.ttf
+    URL_HASH SHA256=2f2cee5fbb2403df352ca2005247f6c4faa70f3086ebd31b6c62308b5f2f9865
+    DOWNLOAD_NO_EXTRACT TRUE
+    DOWNLOAD_NAME CorsixTHUnicode.ttf)
+
+  fetchcontent_makeavailable(GoNoto)
+  set(GONOTO_FILE ${gonoto_SOURCE_DIR}/CorsixTHUnicode.ttf)
+endif()
+
 if(WITH_TRACY)
   find_package(Tracy CONFIG REQUIRED)
   target_link_libraries(CorsixTH_lib PUBLIC Tracy::TracyClient)
@@ -364,6 +382,9 @@ if(NOT USE_SOURCE_DATADIRS)
 
   if(FETCH_SOUNDFONT)
     install(FILES ${FLUIDR3_FILE} DESTINATION ${CORSIX_TH_DATADIR})
+  endif()
+  if(FETCH_UNICODE_FONT)
+    install(FILES ${GONOTO_FILE} DESTINATION ${CORSIX_TH_DATADIR})
   endif()
 
   if(UNIX AND NOT APPLE)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -459,7 +459,7 @@ http://www.libsdl.org/ under the following terms (zlib license).
 
 
 Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
-  
+
 This software is provided 'as-is', without any express or implied
 warranty.  In no event will the authors be held liable for any damages
 arising from the use of this software.
@@ -467,11 +467,11 @@ arising from the use of this software.
 Permission is granted to anyone to use this software for any purpose,
 including commercial applications, and to alter it and redistribute it
 freely, subject to the following restrictions:
-  
+
 1. The origin of this software must not be misrepresented; you must not
    claim that you wrote the original software. If you use this software
    in a product, an acknowledgment in the product documentation would be
-   appreciated but is not required. 
+   appreciated but is not required.
 2. Altered source versions must be plainly marked as such, and must not be
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
@@ -645,7 +645,7 @@ THE SOFTWARE.
 -------------------------------------------------------------------------------
 
 Uses OpenSSL which is available from https://www.openssl.org under the
-Apache License 2.0 
+Apache License 2.0
 
 -------------------------------------------------------------------------------
 
@@ -1341,3 +1341,102 @@ DAMAGES.
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
+
+-------------------------------------------------------------------------------
+
+Uses the GoNoto font available from https://github.com/satbyy/go-noto-universal
+under the following terms
+Copyright 2018 The Noto Project Authors (github.com/googlei18n/noto-fonts)
+
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to
+provide a free and open framework in which fonts may be shared and
+improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software
+components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to,
+deleting, or substituting -- in part or in whole -- any of the
+components of the Original Version, by changing formats or by porting
+the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed,
+modify, redistribute, and sell modified and unmodified copies of the
+Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.


### PR DESCRIPTION
**Describe what the proposed change does**
- With cmake switch -DFETCH_UNICODE_FONT=1, it will install the GoNoto font to the folder containing CorsixTH.lua, renamed as CorsixTHUnicode.ttf.

> -- Up-to-date: /Applications/CorsixTH.app/Contents/Resources/FluidR3.sf3
-- Installing: /Applications/CorsixTH.app/Contents/Resources/CorsixTHUnicode.ttf


Should this be included in cmake presets with the soundfont? The licence in the licence file?
