### PR TITLE
Move the Machine Menu button to the right of the Research button

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -108,44 +108,25 @@ function UIBottomPanel:drawPanels()
   -- Buttons that are shown instead of the dynamic info bar when hovering over it.
   local panels = {}
   local buttons = {}
-  local app = self.ui.app
   panels[1]  = self:addPanel(15, 364, 0) -- Staff management button
   buttons[1] = panels[1]:makeToggleButton(6, 6, 35, 36, 16, self.dialogStaffManagement):setTooltip(_S.tooltip.toolbar.staff_list)
-  if self:machineMenuButtonExists() then
-    -- Sprites for machine menu button doesn't exist in original game. Let's import them from aux_ui.dat and draw
-    local aux_sprites = app.gfx:loadSpriteTable("Bitmap", "aux_ui", true)
-    self:addPanel(0, 407, 0):makeToggleButton(2, 6, 36, 36, 0, self.dialogMachineMenu)
-      :setSound() -- override
-      :setTooltip(_S.tooltip.toolbar.machine_menu)
-      .panel_for_sprite.custom_draw = --[[persistable:machine_menu_buttons]] function(panel, canvas, x, y)
-      local s = TheApp.config.ui_scale
-      x = x + panel.x * s
-      y = y + panel.y * s
-      panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y, { scaleFactor = s })
-      local btn = panel.window.active_button
-      if panels[1].visible then
-        local w = self.ui:getWindow(UIMachineMenu)
-        if w or btn and btn.panel_for_sprite == panel and btn.active then
-          aux_sprites:draw(canvas, 23, x, y, { scaleFactor = s })
-        else
-          aux_sprites:draw(canvas, 22, x, y, { scaleFactor = s })
-        end
-      end
-    end
-  end
-  panels[2]  = self:addPanel(17, 407 + self.offset, 0) -- Town map button
+  panels[2]  = self:addPanel(17, 407, 0) -- Town map button
   buttons[2] = panels[2]:makeToggleButton(1, 6, 35, 36, 18, self.dialogTownMap):setTooltip(_S.tooltip.toolbar.town_map)
-  panels[3]  = self:addPanel(19, 445 + self.offset, 0) -- Casebook button
+  panels[3]  = self:addPanel(19, 445, 0) -- Casebook button
   buttons[3] = panels[3]:makeToggleButton(1, 6, 35, 36, 20, self.dialogDrugCasebook):setTooltip(_S.tooltip.toolbar.casebook)
-  panels[4]  = self:addPanel(21, 483 + self.offset, 0) -- Research button
+  panels[4]  = self:addPanel(21, 483, 0) -- Research button
   buttons[4] = panels[4]:makeToggleButton(1, 6, 35, 36, 22, self.dialogResearch)
     :setSound():setTooltip(_S.tooltip.toolbar.research) -- Remove default sound for this button
+  if self:machineMenuButtonExists() then
+    self:_addMachineButton(panels, 521) -- Machine menu button
+  end
   panels[5]  = self:addPanel(23, 521 + self.offset, 0) -- Status button
   buttons[5] = panels[5]:makeToggleButton(1, 6, 35, 36, 24, self.dialogStatus):setTooltip(_S.tooltip.toolbar.status)
   panels[6]  = self:addPanel(25, 559 + self.offset, 0) -- Charts button
   buttons[6] = panels[6]:makeToggleButton(1, 6, 35, 36, 26, self.dialogCharts):setTooltip(_S.tooltip.toolbar.charts)
   panels[7]  = self:addPanel(27, 597 + self.offset, 0) -- Policy button
   buttons[7] = panels[7]:makeToggleButton(1, 6, 35, 36, 28, self.dialogPolicy):setTooltip(_S.tooltip.toolbar.policy)
+
   for _, panel in ipairs(panels) do
     panel.visible = false
   end
@@ -158,6 +139,29 @@ function UIBottomPanel:drawPanels()
   return _S.tooltip.toolbar.reputation .. " (" .. self.ui.hospital.reputation .. ")"
   end, 41, 30, 137, 42)
 
+end
+
+function UIBottomPanel:_addMachineButton(panels, x_offset)
+  -- Sprites for machine menu button doesn't exist in original game. Let's import them from aux_ui.dat and draw
+  local aux_sprites = self.ui.app.gfx:loadSpriteTable("Bitmap", "aux_ui", true)
+  self:addPanel(0, x_offset, 0):makeToggleButton(2, 6, 36, 36, 0, self.dialogMachineMenu)
+    :setSound() -- override
+    :setTooltip(_S.tooltip.toolbar.machine_menu)
+    .panel_for_sprite.custom_draw = --[[persistable:machine_menu_buttons]] function(panel, canvas, x, y)
+    local s = TheApp.config.ui_scale
+    x = x + panel.x * s
+    y = y + panel.y * s
+    panel.window.panel_sprites:draw(canvas, panel.sprite_index, x, y, { scaleFactor = s })
+    local btn = panel.window.active_button
+    if panels[1].visible then
+      local w = self.ui:getWindow(UIMachineMenu)
+      if w or btn and btn.panel_for_sprite == panel and btn.active then
+        aux_sprites:draw(canvas, 23, x, y, { scaleFactor = s })
+      else
+        aux_sprites:draw(canvas, 22, x, y, { scaleFactor = s })
+      end
+    end
+  end
 end
 
 function UIBottomPanel:_initFonts(gfx)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**Describe what the proposed change does**
- Move the Machine Menu button to the right of the Research button

Before:
<img width="315" height="47" alt="Screenshot 2026-05-31 at 10 13 42" src="https://github.com/user-attachments/assets/4bfda9c7-e493-455d-b9da-faeaa47741f9" />

After:
<img width="316" height="48" alt="Screenshot 2026-05-30 at 14 42 15" src="https://github.com/user-attachments/assets/9af98dd6-77f8-4eed-9c0c-0022cb250d39" />

Justification for the change:

The downside with "Machine Menu" button as second position is that when you launch the game in 640x480, the "Machine Menu" button disappears, and "Town Map" is now the second button again. 

If you play the original game occasionally, "Town Map" is also the second button. 

When you're heating a hospital and positioning heaters, you have to constantly press the Town Map button to make sure you haven't overheated anything and are covering the maximum area.
Open the map and see if any heating adjustments need to be made. Then open the map again, and repeat the process.
So has to be pressed many times trying to optimally place the radiators.
If you do this with a mouse, then you already start clicking Town Map by muscle memory.

As a result, you're torturing your muscle memory with constant, contradictory trainings with "Town Map" button. 
When it is sometimes in second position, and sometimes in third.

And if you've played the game before, you might already be used to Town Map being in second place.

This way I always press the Machine Menu button when I want to open the map.

This problem is further exacerbated by the fact that until your cursor moves to this block, the display info appears instead, and you can't see the buttons at all.

So you press buttons from memory if you don't make pause see buttons beforehand.

<img width="472" height="47" alt="Screenshot 2026-05-31 at 10 42 30" src="https://github.com/user-attachments/assets/abee06e6-e955-4cc1-b3a6-eb1354f97069" />

.
I've noticed that the buttons in the center are used less often and are less susceptible to muscle memory because they are too far from the edge to be oriented relative to the edge.

Therefore, a place on the right, for example after the research button but before the progress button, seems more appropriate.

Although initially placing the Machine Menu button next to the Staff button was quite sensible and consistent, and at the time it seemed like the right decision.

But after playing around with it, I came to what It's better for the new Machine button not to take up the space of those buttons that are located on the edge and are subject to good muscle memory training.

