### PR TITLE
Close the door if fax isn't available

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 243 -- Cache list of reception desks
+local SAVEGAME_VERSION = 244 -- Fax door refactor
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -24,9 +24,6 @@ class "UIBottomPanel" (Window)
 ---@type UIBottomPanel
 local UIBottomPanel = _G["UIBottomPanel"]
 
-local FACTORY_DIR_OPENING = -1
-local FACTORY_DIR_CLOSING = 1
-
 local FAX_DOOR_FULLY_OPEN = 0
 local FAX_DOOR_FULLY_SHUT = 22
 
@@ -608,9 +605,7 @@ function UIBottomPanel:createMessageWindow(index)
     onClose, message_info.type, message_info.message, message_info.owner, message_info.timeout, message_info.default_choice, message_info.callback)
   message_windows[#message_windows + 1] = alert_window
   self:addWindow(alert_window)
-  self.factory_direction = FACTORY_DIR_CLOSING
   self.show_animation = true
-  self.factory_counter = -50                -- Delay close of message factory
   table.remove(self.message_queue, index)   -- Delete the last element of the queue
 end
 

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -26,9 +26,9 @@ local UIBottomPanel = _G["UIBottomPanel"]
 
 local FACTORY_DIR_OPENING = -1
 local FACTORY_DIR_CLOSING = 1
-local FACTORY_DIR_NONE = 0
 
-local FACTORY_ANIM_TICKS = 22
+local FAX_DOOR_FULLY_OPEN = 0
+local FAX_DOOR_FULLY_SHUT = 22
 
 function UIBottomPanel:UIBottomPanel(ui)
   self:Window()
@@ -45,16 +45,10 @@ function UIBottomPanel:UIBottomPanel(ui)
   -- State relating to fax notification messages
   self.show_animation = true
 
-  -- The factory counter is a tick counter that is used for opening and closing
-  -- the fax message door. When it is equal to FACTORY_ANIM_TICKS then the door
-  -- is fully closed. When it is less than 0 the door is fully open. At times it
-  -- is explicitly set to another value (less than zero when counting up, or
-  -- greater than zero when counting down) to delay the opening or closing of
-  -- the door.
-  self.factory_counter = FACTORY_ANIM_TICKS
-
-  -- Whether the door is opening, closing, or neutral
-  self.factory_direction = FACTORY_DIR_NONE
+  self.fax_door = {
+    closed_amount = FAX_DOOR_FULLY_OPEN -- How open or shut the door is
+    next_action_ticks = 0
+  }
 
   -- Visible fax panels on the left side of the bottom panel
   self.message_windows = {}
@@ -280,20 +274,18 @@ function UIBottomPanel:draw(canvas, x, y)
     self:drawDynamicInfo(canvas, x + 364 * s, y)
   end
 
-  if self.show_animation then
-    if self.factory_counter >= 1 then
-        self.panel_sprites:draw(canvas, 40, x + 177 * s, y + 1, { scaleFactor = s })
-    end
+  if self.fax_door.closed_amount >= 1 then
+      self.panel_sprites:draw(canvas, 40, x + 177 * s, y + 1, { scaleFactor = s })
+  end
 
-    if self.factory_counter > 1 and self.factory_counter <= FACTORY_ANIM_TICKS then
-      for dx = 0, self.factory_counter do
-        self.panel_sprites:draw(canvas, 41, x + 179 * s + dx * s, y + 1 * s, { scaleFactor = s })
-      end
+  if self.fax_door.closed_amount > 1 then
+    for dx = 0, self.fax_door.closed_amount do
+      self.panel_sprites:draw(canvas, 41, x + 179 * s + dx * s, y + 1 * s, { scaleFactor = s })
     end
+  end
 
-    if self.factory_counter == FACTORY_ANIM_TICKS then
-      self.panel_sprites:draw(canvas, 42, x + 201 * s, y + 1 * s, { scaleFactor = s })
-    end
+  if self.fax_door.closed_amount == FAX_DOOR_FULLY_SHUT then
+    self.panel_sprites:draw(canvas, 42, x + 201 * s, y + 1 * s, { scaleFactor = s })
   end
 
   self:drawReputationMeter(canvas, x + 55 * s, y + 35 * s)
@@ -533,23 +525,6 @@ function UIBottomPanel:openLastMessage()
   self.message_windows[#self.message_windows]:openMessage()
 end
 
---! Trigger a message to be moved from the queue into a actual window, after
--- first performing the necessary animation.
-function UIBottomPanel:_showMessage()
-  if self.factory_direction ~= FACTORY_DIR_OPENING then
-    self.factory_direction = FACTORY_DIR_OPENING
-    if self.factory_counter < 0 then
-      -- Factory is already opened so don't wait to show the message
-      self.show_animation = false
-      self.factory_counter = 9
-    else
-      -- Delay the appearance of the message to when the factory is opened
-      self.show_animation = true
-      self.factory_counter = FACTORY_ANIM_TICKS
-    end
-  end
-end
-
 -- Return the index of the first fax message in the queue that is suitable to be
 -- shown, and nil if there are none. A message is suitable to be shown if there
 -- are less than 5 currently shown messages, no message of the same type is
@@ -640,36 +615,6 @@ function UIBottomPanel:createMessageWindow(index)
 end
 
 function UIBottomPanel:onTick()
-  local msg_to_show = self:_findMessageToShow()
-
-  -- Advance the animation on the message factory
-  if self.factory_direction == FACTORY_DIR_CLOSING then
-    -- Close factory animation
-    if self.factory_counter < FACTORY_ANIM_TICKS then
-      self.factory_counter = self.factory_counter + 1
-    end
-  elseif self.factory_direction == FACTORY_DIR_OPENING then
-    if not msg_to_show then
-      -- Message was removed before we could display it. Reset.
-      self.factory_direction = FACTORY_DIR_CLOSING
-      self.factory_counter = FACTORY_ANIM_TICKS
-    end
-    -- Open factory animation
-    if self.factory_counter >= 0 then
-      if self.factory_counter == 0 then
-        -- Animation ends so we can now show the message
-        self:createMessageWindow()
-      end
-      self.factory_counter = self.factory_counter - 1
-    end
-  end
-
-  -- Start moving message out of the queue if a suitable one is available
-  if msg_to_show then
-    self:_showMessage()
-  end
-
-
   -- The dynamic info bar is there a while longer when hovering an entity has stopped
   if self.countdown then
     if self.countdown < 1 then
@@ -689,7 +634,30 @@ function UIBottomPanel:onTick()
     end
   end
 
+  self:_faxDoorTick()
+
   Window.onTick(self)
+end
+
+function UIBottomPanel:_faxDoorTick()
+  if self.fax_door.next_action_delay > 0 then
+    self.fax_door.next_action_delay = self.fax_door.next_action_delay - 1
+    return
+  end
+
+  local msg_to_show = self:_findMessageToShow()
+
+  if msg_to_show and self.fax_door.closed_amount == 0 then
+    self:createMessageWindow()
+    self.fax_door.next_action_delay = 9
+    return
+  end
+
+  if msg_to_show and self.fax_door.closed_amount > 0 then
+    self.fax_door.closed_amount = self.fax_door.closed_amount - 1
+  elseif not msg_to_show and self.fax_door.closed_amount < FAX_DOOR_FULLY_SHUT then
+    self.fax_door.closed_amount = self.fax_door.closed_amount + 1
+  end
 end
 
 function UIBottomPanel:dialogBankManager(enable)

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -43,7 +43,7 @@ function UIBottomPanel:UIBottomPanel(ui)
   self.show_animation = true
 
   self.fax_door = {
-    closed_amount = FAX_DOOR_FULLY_OPEN, -- How open or shut the door is
+    closed_amount = FAX_DOOR_FULLY_SHUT,
     next_action_delay = 0
   }
 

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -642,13 +642,13 @@ function UIBottomPanel:_faxDoorTick()
 
   local msg_to_show = self:_findMessageToShow()
 
-  if msg_to_show and self.fax_door.closed_amount == 0 then
+  if msg_to_show and self.fax_door.closed_amount == FAX_DOOR_FULLY_OPEN then
     self:createMessageWindow()
     self.fax_door.next_action_delay = 9
     return
   end
 
-  if msg_to_show and self.fax_door.closed_amount > 0 then
+  if msg_to_show and self.fax_door.closed_amount > FAX_DOOR_FULLY_OPEN then
     self.fax_door.closed_amount = self.fax_door.closed_amount - 1
   elseif not msg_to_show and self.fax_door.closed_amount < FAX_DOOR_FULLY_SHUT then
     self.fax_door.closed_amount = self.fax_door.closed_amount + 1

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -271,18 +271,17 @@ function UIBottomPanel:draw(canvas, x, y)
     self:drawDynamicInfo(canvas, x + 364 * s, y)
   end
 
-  if self.fax_door.closed_amount >= 1 then
-      self.panel_sprites:draw(canvas, 40, x + 177 * s, y + 1, { scaleFactor = s })
-  end
+  -- Draw the fax door if it is not fully open
+  if self.fax_door.closed_amount ~= FAX_DOOR_FULLY_OPEN then
+    self.panel_sprites:draw(canvas, 40, x + 177 * s, y + 1, { scaleFactor = s })
 
-  if self.fax_door.closed_amount > 1 then
     for dx = 0, self.fax_door.closed_amount do
       self.panel_sprites:draw(canvas, 41, x + 179 * s + dx * s, y + 1 * s, { scaleFactor = s })
     end
-  end
 
-  if self.fax_door.closed_amount == FAX_DOOR_FULLY_SHUT then
-    self.panel_sprites:draw(canvas, 42, x + 201 * s, y + 1 * s, { scaleFactor = s })
+    if self.fax_door.closed_amount == FAX_DOOR_FULLY_SHUT then
+      self.panel_sprites:draw(canvas, 42, x + 201 * s, y + 1 * s, { scaleFactor = s })
+    end
   end
 
   self:drawReputationMeter(canvas, x + 55 * s, y + 35 * s)

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -24,8 +24,8 @@ class "UIBottomPanel" (Window)
 ---@type UIBottomPanel
 local UIBottomPanel = _G["UIBottomPanel"]
 
-local FAX_DOOR_FULLY_OPEN = 0
-local FAX_DOOR_FULLY_SHUT = 22
+local MESSAGE_DOOR_FULLY_OPEN = 0
+local MESSAGE_DOOR_FULLY_SHUT = 22
 
 function UIBottomPanel:UIBottomPanel(ui)
   self:Window()
@@ -39,8 +39,8 @@ function UIBottomPanel:UIBottomPanel(ui)
   self:setDefaultPosition(0.5, -0.1)
   self:_initFonts(app.gfx)
 
-  self.fax_door = {
-    closed_amount = FAX_DOOR_FULLY_SHUT,
+  self.message_door = {
+    closed_amount = MESSAGE_DOOR_FULLY_SHUT,
     next_action_delay = 0
   }
 
@@ -269,14 +269,14 @@ function UIBottomPanel:draw(canvas, x, y)
   end
 
   -- Draw the fax door if it is not fully open
-  if self.fax_door.closed_amount ~= FAX_DOOR_FULLY_OPEN then
+  if self.message_door.closed_amount ~= MESSAGE_DOOR_FULLY_OPEN then
     self.panel_sprites:draw(canvas, 40, x + 177 * s, y + 1, { scaleFactor = s })
 
-    for dx = 0, self.fax_door.closed_amount do
+    for dx = 0, self.message_door.closed_amount do
       self.panel_sprites:draw(canvas, 41, x + 179 * s + dx * s, y + 1 * s, { scaleFactor = s })
     end
 
-    if self.fax_door.closed_amount == FAX_DOOR_FULLY_SHUT then
+    if self.message_door.closed_amount == MESSAGE_DOOR_FULLY_SHUT then
       self.panel_sprites:draw(canvas, 42, x + 201 * s, y + 1 * s, { scaleFactor = s })
     end
   end
@@ -624,29 +624,29 @@ function UIBottomPanel:onTick()
     end
   end
 
-  self:_faxDoorTick()
+  self:_messageDoorTick()
 
   Window.onTick(self)
 end
 
-function UIBottomPanel:_faxDoorTick()
-  if self.fax_door.next_action_delay > 0 then
-    self.fax_door.next_action_delay = self.fax_door.next_action_delay - 1
+function UIBottomPanel:_messageDoorTick()
+  if self.message_door.next_action_delay > 0 then
+    self.message_door.next_action_delay = self.message_door.next_action_delay - 1
     return
   end
 
   local msg_to_show = self:_findMessageToShow()
 
-  if msg_to_show and self.fax_door.closed_amount == FAX_DOOR_FULLY_OPEN then
+  if msg_to_show and self.message_door.closed_amount == MESSAGE_DOOR_FULLY_OPEN then
     self:createMessageWindow()
-    self.fax_door.next_action_delay = 9
+    self.message_door.next_action_delay = 9
     return
   end
 
-  if msg_to_show and self.fax_door.closed_amount > FAX_DOOR_FULLY_OPEN then
-    self.fax_door.closed_amount = self.fax_door.closed_amount - 1
-  elseif not msg_to_show and self.fax_door.closed_amount < FAX_DOOR_FULLY_SHUT then
-    self.fax_door.closed_amount = self.fax_door.closed_amount + 1
+  if msg_to_show and self.message_door.closed_amount > MESSAGE_DOOR_FULLY_OPEN then
+    self.message_door.closed_amount = self.message_door.closed_amount - 1
+  elseif not msg_to_show and self.message_door.closed_amount < MESSAGE_DOOR_FULLY_SHUT then
+    self.message_door.closed_amount = self.message_door.closed_amount + 1
   end
 end
 
@@ -995,12 +995,12 @@ function UIBottomPanel:afterLoad(old, new)
   end
   if old < 244 then
     -- ignore the delay logic for save games, minor
-    if self.factory_counter < FAX_DOOR_FULLY_OPEN then
-      self.factory_counter = FAX_DOOR_FULLY_OPEN
-    elseif self.factory_counter > FAX_DOOR_FULLY_SHUT then
-      self.factory_counter = FAX_DOOR_FULLY_SHUT
+    if self.factory_counter == nil or self.factory_counter > MESSAGE_DOOR_FULLY_SHUT then
+      self.factory_counter = MESSAGE_DOOR_FULLY_SHUT
+    elseif self.factory_counter < MESSAGE_DOOR_FULLY_OPEN then
+      self.factory_counter = MESSAGE_DOOR_FULLY_OPEN
     end
-    self.fax_door = {
+    self.message_door = {
       closed_amount = self.factory_counter,
       next_action_delay = 0
     }

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -640,6 +640,8 @@ function UIBottomPanel:createMessageWindow(index)
 end
 
 function UIBottomPanel:onTick()
+  local msg_to_show = self:_findMessageToShow()
+
   -- Advance the animation on the message factory
   if self.factory_direction == FACTORY_DIR_CLOSING then
     -- Close factory animation
@@ -647,7 +649,7 @@ function UIBottomPanel:onTick()
       self.factory_counter = self.factory_counter + 1
     end
   elseif self.factory_direction == FACTORY_DIR_OPENING then
-    if #self.message_queue == 0 then
+    if not msg_to_show then
       -- Message was removed before we could display it. Reset.
       self.factory_direction = FACTORY_DIR_CLOSING
       self.factory_counter = FACTORY_ANIM_TICKS
@@ -661,6 +663,12 @@ function UIBottomPanel:onTick()
       self.factory_counter = self.factory_counter - 1
     end
   end
+
+  -- Start moving message out of the queue if a suitable one is available
+  if msg_to_show then
+    self:_showMessage()
+  end
+
 
   -- The dynamic info bar is there a while longer when hovering an entity has stopped
   if self.countdown then
@@ -679,11 +687,6 @@ function UIBottomPanel:onTick()
     else
       self.countdown = self.countdown - 1
     end
-  end
-
-  -- Start moving message out of the queue if a suitable one is available
-  if self:_findMessageToShow() then
-    self:_showMessage()
   end
 
   Window.onTick(self)

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -39,9 +39,6 @@ function UIBottomPanel:UIBottomPanel(ui)
   self:setDefaultPosition(0.5, -0.1)
   self:_initFonts(app.gfx)
 
-  -- State relating to fax notification messages
-  self.show_animation = true
-
   self.fax_door = {
     closed_amount = FAX_DOOR_FULLY_SHUT,
     next_action_delay = 0
@@ -604,7 +601,6 @@ function UIBottomPanel:createMessageWindow(index)
     onClose, message_info.type, message_info.message, message_info.owner, message_info.timeout, message_info.default_choice, message_info.callback)
   message_windows[#message_windows + 1] = alert_window
   self:addWindow(alert_window)
-  self.show_animation = true
   table.remove(self.message_queue, index)   -- Delete the last element of the queue
 end
 
@@ -1010,6 +1006,7 @@ function UIBottomPanel:afterLoad(old, new)
     }
     self.factory_counter = nil
     self.factory_direction = nil
+    self.show_animation = nil
   end
   -- Hotfix to force re-calculation of the money font (see issue #1193)
   self.money_font = TheApp.gfx:loadFontAndSpriteTable("QData", "Font05V", nil, nil, { apply_ui_scale = true })

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -46,8 +46,8 @@ function UIBottomPanel:UIBottomPanel(ui)
   self.show_animation = true
 
   self.fax_door = {
-    closed_amount = FAX_DOOR_FULLY_OPEN -- How open or shut the door is
-    next_action_ticks = 0
+    closed_amount = FAX_DOOR_FULLY_OPEN, -- How open or shut the door is
+    next_action_delay = 0
   }
 
   -- Visible fax panels on the left side of the bottom panel
@@ -1002,6 +1002,20 @@ function UIBottomPanel:afterLoad(old, new)
   end
   if old < 236 then
    self:_initFonts(self.ui.app.gfx)
+  end
+  if old < 244 then
+    -- ignore the delay logic for save games, minor
+    if self.factory_counter < FAX_DOOR_FULLY_OPEN then
+      self.factory_counter = FAX_DOOR_FULLY_OPEN
+    elseif self.factory_counter > FAX_DOOR_FULLY_SHUT then
+      self.factory_counter = FAX_DOOR_FULLY_SHUT
+    end
+    self.fax_door = {
+      closed_amount = self.factory_counter,
+      next_action_delay = 0
+    }
+    self.factory_counter = nil
+    self.factory_direction = nil
   end
   -- Hotfix to force re-calculation of the money font (see issue #1193)
   self.money_font = TheApp.gfx:loadFontAndSpriteTable("QData", "Font05V", nil, nil, { apply_ui_scale = true })


### PR DESCRIPTION
Fix regression in #3341

Refactors the fax door (factory) logic to be quite a bit simpler and less prone to bad state issues.

One thing that was dropped was that there was two different delays for an open fax door, 9 ticks to show the next message from whenever it became available if the door was open (which sounds a bit broken when said out loud) and 50 ticks to begin closing the door after popping the fax. I reduced them to a single 9 tick delay for either action. In my play experience this seems fine, but if others consider it unacceptable I can introduce a separate delay counter for each.

I made a separate branch that keeps the logic at https://github.com/CorsixTH/CorsixTH/commit/25a89eff6311289b505164cfead6e55e45ff2f38 to compare. 