### PR TITLE
Persist blueprints in saves

### DIFF
--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -155,6 +155,17 @@ animation* l_map_updateblueprint_getnextanim(lua_State* L, int& iIndex) {
     lua_pushvalue(L, 12);
     lua_setfield(L, -2, "animator");
     lua_setfenv(L, -2);
+
+    // Blueprint wall animations are created directly, so add them to the weak
+    // animation lookup used by level_map::persist(); otherwise they save as nil
+    // and disappear after reload.
+    int anim_index = lua_gettop(L);
+    lua_rawgeti(L, luaT_upvalueindex(2), 2);
+    lua_pushlightuserdata(L, pAnim);
+    lua_pushvalue(L, anim_index);
+    lua_rawset(L, -3);
+    lua_pop(L, 1);
+
     lua_rawseti(L, 11, iIndex);
   } else {
     pAnim = luaT_testuserdata<animation>(L, -1, luaT_upvalueindex(2));

--- a/CorsixTH/Src/th_lua_map.cpp
+++ b/CorsixTH/Src/th_lua_map.cpp
@@ -144,10 +144,11 @@ int l_map_save(lua_State* L) {
 animation* l_map_updateblueprint_getnextanim(lua_State* L, int& iIndex) {
   animation* pAnim;
   lua_rawgeti(L, 11, iIndex);
+  const int animation_upvalue = luaT_upvalueindex(2);
   if (lua_type(L, -1) == LUA_TNIL) {
     lua_pop(L, 1);
     pAnim = luaT_new<animation>(L);
-    lua_pushvalue(L, luaT_upvalueindex(2));
+    lua_pushvalue(L, animation_upvalue);
     lua_setmetatable(L, -2);
     lua_createtable(L, 0, 2);
     lua_pushvalue(L, 1);
@@ -160,7 +161,7 @@ animation* l_map_updateblueprint_getnextanim(lua_State* L, int& iIndex) {
     // animation lookup used by level_map::persist(); otherwise they save as nil
     // and disappear after reload.
     int anim_index = lua_gettop(L);
-    lua_rawgeti(L, luaT_upvalueindex(2), 2);
+    lua_rawgeti(L, animation_upvalue, 2);
     lua_pushlightuserdata(L, pAnim);
     lua_pushvalue(L, anim_index);
     lua_rawset(L, -3);


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #345*
*Fixes #1583* (New saves only)

**Describe what the proposed change does**
- Persists the blueprint walls/doors/windows when loading saves while in edit room

This was just several hours of @colinjmatt and myself having some fun so it could be pure drivel, but I have run and tested it and it seems to work (doesn't fix existing saves).

If this PR inspires some more preferred solution please feel free to override it.