### PR TITLE
Messages drawer crashfix

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -651,7 +651,7 @@ function UIBottomPanel:_messageDoorTick()
   local msg_to_show = self:_findMessageToShow()
 
   if msg_to_show and self.message_door.closed_amount == MESSAGE_DOOR_FULLY_OPEN then
-    self:createMessageWindow()
+    self:_showMessageIcon()
     self.message_door.next_action_delay = 9
     return
   end

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -453,7 +453,9 @@ function UIBottomPanel:queueMessage(type, message, owner, timeout, default_choic
         this_icon_index = i
       end
     end
-    table.remove(self.message_windows, this_icon_index)
+    if this_icon_index then
+      table.remove(self.message_windows, this_icon_index)
+    end
     self:deleteMessage(this_icon.owner)
   end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**Describe what the proposed change does**
- Fixed regress crash due error in merge 3345 and 3347.
```Lua
Lua\dialogs\bottom_panel.lua:654: attempt to call a nil value (method 'createMessageWindow')
```
- Resolved issue when icons in drawer overlaps. Regress in 3347.

[Screen Recording 2026-05-27 at 17.15.09.webm](https://github.com/user-attachments/assets/70b319dd-526f-4e09-af3a-30e31598f34a)

Thanks @lewri for reporting these issues.