### PR TITLE
docs: fix remaining typos in code comments (#3384)

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1101,8 +1101,8 @@ function UIEditRoom:onLeftButtonDown(x, y)
 end
 
 --! Attempt to remove a window placed on the room blueprints
---!param x co-ordinate
---!param y co-ordinate
+--!param x coordinate
+--!param y coordinate
 function UIEditRoom:tryRemoveWindowFromWall(x, y)
   local cell_x, cell_y, wall_dir = self:screenToWall(self.x + x, self.y + y)
   if not cell_x then

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -890,7 +890,7 @@ function UIPlaceObjects:_isNonSideObjectPlacementValid(x, y, object, object_orie
           end
         else
           -- user not in a room editing mode.
-          -- as we are not in a room editing mode, then there possbile be humanoids in the room.
+          -- as we are not in a room editing mode, then there may be humanoids in the room.
           -- this means that placing object can block a humanoid's passage to the door.
           -- To prevent that case we fallback to strict placing approach.
           invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, room_id)

--- a/CorsixTH/Lua/sprite_viewer.lua
+++ b/CorsixTH/Lua/sprite_viewer.lua
@@ -81,7 +81,7 @@ end
 
 -- Find the palette with the longest common prefix with the sprite table path,
 -- as this is likely the correct palette to use for the sprite table.
--- Avoids hardcoding a mapping of sprites to palettes and accounts for THs
+-- Avoids hardcoding a mapping of sprites to palettes and accounts for the
 -- naming e.g. AWARD01.PAL and AWARD02.PAL used for AWARD03.TAB
 --
 --!param sprite_table_name (string) The name of the sprite table, without the


### PR DESCRIPTION
Follow-up to #3384. #3385 already cleaned up most of the typos listed in the issue, but four valid ones were left behind:

- `place_objects.lua` line 893: \`possbile\` in a comment about the soft-placing fallback. The spell-checker suggestions (\`possible\`, \`possibly\`) don't fit the surrounding "then there ... be humanoids" construction, so I changed it to \`may\` to fix the typo without rewriting the comment.
- `edit_room.lua` lines 1104-1105: \`co-ordinate\` -> \`coordinate\` in the docstring of \`tryRemoveWindowFromWall\`.
- `sprite_viewer.lua` line 84: the unexplained \`THs\` -> \`the\` in the \`closest_matching_palette\` docstring.

All changes are in comments only. \`luacheck\` passes on the three files. Diff is +4/-4 across 3 files.