### PR TITLE
Fix regressed staff circle tooltip

### DIFF
--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -147,8 +147,8 @@ function UIStaff:UIStaff(ui, staff)
 
   self:makeTooltip(_S.tooltip.staff_window.salary, 90, 191 + offset, 204, 214 + offset)
   -- Non-rectangular tooltip has to be realized with dynamic tooltip at the moment
-  self:makeDynamicTooltip(--[[persistable:staff_dialog_center_tooltip]]function(x, y)
-    if is_in_view_circle(x, y, class.is(staff, Handyman)) then
+  self:makeDynamicTooltip(--[[persistable:staff_dialog_center_tooltip]]function(x, y, target_staff)
+    if is_in_view_circle(x, y, class.is(target_staff, Handyman)) then
       return _S.tooltip.staff_window.center_view
     end
   end, 17, 211 + offset, 92, 286 + offset)

--- a/CorsixTH/Lua/dialogs/staff_dialog.lua
+++ b/CorsixTH/Lua/dialogs/staff_dialog.lua
@@ -147,8 +147,8 @@ function UIStaff:UIStaff(ui, staff)
 
   self:makeTooltip(_S.tooltip.staff_window.salary, 90, 191 + offset, 204, 214 + offset)
   -- Non-rectangular tooltip has to be realized with dynamic tooltip at the moment
-  self:makeDynamicTooltip(--[[persistable:staff_dialog_center_tooltip]]function(x, y, target_staff)
-    if is_in_view_circle(x, y, class.is(target_staff, Handyman)) then
+  self:makeDynamicTooltip(--[[persistable:staff_dialog_center_tooltip]]function(x, y)
+    if is_in_view_circle(x, y, profile:isType("Handyman")) then
       return _S.tooltip.staff_window.center_view
     end
   end, 17, 211 + offset, 92, 286 + offset)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**0.70.0 beta 1**

**Describe what the proposed change does**
- Fixes a regression found in the save at https://github.com/CorsixTH/CorsixTH/issues/1583#issuecomment-3368900763 where 0.68.0 saves would crash when hovering over the staff view circle.
