### PR TITLE
Avoid duplicates in `world.entities`

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -30,7 +30,7 @@ globals = { -- Globals
             "pause_gc_and_use_weak_keys", "permanent",
             "rangeMapLookup", "rnc", "strict_declare_global",
             "unpermanent", "values", "serialize",
-            "array_join", "table_merge", "shallow_clone", "staff_initials_cache",
+            "array_join", "table_merge", "is_contains", "shallow_clone", "staff_initials_cache",
             "hasBit", "bitOr", "inspect", "getRandomEntryFromArray", "isTableEmpty",
             "stripTrailingSlashes", "isDirectory", "canOpenDirectory", "tracy",
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -30,9 +30,11 @@ globals = { -- Globals
             "pause_gc_and_use_weak_keys", "permanent",
             "rangeMapLookup", "rnc", "strict_declare_global",
             "unpermanent", "values", "serialize",
-            "array_join", "table_merge", "is_contains", "shallow_clone", "staff_initials_cache",
-            "hasBit", "bitOr", "inspect", "getRandomEntryFromArray", "isTableEmpty",
-            "stripTrailingSlashes", "isDirectory", "canOpenDirectory", "tracy",
+            "array_join", "table_merge", "table_contains", "shallow_clone",
+            "staff_initials_cache", "hasBit", "bitOr", "inspect",
+            "getRandomEntryFromArray", "isTableEmpty",
+            "stripTrailingSlashes", "isDirectory",
+            "canOpenDirectory", "tracy",
 
             -- Game classes
             "AIHospital", "AnimationManager", "AnimationEffect", "App", "Audio",

--- a/CorsixTH/Lua/utility.lua
+++ b/CorsixTH/Lua/utility.lua
@@ -423,8 +423,8 @@ function table_merge(...)
 end
 
 --! Checks if the table contains item
-function is_contains(table, value)
-  for index, val in ipairs(table) do
+function table_contains(table, value)
+  for _, val in pairs(table) do
     if val == value then
       return true
     end

--- a/CorsixTH/Lua/utility.lua
+++ b/CorsixTH/Lua/utility.lua
@@ -422,6 +422,16 @@ function table_merge(...)
   return result
 end
 
+--! Checks if the table contains item
+function is_contains(table, value)
+  for index, val in ipairs(table) do
+    if val == value then
+      return true
+    end
+  end
+  return false
+end
+
 local function serialize_string(val, options)
   local level = options and options.long_bracket_level_start or 0
   while string.find(val, ']' .. string.rep('=', level) .. ']') do

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1781,7 +1781,9 @@ function World:newEntity(class, animation, mood_marker)
   local th = TH.animation()
   th:setAnimation(self.anims, animation)
   local entity = _G[class](th)
-  self.entities[#self.entities + 1] = entity
+  if not is_contains(self.entities, entity) then
+    self.entities[#self.entities + 1] = entity
+  end
   entity.world = self
   entity.mood_marker = mood_marker
   return entity
@@ -2178,7 +2180,9 @@ function World:objectPlaced(entity, id)
     id = entity.object_type.id
   end
 
-  self.entities[#self.entities + 1] = entity
+  if not is_contains(self.entities, entity) then
+    self.entities[#self.entities + 1] = entity
+  end
 
   -- Warn a hospital if that is possible.
   if not entity.tile_x or not entity.tile_y then return end

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -1781,7 +1781,7 @@ function World:newEntity(class, animation, mood_marker)
   local th = TH.animation()
   th:setAnimation(self.anims, animation)
   local entity = _G[class](th)
-  if not is_contains(self.entities, entity) then
+  if not table_contains(self.entities, entity) then
     self.entities[#self.entities + 1] = entity
   end
   entity.world = self
@@ -2180,7 +2180,7 @@ function World:objectPlaced(entity, id)
     id = entity.object_type.id
   end
 
-  if not is_contains(self.entities, entity) then
+  if not table_contains(self.entities, entity) then
     self.entities[#self.entities + 1] = entity
   end
 


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

<img width="567" height="74" alt="Screenshot 2026-06-02 at 15 08 12" src="https://github.com/user-attachments/assets/731a90bc-6a65-4e1e-bd16-ee9cfbab3cc7" />

.
**0.70.0 beta 1**
Dirty hack fix for a bug that prevented the game from loading.

Fixes #3376

**Describe what the proposed change does**
- Avoid adding duplicates to `world.entities`.
- Before adding entity to , check that this object is not already there.

Issue introduced by #3304

**How to reproduce:**

1. Take **0.70.0 beta 1** build. Run game.
1. Start new level among Single Scenario.
2. Buy and place one Radiator.
3. Pick it up from the floor and then cancel the grab by pressing `Esc`.
4. Pick it up from the floor and press the red `X` in menu, thereby selling the item.
5. Save the game.
6. Load the save you just made.
7. Observe error: 
`Error while loading game: ../Resources/Lua/entities/object.lua:827: bad argument #1 to 'eraseObjectTypes' (number expected, got nil)`

**Why is this happening?**

Every time player place an object, `World:objectPlaced(entity)` is called.
`World:objectPlaced(entity)` executes `self.entities[#self.entities + 1] = entity`.

Because before 3304 objects couldn't exist before they were placed, so it was make sense to add the object to the `World.entities` array when `objectPlaced` was called.

But now, with 3304, an object can already exist before `objectPlaced` and already be in `World.entities`. 
This is because `objectPlaced` was previously called for that object when it was placed previous time.

And now, when we move object from place to place the same object is added to `World.entities` again and again.
Because `World:objectPlaced(entity)` doesn't check whether placed object already exists in `World.entities` or not.

Therefore, when we delete an object from the world that has been added to `World.entities` multiple times, only one of its entries is deleted from `World.entities`. The others entries remain, since it was added there multiple times.

Also, since we're deleting object from the world, its coordinates are reset to `nil`.

As a result, we end up with references to this object in `World.entities` that have `nil` coordinates, since it was set to `nil` for the object.

This crashes the game in `object.lua` line 827.

Perhaps a more bold solution here would be to remove the object from `World.entities` when we pick it up object from the floor.

But due to concerns that this could lead to a new issues, I settled on a more defending solution.
