### PR TITLE
Prevent objects placing in tiles with humanoids

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -256,7 +256,7 @@ function UIEditRoom:confirm(force)
   end
 end
 
-local function isHumanoidObscuringArea(humanoid, x1, x2, y1, y2)
+function UIEditRoom.isHumanoidObscuringArea(humanoid, x1, x2, y1, y2)
   if humanoid.tile_x then
     if x1 <= humanoid.tile_x and humanoid.tile_x <= x2 and
         y1 <= humanoid.tile_y and humanoid.tile_y <= y2 then
@@ -294,7 +294,7 @@ function UIEditRoom:clearArea()
     local y2 = rect.y + rect.h
     for _, entity in ipairs(world.entities) do
       if class.is(entity, Humanoid) and
-          isHumanoidObscuringArea(entity, x1, x2, y1, y2) then
+          UIEditRoom.isHumanoidObscuringArea(entity, x1, x2, y1, y2) then
         humanoids_to_watch[entity] = true
 
         -- Try to make the humanoid leave the area
@@ -366,7 +366,7 @@ function UIEditRoom:onTick()
           if not humanoid.hospital then
             self.humanoids_to_watch[humanoid] = nil
           end
-        elseif not isHumanoidObscuringArea(humanoid, x1, x2, y1, y2) then
+        elseif not UIEditRoom.isHumanoidObscuringArea(humanoid, x1, x2, y1, y2) then
           self.humanoids_to_watch[humanoid] = nil
         end
       end

--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -256,31 +256,6 @@ function UIEditRoom:confirm(force)
   end
 end
 
-function UIEditRoom.isHumanoidObscuringArea(humanoid, x1, x2, y1, y2)
-  if humanoid.tile_x then
-    if x1 <= humanoid.tile_x and humanoid.tile_x <= x2 and
-        y1 <= humanoid.tile_y and humanoid.tile_y <= y2 then
-      if (x1 == humanoid.tile_x or x2 == humanoid.tile_x) or
-          (y1 == humanoid.tile_y or y2 == humanoid.tile_y) then
-        -- Humanoid not in the rectangle, but might be walking into it
-        local action = humanoid:getCurrentAction()
-        if action.name ~= "walk" then
-          return false
-        end
-        if action.path_x then -- in a (rare) special case, path_x is nil (see action_walk_start)
-          local next_x = action.path_x[action.path_index]
-          local next_y = action.path_y[action.path_index]
-          if x1 >= next_x or next_x >= x2 or y1 >= next_y or next_y >= y2 then
-            return false
-          end
-        end
-      end
-      return true
-    end
-  end
-  return false
-end
-
 function UIEditRoom:clearArea()
   self.confirm_button:enable(false)
   local rect = self.blueprint_rect
@@ -294,7 +269,7 @@ function UIEditRoom:clearArea()
     local y2 = rect.y + rect.h
     for _, entity in ipairs(world.entities) do
       if class.is(entity, Humanoid) and
-          UIEditRoom.isHumanoidObscuringArea(entity, x1, x2, y1, y2) then
+          entity:isObscuringArea(x1, x2, y1, y2) then
         humanoids_to_watch[entity] = true
 
         -- Try to make the humanoid leave the area
@@ -366,7 +341,7 @@ function UIEditRoom:onTick()
           if not humanoid.hospital then
             self.humanoids_to_watch[humanoid] = nil
           end
-        elseif not UIEditRoom.isHumanoidObscuringArea(humanoid, x1, x2, y1, y2) then
+        elseif not humanoid:isObscuringArea(x1, x2, y1, y2) then
           self.humanoids_to_watch[humanoid] = nil
         end
       end

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -472,11 +472,15 @@ function UIPlaceObjects:onMouseUp(button, x, y)
       local s = TheApp.config.ui_scale
       if 0 <= x and x < self.width * s and 0 <= y and y < self.height * s then -- luacheck: ignore 542
         -- Click within window - do nothing
-      elseif self.object_cell_x and self.object_cell_y and self.object_blueprint_good then
-        self:placeObject()
-        repaint = true
-      elseif self.object_cell_x and self.object_cell_y and not self.object_blueprint_good then
-        self.ui:tutorialStep(3, {13, 15}, 14)
+      elseif self.object_cell_x and self.object_cell_y then
+        if self.object_blueprint_good then
+          if not self.world:anyHumanoidObscuringArea(self.object_cell_x, self.object_cell_y) then
+            self:placeObject()
+            repaint = true
+          end
+        else
+          self.ui:tutorialStep(3, {13, 15}, 14)
+        end
       end
     end
   end

