### PR TITLE
Fix operating table placement issue for blocking off areas in rooms

### DIFF
--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -323,6 +323,7 @@ function Object:usePositionNames()
   return {
     "use_position",
     "use_position_secondary",
+    "slave_position",
     "finish_use_position",
     "finish_use_position_secondary",
     "handyman_position",


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**0.70.0 beta 1**

**Describe what the proposed change does**
- When placing an object, take into account that the object may have `slave_position` point (tile for second surgeon for operating table in operating theatre).

Without such verification, such placement is allowed:

<img width="276" height="192" alt="Screenshot 2026-06-08 at 17 16 32" src="https://github.com/user-attachments/assets/9706a58b-b649-4c3b-8844-83db2dcd9063" />

Which lead to this crash:

<img width="737" height="305" alt="Screenshot 2026-06-07 at 16 20 45" src="https://github.com/user-attachments/assets/605ab94f-e74f-417e-aacb-df6ba8bab793" />

Regressed by #3282

