### PR TITLE
Allow to open a fax even if the message isn't in the drawer

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -610,12 +610,11 @@ function UIBottomPanel:_showMessageIcon(index)
   if not message_info then
     return
   end
-  -- Create the message window, note this does not show it to the player on creation.
-  local alert_window = UIMessage(self.ui, 175, 1 + #message_windows * 30,
-    onClose, message_info.type, message_info.message, message_info.owner, message_info.timeout, message_info.default_choice, message_info.callback)
-  message_windows[#message_windows + 1] = alert_window
-  self:addWindow(alert_window)
-  table.remove(self.message_queue, index)   -- Delete the last element of the queue
+  local drawer_icon = message_info.drawer_icon
+  drawer_icon:setXLimit(1 + #message_windows * FACTORY_ICON_WIDTH)
+  message_windows[#message_windows + 1] = drawer_icon
+  self:addWindow(drawer_icon)
+  table.remove(self.message_queue, index)   -- Delete element of the queue
 end
 
 function UIBottomPanel:onTick()

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -461,7 +461,9 @@ function UIBottomPanel:queueMessage(type, message, owner, timeout, default_choic
       -- If icon position found
       if this_icon_index ~= nil then
         -- Shift all icons that are on the right to the left
-        icon:setXLimit(1 + (i - 2) * FACTORY_ICON_WIDTH)
+        -- The '_factoryIconWitdh()' call is used for compatibility with 0.69 saves and older
+        -- where FACTORY_ICON_WIDTH was not yet declared when the closure was created.
+        icon:setXLimit(1 + (i - 2) * self._factoryIconWitdh())
       elseif icon == this_icon then
         this_icon_index = i
       end
@@ -493,6 +495,10 @@ function UIBottomPanel:queueMessage(type, message, owner, timeout, default_choic
   else
     self:cancelFax(message_info.type)
   end
+end
+
+function UIBottomPanel:_factoryIconWitdh()
+  return FACTORY_ICON_WIDTH
 end
 
 --[[ A fax can be queued if the event the fax causes does not affect

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -27,8 +27,9 @@ local UIBottomPanel = _G["UIBottomPanel"]
 local FACTORY_DIR_OPENING = -1
 local FACTORY_DIR_CLOSING = 1
 local FACTORY_DIR_NONE = 0
-
+local FACTORY_PAUSE_BEFORE_NEXT_TICKS = 9
 local FACTORY_ANIM_TICKS = 22
+local FACTORY_ICON_WIDTH = 30
 
 function UIBottomPanel:UIBottomPanel(ui)
   self:Window()
@@ -453,7 +454,23 @@ function UIBottomPanel:queueMessage(type, message, owner, timeout, default_choic
     self.world.ui.adviser:say(_A.information.fax_received)
     self.ui.hospital.message_popup = true
   end
-  local fax = {
+
+  local --[[persistable:bottom_panel_message_window_close]] function onClose(this_icon)
+    local this_icon_index
+    for i, icon in ipairs(self.message_windows) do
+      -- If icon position found
+      if this_icon_index ~= nil then
+        -- Shift all icons that are on the right to the left
+        icon:setXLimit(1 + (i - 2) * FACTORY_ICON_WIDTH)
+      elseif icon == this_icon then
+        this_icon_index = i
+      end
+    end
+    table.remove(self.message_windows, this_icon_index)
+    self:deleteMessage(this_icon.owner)
+  end
+
+  local message_info = {
     type = type,
     message = message,
     owner = owner,
@@ -462,14 +479,19 @@ function UIBottomPanel:queueMessage(type, message, owner, timeout, default_choic
     callback = callback,
   }
 
-  if self:canQueueFax(fax) then
-    self.message_queue[#self.message_queue + 1] = fax
-    -- create reference to message in owner
+  if self:canQueueFax(message_info) then
+    self.message_queue[#self.message_queue + 1] = message_info
+    -- Create the drawer message icon, note this does not show it to the player on creation.
+    local drawer_icon = UIMessage(self.ui, 175, nil,
+      onClose, message_info.type, message_info.message, message_info.owner,
+      message_info.timeout, message_info.default_choice, message_info.callback)
+    message_info["drawer_icon"] = drawer_icon
+    -- Сreate reference to message in owner
     if owner then
       owner.message = message
     end
   else
-    self:cancelFax(fax.type)
+    self:cancelFax(message_info.type)
   end
 end
 
@@ -527,8 +549,7 @@ end
 -- Opens the last available message. Currently used to open the level completed message.
 function UIBottomPanel:openLastMessage()
   if #self.message_queue > 0 then
-    self:createMessageWindow(#self.message_queue)
-    table.remove(self.message_queue, #self.message_queue)
+    self:_showMessageIcon(#self.message_queue)
   end
   self.message_windows[#self.message_windows]:openMessage()
 end
@@ -541,7 +562,7 @@ function UIBottomPanel:_showMessage()
     if self.factory_counter < 0 then
       -- Factory is already opened so don't wait to show the message
       self.show_animation = false
-      self.factory_counter = 9
+      self.factory_counter = FACTORY_PAUSE_BEFORE_NEXT_TICKS
     else
       -- Delay the appearance of the message to when the factory is opened
       self.show_animation = true
@@ -582,18 +603,20 @@ end
 
 -- Removes a message from the message queue (for example if a room is built before the player
 -- says what to do with the patient.
-function UIBottomPanel:removeMessage(owner)
+function UIBottomPanel:deleteMessage(owner)
   for i, msg_info in ipairs(self.message_queue) do
     if msg_info.owner == owner then
       -- TODO: restructure message_queue to contain UIMessage objects already, so this special handling isn't required
-      owner.message = nil
       table.remove(self.message_queue, i)
+      msg_info.drawer_icon.onClose = nil
+      msg_info.drawer_icon = nil
+      owner.message = nil
       return true
     end
   end
-  for _, window in ipairs(self.message_windows) do
-    if window.owner == owner then
-      window:removeMessage()
+  for index, drawer_icon in ipairs(self.message_windows) do
+    if drawer_icon.owner == owner then
+      drawer_icon:removeMessage()
       return true
     end
   end
@@ -604,22 +627,7 @@ end
 -- an actual message window; if no index is provided the first suitable message
 -- in the queue is popped.
 --!param index (integer|nil) the index in the message_queue to pop
-function UIBottomPanel:createMessageWindow(index)
-  local --[[persistable:bottom_panel_message_window_close]] function onClose(window)
-    local index_to_remove
-    for i, win in ipairs(self.message_windows) do
-      if index_to_remove ~= nil then
-        win:setXLimit(1 + (i - 2) * 30)
-      elseif win == window then
-        index_to_remove = i
-        if win.callback then
-          win.callback()
-        end
-      end
-    end
-    table.remove(self.message_windows, index_to_remove)
-  end
-
+function UIBottomPanel:_showMessageIcon(index)
   if not index then
     index = self:_findMessageToShow()
   end
@@ -628,15 +636,15 @@ function UIBottomPanel:createMessageWindow(index)
   if not message_info then
     return
   end
-  -- Create the message window, note this does not show it to the player on creation.
-  local alert_window = UIMessage(self.ui, 175, 1 + #message_windows * 30,
-    onClose, message_info.type, message_info.message, message_info.owner, message_info.timeout, message_info.default_choice, message_info.callback)
-  message_windows[#message_windows + 1] = alert_window
-  self:addWindow(alert_window)
+
+  local drawer_icon = message_info.drawer_icon
+  drawer_icon:setXLimit(1 + #message_windows * FACTORY_ICON_WIDTH)
+  message_windows[#message_windows + 1] = drawer_icon
+  self:addWindow(drawer_icon)
   self.factory_direction = FACTORY_DIR_CLOSING
   self.show_animation = true
   self.factory_counter = -50                -- Delay close of message factory
-  table.remove(self.message_queue, index)   -- Delete the last element of the queue
+  table.remove(self.message_queue, index)   -- Delete element of the queue
 end
 
 function UIBottomPanel:onTick()
@@ -656,7 +664,7 @@ function UIBottomPanel:onTick()
     if self.factory_counter >= 0 then
       if self.factory_counter == 0 then
         -- Animation ends so we can now show the message
-        self:createMessageWindow()
+        self:_showMessageIcon()
       end
       self.factory_counter = self.factory_counter - 1
     end

--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -147,8 +147,9 @@ function UIMessage:removeMessage(choice_number)
       self.owner.message_callback = nil
     end
     if self.onClose then
-      self:onClose(false)
+      local onClose = self.onClose
       self.onClose = nil
+      onClose(self)
     end
     self:close()
   end
@@ -165,7 +166,6 @@ function UIMessage:dismissMessage()
 end
 
 function UIMessage:setXLimit(stop_x)
-  assert(stop_x <= self.stop_x, "UIMessage moved in wrong direction")
   self.stop_x = stop_x
 end
 

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -735,7 +735,7 @@ end
 --[[ For Cheat - Cancel the epidemic. ]]
 function Epidemic:cancelEpidemic()
   -- Remove init epidemic fax
-  self.world.ui.bottom_panel:removeMessage(self)
+  self.world.ui.bottom_panel:deleteMessage(self)
   -- Turn vaccination mode off if enabled
   self:turnOffVaccinationMode()
   -- Remove epidemic timer

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -735,7 +735,7 @@ end
 --!param humanoid (table) The humanoid
 function PlayerHospital:removeMessage(humanoid)
   if humanoid.message then
-    self.world.ui.bottom_panel:removeMessage(humanoid)
+    self.world.ui.bottom_panel:deleteMessage(humanoid)
   end
 end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #1827*

**Describe what the proposed change does**
- If the incoming message had not yet get into the drawer, then it was impossible to open it in any other way, not from the drawer. This limitation has been removed.
- For example, suppose 10 doctors want a promotion, but only 5 of them will show up in the drawer. If we find one of the doctors in the hospital whose message is in the drawer and click on they, the promotion request will be displayed on screen. If we find one of the doctors in the hospital whose message isn't in the drawer and click on they, the promotion request won't be displayed. The situation is similar with patients who don’t know where to go and ask for your decision.
- This issue happens because the `UIMessage` object, which is responsible for displaying a fax or promotion request on the screen, was created too late, only when the message got in the drawer. Therefore, if the message wasn't in the drawer, it simply couldn't be opened.
- And since we implemented the restriction to prevent messages of the same type from displaying in the drawer at the same time in #3341, the situation with this issue has become even worse. Because now out of 10 simultaneous requests for salary increases, only 1 is displayed in drawer. And only that 1 can be opened.
- So now `UIMessage` are created as soon as an incoming message is received in the queue.
