### PR TITLE
Use `avoidTile` flag on room build

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -198,6 +198,7 @@ function UIEditRoom:cancel()
       self.ui:setDefaultCursor(nil)
       self.check_for_clear_area_timer = nil
       self.humanoids_to_watch = nil
+      self:_setCellFlagsOnBlueprint({avoidTile = false})
     end
     self.phase = "walls"
     self:returnToWallPhase()
@@ -262,6 +263,7 @@ function UIEditRoom:clearArea()
   local world = self.ui.app.world
   world:clearCaches() -- To invalidate idle tiles in case we need to move people
   local humanoids_to_watch = {}
+  self:_setCellFlagsOnBlueprint({avoidTile = true})
   do
     local x1 = rect.x - 1
     local x2 = rect.x + rect.w
@@ -363,6 +365,7 @@ function UIEditRoom:finishRoom()
   local map = self.ui.app.map.th
   local rect = self.blueprint_rect
   local door, door2
+  self:_setCellFlagsOnBlueprint({avoidTile = false})
   -- Add the transparency flag if it is set.
   local flag = 0
   if self.ui.transparent_walls then
@@ -379,7 +382,6 @@ function UIEditRoom:finishRoom()
       return  map:getCell(wall_x, wall_y, layer) == spr_num1
           or map:getCell(wall_x, wall_y, layer) == spr_num2
     end
-
 
     -- If a wall is built which is normal to an external window, then said
     -- window needs to be removed, otherwise it looks odd.
@@ -744,6 +746,7 @@ function UIEditRoom:returnToDoorPhase()
   rect.w = 0
   rect.h = 0
   self:setBlueprintRect(rect.x, rect.y, old_w, old_h)
+  self:_setCellFlagsOnBlueprint({avoidTile = false})
 
   -- We've gone all the way back to wall phase, so step forward to door phase
   self.phase = "door"
@@ -914,12 +917,11 @@ end
 
 function UIEditRoom:enterDoorPhase()
   self.ui:tutorialStep(3, 8, 9)
+  local rect = self.blueprint_rect
+  local map = self.ui.app.map.th
+
   -- make tiles impassable
-  for y = self.blueprint_rect.y, self.blueprint_rect.y + self.blueprint_rect.h - 1 do
-    for x = self.blueprint_rect.x, self.blueprint_rect.x + self.blueprint_rect.w - 1 do
-      self.ui.app.map:setCellFlags(x, y, {passable = false})
-    end
-  end
+  self:_setCellFlagsOnBlueprint({passable = false})
 
   -- check if all adjacent tiles of the rooms are still connected
   if not self:checkReachability() then
@@ -938,13 +940,15 @@ function UIEditRoom:enterDoorPhase()
     end
   end
 
+  -- make tiles passable back
+  self:_setCellFlagsOnBlueprint({passable = true})
+
   self.desc_text = _S.place_objects_window.place_door
   self.confirm_button:enable(false) -- Confirmation is via placing door
 
   -- Change the floor tiles to opaque blue
-  local map = self.ui.app.map.th
-  for y = self.blueprint_rect.y, self.blueprint_rect.y + self.blueprint_rect.h - 1 do
-    for x = self.blueprint_rect.x, self.blueprint_rect.x + self.blueprint_rect.w - 1 do
+  for y = rect.y, rect.y + rect.h - 1 do
+    for x = rect.x, rect.x + rect.w - 1 do
       map:setCell(x, y, 4, 24)
     end
   end
@@ -1636,6 +1640,16 @@ function UIEditRoom:placeObject()
   local obj = UIPlaceObjects.placeObject(self, true)
   if obj then
     self:checkEnableConfirm()
+  end
+end
+
+function UIEditRoom:_setCellFlagsOnBlueprint(flags)
+  local rect = self.blueprint_rect
+  local map = self.ui.app.map.th
+  for y = rect.y, rect.y + rect.h - 1 do
+    for x = rect.x, rect.x + rect.w - 1 do
+      map:setCellFlags(x, y, flags)
+    end
   end
 end
 

--- a/CorsixTH/Lua/humanoid_actions/walk.lua
+++ b/CorsixTH/Lua/humanoid_actions/walk.lua
@@ -198,28 +198,33 @@ local action_walk_tick; action_walk_tick = permanent"action_walk_tick"( function
   local map = humanoid.world.map.th
   map:getCellFlags(x1, y1, flags_here)
   map:getCellFlags(x2, y2, flags_there)
-  local recalc_route = not flags_there.passable and flags_here.passable
+  local avoid = (not flags_here.avoidTile) and flags_there.avoidTile
+  local not_passable = flags_here.passable and (not flags_there.passable)
+  local obstacle_on_the_way = not_passable or avoid -- approaching avoidable or impassable tile
+
   -- Also make sure that a room hasn't unexpectedly been built on top of the
   -- path since the route was calculated.
-  if not recalc_route and flags_here.roomId ~= flags_there.roomId then
+  if not obstacle_on_the_way and flags_here.roomId ~= flags_there.roomId then
     -- if going to the corridor we don't care as we are at the door
     -- as this will be false we won't bother checking for rerouting
-    recalc_route = flags_there.room
     local door = TheApp.objects.door.id
     local door2 = TheApp.objects.swing_door_right.id
     local doorcheck = {[door] = true, [door2] = true}
     -- but we should see if this is the same room id we want to go to and cancel the reroute
     -- ensure we still have a door on this route
-    if recalc_route and (humanoid.world:getObject(x1, y1, doorcheck) or
+    if flags_there.room and (humanoid.world:getObject(x1, y1, doorcheck) or
         humanoid.world:getObject(x2, y2, doorcheck)) and -- is there any door
         map:getCellFlags(path_x[#path_x], path_y[#path_y]).roomId ==
         flags_there.roomId then
       -- A walk including a trimmed path could have the last tile inside a room, and
       -- might need a new route completely (e.g. seek reception)
-      recalc_route = action.trimmed
+      obstacle_on_the_way = action.trimmed
+    else
+      obstacle_on_the_way = flags_there.room
     end
   end
-  if recalc_route then
+
+  if obstacle_on_the_way then
     if map:getCellFlags(x1, y1).passable then
       humanoid:setTilePositionSpeed(x1, y1)
       if action.on_next_tile_set then
@@ -229,6 +234,7 @@ local action_walk_tick; action_walk_tick = permanent"action_walk_tick"( function
         humanoid:finishAction(action)
         return
       end
+      -- find new path
       return action:on_restart(humanoid)
     end
   end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

Together with and on top of the #3414

This PR 

*Fixes #3382*
*Fixes #3386*

and forces humanoids to bypass construction sites.

**Describe what the proposed change does**
- Leave the `{passable = false}` setting to ensure the room won't create blocked areas. But immediately after checking, remove the `{passable = false}` just set. This way stop use `{passable = false}` as way to kick out humanoids away from a construction site. (Albert thoughts https://github.com/CorsixTH/CorsixTH/issues/3331#issuecomment-4744284886 taken into account)
- Instead of `{passable = false}` use `{avoidTile = true}`. Place `{avoidTile = true}` and `{avoidTile = false}` in the appropriate places in the room build code.
- Some refactor and move `map:setCellFlags(x, y, flags)` code to separated `function UIEditRoom:_setCellFlagsOnBlueprint(flags)`
- Finally, in `walk.lua` check `avoidTile` while walking to prevent entering construction site and passing through walls from construction site.
