### PR TITLE
Center staff headcount labels

### DIFF
--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -274,10 +274,11 @@ function UIStaffManagement:draw(canvas, x, y)
 
   -- Number of employees
   local ney = y + 57 * s
-  titles:draw(canvas, #self.staff_members["Doctor"], x + 53 * s, ney, 58 * s, 0)
-  titles:draw(canvas, #self.staff_members["Nurse"], x + 119 * s, ney, 58 * s, 0)
-  titles:draw(canvas, #self.staff_members["Handyman"], x + 185 * s, ney, 58 * s, 0)
-  titles:draw(canvas, #self.staff_members["Receptionist"], x + 251 * s, ney, 58 * s, 0)
+  local ne_width = 58 * s
+  titles:draw(canvas, #self.staff_members["Doctor"], x + 53 * s, ney, ne_width, 0)
+  titles:draw(canvas, #self.staff_members["Nurse"], x + 119 * s, ney, ne_width, 0)
+  titles:draw(canvas, #self.staff_members["Handyman"], x + 185 * s, ney, ne_width, 0)
+  titles:draw(canvas, #self.staff_members["Receptionist"], x + 251 * s, ney, ne_width, 0)
 
   local total_happiness = 0
   local total_fatigue = 0

--- a/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen/staff_management.lua
@@ -274,10 +274,10 @@ function UIStaffManagement:draw(canvas, x, y)
 
   -- Number of employees
   local ney = y + 57 * s
-  titles:draw(canvas, #self.staff_members["Doctor"], x + 79 * s, ney)
-  titles:draw(canvas, #self.staff_members["Nurse"], x + 145 * s, ney)
-  titles:draw(canvas, #self.staff_members["Handyman"], x + 211 * s, ney)
-  titles:draw(canvas, #self.staff_members["Receptionist"], x + 277 * s, ney)
+  titles:draw(canvas, #self.staff_members["Doctor"], x + 53 * s, ney, 58 * s, 0)
+  titles:draw(canvas, #self.staff_members["Nurse"], x + 119 * s, ney, 58 * s, 0)
+  titles:draw(canvas, #self.staff_members["Handyman"], x + 185 * s, ney, 58 * s, 0)
+  titles:draw(canvas, #self.staff_members["Receptionist"], x + 251 * s, ney, 58 * s, 0)
 
   local total_happiness = 0
   local total_fatigue = 0


### PR DESCRIPTION
Draw the staff headcounts within the pixel width of it's category button so that the headcounts with multiple digits will remain horizontally centered.

Fixes #3442