### PR TITLE
Handle messages with `owner` `nil`

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -458,7 +458,7 @@ function UIBottomPanel:queueMessage(type, message, owner, timeout, default_choic
     if this_icon_index then
       table.remove(self.message_windows, this_icon_index)
     end
-    self:_deleteMessageByIcon(this_icon)
+    self:deleteMessage(nil, this_icon)
   end
 
   local message_info = {
@@ -579,45 +579,39 @@ function UIBottomPanel:openFirstMessage()
   end
 end
 
--- Removes a message from the message queue (for example if a room is built before the player
+--! Removes a message from the message queue (for example if a room is built before the player
 -- says what to do with the patient.
---!param owner (object) message owner
-function UIBottomPanel:deleteMessage(owner)
+--!param owner (object) optional message owner
+--!param icon (object) optional drawer icon object
+--!return (boolean) true if message was removed
+function UIBottomPanel:deleteMessage(owner, icon)
+  assert(owner or icon, "Both owner and icon are nil!")
+  -- A message can only ever exist in either the message queue or in message windows. Once it
+  -- is found, we don't need to check the other.
   for i, msg_info in ipairs(self.message_queue) do
-    if msg_info.owner == owner then
-      -- TODO: restructure message_queue to contain UIMessage objects already, so this special handling isn't required
+    if (owner and msg_info.owner == owner) or
+        (icon and msg_info.drawer_icon == icon) then
       table.remove(self.message_queue, i)
+
+      -- TODO: restructure message_queue to contain UIMessage objects already,
+      -- so this special handling isn't required.
       msg_info.drawer_icon.onClose = nil
       msg_info.drawer_icon = nil
-      owner.message = nil
+
+      if msg_info.owner then
+        msg_info.owner.message = nil
+      end
       return true
     end
   end
-  for index, drawer_icon in ipairs(self.message_windows) do
-    if drawer_icon.owner == owner then
+
+  for _, drawer_icon in ipairs(self.message_windows) do
+    if (owner and drawer_icon.owner == owner) or (icon and drawer_icon == icon) then
       drawer_icon:removeMessage()
       return true
     end
   end
   return false
-end
-
--- Removes a message from the message queue
---!param icon (object) drawer icon object for target message
-function UIBottomPanel:_deleteMessageByIcon(icon)
-  for i, msg_info in ipairs(self.message_queue) do
-    if msg_info.drawer_icon == icon then
-      -- TODO: restructure message_queue to contain UIMessage objects already, so this special handling isn't required
-      table.remove(self.message_queue, i)
-      msg_info.drawer_icon.onClose = nil
-      msg_info.drawer_icon = nil
-    end
-  end
-  for index, drawer_icon in ipairs(self.message_windows) do
-    if drawer_icon == icon then
-      drawer_icon:removeMessage()
-    end
-  end
 end
 
 --! Pop the message with the given index from the message queue and turn it into

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -458,7 +458,7 @@ function UIBottomPanel:queueMessage(type, message, owner, timeout, default_choic
     if this_icon_index then
       table.remove(self.message_windows, this_icon_index)
     end
-    self:deleteMessage(this_icon.owner)
+    self:_deleteMessageByIcon(this_icon)
   end
 
   local message_info = {
@@ -581,6 +581,7 @@ end
 
 -- Removes a message from the message queue (for example if a room is built before the player
 -- says what to do with the patient.
+--!param owner (object) message owner
 function UIBottomPanel:deleteMessage(owner)
   for i, msg_info in ipairs(self.message_queue) do
     if msg_info.owner == owner then
@@ -599,6 +600,24 @@ function UIBottomPanel:deleteMessage(owner)
     end
   end
   return false
+end
+
+-- Removes a message from the message queue
+--!param icon (object) drawer icon object for target message
+function UIBottomPanel:_deleteMessageByIcon(icon)
+  for i, msg_info in ipairs(self.message_queue) do
+    if msg_info.drawer_icon == icon then
+      -- TODO: restructure message_queue to contain UIMessage objects already, so this special handling isn't required
+      table.remove(self.message_queue, i)
+      msg_info.drawer_icon.onClose = nil
+      msg_info.drawer_icon = nil
+    end
+  end
+  for index, drawer_icon in ipairs(self.message_windows) do
+    if drawer_icon == icon then
+      drawer_icon:removeMessage()
+    end
+  end
 end
 
 --! Pop the message with the given index from the message queue and turn it into


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

<img width="205" height="283" alt="Screenshot 2026-06-07 at 10 38 03" src="https://github.com/user-attachments/assets/6c0334c7-5c71-4cef-999a-f2643270958e" />

.
**0.70.0 beta 1** 
game crash if player have to deal with message which have `owner` is `nil`.

**Why is this happening?**

If user get some message with `owner` `nil` and will ignore or handle that message, game will crash.
Not all messages have `owner` `nil`.
For example, messages about the discovery of a new disease don't have an owner.

Initially there was only 1 function for deleting messages. And it was taking `owner` as a ID for target message search and delete. `UIBottomPanel:deleteMessage(owner)`. It seemed perfectly reasonable and safe to continue using this function for broader purposes. But this was a wrong assumption.

So we have to have 2 delete functions now, not 1... one searches for the target message by `owner`, and the second searches for the target message by `drawer_icon`.

Issue introduced by #3347

**How to reproduce:**

[0.70.0_fax-message-crash.sav.zip](https://github.com/user-attachments/files/28677482/0.70.0_fax-message-crash.sav.zip)
1. Take **0.70.0 beta 1** build. Run game.
2. Load save game and wait until 26 May. Game will crash.

```Lua
A stack trace is included below, and the handler has been disconnected.
Lua\dialogs\bottom_panel.lua:591: attempt to index a nil value (local 'owner')
stack traceback:
        Lua\dialogs\bottom_panel.lua:591: in method 'deleteMessage'
        Lua\dialogs\bottom_panel.lua:461: in local 'onClose'
        Lua\dialogs\message.lua:149: in method 'removeMessage'
        Lua\dialogs/fullscreen\fax.lua:244: in method 'choice'
        Lua\dialogs\message.lua:137: in method 'removeMessage'
        Lua\dialogs\message.lua:195: in method 'onWorldTick'
        Lua\window.lua:1939: in method 'onWorldTick'
        Lua\window.lua:1939: in method 'onWorldTick'
        Lua\world.lua:972: in method 'onTick'
        Lua\app.lua:1275: in function <Lua\app.lua:1272>
        (...tail calls...)
```

**Describe what the proposed change does**
- When deleting messages, take in account that some messages have a `owner` `nil`. Therefore, we cannot use `owner` as a unique identifier among messages.
- Since a "draw icon" object is now created for absolutely all messages, even for those that are not yet displayed, add a function for deleting a message using this object as an identifier as a reference.

Thanks @Lewri for detecting and report.