### PR TITLE
Machines wearing out broken fix

### DIFF
--- a/CorsixTH/Lua/entities/machine.lua
+++ b/CorsixTH/Lua/entities/machine.lua
@@ -370,17 +370,17 @@ end
 
 --! Call on machine repaired.
 --!param room (object) machine room
-function Machine:machineRepaired(room, should_reduce_strength)
-  should_reduce_strength = should_reduce_strength or true
+--!param strength_reducible (bool) machine room
+function Machine:machineRepaired(room, strength_reducible)
+  strength_reducible = strength_reducible or true
+  if strength_reducible then
+    self:reduceStrengthOnRepair()
+  end
   room:unlockRoomOnRepair()
-  self.times_used = 0
   self:removeRepairingStatus()
   setSmoke(self, false)
   self:removeHandymanRepairTask()
-
-  if should_reduce_strength then
-    self:reduceStrengthOnRepair()
-  end
+  self.times_used = 0
 end
 
 --! Call on machine repaired. Removes repair task for that machine.


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**0.70.0 rc 1**

**Describe what the proposed change does**
- Reduce strength change calculation code swapped with `machine.times_used = 0` code (result of repair).

After #2998 the maximum strength of the machines never decreases.

Currently, on machine repair, `machine.times_used = 0` occurs first, and then the wear probability is calculated.
But with `machine.times_used = 0`, the wear probability is always 0.
So wear probability calculation should happen before `machine.times_used = 0`.
