### PR TITLE
[Draft] Prevent return to the toilet after leaving the toilet

### DIFF
--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -194,7 +194,7 @@ end
 
 --! Updates the patients diagnostic progress based on the doctors skill
 -- called when they are done using a diagnosis room
-function Patient:completeDiagnosticStep(room)
+function Patient:advanceDiagnosticProgress(room)
   -- Base: depending on difficulty of disease as set in sam file
   -- tiredness reduces the chance of diagnosis if staff member is above 50% tired
   local multiplier = 1
@@ -354,10 +354,6 @@ function Patient:isTreatmentEffective()
   cure_chance = cure_chance + (service_base * service_factor)
 
   return (cure_chance >= math.random(1,100))
-end
-
-function Patient:hasMoreDiagnosisRoomsAvailable()
-  return #self.available_diagnosis_rooms ~= 0
 end
 
 --! Change patient internal state to "cured".
@@ -1363,6 +1359,73 @@ function Patient:interruptAndRequeueAction(current_action, queue_pos, meander_be
     current_action.on_interrupt(current_action, self)
   else
     self:finishAction()
+  end
+end
+
+function Patient:hasMoreDiagnosisRoomsAvailable()
+  return #self.available_diagnosis_rooms ~= 0
+end
+
+function Patient:decideWhichRoomToGoToNext()
+  if not self.has_passed_reception then
+    self:setNextAction(SeekReceptionAction())
+    return
+  end
+
+  if self.diagnosed then
+    self:sendPatientToTreatmentRoom()
+    return
+  end
+
+  local last_room_gp = self.treatment_history[#self.treatment_history] == _S.rooms_short.gps_office
+  if last_room_gp then
+    self:sendPatientToNextDiagnosisRoom()
+  else
+    self:sendPatientToGPRoom()
+  end
+end
+
+function Patient:attemptToSetFinalDiagnosis()
+  local no_need_diagnose_further =
+    self.diagnosis_progress >= self.hospital.policies["stop_procedure"]
+  local cant_diagnose_further_but_can_set_diagnosis =
+    (self.diagnosis_progress >= 1.0) and (not self:hasMoreDiagnosisRoomsAvailable())
+
+  if no_need_diagnose_further or cant_diagnose_further_but_can_set_diagnosis then
+    self:setDiagnosed()
+  end
+end
+
+function Patient:sendPatientToGPRoom()
+  if self:agreesToPay("diag_gp") then
+    self:queueAction(SeekRoomAction("gp"))
+  else
+    self:goHome("over_priced", "diag_gp")
+  end
+end
+
+function Patient:sendPatientToNextDiagnosisRoom()
+  if self:hasMoreDiagnosisRoomsAvailable() then
+    local next_room_id = math.random(1, #self.available_diagnosis_rooms)
+    local next_room = self.available_diagnosis_rooms[next_room_id]
+    if self:agreesToPay("diag_" .. next_room) then
+      self:queueAction(SeekRoomAction(next_room):setDiagnosisRoom(next_room_id))
+    else
+      self:goHome("over_priced", "diag_" .. next_room)
+    end
+  else
+    -- The very rare case where the patient has visited all his/her possible diagnosis rooms
+    -- There's not much to do then... Send home
+    self:goHome("kicked")
+    self:setDynamicInfoText(_S.dynamic_info.patient.actions.no_diagnoses_available)
+  end
+end
+
+function Patient:sendPatientToTreatmentRoom()
+  if self:agreesToPay(self.disease.id) then
+    self:queueAction(SeekRoomAction(self.disease.treatment_rooms[1]):enableTreatmentRoom())
+  else
+    self:goHome("over_priced", self.disease.id)
   end
 end
 

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -209,14 +209,9 @@ function Room:dealtWithPatient(patient)
     if not patient.diagnosed then
       -- Patient not yet diagnosed, hence just been in a diagnosis room.
       -- Increment diagnosis_progress, and send patient back to GP.
-
-      patient:completeDiagnosticStep(self)
       self.hospital:receiveMoneyForTreatment(patient)
-      if patient:agreesToPay("diag_gp") then
-        patient:queueAction(SeekRoomAction("gp"))
-      else
-        patient:goHome("over_priced", "diag_gp")
-      end
+      patient:advanceDiagnosticProgress(self)
+      patient:decideWhichRoomToGoToNext()
     else
       -- Patient just been in a cure room, so either patient now cured, or needs
       -- to move onto next cure room.
@@ -234,7 +229,6 @@ function Room:dealtWithPatient(patient)
     patient:queueAction(MeanderAction():setCount(2))
     patient:queueAction(IdleAction())
   end
-
 end
 
 local profile_attributes = {

--- a/CorsixTH/Lua/rooms/gp.lua
+++ b/CorsixTH/Lua/rooms/gp.lua
@@ -126,34 +126,26 @@ function GPRoom:dealtWithPatient(patient)
   patient:setNextAction(self:createLeaveAction())
   patient:addToTreatmentHistory(self.room_info)
 
-  -- If the patient got sent to the wrong room and needs telling where
-  -- to go next - this happens when a disease changes for an epidemic
+  local doctor = self.staff_member
   if patient.needs_redirecting then
-    self:sendPatientToNextDiagnosisRoom(patient)
+    -- The patient got sent to the wrong room and needs telling where
+    -- to go next - this happens when a disease changes for an epidemic
+    patient:decideWhichRoomToGoToNext()
     patient.needs_redirecting = false
   elseif patient.disease and not patient.diagnosed then
     self.hospital:receiveMoneyForTreatment(patient)
-    patient:completeDiagnosticStep(self)
-    local no_need_diagnose_further =
-      patient.diagnosis_progress >= self.hospital.policies["stop_procedure"]
-    local cant_diagnose_further_but_can_set_diagnosis =
-      (patient.diagnosis_progress >= 1.0) and (not patient:hasMoreDiagnosisRoomsAvailable())
-    if no_need_diagnose_further or cant_diagnose_further_but_can_set_diagnosis then
-      patient:setDiagnosed()
-      if patient:agreesToPay(patient.disease.id) then
-        patient:queueAction(SeekRoomAction(patient.disease.treatment_rooms[1]):enableTreatmentRoom())
-      else
-        patient:goHome("over_priced", patient.disease.id)
-      end
-
-      self.staff_member:setMood("idea3", "activate") -- Show the light bulb over the doctor
+    patient:advanceDiagnosticProgress(self)
+    patient:attemptToSetFinalDiagnosis()
+    if patient.diagnosed then
+      doctor:setMood("idea3", "activate") -- Show the light bulb over the doctor
       -- Check if this disease has just been discovered
       if not self.hospital.disease_casebook[patient.disease.id].discovered then
         self.hospital.research:discoverDisease(patient.disease)
       end
     else
-      self:sendPatientToNextDiagnosisRoom(patient)
+      doctor:setMood("reflexion", "activate") -- Show the uncertainty mood over the doctor
     end
+    patient:decideWhichRoomToGoToNext()
   else
     patient:queueAction(MeanderAction():setCount(2))
     patient:queueAction(IdleAction())
@@ -161,24 +153,6 @@ function GPRoom:dealtWithPatient(patient)
 
   if self.staff_member then
     self:setStaffMembersAttribute("dealing_with_patient", false)
-  end
-end
-
-function GPRoom:sendPatientToNextDiagnosisRoom(patient)
-  if not patient:hasMoreDiagnosisRoomsAvailable() then
-    -- The very rare case where the patient has visited all his/her possible diagnosis rooms
-    -- There's not much to do then... Send home
-    patient:goHome("kicked")
-    patient:setDynamicInfoText(_S.dynamic_info.patient.actions.no_diagnoses_available)
-  else
-    self.staff_member:setMood("reflexion", "activate") -- Show the uncertainty mood over the doctor
-    local next_room_id = math.random(1, #patient.available_diagnosis_rooms)
-    local next_room = patient.available_diagnosis_rooms[next_room_id]
-    if patient:agreesToPay("diag_" .. next_room) then
-      patient:queueAction(SeekRoomAction(next_room):setDiagnosisRoom(next_room_id))
-    else
-      patient:goHome("over_priced", "diag_" .. next_room)
-    end
   end
 end
 

--- a/CorsixTH/Lua/rooms/toilets.lua
+++ b/CorsixTH/Lua/rooms/toilets.lua
@@ -62,10 +62,11 @@ end
 function ToiletRoom:dealtWithPatient(patient)
   -- Continue going to the room before going to the toilets.
   patient:setNextAction(self:createLeaveAction())
-  if patient.next_room_to_visit then
+  if patient.next_room_to_visit and patient.next_room_to_visit.room_info.id ~= "toilets" then
     patient:queueAction(SeekRoomAction(patient.next_room_to_visit.room_info.id))
   else
-    patient:queueAction(SeekReceptionAction())
+    patient.next_room_to_visit = nil
+    patient:decideWhichRoomToGoToNext()
   end
 end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #555*

**Describe what the proposed change does**
- When leaving the toilet, if the room where the patient went before the toilet is a toilet, do not return to the toilet.
- Instead of that to decide which room should be next.
