### PR TITLE
Cured patients count float number fix

### DIFF
--- a/CorsixTH/Lua/hospital.lua
+++ b/CorsixTH/Lua/hospital.lua
@@ -1703,8 +1703,6 @@ end
 --! Update the 'cured' counts of the hospital.
 --!param patient Patient that was cured.
 function Hospital:updateCuredCounts(patient)
-  self:msgCured()
-
   if not patient.is_debug then
     self:changeReputation("cured", patient.disease)
   end
@@ -1718,6 +1716,8 @@ function Hospital:updateCuredCounts(patient)
   if patient.is_emergency then
     self.emergency.cured_emergency_patients = self.emergency.cured_emergency_patients + 1
   end
+
+  self:msgCured()
 end
 
 --! Update the 'not cured' counts of the hospital.

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -403,10 +403,10 @@ end
 function PlayerHospital:msgCured()
   self.world.ui:playSound("cheer.wav") -- This sound is always heard
 
-  if self.num_cured == 1 then -- First cure is always reported.
+  local num_cured = math.floor(self.num_cured)
+  if num_cured == 1 then -- First cure is always reported.
     self:giveAdvice({_A.information.first_cure})
-  elseif self.num_cured > 1 and not self.adviser_data.cured_died_message then
-    local num_cured = math.floor(self.num_cured)
+  elseif num_cured > 1 and not self.adviser_data.cured_died_message then
     local cured_msgs = {
       _A.level_progress.another_patient_cured:format(num_cured),
       _A.praise.patients_cured:format(num_cured)

--- a/CorsixTH/Lua/hospitals/player_hospital.lua
+++ b/CorsixTH/Lua/hospitals/player_hospital.lua
@@ -403,13 +403,13 @@ end
 function PlayerHospital:msgCured()
   self.world.ui:playSound("cheer.wav") -- This sound is always heard
 
-  if self.num_cured < 1 then -- First cure is always reported.
+  if self.num_cured == 1 then -- First cure is always reported.
     self:giveAdvice({_A.information.first_cure})
-
   elseif self.num_cured > 1 and not self.adviser_data.cured_died_message then
+    local num_cured = math.floor(self.num_cured)
     local cured_msgs = {
-      _A.level_progress.another_patient_cured:format(self.num_cured),
-      _A.praise.patients_cured:format(self.num_cured)
+      _A.level_progress.another_patient_cured:format(num_cured),
+      _A.praise.patients_cured:format(num_cured)
     }
     self.adviser_data.cured_died_message = self:giveAdvice(cured_msgs, 2/15)
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3324*

**Describe what the proposed change does**
- Truncate number before format to output string.
- Also, the call to report the number of cured patients has been moved after the increment of the number of cured patients (previously it was before).
