### PR TITLE
Move fax sound

### DIFF
--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -631,6 +631,7 @@ function UIBottomPanel:_showMessageIcon(index)
   drawer_icon:setXLimit(1 + #message_windows * FACTORY_ICON_WIDTH)
   message_windows[#message_windows + 1] = drawer_icon
   self:addWindow(drawer_icon)
+  self.ui:playSound("NewFax.wav")
   table.remove(self.message_queue, index)   -- Delete element of the queue
 end
 

--- a/CorsixTH/Lua/dialogs/message.lua
+++ b/CorsixTH/Lua/dialogs/message.lua
@@ -28,7 +28,6 @@ function UIMessage:UIMessage(ui, x, stop_x, onClose, type, message, owner, timeo
   self:Window()
 
   local app = ui.app
-  ui:playSound("NewFax.wav")
 
   self.esc_closes = false
   self.on_top = false


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**0.70.0 beta 2**

**Describe what the proposed change does**
- Play the fax sound when the fax appears on the screen, not when the `UIMessage` is created.
- This will eliminate the bug when you hear the fax sound but the message does not appear in the drawer.

Regressed in #3347
