### PR TITLE
Cap UI scales to 3x

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -1132,10 +1132,10 @@ function App:fixConfig()
     elseif key == "height" and (type(value) ~= "number" or value < App.MIN_WINDOW_HEIGHT) then
       self.config[key] = App.MIN_WINDOW_HEIGHT
 
-    -- For scale, clamp to integer scale >= 1
+    -- For scale, clamp to integer scale >= 1 and <= 3
     elseif key == "ui_scale" then
       if type(value) == "number" then
-        self.config[key] = math.max(math.floor(value), 1)
+        self.config[key] = math.min(math.max(math.floor(value), 1), 3)
       else
         self.config[key] = 1
       end

--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -121,7 +121,7 @@ local available_ui_scales = function()
   local res = {}
   local s = 1
   while s * App.MIN_WINDOW_WIDTH <= TheApp.config.width and
-      s * App.MIN_WINDOW_HEIGHT <= TheApp.config.height do
+      s * App.MIN_WINDOW_HEIGHT <= TheApp.config.height and s < 4 do
     res[#res + 1] = { text = tostring(s * 100) .. '%', scale = s }
     s = s + 1
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes unlimited UI scaling*

I.e. this was possible:
<img width="322" height="107" alt="image" src="https://github.com/user-attachments/assets/2ac687a4-b84d-4a87-86f9-4be37b056eba" />


**Describe what the proposed change does**
- #3170 made it possible for UI scales to be unlimited if the resolution was high enough. Now force caps to 3x

@TheCycoONE <del>this only fixes the UI setting. It likely it still possible to change in the settings file. File has notes on what values to use already.</del> Up to you if you want this merged now or after release.