### PR TITLE
Clear staffroom flags on placing staff

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 249 -- Advisor message history dialog afterLoad close
+local SAVEGAME_VERSION = 250 -- Properly clear staffroom flags on pickup
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/place_staff.lua
+++ b/CorsixTH/Lua/dialogs/place_staff.lua
@@ -57,6 +57,7 @@ function UIPlaceStaff:close()
   local play_placement_sound = true
   if employed_staff then
     employed_staff.pickup = false
+    employed_staff.staffroom_needed = nil
     employed_staff.going_to_staffroom = nil
     employed_staff:getCurrentAction().window = nil
     local room = self.world:getRoom(employed_staff.tile_x, employed_staff.tile_y)

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -722,6 +722,16 @@ function Staff:afterLoad(old, new)
     self.mood_marker = 2
   end
 
+  if old < 250 then
+    -- Staff members picked up and moved to rest didn't reset the
+    -- staffroom_needed flag. If a staff member genuinely needed it they would
+    -- get it back again next tick.
+    if self:getAttribute("fatigue") < self.hospital.policies["goto_staffroom"] then
+      self.staffroom_needed = nil
+      self.going_to_staffroom = nil -- also clear for consistency
+    end
+  end
+
   self:updateDynamicInfo()
   Humanoid.afterLoad(self, old, new)
 end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3379*

**Describe what the proposed change does**
- Clears both staffroom flags on placing a staff member
- Also an afterLoad. If the cleared flags were needed they come back next tick

Can't test myself right now, please test.