### PR TITLE
Properly reset `Last room` for humanoid if he unable to return

### DIFF
--- a/CorsixTH/Lua/humanoid_actions/use_staffroom.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_staffroom.lua
@@ -128,7 +128,8 @@ local function use_staffroom_action_start(action, humanoid)
         humanoid:queueAction(room:createEnterAction(humanoid))
         humanoid:setDynamicInfoText(_S.dynamic_info.staff.actions.heading_for:format(room.room_info.name))
       else
-        -- Send the staff out of the room
+        -- Forget last room and send the staff out of the room
+        humanoid.last_room = nil
         humanoid:queueAction(MeanderAction())
       end
     else

--- a/CorsixTH/Lua/humanoid_actions/use_staffroom.lua
+++ b/CorsixTH/Lua/humanoid_actions/use_staffroom.lua
@@ -128,8 +128,12 @@ local function use_staffroom_action_start(action, humanoid)
         humanoid:queueAction(room:createEnterAction(humanoid))
         humanoid:setDynamicInfoText(_S.dynamic_info.staff.actions.heading_for:format(room.room_info.name))
       else
-        -- Forget last room and send the staff out of the room
-        humanoid.last_room = nil
+        -- Send the staff out of the room
+        if room and room.is_active and
+          (room.room_info.id == "research" or room.room_info.id == "training") then
+          -- Clear the last room if it was training/research as we can't go back here anymore
+          humanoid.last_room = nil
+        end
         humanoid:queueAction(MeanderAction())
       end
     else


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**0.70.0 beta 2**

*Fixes #3410*

**Describe what the proposed change does**
- Properly reset `Last room` for humanoid if he unable to return to that last room.
