### PR TITLE
fix: correct spelling errors in comments across handyman, ui, window, and adviser_history

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/adviser_history.lua
+++ b/CorsixTH/Lua/dialogs/resizables/adviser_history.lua
@@ -175,7 +175,7 @@ function UIAdviserHistory:onTick()
   -- New messages only get added to the top (it's a stack) or, if duplicate, a message
   -- gets moved from the middle to the top.
 
-  -- Checking the lenght of both lists would fail if a message was moved from the middle to the top due to duplication.
+  -- Checking the length of both lists would fail if a message was moved from the middle to the top due to duplication.
   -- So we just check if the top string between lists has changed to determine if we need to update
   local new_history_top = self.ui.adviser.message_history[1]
 

--- a/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff/handyman.lua
@@ -95,7 +95,7 @@ function Handyman:onPickup()
   Staff.onPickup(self)
 end
 
--- Deattaches the handyman from the task and forces him to search for a new one.
+-- Detaches the handyman from the task and forces him to search for a new one.
 --!param reset_action_queue (bool) Should the handyman interrupt
 -- the current action to search for a new task
 function Handyman:releaseHandymanFromTask(reset_action_queue)
@@ -122,7 +122,7 @@ function Handyman:searchForHandymanTask()
   else
     task_type_1, task_type_2, task_type_3 = "repairing", "watering", "cleaning"
   end
-  -- Let's search First priority type taks.
+  -- Let's search First priority type task.
   local index = self.hospital:searchForHandymanTask(self, task_type_1)
   if index ~= -1 then
     -- Found a task for the handyman

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -740,7 +740,7 @@ end
 
 --! Called when the user presses a key on the keyboard
 --!param rawchar (string) The name of the key the user pressed.
---!param modifiers (table) The current applied modifers to key input e.g. numlock
+--!param modifiers (table) The current applied modifiers to key input e.g. numlock
 function UI:onKeyDown(rawchar, modifiers)
   local handled = false
   local rawchar_transformed, key = self:_determineKeyPressed(
@@ -789,7 +789,7 @@ end
 
 --! Called when the user releases a key on the keyboard
 --!param rawchar (string) The name of the key the user pressed.
---!param modifiers (table) The current applied modifers to key input e.g. numlock
+--!param modifiers (table) The current applied modifiers to key input e.g. numlock
 function UI:onKeyUp(rawchar, modifiers)
   local _, key = self:_determineKeyPressed(rawchar, modifiers)
   self.buttons_down[key] = nil

--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -1742,7 +1742,7 @@ function Window:onMouseUp(button, x, y)
 end
 
 --! This function can be used to control mousewheel input (i.e. scrolling).
---! Override this function in dervied classes, with what you'd like to happen
+--! Override this function in derived classes, with what you'd like to happen
 --! on this event.
 --!param x (int) Mousewheel has moved on the horizontal axis (-1 is
 -- leftward movement, +1 is rightward movement)


### PR DESCRIPTION
This is an independent contribution and is not affiliated with any hackathon, competition, or promotional event.

## Summary
Corrects six spelling errors found in code comments across four files, as identified by CI typo detection.

## Changes
| File | Change |
|------|--------|
| handyman.lua:98 | Deattaches -> Detaches |
| handyman.lua:125 | taks -> task |
| ui.lua:743,792 | modifers -> modifiers |
| adviser_history.lua:178 | lenght -> length |
| window.lua:1745 | dervied -> derived |

## Root Cause
Historical spelling errors in documentation comments that were flagged by the CI linting pipeline.

## Testing
- Verified each change with grep to confirm old strings no longer exist and new strings are present
- All changes are in comments only - no runtime behavior affected

Addresses #3384