### PR TITLE
Reinsert discarded music call for Windows

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -287,7 +287,7 @@ function App:init()
   self.audio:init()
 
   -- Hack to early initialise the audio and reduce delay on Windows
-  self:playRandomBackgroundTrack()
+  self.audio:playRandomBackgroundTrack()
   self.audio:stopBackgroundTrack()
 
   -- Load movie player

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -286,6 +286,10 @@ function App:init()
   self:initMusicDir()
   self.audio:init()
 
+  -- Hack to early initialise the audio and reduce delay on Windows
+  self:playRandomBackgroundTrack()
+  self.audio:stopBackgroundTrack()
+
   -- Load movie player
   corsixth.require("movie_player")
   self.moviePlayer = MoviePlayer(self, self.audio, self.video)

--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -193,6 +193,8 @@ function Audio:init()
     self.background_playlist = {}
     return
   end
+
+  -- Hack to early initialise the audio and reduce delay on Windows
   self:playRandomBackgroundTrack()
 end
 
@@ -725,10 +727,10 @@ function Audio:playBackgroundTrack(index)
         if music_data == nil then
           info.enabled = false
           local name, msg = (info.filename_music or info.filename)
-          if not self.warned then -- Warn once per session
-            self.app.ui:addWindow(UIInformation(self.app.ui, {_S.errors.music}))
+          if not self.warned and TheApp.ui then -- Warn once per session
+            TheApp.ui:addWindow(UIInformation(TheApp.ui, {_S.errors.music}))
+            self.warned = true
           end
-          self.warned = true
           if err == "No SoundFonts have been requested" then
             msg = "Required soundfont is not found, please download one. A suitable soundfont is linked from the CorsixTH wiki."
           elseif err == "XMP: Unrecognized file format" or err == "ModPlug_Load failed" then
@@ -816,7 +818,7 @@ end
 
 -- search for jukebox and notify it to update its play button
 function Audio:notifyJukebox()
-  local jukebox = self.app.ui:getWindow(UIJukebox)
+  local jukebox = TheApp.ui and TheApp.ui:getWindow(UIJukebox)
   if jukebox then
     jukebox:updatePlayButton()
   end

--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -193,6 +193,7 @@ function Audio:init()
     self.background_playlist = {}
     return
   end
+  self:playRandomBackgroundTrack()
 end
 
 function Audio:initMidiPlayer()

--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -193,9 +193,6 @@ function Audio:init()
     self.background_playlist = {}
     return
   end
-
-  -- Hack to early initialise the audio and reduce delay on Windows
-  self:playRandomBackgroundTrack()
 end
 
 function Audio:initMidiPlayer()


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**Describe what the proposed change does**
- Reinserts the discarded `playRandomBackgroundTrack` call during audio init to have Windows prepare the async music playback in the background in the movie.

As I'm not sure if cyco still wants to try to async call a midi silence instead this simply just reverts behaviour to how it was before #3286 (where the movie masks the setup call -- demo or movies off still always had this issue).
