### PR TITLE
Basic scale factor support for sprite lists

### DIFF
--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2711;
+return 2712;

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -199,10 +199,8 @@ function UIMenuBar:drawMenu(menu, canvas)
   local panel_sprites_draw = panel_sprites.draw
   local x, y, w, h = menu.x * s, menu.y * s, menu.width * s, menu.height * s
 
-  -- It would be better if spriteList supported scaling directly
-  canvas:scale(s)
-  menu.render_list:draw(canvas, menu.x, menu.y)
-  canvas:scale(1)
+  menu.render_list:setScaleFactor(s)
+  menu.render_list:draw(canvas, x, y)
 
   local btmy = y + h - 6 * s
   panel_sprites_draw(panel_sprites, canvas, 3, x + w - 10 * s, y, { scaleFactor = s })

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1722,30 +1722,31 @@ void sprite_render_list::draw(render_target* canvas, const xy_pair& draw_pos) {
     return;
   }
 
-  int x = draw_pos.x + pixel_offset.x;
-  int y = draw_pos.y + pixel_offset.y;
+  int x = draw_pos.x + pixel_offset.x * scale_factor;
+  int y = draw_pos.y + pixel_offset.y * scale_factor;
 
   std::unique_ptr<render_target::scoped_buffer> intermediate_buffer;
   if (use_intermediate_buffer) {
     int minX = INT_MAX, minY = INT_MAX, maxX = INT_MIN, maxY = INT_MIN;
     for (const sprite& pSprite : sprites) {
-      int spriteX = x + pSprite.x;
-      int spriteY = y + pSprite.y;
+      int spriteX = x + pSprite.x * scale_factor;
+      int spriteY = y + pSprite.y * scale_factor;
       int spriteWidth, spriteHeight;
       sheet->get_sprite_size_unchecked(pSprite.index, &spriteWidth,
                                        &spriteHeight);
       minX = std::min(minX, spriteX);
       minY = std::min(minY, spriteY);
-      maxX = std::max(maxX, spriteX + spriteWidth);
-      maxY = std::max(maxY, spriteY + spriteHeight);
+      maxX = std::max(maxX, spriteX + spriteWidth * scale_factor);
+      maxY = std::max(maxY, spriteY + spriteHeight * scale_factor);
     }
     intermediate_buffer = canvas->begin_intermediate_drawing(
         minX, minY, maxX - minX, maxY - minY);
   }
 
   for (const sprite& pSprite : sprites) {
-    sheet->draw_sprite(canvas, pSprite.index, x + pSprite.x, y + pSprite.y,
-                       flags);
+    sheet->draw_sprite(canvas, pSprite.index, x + pSprite.x * scale_factor,
+                       y + pSprite.y * scale_factor, flags, 0,
+                       animation_effect::none, scale_factor);
   }
 }
 
@@ -1765,6 +1766,8 @@ void sprite_render_list::set_lifetime(int life_time) {
 void sprite_render_list::set_use_intermediate_buffer() {
   use_intermediate_buffer = true;
 }
+
+void sprite_render_list::set_scale_factor(int s) { scale_factor = s; }
 
 void sprite_render_list::append_sprite(size_t spr_num, int xpos, int ypos) {
   sprite s{spr_num, xpos, ypos};

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -607,6 +607,7 @@ class sprite_render_list : public animation_base {
   void set_lifetime(int life_time);
   void set_use_intermediate_buffer();
   void append_sprite(size_t spr_num, int xpos, int ypos);
+  void set_scale_factor(int scale_factor);
   bool is_dead() const { return lifetime == 0; }
 
   void persist(lua_persist_writer* writer) const;
@@ -643,8 +644,10 @@ class sprite_render_list : public animation_base {
   //! Number of ticks until reports as dead (-1 = never dies)
   int lifetime{-1};
   //! Whether to draw to an intermediate buffer. This is used to preserve text
-  //! rendering quality when scaling.
+  //! rendering quality when scaling. Not persisted.
   bool use_intermediate_buffer{false};
+  //! Scale factor for the render list. Not persisted.
+  int scale_factor{1};
 };
 
 // Find the appropriate subclass of animation_base for a given

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -658,6 +658,12 @@ int l_srl_set_use_intermediate_buffer(lua_State* L) {
   return 0;
 }
 
+int l_srl_set_scale_factor(lua_State* L) {
+  sprite_render_list* srl = luaT_testuserdata<sprite_render_list>(L);
+  srl->set_scale_factor(static_cast<int>(luaL_checkinteger(L, 2)));
+  return 0;
+}
+
 int l_srl_is_dead(lua_State* L) {
   sprite_render_list* pSrl = luaT_testuserdata<sprite_render_list>(L);
   lua_pushboolean(L, pSrl->is_dead() ? 1 : 0);
@@ -772,6 +778,7 @@ void lua_register_anims(const lua_register_state* pState) {
     lcb.add_function(l_srl_set_lifetime, "setLifetime");
     lcb.add_function(l_srl_set_use_intermediate_buffer,
                      "setUseIntermediateBuffer");
+    lcb.add_function(l_srl_set_scale_factor, "setScaleFactor");
     lcb.add_function(l_srl_is_dead, "isDead");
     lcb.add_function(l_anim_set_tile<sprite_render_list>, "setTile",
                      lua_metatable::map);


### PR DESCRIPTION
Adds support for setting a scale factor on a sprite list and using it to draw. This patch does not account for the scale factor for hit tests which may be desired (though I don't see any use in the game). The immediate use for this patch is for drawing menus.

Fixes #3389
