### PR TITLE
Fix panel keys overflow

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/hotkey_assign.lua
+++ b/CorsixTH/Lua/dialogs/resizables/hotkey_assign.lua
@@ -414,7 +414,16 @@ function UIHotkeyAssign:UIHotkeyAssign(ui, mode)
             "ingame_panel_buildRoom",
             "ingame_panel_furnishCorridor",
             "ingame_panel_editRoom",
-            "ingame_panel_hireStaff",
+            "ingame_panel_hireStaff",}}}},
+    {
+      -- FIXME: Rename to "Alternate Panel Keys"
+      -- New strings required but string freeze applies at time of patch
+      id = "panels2",
+      title = _S.hotkey_window.caption_panels,
+      tooltip = _S.tooltip.hotkey_window.caption_panels,
+      sections = {{
+          title = _S.hotkey_window.caption_panels,
+          keys = {
             "ingame_panel_map_alt",
             "ingame_panel_research_alt",
             "ingame_panel_casebook_alt",


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

**0.70.0 rc 1**

Thanks Mickmane for bringing to our attention!

<details>
<summary>Expand for bug screenshot</summary>

<img width="1331" height="1041" alt="image" src="https://github.com/user-attachments/assets/eb1d81b8-0ae3-444d-9c03-2cc4b7776df7" />
</details>

*Fixes Panel Keys hot key assignment overflowing due to new adviser history*

**Describe what the proposed change does**
- Adds a second panel keys tab in hotkey assignment. **This fix is dirty, because we're in a string freeze, but it should be enough to get by for release**.

<details>
<summary>Expand for fix for now</summary>

<img width="651" height="504" alt="image" src="https://github.com/user-attachments/assets/c888ca20-03e2-4fbd-8ef4-607f97803023" />
</details>

I will make a second PR to add the proper strings, but the FIXME is in case I'm otherwise unavailable.
