### PR TITLE
Early exit for drawing null or empty messages

### DIFF
--- a/CorsixTH/Src/th_gfx_font.cpp
+++ b/CorsixTH/Src/th_gfx_font.cpp
@@ -423,6 +423,10 @@ text_layout freetype_font::draw_text_wrapped(render_target* pCanvas,
   int iNumRows = 0;
   int iHandledRows = 0;
 
+  if (!sMessage || sMessage[0] == '\0') {
+    return oDrawArea;
+  }
+
   // Calculate an index into the cache to use for this piece of text.
   size_t iHash = iMessageLength +
                  (static_cast<size_t>(iMaxRows) << (cache_size_log2 / 8)) +


### PR DESCRIPTION
When drawing unicode messages there are parts of the algorithm that do not properly initiate the cache if the message is null or empty which can lead to later attempts to perform memcmp against a null pointer.

By checking up front for null or empty messages we avoid this condition.

Fixes #3398