### PR TITLE
Adviser history delete message fix

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 248 -- 0.70.0 beta 2
+local SAVEGAME_VERSION = 249 -- Advisor message history dialog afterLoad close
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/resizables/adviser_history.lua
+++ b/CorsixTH/Lua/dialogs/resizables/adviser_history.lua
@@ -190,3 +190,9 @@ function UIAdviserHistory:onTick()
   end
 end
 
+function UIAdviserHistory:afterLoad(old, new)
+  if old < 249 then
+    self:close()
+  end
+  Window.afterLoad(self, old, new)
+end

--- a/CorsixTH/Lua/dialogs/resizables/adviser_history.lua
+++ b/CorsixTH/Lua/dialogs/resizables/adviser_history.lua
@@ -40,6 +40,7 @@ function UIAdviserHistory:UIAdviserHistory(ui)
   self.resizable = false
 
   self.last_seen_history_top = nil  -- Stores the top message in the adviser's 'message_history' list at the time of the last update
+  self.last_history_count = nil -- Stores the messages count in the adviser's 'message_history' list at the time of the last update
   self.list_table = {}       -- List of controls in this dialog
 
   self.default_button_sound = "selectx.wav"
@@ -84,7 +85,9 @@ function UIAdviserHistory:createControls()
   if rows ~= self.rows_shown then
     local function delete_factory(num)
       return --[[persistable:adviser_history_delete_button]] function()
-        self:deleteButtonClicked(num)
+        local scrollbar_offset = self.scrollbar.value - 1
+        local message_index = scrollbar_offset + num
+        self:deleteButtonClicked(message_index)
       end
     end
     local scrollbarMovedCallback = --[[persistable:adviser_history_scrollbar]] function()
@@ -146,6 +149,7 @@ end
 function UIAdviserHistory:update()
   local adviser_messages = self.ui.adviser.message_history
   self.last_seen_history_top = adviser_messages[1]
+  self.last_history_count = #adviser_messages
 
   self.scrollbar:setRange(1, math.max(1, #adviser_messages), self.rows_shown, self.scrollbar.value)
   self:scrollbarMoved()
@@ -178,8 +182,10 @@ function UIAdviserHistory:onTick()
   -- Checking the length of both lists would fail if a message was moved from the middle to the top due to duplication.
   -- So we just check if the top string between lists has changed to determine if we need to update
   local new_history_top = self.ui.adviser.message_history[1]
+  local new_history_count = #self.ui.adviser.message_history
+  local out_of_date = self.last_seen_history_top ~= new_history_top or self.last_history_count ~= new_history_count
 
-  if self.last_seen_history_top ~= new_history_top then
+  if out_of_date then
     self:update()
   end
 end

--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -2151,14 +2151,23 @@ function Window:afterLoad(old, new)
     self.apply_ui_scale = true
   end
 
+  -- If a window or panel is asked to close during an afterLoad cycle we
+  -- can skip entries so use backwards iteration here instead
   if self.windows then
-    for _, w in pairs(self.windows) do
-      w:afterLoad(old, new)
+    for i = #self.windows, 1, -1 do
+      local window = self.windows[i]
+      if window then
+        window:afterLoad(old, new)
+      end
     end
   end
+
   if self.panels then
-    for _, p in pairs(self.panels) do
-      p:afterLoad(old, new)
+    for i = #self.panels, 1, -1 do
+      local panel = self.panels[i]
+      if panel then
+        panel:afterLoad(old, new)
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**0.70.0 beta 2**

<img width="518" height="243" alt="Screenshot 2026-06-15 at 09 39 42" src="https://github.com/user-attachments/assets/8110b152-47f8-4a79-b294-f7b8c5f129d6" />

*Fixes #3395*

### **Describe what the proposed change does**

- Messages deleted now match the one the user clicks on.
- After message delete list now properly updates.

### **More Details**

**Firstly, previously the messages that are deleted are not the ones user click the cross on.**

When deleting a message, the order number of that message on the screen was passed. 
This number was then used as the index of the message to be deleted in the array of all messages.
For example, you have 8 messages in the history. 
The message window displays no more than 4 messages at a time.
Suppose we want to delete message number 5. 
We open the message history window. After opening the message history window, we don't see message number 5, but only the first 1-4 messages. We scroll to the very bottom, and now we see messages 5-8.
So, if we click the cross next to message 5, the delete function will receive index 1, not 5... why 1? 
Because the current number of the message on the screen is passed, not the one in the array. This is incorrect.
This will delete the wrong message.
This also can produce `adviser.lua:102: bad argument #1 to 'remove' (position out of bounds)
stack traceback:` because this error gives opportunity to delete the number out of array bounds.
To delete the correct message, the index is now calculated as:
the number of the message on the screen + scroll offset.

**Secondly, previously the message list is not updates on delete.**

The message history list is trying to update on `UIAdviserHistory:onTick()`.
But to prevent the message history list from being updated unnecessarily, a check is placed every tick to determine whether the list has changed.
If there have been changes, it updates the list.
If there have been no updates, it doesn't update the list at that tick.
This check only remembered the topmost, most recent message. 
And each time, it checked: if the last message has changed, then it updates the list and remembers the new first message.
This logic works well if messages are deleted or added only to the very top.
But when we click the cross next to a message, we can delete not only just the first message.
Therefore, the list didn't respond or update if any message other than the first message was deleted.
I had to add variable for the message count.
So this function would check not only whether the topmost message has changed, but also whether the total number of messages has changed.
Thus, if we delete messages, the total number of messages changes, and the function updates the UI.

---------

*Additional note from lewri*
Extra commit fixes a longstanding bug where if afterLoads run through `self.windows` closed the window, it would mutate the list and cause an early termination.