### PR TITLE
Machine menu crash on open fix

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/machine_menu.lua
+++ b/CorsixTH/Lua/dialogs/resizables/machine_menu.lua
@@ -311,7 +311,10 @@ function UIMachineMenu:update()
       local assigned_handyman
       local repair_call = dispatcher.call_queue[machine]
       if repair_call then
-        assigned_handyman = repair_call["repair"].assigned
+        local repair = repair_call["repair"]
+        if repair and repair.assigned then
+          assigned_handyman = repair.assigned
+        end
       end
 
       local machine_for_list = machineForList(machine, assigned_handyman)


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**0.70.0 beta 2**

**Describe what the proposed change does**
- check that `repair` in `repair_call` in not `nil`, before accessing `repair.assigned` for Machine Menu.

<details>
  <summary>Issue Details. Press here 👈</summary>

### Describe the issue

Machine menu crash on open

----


### Save Game

[Saves.zip](https://github.com/user-attachments/files/26073054/Saves.zip)

----


### CorsixTH Version

0.70.0

----


### Steps to Reproduce

1. Run 0.70.0.
2. Load attached save game `HVM3.7.sav`.
3. Press Machine Menu in Bottom Panel.
4. Observe Lua crash. UI not responsive anymore.

----

### Gamelog.txt

```yaml
A stack trace is included below, and the handler has been disconnected.
../Resources/Lua/dialogs/resizables/machine_menu.lua:291: attempt to index a nil value (field 'repair')
stack traceback:
	../Resources/Lua/dialogs/resizables/machine_menu.lua:291: in method 'update'
	../Resources/Lua/dialogs/resizables/machine_menu.lua:68: in local 'constructor'
	../Resources/Lua/class.lua:74: in global 'UIMachineMenu'
	../Resources/Lua/dialogs/menu.lua:819: in field 'handler'
	../Resources/Lua/dialogs/menu.lua:429: in method 'onMouseUp'
	../Resources/Lua/window.lua:1703: in field 'onMouseUp'
	../Resources/Lua/ui.lua:895: in function <../Resources/Lua/ui.lua:882>
	(...tail calls...)
	../Resources/Lua/app.lua:1126: in function <../Resources/Lua/app.lua:1121>
```

</details>

