### PR TITLE
Bump vcpkg

### DIFF
--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -308,6 +308,11 @@ if(FETCH_UNICODE_FONT)
 endif()
 
 if(WITH_TRACY)
+  # If tracy is compiled on a machine with rocprofiler installed it
+  # automatically adds it as a dependency. Using an optional find_package
+  # before finding Tracy allows that dependency to resolve.
+  find_package(rocprofiler-sdk QUIET)
+
   find_package(Tracy CONFIG REQUIRED)
   target_link_libraries(CorsixTH_lib PUBLIC Tracy::TracyClient)
 endif()

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -112,6 +112,9 @@ if(NOT VCPKG_TARGET_TRIPLET)
   find_package(PkgConfig QUIET)
 endif()
 
+find_package(ZLIB REQUIRED)
+target_link_libraries(CorsixTH_lib PRIVATE ZLIB::ZLIB)
+
 # Find SDL
 if(VCPKG_TARGET_TRIPLET)
   find_package(SDL2 CONFIG REQUIRED)
@@ -256,10 +259,6 @@ endif()
 # Find libpng
 find_package(PNG REQUIRED)
 target_link_libraries(CorsixTH_lib PRIVATE PNG::PNG)
-
-# Find zlib
-find_package(ZLIB REQUIRED)
-target_link_libraries(CorsixTH_lib PRIVATE ZLIB::ZLIB)
 
 if(WITH_MIDI_DEVICE)
   find_package(RtMidi)

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "b472291f295551b7127359ea38fdd2ca092f6f1b",
+    "baseline": "bee87c32fcf25e81b0d9c312144475b5e34181a8",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [
@@ -13,7 +13,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/CorsixTH/vcpkg-registry",
-      "baseline": "edaf3aa6d9a5d6d96fa71f7d29a5e1e85a15dd49",
+      "baseline": "ddc4effddd5f69d77c2eae918d7f8ba55fc8ab37",
       "packages": [ "ffmpeg", "ffmpeg-bin2c" ]
     }
   ]


### PR DESCRIPTION
Note zlib needs to be added early now due to some transitive breakage.

    catch2@3.15.1
    curl@8.20.0#2
    ffmpeg@8.1.1
    fluidsynth@2.5.5
    freetype@2.14.3
    libpng@1.6.58
    lpeg@1.1.0#1
    lua@5.5.0#1
    luafilesystem@1.9.0
    rtmidi@6.0.0
    sdl2@2.32.10#1
    sdl2-mixer@2.8.2
    wxwidgets@3.3.1#1
    zlib@1.3.2#1

The version of vcpkg we were using no longer built on my system; and I like to be able to build :smile: 