### PR TITLE
Fix assert crash on MSVC debug builds

### DIFF
--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1069,9 +1069,7 @@ void chunk_renderer::chunk_copy(int npixels, const uint8_t* in_data) {
 }
 
 void chunk_renderer::fix_n_pixels(int& npixels) const {
-  if (ptr + npixels > end) {
-    npixels = static_cast<int>(end - ptr);
-  }
+  npixels = std::min(npixels, static_cast<int>(end - ptr));
 }
 
 void chunk_renderer::increment_position(int npixels) {


### PR DESCRIPTION
On MSVC debug builds there is an assert that verfies that an iterator is never out of range even if it is not accessed. This update accomplishes the same clamping without an out of range iterator.

Without this, you cannot run the CorsixTH in MSVC on Debug mode (at least with the latest runtimes)