### PR TITLE
Add scale_factor support to animations

### DIFF
--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2712;
+return 2713;

--- a/CorsixTH/Lua/dialogs/adviser.lua
+++ b/CorsixTH/Lua/dialogs/adviser.lua
@@ -238,10 +238,8 @@ function UIAdviser:draw(canvas, x, y)
   local s = TheApp.config.ui_scale
   x, y = x + self.x * s, y + self.y * s
 
-  -- no scaleFactor for animation yet
-  canvas:scale(s)
-  self.th:draw(canvas, math.floor(x / s) + 200, math.floor(y / s))
-  canvas:scale(1)
+  self.th:setScaleFactor(s)
+  self.th:draw(canvas, x + 200 * s, y)
 
   if self.phase == 2 then
     -- Draw balloon only in the "talk" phase.

--- a/CorsixTH/Lua/dialogs/build_room.lua
+++ b/CorsixTH/Lua/dialogs/build_room.lua
@@ -145,9 +145,8 @@ function UIBuildRoom:draw(canvas, x, y)
   self.white_font:draw(canvas, self.cost_box, x + 163 * s, y + 232 * s)
 
   if self.preview_anim then
-    canvas:scale(s)
-    self.preview_anim:draw(canvas, math.floor(x / s) + 70, math.floor(y / s) + 200)
-    canvas:scale(1)
+    self.preview_anim:setScaleFactor(s)
+    self.preview_anim:draw(canvas, x + 70 * s, y + 200 * s)
   end
 end
 

--- a/CorsixTH/Lua/dialogs/furnish_corridor.lua
+++ b/CorsixTH/Lua/dialogs/furnish_corridor.lua
@@ -230,9 +230,8 @@ function UIFurnishCorridor:draw(canvas, x, y)
     font:draw(canvas, o.qty, x + 306 * s, y + 20 * s + i * 19 * s, 19 * s, 0)
   end
 
-  canvas:scale(s)
-  self.preview_anim:draw(canvas, math.floor(x / s) + 72, math.floor(y / s) + 57)
-  canvas:scale(1)
+  self.preview_anim:setScaleFactor(s)
+  self.preview_anim:draw(canvas, x + 72 * s, y + 57 * s)
 end
 
 function UIFurnishCorridor:onMouseMove(x, y, dx, dy)

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -920,7 +920,8 @@ void animation_manager::draw_frame(render_target* pCanvas, size_t iFrame,
                                    const ::layers& oLayers, int iX, int iY,
                                    uint32_t iFlags,
                                    animation_effect patient_effect,
-                                   size_t patient_effect_offset) const {
+                                   size_t patient_effect_offset,
+                                   int scale_factor) const {
   if (iFrame >= frame_count) {
     return;
   }
@@ -963,20 +964,25 @@ void animation_manager::draw_frame(render_target* pCanvas, size_t iFrame,
         (oElement.layer > 0 || oElement.layer_id > 0) ? patient_effect
                                                       : animation_effect::none;
     size_t effect_ticks = game_ticks + patient_effect_offset;
+    int oex = oElement.x * scale_factor;
+    int oey = oElement.y * scale_factor;
     if (iFlags & thdf_flip_horizontal) {
       int iWidth;
       int iHeight;
       oElement.element_sprite_sheet->get_sprite_size_unchecked(
           oElement.sprite, &iWidth, &iHeight);
+      iWidth *= scale_factor;
+      iHeight *= scale_factor;
 
       oElement.element_sprite_sheet->draw_sprite(
-          pCanvas, oElement.sprite, iX - oElement.x - iWidth, iY + oElement.y,
+          pCanvas, oElement.sprite, iX - oex - iWidth, iY + oey,
           iPassOnFlags | (oElement.flags ^ thdf_flip_horizontal), effect_ticks,
-          render_effect);
+          render_effect, scale_factor);
     } else {
       oElement.element_sprite_sheet->draw_sprite(
-          pCanvas, oElement.sprite, iX + oElement.x, iY + oElement.y,
-          iPassOnFlags | oElement.flags, effect_ticks, render_effect);
+          pCanvas, oElement.sprite, iX + oex, iY + oey,
+          iPassOnFlags | oElement.flags, effect_ticks, render_effect,
+          scale_factor);
     }
   }
 }
