### PR TITLE
Disable sell hotkey in UIEditRoom

### DIFF
--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -93,7 +93,7 @@ end
 function UIPlaceObjects:registerKeyHandlers()
   self:addKeyHandler("global_cancel", self.undo)
   self:addKeyHandler("global_cancel_alt", self.cancel)
-  self:addKeyHandler("ingame_sellPickedUpItem", self.cancel)
+  self:addKeyHandler("ingame_sellPickedUpItem", self.sell)
   self:addKeyHandler("ingame_rotateobject", self.tryNextOrientation)
 end
 
@@ -353,6 +353,13 @@ end
 
 function UIPlaceObjects:cancel()
   self:close(false)
+end
+
+--! Helper function to stop UIEditRoom going back to doors phase
+function UIPlaceObjects:sell()
+  if not self.ui:getWindow(UIEditRoom) then
+    self:close(false)
+  end
 end
 
 function UIPlaceObjects:undo()


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**0.70.0 beta 1**

Pressing Delete when editing a room causes breakage by returning edit room to doors phase

**Describe what the proposed change does**
- With #3304 we accidentally added a route to UIEditRoom where Delete (sell hotkey) caused the room to go backward to doors phase.
- Hotkey now has no effect when editing a room. As discussed on discord, a nice future todo is having the hotkey sell any non-core room items instead in objects phase.
