### PR TITLE
docs: fix remaining typos in code comments (#3384)

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1101,8 +1101,8 @@ function UIEditRoom:onLeftButtonDown(x, y)
 end
 
 --! Attempt to remove a window placed on the room blueprints
---!param x co-ordinate
---!param y co-ordinate
+--!param x coordinate
+--!param y coordinate
 function UIEditRoom:tryRemoveWindowFromWall(x, y)
   local cell_x, cell_y, wall_dir = self:screenToWall(self.x + x, self.y + y)
   if not cell_x then

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -890,7 +890,7 @@ function UIPlaceObjects:_isNonSideObjectPlacementValid(x, y, object, object_orie
           end
         else
           -- user not in a room editing mode.
-          -- as we are not in a room editing mode, then there possbile be humanoids in the room.
+          -- as we are not in a room editing mode, then there may be humanoids in the room.
           -- this means that placing object can block a humanoid's passage to the door.
           -- To prevent that case we fallback to strict placing approach.
           invalid_placement = world:wouldNonSideObjectBreakPathfindingIfSpawnedAt(x, y, object, object_orientation, room_id)


### PR DESCRIPTION
Follow-up to #3384. #3385 already cleaned up most of the typos listed in the issue, but two valid ones remain:

- `place_objects.lua` line 893: `possbile` -> `may` in a comment about the soft-placing fallback. The spell-checker suggestions (`possible`, `possibly`) don't fit the surrounding "then there ... be humanoids" construction, so using `may` fixes the typo while keeping the comment readable.

- `edit_room.lua` lines 1104-1105: `co-ordinate` -> `coordinate` in the docstring of `tryRemoveWindowFromWall`.

Note: Leaving `THs` unchanged in `sprite_viewer.lua` as it's a standard abbreviation for "Theme Hospital's" in the project.

All changes are in comments only.