@@ -1190,8 +1196,8 @@ animation::animation() { patient_effect_offset = rand(); }
 void animation::draw(render_target* canvas, const xy_pair& draw_pos) {
   if (are_flags_set(flags, thdf_alpha_50 | thdf_alpha_75)) return;
 
-  int x = draw_pos.x + pixel_offset.x;
-  int y = draw_pos.y + pixel_offset.y;
+  int x = draw_pos.x + pixel_offset.x * scale_factor;
+  int y = draw_pos.y + pixel_offset.y * scale_factor;
   if (sound_to_play) {
     sound_player* pSounds = sound_player::get_singleton();
     if (pSounds) pSounds->play_at(sound_to_play, x, y, 0);
@@ -1202,14 +1208,14 @@ void animation::draw(render_target* canvas, const xy_pair& draw_pos) {
       clip_rect rcNew;
       rcNew.y = 0;
       rcNew.h = canvas->get_height();
-      rcNew.x = x + (crop_column - 1) * 32;
-      rcNew.w = 64;
+      rcNew.x = x + (crop_column - 1) * 32 * scale_factor;
+      rcNew.w = 64 * scale_factor;
       render_target::scoped_clip clip(canvas, &rcNew);
       manager->draw_frame(canvas, frame_index, layers, x, y, flags,
-                          patient_effect, patient_effect_offset);
+                          patient_effect, patient_effect_offset, scale_factor);
     } else
       manager->draw_frame(canvas, frame_index, layers, x, y, flags,
-                          patient_effect, patient_effect_offset);
+                          patient_effect, patient_effect_offset, scale_factor);
   }
 }
 
