### PR TITLE
Prevent accidentally closed windows fax

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 244 -- Fax door refactor
+local SAVEGAME_VERSION = 245 -- Prevent accidentally closed windows fax refactor
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/confirm_dialog.lua
+++ b/CorsixTH/Lua/dialogs/confirm_dialog.lua
@@ -79,17 +79,11 @@ function UIConfirmDialog:UIConfirmDialog(ui, must_pause, text, callback_ok, call
   self.height = last_y + 63
 
   self:registerKeyHandlers()
-  if self.must_pause then self:systemPause() end
 end
 
 -- Confirm dialogs are used for errors, if it is an error then pause the game
 function UIConfirmDialog:mustPause()
   return self.must_pause
-end
-
---! Function to tell the game a system pause is needed
-function UIConfirmDialog:systemPause()
-  TheApp.world:setSystemPause(true)
 end
 
 function UIConfirmDialog:registerKeyHandlers()
@@ -109,7 +103,6 @@ end
 --!param confirmed (boolean or nil) whether to call the confirm callback (true) or cancel callback (false/nil)
 function UIConfirmDialog:close(confirmed)
   -- NB: Window is closed before executing the callback in order to not save the confirmation dialog in a savegame
-  if self.must_pause then TheApp.world:setSystemPause(false) end -- Error dealt with
   Window.close(self)
   if confirmed then
     if self.callback_ok then

--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -105,13 +105,10 @@ end
 
 --! Displays the fax/strike message to the player when opened from the bottom_panel.
 function UIMessage:openMessage()
-  if TheApp.world:isUserActionProhibited() and not self.ui:checkForMustPauseWindows() then
+  if TheApp.world:isUserActionProhibited() then
     self.ui:playSound("wrong2.wav")
     self:adjustToggle()
     return
-  end
-  if TheApp.world:isCurrentSpeed("Speed Up") then
-    TheApp.world:previousSpeed()
   end
   if self.type == "strike" then -- strikes are special cases, as they are not faxes
     self.ui:addWindow(UIStaffRise(self.ui, self.owner, self.message))

--- a/CorsixTH/Lua/persistance.lua
+++ b/CorsixTH/Lua/persistance.lua
@@ -316,9 +316,7 @@ function LoadGame(data)
   -- Check if the blueish tone should be applied.
   -- Note: Blue filter control should be handled from world or ui, however when
   -- loading a game we should let persistence do it.
-  if not TheApp.ui:checkForMustPauseWindows() and TheApp.world:isUserActionProhibited() then
-    TheApp.video:setBlueFilterActive(true)
-  end
+  TheApp.world:updateScreenBlueFilter()
 end
 
 function LoadGameFile(filename)

--- a/CorsixTH/Lua/persistance.lua
+++ b/CorsixTH/Lua/persistance.lua
@@ -316,6 +316,7 @@ function LoadGame(data)
   -- Check if the blueish tone should be applied.
   -- Note: Blue filter control should be handled from world or ui, however when
   -- loading a game we should let persistence do it.
+  TheApp.world:updateUserActionsAllowed()
   TheApp.world:updateScreenBlueFilter()
 end
 

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1052,13 +1052,10 @@ function UI:addWindow(window)
     end
     self.modal_windows[window.modal_class] = window
   end
-  if self.app.world and window:mustPause() then
-    self.app.world:setSpeed("Pause")
-    self.app.video:setBlueFilterActive(false) -- mustPause windows shouldn't cause tainting
-  end
   if window.modal_class == "main" or window.modal_class == "fullscreen" then
     self.editing_allowed = false -- do not allow editing rooms if main windows (build, furnish, hire) are open
   end
+  self:updateSystemPause(true, window)
   Window.addWindow(self, window)
 end
 
@@ -1068,18 +1065,26 @@ function UI:removeWindow(closing_window)
     if class and self.modal_windows[class] == closing_window then
       self.modal_windows[class] = nil
     end
-    if self.app.world and self.app.world:isCurrentSpeed("Pause") then
-      local pauseGame = self:checkForMustPauseWindows()
-      if not pauseGame and closing_window:mustPause() then
-        self.app.world:setSpeed(self.app.world.prev_speed)
-      end
-    end
     if closing_window.modal_class == "main" or closing_window.modal_class == "fullscreen" then
       self.editing_allowed = true -- allow editing rooms again when main window is closed
     end
+    self:updateSystemPause(false, closing_window)
     return true
   else
     return false
+  end
+end
+
+--! Toggles system pause on and off if needed
+--!param pause (bool) flag indicating whether to turn the pause state on or off
+--!param window (object) window causing the status update
+function UI:updateSystemPause(pause, window)
+  if not self.app.world then return end
+  if window:mustPause() then
+    local otherPauseWindows = self:checkForMustPauseWindows()
+    if not otherPauseWindows then
+      self.app.world:setSystemPause(pause)
+    end
   end
 end
 

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1056,7 +1056,7 @@ function UI:addWindow(window)
     self.editing_allowed = false -- do not allow editing rooms if main windows (build, furnish, hire) are open
   end
   Window.addWindow(self, window)
-  self:updateSystemPause(true, window)
+  self:_onAddWindow(window)
 end
 
 function UI:removeWindow(closing_window)
@@ -1068,30 +1068,34 @@ function UI:removeWindow(closing_window)
     if closing_window.modal_class == "main" or closing_window.modal_class == "fullscreen" then
       self.editing_allowed = true -- allow editing rooms again when main window is closed
     end
-    self:updateSystemPause(false, closing_window)
+    self:_onRemoveWindow(closing_window)
     return true
   else
     return false
   end
 end
 
---! Toggles system pause on and off if needed
---!param pause (bool) flag indicating whether to turn the pause state on or off
---!param window (object) window causing the status update
-function UI:updateSystemPause(pause, window)
-  if not self.app.world then return end
-  if window:mustPause() then
-    if pause then
-      self.app.world:systemPause()
-    else
-      self.app.world:systemUnpause()
-    end
+-- Function for signaling that the window is added.
+-- To pause game if the necessary requirements are met.
+--!param window (object) window added
+function UI:_onAddWindow(window)
+  if self.app.world and window:mustPause() then
+    self.app.world:mustPauseWindowAdd()
+  end
+end
+
+-- Function for signaling that the window is to be removed.
+-- To unpause game if the necessary requirements are met.
+--!param window (object) window to be removed
+function UI:_onRemoveWindow(window)
+  if self.app.world and window:mustPause() then
+    self.app.world:mustPauseWindowRemoved()
   end
 end
 
 --! Function to check if we have any must pause windows open
 --!return (bool) Returns true if a must pause window is found
-function UI:checkForMustPauseWindows()
+function UI:anyMustPauseWindowOpen()
   for _, window in pairs(self.windows) do
     if window:mustPause() then return true end
   end

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -1055,8 +1055,8 @@ function UI:addWindow(window)
   if window.modal_class == "main" or window.modal_class == "fullscreen" then
     self.editing_allowed = false -- do not allow editing rooms if main windows (build, furnish, hire) are open
   end
-  self:updateSystemPause(true, window)
   Window.addWindow(self, window)
+  self:updateSystemPause(true, window)
 end
 
 function UI:removeWindow(closing_window)
@@ -1081,9 +1081,10 @@ end
 function UI:updateSystemPause(pause, window)
   if not self.app.world then return end
   if window:mustPause() then
-    local otherPauseWindows = self:checkForMustPauseWindows()
-    if not otherPauseWindows then
-      self.app.world:setSystemPause(pause)
+    if pause then
+      self.app.world:systemPause()
+    else
+      self.app.world:systemUnpause()
     end
   end
 end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -757,7 +757,7 @@ end
 -- "Max speed", or "And then some more".
 function World:setSpeed(new_speed)
   if self:isCurrentSpeed(new_speed) then return end
-  if self:mustPause() and new_speed ~= "Pause" then return end -- System pause takes precedence
+  if self:mustPause() and new_speed ~= "Pause" then return end -- "Must pause" takes precedence
   tracy.Message("Changing speed to " .. new_speed)
 
   if new_speed == "Pause" then
@@ -802,8 +802,8 @@ function World:mustPauseWindowRemoved()
   end
 end
 
---! Check if we have any must pause windows open
---!return (bool) returns true if we have any must pause windows open
+--! Check if "Must Pause" mode enabled
+--!return (bool) returns true if "Must Pause" mode enabled
 function World:mustPause()
   return self.ui:anyMustPauseWindowOpen()
 end
@@ -819,7 +819,7 @@ end
 
 --! Dedicated function to allow unpausing by pressing 'p' again
 function World:pauseOrUnpause()
-  if self:mustPause() then return end -- System pause takes precedence
+  if self:mustPause() then return end -- "Must pause" takes precedence
   if not self:isCurrentSpeed("Pause") then
     self:setSpeed("Pause")
   elseif self.prev_speed then
@@ -2789,6 +2789,9 @@ function World:afterLoad(old, new)
         entity:setIfHoverMoodsVisible()
       end
     end
+  end
+  if old < 244 then
+    self.system_pause = nil
   end
 
   -- Fix the initial of staff names

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -758,18 +758,22 @@ end
 -- Set the (approximate) number of seconds per tick.
 --!param speed (string) One of: "Pause", "Slowest", "Slower", "Normal",
 -- "Max speed", or "And then some more".
-function World:setSpeed(speed)
-  if self:isCurrentSpeed(speed) then
-    return
-  end
-  tracy.Message("Changing speed to " .. speed)
-  if speed == "Pause" or self.system_pause then
+function World:setSpeed(new_speed)
+  local isSystemPause = self:isSystemPauseActive()
+  if self:isCurrentSpeed(new_speed) then return end
+  if isSystemPause and new_speed ~= "Pause" then return end -- System pause takes precedence
+  tracy.Message("Changing speed to " .. new_speed)
+
+  if isSystemPause then
     self.ui.hospital:tickEarthquake("pause")
-    -- By default actions are not allowed when the game is paused.
-    self.user_actions_allowed = TheApp.config.allow_user_actions_while_paused
-  elseif self:getCurrentSpeed() == "Pause" then
-    self.user_actions_allowed = true
   end
+
+  -- Actions are not allowed when the game is System paused.
+  self.user_actions_allowed = not isSystemPause and
+    (new_speed ~= "Pause" or TheApp.config.allow_user_actions_while_paused)
+
+  -- Set the blue filter according to whether the user can build or not.
+  TheApp.video:setBlueFilterActive(not isSystemPause and not self.user_actions_allowed)
 
   local old_speed = self:getCurrentSpeed()
   if old_speed ~= "Pause" and old_speed ~= "Speed Up" then
@@ -778,7 +782,7 @@ function World:setSpeed(speed)
 
   local was_paused = old_speed == "Pause"
   local old_tick_rate = self.tick_rate or 1
-  local new_hours_per_tick, new_tick_rate = unpack(tick_rates[speed])
+  local new_hours_per_tick, new_tick_rate = unpack(tick_rates[new_speed])
 
   if was_paused then
     TheApp.audio:onEndPause()
@@ -790,8 +794,6 @@ function World:setSpeed(speed)
   self.hours_per_tick = new_hours_per_tick
   self.tick_rate = new_tick_rate
 
-  -- Set the blue filter according to whether the user can build or not.
-  TheApp.video:setBlueFilterActive(not self.user_actions_allowed and not self.ui:checkForMustPauseWindows())
   return false
 end
 
@@ -810,9 +812,16 @@ function World:pauseOrUnpause()
 end
 
 --! Sets the system_pause parameter
---!param state (bool)
-function World:setSystemPause(state)
-  self.system_pause = state
+--!param enabled (bool)
+function World:setSystemPause(enabled)
+  self.system_pause = enabled
+  if enabled then
+    self:setSpeed("Pause")
+  else
+    if self.prev_speed then
+      self:setSpeed(self.prev_speed)
+    end
+  end
 end
 
 --! Reports the system pause status

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -764,12 +764,6 @@ function World:setSpeed(new_speed)
     self.ui.hospital:tickEarthquake("pause")
   end
 
-  -- Actions are not allowed when the game is System paused.
-  self.user_actions_allowed = not self:mustPause() and
-    (new_speed ~= "Pause" or TheApp.config.allow_user_actions_while_paused)
-
-  self:updateScreenBlueFilter()
-
   local old_speed = self:getCurrentSpeed()
   if old_speed ~= "Pause" and old_speed ~= "Speed Up" then
     self.prev_speed = old_speed
@@ -788,6 +782,9 @@ function World:setSpeed(new_speed)
 
   self.hours_per_tick = new_hours_per_tick
   self.tick_rate = new_tick_rate
+
+  self:updateUserActionsAllowed()
+  self:updateScreenBlueFilter()
 
   return false
 end
@@ -812,14 +809,21 @@ function World:isPaused()
   return self:isCurrentSpeed("Pause")
 end
 
+--! Set the "actions allowed" flag according to whether the user can do some actions with UI or not.
+function World:updateUserActionsAllowed()
+  -- Actions are not allowed when the game in "Must Pause" mode.
+  self.user_actions_allowed = not self:mustPause() and
+    (not self:isCurrentSpeed("Pause") or TheApp.config.allow_user_actions_while_paused)
+end
+
 --! Set the blue filter according to whether the user can build or not.
 function World:updateScreenBlueFilter()
-  TheApp.video:setBlueFilterActive(not self:mustPause() and not self.user_actions_allowed)
+  TheApp.video:setBlueFilterActive(not self.user_actions_allowed and not self:mustPause())
 end
 
 --! Dedicated function to allow unpausing by pressing 'p' again
 function World:pauseOrUnpause()
-  if self:mustPause() then return end -- "Must pause" takes precedence
+  if self:mustPause() then return end -- "Must Pause" takes precedence
   if not self:isCurrentSpeed("Pause") then
     self:setSpeed("Pause")
   elseif self.prev_speed then

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -2821,7 +2821,7 @@ function World:afterLoad(old, new)
       end
     end
   end
-  if old < 244 then
+  if old < 245 then
     self.system_pause = nil
   end
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -756,21 +756,19 @@ end
 -- One of: "Pause", "Slowest", "Slower", "Normal",
 -- "Max speed", or "And then some more".
 function World:setSpeed(new_speed)
-  local isSystemPause = self:isSystemPauseActive()
   if self:isCurrentSpeed(new_speed) then return end
-  if isSystemPause and new_speed ~= "Pause" then return end -- System pause takes precedence
+  if self:mustPause() and new_speed ~= "Pause" then return end -- System pause takes precedence
   tracy.Message("Changing speed to " .. new_speed)
 
-  if isSystemPause or new_speed == "Pause" then
+  if new_speed == "Pause" then
     self.ui.hospital:tickEarthquake("pause")
   end
 
   -- Actions are not allowed when the game is System paused.
-  self.user_actions_allowed = not isSystemPause and
+  self.user_actions_allowed = not self:mustPause() and
     (new_speed ~= "Pause" or TheApp.config.allow_user_actions_while_paused)
 
-  -- Set the blue filter according to whether the user can build or not.
-  TheApp.video:setBlueFilterActive(not isSystemPause and not self.user_actions_allowed)
+  self:updateScreenBlueFilter()
 
   local old_speed = self:getCurrentSpeed()
   if old_speed ~= "Pause" and old_speed ~= "Speed Up" then
@@ -794,23 +792,34 @@ function World:setSpeed(new_speed)
   return false
 end
 
-function World:systemPause()
+function World:mustPauseWindowAdd()
   self:setSpeed("Pause")
 end
 
-function World:systemUnpause()
-  if self:isCurrentSpeed("Pause") and not self:isSystemPauseActive() then
+function World:mustPauseWindowRemoved()
+  if self:isCurrentSpeed("Pause") then
     self:pauseOrUnpause()
   end
+end
+
+--! Check if we have any must pause windows open
+--!return (bool) returns true if we have any must pause windows open
+function World:mustPause()
+  return self.ui:anyMustPauseWindowOpen()
 end
 
 function World:isPaused()
   return self:isCurrentSpeed("Pause")
 end
 
+--! Set the blue filter according to whether the user can build or not.
+function World:updateScreenBlueFilter()
+  TheApp.video:setBlueFilterActive(not self:mustPause() and not self.user_actions_allowed)
+end
+
 --! Dedicated function to allow unpausing by pressing 'p' again
 function World:pauseOrUnpause()
-  if self:isSystemPauseActive() then return end -- System pause takes precedence
+  if self:mustPause() then return end -- System pause takes precedence
   if not self:isCurrentSpeed("Pause") then
     self:setSpeed("Pause")
   elseif self.prev_speed then
@@ -818,16 +827,10 @@ function World:pauseOrUnpause()
   end
 end
 
---! Reports the system pause status
---!return (bool) true is system pause is active, else false
-function World:isSystemPauseActive()
-  return self.ui:checkForMustPauseWindows()
-end
-
 --! Function to check if player can perform actions when paused
 --!return (bool) Returns true if player hasn't allowed editing while paused
 function World:isUserActionProhibited()
-  if self:isSystemPauseActive() then return true end
+  if self:mustPause() then return true end
   return self:isCurrentSpeed("Pause") and not self.user_actions_allowed
 end
 

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -76,10 +76,6 @@ function World:World(app, free_build_mode)
   -- This is false when the game is paused.
   self.user_actions_allowed = true
 
-  -- The system pause method is used as an additional layer to pause the game, where the user
-  -- needs to deal with a recoverable error
-  self.system_pause = false
-
   -- If set, do not create salary raise requests.
   self.debug_disable_salary_raise = self.free_build_mode
   self.idle_cache = {} -- Cached queue standing positions for all queues.
@@ -756,7 +752,8 @@ function World:getCurrentSpeed()
 end
 
 -- Set the (approximate) number of seconds per tick.
---!param speed (string) One of: "Pause", "Slowest", "Slower", "Normal",
+--!param new_speed (string) New speed to set.
+-- One of: "Pause", "Slowest", "Slower", "Normal",
 -- "Max speed", or "And then some more".
 function World:setSpeed(new_speed)
   local isSystemPause = self:isSystemPauseActive()
@@ -764,7 +761,7 @@ function World:setSpeed(new_speed)
   if isSystemPause and new_speed ~= "Pause" then return end -- System pause takes precedence
   tracy.Message("Changing speed to " .. new_speed)
 
-  if isSystemPause then
+  if isSystemPause or new_speed == "Pause" then
     self.ui.hospital:tickEarthquake("pause")
   end
 
@@ -797,6 +794,16 @@ function World:setSpeed(new_speed)
   return false
 end
 
+function World:systemPause()
+  self:setSpeed("Pause")
+end
+
+function World:systemUnpause()
+  if self:isCurrentSpeed("Pause") and not self:isSystemPauseActive() then
+    self:pauseOrUnpause()
+  end
+end
+
 function World:isPaused()
   return self:isCurrentSpeed("Pause")
 end
@@ -811,23 +818,10 @@ function World:pauseOrUnpause()
   end
 end
 
---! Sets the system_pause parameter
---!param enabled (bool)
-function World:setSystemPause(enabled)
-  self.system_pause = enabled
-  if enabled then
-    self:setSpeed("Pause")
-  else
-    if self.prev_speed then
-      self:setSpeed(self.prev_speed)
-    end
-  end
-end
-
 --! Reports the system pause status
 --!return (bool) true is system pause is active, else false
 function World:isSystemPauseActive()
-  return self.system_pause
+  return self.ui:checkForMustPauseWindows()
 end
 
 --! Function to check if player can perform actions when paused
@@ -2821,7 +2815,6 @@ function World:afterLoad(old, new)
   end
   self.savegame_version = new
   self.release_version = TheApp:getReleaseString(new)
-  self:setSystemPause(false) -- Reset flag on load
 end
 
 function World:playLoadedEntitySounds()


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #2638*

**Describe what the proposed change does**
- The "System Pause" / "Must Pause" logic has been improved. "Must Pause" now used instead "System Pause".
- A "Must Pause" is defined as a pause initiated by the application, not the user, based on specific events. For example, displaying a modal dialog or modal window that requires a response from the user.
- "Must Pause" can only be set and unset by the game. The user cannot unpause the game directly, only by responding to the modal window that initiated the pause.
- "Must Pause" controls the `world.user_actions_allowed` variable, which is determines the restrictions imposed on user actions. The logic behind `user_actions_allowed` effects has not changed. Only the reasons for setting and clearing `user_actions_allowed` have changed.
- The `world.system_pause` variable itself has been removed from the code. Instead, "Must Pause" is managed by the `ui.checkForMustPauseWindows()` function.
- The `mustPause` is set separately for each window, but this functionality was not modified here.
- The logic for set the blue filter on screen has also been improved.
- Logic behind setting/clearing the `user_actions_allowed` and `setBlueFilterActive` moved to one single place. (I hope all of it)
- This "System Pause" / "Must Pause" logic generally existed before this PR, but it had some issues with consistency. As a result, its purpose and how it was originally intended to work weren't entirely clear. In different tests, this functionality gave different and inconsistent results.
- Thus, as a result, the user will no longer be able to unpause or accidentally close a system/modal window by pressing Z, 1, 2, 3, P, or other keys that are not directly related to closing anything.
- The user will have to either make a decision in the modal window or explicitly close the modal window that is the cause.
- I also took inspiration from how it worked in the original game, where the simulation would pause while user working with a fax machine or win letter.