### PR TITLE
Avoid passable walls by sideobjects

### DIFF
--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -544,6 +544,7 @@ function UIPlaceObjects:placeObject(dont_close_if_empty, dont_remove)
       -- deleted from its previous location, but simply made invisible.
       real_obj:setTile(nil)
       real_obj:setInvisible(false)
+      real_obj:rebuildPassableCellFlags()
     end
     real_obj.picked_up = false
 

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -843,6 +843,10 @@ function Object:onDestroy()
   self:resetUsageAndReservaton()
   Entity.onDestroy(self)
 
+  self:rebuildPassableCellFlags()
+end
+
+function Object:rebuildPassableCellFlags()
   -- Issue 1105 - rebuild wall travel<dir> and pathfinding on side object removal
   if self.object_type.class == "SideObject" then
     self.world.map.th:updatePathfinding()


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**0.70.0 beta 1**

*Fixes #3368*

**Describe what the proposed change does**
- Call "rebuild wall travel" on moving object from place to place too.