@@ -1223,14 +1229,16 @@ void animation::draw_child(render_target* canvas, const xy_pair& draw_pos,
   else
     parent->get_secondary_marker(&x, &y);
 
-  x += pixel_offset.x + draw_pos.x;
-  y += pixel_offset.y + draw_pos.y;
+  x += pixel_offset.x * scale_factor + draw_pos.x;
+  y += pixel_offset.y * scale_factor + draw_pos.y;
   if (sound_to_play) {
     sound_player* pSounds = sound_player::get_singleton();
     if (pSounds) pSounds->play_at(sound_to_play, x, y, 0);
     sound_to_play = 0;
   }
-  if (manager) manager->draw_frame(canvas, frame_index, layers, x, y, flags);
+  if (manager)
+    manager->draw_frame(canvas, frame_index, layers, x, y, flags,
+                        animation_effect::none, 0, scale_factor);
 }
 
 bool animation::hit_test_child(const xy_pair& draw_pos,
@@ -1244,8 +1252,8 @@ void animation::draw_morph(render_target* canvas, const xy_pair& draw_pos) {
 
   if (!manager) return;
 
-  int x = draw_pos.x + pixel_offset.x;
-  int y = draw_pos.y + pixel_offset.y;
+  int x = draw_pos.x + pixel_offset.x * scale_factor;
+  int y = draw_pos.y + pixel_offset.y * scale_factor;
   if (sound_to_play) {
     sound_player* pSounds = sound_player::get_singleton();
     if (pSounds) pSounds->play_at(sound_to_play, x, y, 0);
@@ -1257,18 +1265,22 @@ void animation::draw_morph(render_target* canvas, const xy_pair& draw_pos) {
   // vertical clipping is applied.
   oMorphRect.x = 0;
   oMorphRect.w = canvas->get_width();
-  oMorphRect.y = y + morph_target->pixel_offset.x;
-  oMorphRect.h = morph_target->pixel_offset.y - morph_target->pixel_offset.x;
+  oMorphRect.y = y + morph_target->pixel_offset.x * scale_factor;
+  oMorphRect.h = (morph_target->pixel_offset.y - morph_target->pixel_offset.x) *
+                 scale_factor;
   {
     render_target::scoped_clip clip(canvas, &oMorphRect);
-    manager->draw_frame(canvas, frame_index, layers, x, y, flags);
+    manager->draw_frame(canvas, frame_index, layers, x, y, flags,
+                        animation_effect::none, 0, scale_factor);
   }
-  oMorphRect.y = y + morph_target->pixel_offset.y;
-  oMorphRect.h = morph_target->speed.x - morph_target->pixel_offset.y;
+  oMorphRect.y = y + morph_target->pixel_offset.y * scale_factor;
+  oMorphRect.h =
+      (morph_target->speed.x - morph_target->pixel_offset.y) * scale_factor;
   {
     render_target::scoped_clip clip(canvas, &oMorphRect);
     manager->draw_frame(canvas, morph_target->frame_index, morph_target->layers,
-                        x, y, morph_target->flags);
+                        x, y, morph_target->flags, animation_effect::none, 0,
+                        scale_factor);
   }
 }
 
@@ -1766,8 +1778,6 @@ void sprite_render_list::set_lifetime(int life_time) {
 void sprite_render_list::set_use_intermediate_buffer() {
   use_intermediate_buffer = true;
 }
-
-void sprite_render_list::set_scale_factor(int s) { scale_factor = s; }
 
 void sprite_render_list::append_sprite(size_t spr_num, int xpos, int ypos) {
   sprite s{spr_num, xpos, ypos};

--- a/CorsixTH/Src/th_gfx.h
+++ b/CorsixTH/Src/th_gfx.h
@@ -320,11 +320,12 @@ class animation_manager {
       @param patient_effect The animation effect to apply to the patient.
       @param patient_effect_offset The number of ticks to offset the effect
           animation by.
+      @param scale_factor
   */
   void draw_frame(render_target* pCanvas, size_t iFrame,
                   const ::layers& oLayers, int iX, int iY, uint32_t iFlags,
                   animation_effect patient_effect = animation_effect::none,
-                  size_t patient_effect_offset = 0) const;
+                  size_t patient_effect_offset = 0, int scale_factor = 1) const;
 
   void get_frame_extent(size_t iFrame, const ::layers& oLayers, int* pMinX,
                         int* pMaxX, int* pMinY, int* pMaxY,
@@ -480,6 +481,7 @@ class animation_base : public drawable {
   }
   void set_layer(int iLayer, int iId);
   void set_layers_from(const animation_base* pSrc) { layers = pSrc->layers; }
+  void set_scale_factor(int s) { scale_factor = s; }
 
  protected:
   //! Tile containing the animation. A negative x or y means it is not active.
@@ -489,6 +491,17 @@ class animation_base : public drawable {
   xy_pair pixel_offset{0, 0};
 
   ::layers layers{};
+
+  //! Scale factor for the animation.
+  /**
+   * For both animation and sprite_render_list scale_factor is currently only
+   * implemented for drawing. Support for hit_test should be implemented if
+   * a need to hit_test on a scaled sprite_render_list or animation arises.
+   *
+   * In all cases scale_factor is not persisted, and expected to be set
+   * according to the current game options before calling draw.
+   */
+  int scale_factor{1};
 };
 
 //! The kind of animation.
@@ -607,7 +620,6 @@ class sprite_render_list : public animation_base {
   void set_lifetime(int life_time);
   void set_use_intermediate_buffer();
   void append_sprite(size_t spr_num, int xpos, int ypos);
-  void set_scale_factor(int scale_factor);
   bool is_dead() const { return lifetime == 0; }
 
   void persist(lua_persist_writer* writer) const;
@@ -646,8 +658,6 @@ class sprite_render_list : public animation_base {
   //! Whether to draw to an intermediate buffer. This is used to preserve text
   //! rendering quality when scaling. Not persisted.
   bool use_intermediate_buffer{false};
-  //! Scale factor for the render list. Not persisted.
-  int scale_factor{1};
 };
 
 // Find the appropriate subclass of animation_base for a given

--- a/CorsixTH/Src/th_lua_anims.cpp
+++ b/CorsixTH/Src/th_lua_anims.cpp
@@ -626,6 +626,13 @@ int l_anim_set_patient_effect(lua_State* L) {
   return 1;
 }
 
+template <typename T>
+int l_anim_set_scale_factor(lua_State* L) {
+  T* anim = luaT_testuserdata<T>(L);
+  anim->set_scale_factor(static_cast<int>(luaL_checkinteger(L, 2)));
+  return 0;
+}
+
 int l_srl_set_sheet(lua_State* L) {
   sprite_render_list* pSrl = luaT_testuserdata<sprite_render_list>(L);
   sprite_sheet* pSheet = luaT_testuserdata<sprite_sheet>(L, 2);
@@ -655,12 +662,6 @@ int l_srl_set_lifetime(lua_State* L) {
 int l_srl_set_use_intermediate_buffer(lua_State* L) {
   sprite_render_list* pSrl = luaT_testuserdata<sprite_render_list>(L);
   pSrl->set_use_intermediate_buffer();
-  return 0;
-}
-
-int l_srl_set_scale_factor(lua_State* L) {
-  sprite_render_list* srl = luaT_testuserdata<sprite_render_list>(L);
-  srl->set_scale_factor(static_cast<int>(luaL_checkinteger(L, 2)));
   return 0;
 }
 
@@ -744,6 +745,7 @@ void lua_register_anims(const lua_register_state* pState) {
     lcb.add_function(l_anim_set_speed<animation>, "setSpeed");
     lcb.add_function(l_anim_set_layer<animation>, "setLayer");
     lcb.add_function(l_anim_set_layers_from, "setLayersFrom");
+    lcb.add_function(l_anim_set_scale_factor<animation>, "setScaleFactor");
     lcb.add_function(l_anim_set_hitresult, "setHitTestResult");
     lcb.add_function(l_anim_get_primary_marker, "getPrimaryMarker");
     lcb.add_function(l_anim_get_secondary_marker, "getSecondaryMarker");
@@ -778,7 +780,8 @@ void lua_register_anims(const lua_register_state* pState) {
     lcb.add_function(l_srl_set_lifetime, "setLifetime");
     lcb.add_function(l_srl_set_use_intermediate_buffer,
                      "setUseIntermediateBuffer");
-    lcb.add_function(l_srl_set_scale_factor, "setScaleFactor");
+    lcb.add_function(l_anim_set_scale_factor<sprite_render_list>,
+                     "setScaleFactor");
     lcb.add_function(l_srl_is_dead, "isDead");
     lcb.add_function(l_anim_set_tile<sprite_render_list>, "setTile",
                      lua_metatable::map);


### PR DESCRIPTION
Support scale_factor for drawing animations
This removes the need to use the canvas:scale method to scale the
advisor which was a hack that caused issues for indirect zoom.

This commit does not consider scale_factor for hit_test which is would
be needed if the scale_factor was applied broader, but is not necessary
for supporting the advisor or item previews.

Fixes https://github.com/CorsixTH/CorsixTH/issues/3394