### PR TITLE
Reset pickedup on placeObject

### DIFF
--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -544,8 +544,8 @@ function UIPlaceObjects:placeObject(dont_close_if_empty, dont_remove)
       -- deleted from its previous location, but simply made invisible.
       real_obj:setTile(nil)
       real_obj:setInvisible(false)
-      real_obj.picked_up = false
     end
+    real_obj.picked_up = false
 
     if real_obj.orientation_before and real_obj.orientation_before ~= self.object_orientation then
       real_obj:initOrientation(self.object_orientation)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

<img width="356" height="237" alt="Screenshot 2026-06-02 at 15 30 34" src="https://github.com/user-attachments/assets/b553b66c-b205-43ed-aea6-e8d51e25ec4e" />

.
**0.70.0 beta 1**
.
**Describe what the proposed change does**
- Fixes bug when `object.picked_up` stay `true` after object placed.
- Always set `object.picked_up = false` on `objectPlaced`.

Issue introduced by #3304

**How to reproduce:**

1. Take **0.70.0 beta 1** build. Run game.
2. Start new level among Single Scenario.
3. Build Training Room. Place one chair in room. Finish build that room.
4. Enter room edit mode and edit that Training Room.
5. Pickup chair and place it in the same place.
6. Finish edit that room.
7. Hire any student and place they in that room.
8. Observe as the advisor says there are no free chairs in the room and the student leaves the room without starting the study.

