### PR TITLE
ci: Trigger website rebuild on more release events

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -3,7 +3,10 @@ name: Update website
 on:
   release:
     types:
-      - published
+      - created
+      - deleted
+      - released
+      - unpublished
 
 jobs:
   dispatch:


### PR DESCRIPTION
When a release was deleted/unpublished, the website was not updated and the release would still appear there.

This PR make the website update on these release events (from https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=published#release):

- `created`: A draft was saved, or a release or pre-release was published without previously being saved as a draft.
- `deleted`: A release, pre-release, or draft release was deleted.
- `released`: A release was published, or a pre-release was changed to a release.
- `unpublished`: A release or pre-release was unpublished.