### PR TITLE
Set builtin/unicode for soundfont path

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/sound_setting.lua
+++ b/CorsixTH/Lua/dialogs/resizables/sound_setting.lua
@@ -80,6 +80,7 @@ function UISoundSettings:UISoundSettings(ui, mode)
   self:setDefaultPosition(0.5, 0.25)
   self.default_button_sound = "selectx.wav"
   self.app = ui.app
+  local built_in = app.gfx:loadMenuFont()
 
 
   self.volume_options = { { text = _S.customise_window.option_off, volume = 0 } }
@@ -182,9 +183,11 @@ function UISoundSettings:UISoundSettings(ui, mode)
   local tooltip_soundfont = app.config.soundfont and
       _S.tooltip.audio_window.browse_soundfont:format(app.config.soundfont) or
       _S.tooltip.audio_window.no_soundfont_specified
+  local soundfont_path = app.config.soundfont
   local soundfont_button_panel = self:addBevelPanel(BTN_X, y, BTN_WIDTH, BTN_HEIGHT, col_bg)
   soundfont_button_panel
-      :setLabel(app.config.soundfont and app.config.soundfont or tooltip_soundfont)
+      :setLabel(soundfont_path or tooltip_soundfont,
+          soundfont_path and built_in)
       :setAutoClip(true)
       :setVisible(not app.config.midi_api)
   local soundfont_button = soundfont_button_panel


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**0.70.0 beta 1**

**Describe what the proposed change does**
- Use unicode font, then builtin font if not available to show soundfont path if set
- If not set, the text stays in the normal game font/language font
- Cleans up unnecessary `a and a or b`  to just `a or b`

<img width="636" height="281" alt="image" src="https://github.com/user-attachments/assets/a9610817-a87f-4930-8c48-de4f0d322942" />

Future todo: add reset button