### PR TITLE
Health Inspector must give epidemic results

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -1196,3 +1196,18 @@ function Humanoid:isObscuringArea(x1, x2, y1, y2)
   end
   return false
 end
+
+--! Check whether humanoids (staff and Inspector) are meandering
+--!return true if they currently has a meander action
+function Humanoid:isMeandering()
+  if #self.action_queue < 2 then return false end
+
+  -- "meander" action always insert "move" or "idle" action before itself.
+  -- so when humanoid "meandering" his action queue usually looks like:
+  -- [1 idle, 2 meander] or [1 walk, 2 meander].
+  local idle_is_first = self.action_queue[1].name == "idle"
+  local walk_is_first = self.action_queue[1].name == "walk"
+  local meander_is_second = self.action_queue[2].name == "meander"
+
+  return (idle_is_first or walk_is_first) and meander_is_second
+end

--- a/CorsixTH/Lua/entities/humanoids/inspector.lua
+++ b/CorsixTH/Lua/entities/humanoids/inspector.lua
@@ -66,6 +66,26 @@ function Inspector:announce()
   self.world.ui:playAnnouncement("vip008.wav", AnnouncementPriority.High)
 end
 
+function Inspector:tick()
+  Humanoid.tick(self)
+  self:checkForReceptionDesk()
+end
+
+--! React to reception desk status
+function Inspector:checkForReceptionDesk()
+  if self.going_home then return end
+  -- When the inspector realises the hospital does not have a reception desk or
+  -- the desk they were aiming for is gone, they will either:
+  if self:isMeandering() then
+    if self.hospital:hasReceptionDesk(true) then
+      self:setNextAction(SeekReceptionAction()) -- Head towards an existing desk
+    else
+      self.hospital.epidemic:handleInspectorArrival() -- Deliver results anyway
+      self:goHome()
+    end
+  end
+end
+
 function Inspector:afterLoad(old, new)
   if old < 213 then
     self.mood_marker = 2

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -509,21 +509,6 @@ function Staff:adviseWrongPersonForThisRoom()
   end
 end
 
---! Check whether staff are meandering
---!return true if staff currently has a meander action
-function Staff:isMeandering()
-  if #self.action_queue < 2 then return false end
-
-  -- "meander" action always insert "move" or "idle" action before itself.
-  -- so when humanoid "meandering" his action queue usually looks like:
-  -- [1 idle, 2 meander] or [1 walk, 2 meander].
-  local idle_is_first = self.action_queue[1].name == "idle"
-  local walk_is_first = self.action_queue[1].name == "walk"
-  local meander_is_second = self.action_queue[2].name == "meander"
-
-  return (idle_is_first or walk_is_first) and meander_is_second
-end
-
 -- Function to decide if staff currently has nothing to do and can be called to a room where they're needed
 function Staff:isIdle()
   -- Make sure we're not in an undesired state

--- a/CorsixTH/Lua/epidemic.lua
+++ b/CorsixTH/Lua/epidemic.lua
@@ -419,8 +419,8 @@ function Epidemic:finishCoverUp()
   self:turnOffVaccinationMode()
 end
 
---[[ Inspector had arrived at reception desk. Check if
-any infected still in hospital and determine final verdict.]]
+--[[ Inspector had arrived at reception desk, or a hospital without a desk.
+Check if any infected still in hospital and determine final verdict.]]
 function Epidemic:handleInspectorArrival()
   local still_infected = self:countInfectedPatients()
   self:determineFaxAndFines(still_infected)


### PR DESCRIPTION
*Fixes #3336*

**Describe what the proposed change does**
- When a health inspector is checking reports of an epidemic, they will wait five days in a hospital without a reception desk before sending the report in anyway and leaving. This wait is arbitrary, but similar to when a VIP visits a hospital without any rooms, they leave after five days.

Original behaviour found by Argamx
> when manipulating by movement and deleting the reception desk, there was a loophole that allowed undeserved epidemic victories. Essentially, it was cheating.
I think this was a bug in the original, and I'm not sure we need to reproduce it.

Previous Corsix behaviour was for the Inspector to stay at the hospital forever and never deliver the report.