--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -1160,3 +1160,39 @@ function Humanoid:unexpectFromRoom(dest_room)
 function Humanoid:getAttribute(attribute, default_value)
   return self.attributes[attribute] or default_value or 0
 end
+
+--! Checks whether a humanoid is within the specified area or is currently
+-- walking into it. To properly check whether a humanoid is entering an area,
+-- pass coordinates 1 tile outside the square where actually need to build.
+-- For example, if the intended wall of the room being built is outside the
+-- perimeter (x1, y1) (x2, y2), then need to pass (x1-1, y1-1) (x2+1, y2+1).
+-- Example input parameters: (50, 55, 60, 65).
+--!param x1 (int) north-west X position of target area.
+--!param x2 (int) south-east X position of target area.
+--!param y1 (int) north-west Y position of target area.
+--!param y2 (int) south-east Y position of target area.
+--!return (bool) true if obscuring given area.
+function Humanoid:isObscuringArea(x1, x2, y1, y2)
+  if self.tile_x then
+    if x1 <= self.tile_x and self.tile_x <= x2 and
+        y1 <= self.tile_y and self.tile_y <= y2 then
+      if (x1 == self.tile_x or x2 == self.tile_x) or
+          (y1 == self.tile_y or y2 == self.tile_y) then
+        -- Humanoid not in the rectangle, but might be walking into it
+        local action = self:getCurrentAction()
+        if action.name ~= "walk" then
+          return false
+        end
+        if action.path_x then -- in a (rare) special case, path_x is nil (see action_walk_start)
+          local next_x = action.path_x[action.path_index]
+          local next_y = action.path_y[action.path_index]
+          if x1 >= next_x or next_x >= x2 or y1 >= next_y or next_y >= y2 then
+            return false
+          end
+        end
+      end
+      return true
+    end
+  end
+  return false
+end

--- a/CorsixTH/Lua/entity_map.lua
+++ b/CorsixTH/Lua/entity_map.lua
@@ -114,6 +114,13 @@ function EntityMap:getEntitiesAtCoordinate(x, y)
 end
 
 --[[Returns a table of all humanoids at a specified coordinate
+! Please note that when a humanoid moves, they will only be
+attached to one tile at the moment. When moving from tile to
+tile, they will only attach to the next tile after they has fully
+completed the animation for moving to the that next tile.
+Therefore, at the last frame of the transition animation from
+tile to tile, they will still attached to the previous one tile, on
+which they is no longer visually located.
 @param x (integer) the x coordinate to retrieve entities from
 @param y (integer) the y coordinate to retrieve entities from
 @return (table) containing the humanoids at the (x, y) coordinate ]]
@@ -137,9 +144,9 @@ end
 --[[ Returns a map of coordinates {{x1, y1}, ... {xn, yn}} directly
 adjacent to a given (x, y) coordinate - no diagonals
 @param x (integer) the x coordinate to obtain adjacent tiles from
-@param y (integer) the y coordinate to obtain adjacent tiles from ]]
+@param y (integer) the y coordinate to obtain adjacent tiles from
+@return (table) containing coordinates {x=integer, y=integer} ]]
 function EntityMap:getAdjacentSquares(x, y)
-  -- Table of coordinates {x=integer, y=integer} representing (x, y) coordinates
   local adjacent_squares = {}
   if x and y then
     if x ~= 1 then
@@ -156,6 +163,21 @@ function EntityMap:getAdjacentSquares(x, y)
     end
   end
   return adjacent_squares
