### PR TITLE
Replace deprecated github action component versions

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-24.04 # noble
     name: Linux apt-get ${{matrix.lua}} ${{inputs.animview == 'true' && 'with AnimView' || ''}}
     steps:
-      - uses: actions/checkout@v4  # Keeps the git OAuth token after checkout
+      - uses: actions/checkout@v6  # Keeps the git OAuth token after checkout
       - name: Checkout selected PR
         env:
           GH_TOKEN: ${{github.token}}
@@ -133,7 +133,7 @@ jobs:
     env:
       VCPKG_BINARY_SOURCES: clear;files,${{github.workspace}}/vcpkg_cache,readwrite
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Checkout selected PR
         env:
           GH_TOKEN: ${{github.token}}
@@ -147,13 +147,13 @@ jobs:
           sudo apt-get install libltdl-dev libx11-dev libxft-dev libxext-dev libxtst-dev \
             libxrandr-dev nasm clang-format-20 clang-tidy-20 autoconf-archive
       - name: Restore vcpkg cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/vcpkg_cache
           key: vcpkg-linux-${{hashFiles('vcpkg.json','vcpkg-configuration.json')}}
           restore-keys: vcpkg-linux-
       - name: Get CMake and Ninja
-        uses: lukka/get-cmake@v4.0.3
+        uses: lukka/get-cmake@v4.3.3
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/WindowsInstaller.yml
+++ b/.github/workflows/WindowsInstaller.yml
@@ -18,30 +18,28 @@ jobs:
     runs-on: ubuntu-24.04
     name: Make and test Windows installer
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install NSIS
         run: sudo apt-get install nsis
       - name: Download x86 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           run-id: ${{inputs.x86}}
-          path: WindowsInstaller
+          path: WindowsInstaller/x86
           github-token: ${{github.token}}
       - name: Download x64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           run-id: ${{inputs.x64}}
-          path: WindowsInstaller
+          path: WindowsInstaller/x64
           github-token: ${{github.token}}
       - name: Create installer
         run: |
           cd WindowsInstaller
-          mv CorsixTH_x86 x86
-          mv CorsixTH x64
           makensis -V4 -WX -- Win32Script.nsi
           sha256sum CorsixTHInstaller.exe >> $GITHUB_STEP_SUMMARY
       - name: Upload installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: 'WindowsInstaller/CorsixTHInstaller.exe'
-          name: 'Windows installer'
+          archive: false


### PR DESCRIPTION
Many github action components were using Node 20 which is end of life and github plans to drop support for them.

As an extra, the new artifact action lets us upload the CorsixTHInstaller.exe without putting it into a zip file.

A WindowsInstaller run can be seen on my repo here: https://github.com/TheCycoONE/CorsixTH/actions/runs/26733063220