+end
+
+--[[ Returns all humanoids in the squares directly adjacent
+to the given (x, y) coordinate - diagonals are not considered
+@param x (integer) the x coordinate to obtain adjacent patients from
+@param y (integer) the y coordinate to obtain adjacent patients from ]]
+function EntityMap:getHumanoidsInSquareAndInAdjacentSquares(x, y)
+  local adjacent_patients = {}
+  local tiles = table_merge({{x = x , y = y}}, self:getAdjacentSquares(x, y))
+  for _, coord in ipairs(tiles) do
+    for _, humanoid in ipairs(self:getHumanoidsAtCoordinate(coord.x, coord.y)) do
+      adjacent_patients[#adjacent_patients + 1] = humanoid
+    end
+  end
+  return adjacent_patients
 end
 
 --[[ Returns all the entities which are patients in the squares directly adjacent

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -673,6 +673,7 @@ function GameUI:onMouseUp(code, x, y)
     return UI.onMouseUp(self, code, x, y)
   end
 
+  -- Controlling debug patients movement with a cursor
   local button = self.button_codes[code]
   if button == "right" and not self.map_editor and highlight_x then
     local window = self:getWindow(UIPatient)

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1477,14 +1477,45 @@ in a room.
 !return (boolean) whether all checks hold.
 --]]
 function World:isTileEmpty(x, y, not_in_room)
-  if #self.entity_map:getHumanoidsAtCoordinate(x, y) ~= 0 or
-      #self.entity_map:getObjectsAtCoordinate(x, y) ~= 0 then
+  if self:atLeastOneHumanoidLocatedAtTile(x, y) or
+    self:atLeastOneObjectLocatedAtTile(x, y) then
     return false
   end
   if not_in_room then
     return self:getRoom(x, y) == nil
   end
   return true
+end
+
+--! Checks if any object is located on a tile.
+--!param x (integer) the queried tile's x coordinate.
+--!param y (integer) the queried tile's y coordinate.
+--!return (boolean) true if any object is located on a tile.
+function World:atLeastOneObjectLocatedAtTile(x, y)
+  return #self.entity_map:getObjectsAtCoordinate(x, y) ~= 0
+end
+
+--! Checks if any humanoid is located on a tile.
+--!param x (integer) the queried tile's x coordinate.
+--!param y (integer) the queried tile's y coordinate.
+--!return (boolean) true if any humanoid is located on a tile.
+function World:atLeastOneHumanoidLocatedAtTile(x, y)
+  return #self.entity_map:getHumanoidsAtCoordinate(x, y) ~= 0
+end
+
+--! Сhecks whether a tile is occupied by any humanoid.
+--!param x (integer) the queried tile's x coordinate.
+--!param y (integer) the queried tile's y coordinate.
+--!return (boolean) true if any humanoid is occupy the tile.
+function World:anyHumanoidObscuringArea(x, y)
+  -- Search for humanoids on the given tile and all neighboring tiles, but not diagonal ones
+  local humanoids = self.entity_map:getHumanoidsInSquareAndInAdjacentSquares(x, y)
+  for _, humanoid in ipairs(humanoids) do
+    if UIEditRoom.isHumanoidObscuringArea(humanoid, x - 1, x + 1, y - 1, y + 1) then
+      return true
+    end
+  end
+  return false
 end
 
 function World:getFreeBench(x, y, distance)

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1511,7 +1511,7 @@ function World:anyHumanoidObscuringArea(x, y)
   -- Search for humanoids on the given tile and all neighboring tiles, but not diagonal ones
   local humanoids = self.entity_map:getHumanoidsInSquareAndInAdjacentSquares(x, y)
   for _, humanoid in ipairs(humanoids) do
-    if UIEditRoom.isHumanoidObscuringArea(humanoid, x - 1, x + 1, y - 1, y + 1) then
+    if humanoid:isObscuringArea(x - 1, x + 1, y - 1, y + 1) then
       return true
     end
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3331*

**Describe what the proposed change does**
- On `UIPlaceObjects:onMouseUp(button, x, y)` added additional check, that any humanoid don't occupy target cell.

I initially planned to use `EntityMap:getHumanoidsAtCoordinate(x, y)` for that purposes.
But this function turned out to be generally unsuitable for this target use case. Read the description before the function I added. I added an description to the function that explains why it wasn't suitable for this case.

After the initial idea with the `EntityMap:getHumanoidsAtCoordinate(x, y)` failed, I was sad.
Then I remembered that when building a room, a check is also made to ensure that humanoids do not occupy a certain territory.
The only minor issue with this function was that it checked by area. After all, no room could be smaller than 4x4. But I needed to check 1x1.
But tests with a function call `UIEditRoom.isHumanoidObscuringArea(humanoid, x - 1, x + 1, y - 1, y + 1)` gave a positive result and I decided to use this option, although it looks strange as if a 3x3 territory is being checked. But surprisingly, in this form it works exactly as it should for this task.
