### PR TITLE
Separate window size from render resolution

### DIFF
--- a/CorsixTH/Lua/api_version.lua
+++ b/CorsixTH/Lua/api_version.lua
@@ -32,4 +32,4 @@ Note: This file compiles as both Lua and C++. */
 
 #endif /*]] --*/
 
-return 2718;
+return 2719;

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -57,7 +57,8 @@ function App:App()
     mousewheel = self.onMouseWheel,
     motion = self.onMouseMove,
     active = self.onWindowActive,
-    window_resize = self.onWindowResize,
+    window_resized = self.onWindowResized,
+    window_pixel_size_changed = self.onWindowPixelSizeChanged,
     music_over = self.onMusicOver,
     movie_over = self.onMovieOver,
     sound_over = self.onSoundOver,
@@ -178,7 +179,6 @@ function App:init()
     SDL.limitFPS(false)
   end
 
-
   -- Create gamelog file.
   self:initGamelogFile()
 
@@ -188,11 +188,13 @@ function App:init()
   local gfx_set = good_install_folder and (self.using_demo_files and "demo" or "full") or "base"
   self.gfx = Graphics(self, gfx_set, charset)
 
+  local scr_w, scr_h = self.video:getRenderSize()
+
   -- Put up the loading screen
   if good_install_folder then
     self.video:startFrame()
     self.gfx:loadRaw("Load01V", 640, 480):draw(self.video,
-      math.floor((self.config.width - 640) / 2), math.floor((self.config.height - 480) / 2))
+      math.floor((scr_w - 640) / 2), math.floor((scr_h - 480) / 2))
     self.video:endFrame()
     -- Add some notices to the loading screen
     local notices = {}
@@ -205,9 +207,9 @@ function App:init()
     if notices ~= "" then
       self.video:startFrame()
       self.gfx:loadRaw("Load01V", 640, 480):draw(self.video,
-        math.floor((self.config.width - 640) / 2), math.floor((self.config.height - 480) / 2))
+        math.floor((scr_w - 640) / 2), math.floor((scr_h - 480) / 2))
       font:drawWrapped(self.video, notices, 32,
-        math.floor((self.config.height + 400) / 2), math.floor(self.config.width - 64), "center")
+        math.floor((scr_h + 400) / 2), math.floor(scr_w - 64), "center")
       self.video:endFrame()
     end
   end
@@ -725,7 +727,7 @@ function App:loadMainMenu(message)
   self.world = nil
   self.map = nil
 
-  self.ui = UI(self)
+  self.ui = UI(self, false)
   self.ui:setMenuBackground()
   self.ui:addWindow(UIMainMenu(self.ui))
   self.ui:addWindow(UITipOfTheDay(self.ui))
@@ -1385,9 +1387,15 @@ function App:onWindowActive(...)
 end
 
 --! Window has been resized by the user
---! Call the UI to handle the new window size
-function App:onWindowResize(...)
-  return self.ui:onWindowResize(...)
+--! Call the UI to report the new window size
+function App:onWindowResized(...)
+  return self.ui:onWindowResized(...)
+end
+
+--! Render size has changed
+--! Call the UI to adjust to the new render size
+function App:onWindowPixelSizeChanged(...)
+  return self.ui:onWindowPixelSizeChanged(...)
 end
 
 function App:onMusicOver(...)

--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -282,7 +282,8 @@ end
 --! Set the visual area for sound effects playback
 function Audio:setSoundStage()
   if self.sound_fx then
-    local w, h = self.app.config.width / 2, self.app.config.height / 2
+    local scr_w, scr_h = self.app.video:getRenderSize()
+    local w, h = scr_w / 2, scr_h / 2
     self.sound_fx:setCamera(math.floor(w), math.floor(h), math.floor((w^2 + h^2)^0.5))
   end
 end

--- a/CorsixTH/Lua/dialogs/bottom_panel.lua
+++ b/CorsixTH/Lua/dialogs/bottom_panel.lua
@@ -60,9 +60,10 @@ function UIBottomPanel:UIBottomPanel(ui)
 end
 
 function UIBottomPanel:machineMenuButtonExists()
-  local config = self.ui.app.config
+  local config = TheApp.config
+  local scr_w = TheApp.video:getRenderSize()
   -- Minimal screen width for a case where machine menu button exists is 676 pixels
-  if config.width / TheApp.config.ui_scale > 676 and config.machine_menu_button then
+  if scr_w > 676 * config.ui_scale and config.machine_menu_button then
     return true
   end
 

--- a/CorsixTH/Lua/dialogs/fullscreen.lua
+++ b/CorsixTH/Lua/dialogs/fullscreen.lua
@@ -44,9 +44,10 @@ end
 
 function UIFullscreen:onChangeResolution()
   local app = self.ui.app
+  local sw, sh = app.video:getRenderSize()
   local s = app.config.ui_scale
-  local sw = app.config.width / s
-  local sh = app.config.height / s
+  sw = sw / s
+  sh = sh / s
   if sw > self.width or sh > self.height then
     if not self.border_sprites then
       self.border_sprites = app.gfx:loadSpriteTable("Bitmap", "aux_ui", true)

--- a/CorsixTH/Lua/dialogs/menu.lua
+++ b/CorsixTH/Lua/dialogs/menu.lua
@@ -36,7 +36,7 @@ function UIMenuBar:UIMenuBar(ui, map_editor)
   self.on_top = true
   self.x = 0
   self.y = 0
-  self.width = app.config.width
+  self.width = app.video:getRenderSize()
   self.height = 16
   self.visible = false
   local selected_label_color = { red = 40, green = 40, blue = 250 }
@@ -103,7 +103,7 @@ function UIMenuBar:onTick()
 end
 
 function UIMenuBar:onChangeResolution()
-  self.width = self.ui.app.config.width
+  self.width = TheApp.video:getRenderSize()
 end
 
 function UIMenuBar:onChangeLanguage()

--- a/CorsixTH/Lua/dialogs/resizables/file_browser.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browser.lua
@@ -78,9 +78,10 @@ function FilteredTreeControl:FilteredTreeControl(root, x, y, width, height, col_
   self.num_rows = (self.tree_rect.h - self.y_offset) / self.row_height
 
   -- Magic numbers used to find a static position across different screen resolutions.
-  local button1x = math.floor(TheApp.ui.app.config.width / 2 - 90)
+  local scr_w, scr_h = TheApp.video:getRenderSize()
+  local button1x = math.floor(scr_w / 2 - 90)
   local button2x = button1x + 210
-  local buttony = math.floor(TheApp.ui.app.config.height / 4 - 95)
+  local buttony = math.floor(scr_h / 4 - 95)
   -- Add the two column headers and make buttons on them.
   if show_dates then
     self:addBevelPanel(1, 1, width - 170, 13, col_bg):setLabel(_S.menu_list_window.name)

--- a/CorsixTH/Lua/dialogs/resizables/options.lua
+++ b/CorsixTH/Lua/dialogs/resizables/options.lua
@@ -458,6 +458,7 @@ function UIOptions:selectUIScale(number)
   TheApp:saveConfig()
   self.scale_ui_panel:setLabel(res.text)
   self.ui:changeResolution(TheApp.config.width, TheApp.config.height)
+  self.ui:onChangeResolution()
   TheApp.gfx:onChangeUIScale()
 end
 

--- a/CorsixTH/Lua/dialogs/resizables/tip_of_the_day.lua
+++ b/CorsixTH/Lua/dialogs/resizables/tip_of_the_day.lua
@@ -34,7 +34,8 @@ function UITipOfTheDay:UITipOfTheDay(ui)
   local app = ui.app
   -- If the application window is not wide enough,
   --  the tips window is narrower and taller to fit beside the main menu
-  local width = math.min(380, math.floor(app.config.width / 2) - 150)
+  local scr_w = app.video:getRenderSize()
+  local width = math.min(380, math.floor(scr_w / 2) - 150)
   local height = width > 290 and 110 or 210
   self:UIResizable(ui, width, height, col_bg)
 

--- a/CorsixTH/Lua/game_ui.lua
+++ b/CorsixTH/Lua/game_ui.lua
@@ -48,7 +48,7 @@ local key_scroll_speed = 10
 --!param local_hospital Hospital to display
 --!param map_editor (bool) Whether the map is editable.
 function GameUI:GameUI(app, local_hospital, map_editor)
-  self:UI(app)
+  self:UI(app, false)
   self.app = app
 
   self.hospital = local_hospital
@@ -69,8 +69,7 @@ function GameUI:GameUI(app, local_hospital, map_editor)
   self.subtitles = Subtitles(self)
   self:addWindow(self.subtitles)
 
-  local scr_w = app.config.width
-  local scr_h = app.config.height
+  local scr_w, scr_h = app.video:getRenderSize()
   self.visible_diamond = self:makeVisibleDiamond(scr_w, scr_h)
   if self.visible_diamond.w <= 0 or self.visible_diamond.h <= 0 then
     -- For a standard 128x128 map, screen size would have to be in the
@@ -196,8 +195,7 @@ end
 --! makeVisibleDiamond. This function calculates the minimum zoom_factor that
 --! would be allowed.
 function GameUI:calculateMinimumZoom()
-  local scr_w = self.app.config.width
-  local scr_h = self.app.config.height
+  local scr_w, scr_h = TheApp.video:getRenderSize()
   local map_h = self.app.map.height
 
   -- Minimum width:  0 = 32 * map_h - (scr_h/factor) - (scr_w/factor) / 2,
@@ -219,8 +217,7 @@ function GameUI:setZoom(factor)
     factor = 1
   end
 
-  local scr_w = self.app.config.width
-  local scr_h = self.app.config.height
+  local scr_w, scr_h = TheApp.video:getRenderSize()
   local new_diamond = self:makeVisibleDiamond(scr_w / factor, scr_h / factor)
   if new_diamond.w < 0 or new_diamond.h < 0 then
     return false
@@ -240,7 +237,7 @@ end
 
 function GameUI:draw(canvas)
   local app = self.app
-  local config = app.config
+  local scr_w, scr_h = canvas:getRenderSize()
   if self.map_editor or not self.in_visible_diamond then
     canvas:fillBlack()
   end
@@ -250,11 +247,11 @@ function GameUI:draw(canvas)
   local dy = self.screen_offset_y +
       math.floor((0.5 - math.random()) * self.shake_screen_intensity * shake_screen_max_movement * 2)
   if canvas:scale(zoom) then
-    app.map:draw(canvas, dx, dy, math.ceil(config.width / zoom), math.ceil(config.height / zoom), 0, 0)
+    app.map:draw(canvas, dx, dy, math.ceil(scr_w / zoom), math.ceil(scr_h / zoom), 0, 0)
     canvas:scale(1)
   else
     self:setZoom(1)
-    app.map:draw(canvas, dx, dy, config.width, config.height, 0, 0)
+    app.map:draw(canvas, dx, dy, scr_w, scr_h, 0, 0)
   end
   Window.draw(self, canvas, 0, 0) -- NB: not calling UI.draw on purpose
   self:drawTooltip(canvas)
@@ -270,8 +267,7 @@ function GameUI:onChangeResolution()
     self:setZoom(minimum_zoom)
   end
   -- Recalculate scrolling bounds
-  local scr_w = self.app.config.width
-  local scr_h = self.app.config.height
+  local scr_w, scr_h = TheApp.video:getRenderSize()
   self.visible_diamond = self:makeVisibleDiamond(scr_w / self.zoom_factor, scr_h / self.zoom_factor)
   self:scrollMap(0, 0)
 
@@ -611,21 +607,22 @@ function GameUI:onMouseMove(x, y, dx, dy)
     -- In windowed mode, a reasonable size is needed, though not too large.
     scroll_region_size = 8
   end
+  local scr_w, scr_h = TheApp.video:getRenderSize()
   if not self.app.config.prevent_edge_scrolling and
       (x < scroll_region_size or y < scroll_region_size or
-       x >= self.app.config.width - scroll_region_size or
-       y >= self.app.config.height - scroll_region_size) then
+       x >= scr_w - scroll_region_size or
+       y >= scr_h - scroll_region_size) then
     local scroll_dx = 0
     local scroll_dy = 0
     local scroll_power = 7
     if x < scroll_region_size then
       scroll_dx = -scroll_power
-    elseif x >= self.app.config.width - scroll_region_size then
+    elseif x >= scr_w - scroll_region_size then
       scroll_dx = scroll_power
     end
     if y < scroll_region_size then
       scroll_dy = -scroll_power
-    elseif y >= self.app.config.height - scroll_region_size then
+    elseif y >= scr_h - scroll_region_size then
       scroll_dy = scroll_power
     end
 
@@ -903,9 +900,9 @@ local abs, sqrt_5, floor = math.abs, math.sqrt(1 / 5), math.floor
 
 function GameUI:scrollMapTo(x, y)
   local zoom = 2 * self.zoom_factor
-  local config = self.app.config
-  return self:scrollMap(x - self.screen_offset_x - config.width / zoom,
-                        y - self.screen_offset_y - config.height / zoom)
+  local scr_w, scr_h = TheApp.video:getRenderSize()
+  return self:scrollMap(x - self.screen_offset_x - scr_w / zoom,
+                        y - self.screen_offset_y - scr_h / zoom)
 end
 
 function GameUI.limitPointToDiamond(dx, dy, visible_diamond, do_limit)
@@ -1227,7 +1224,8 @@ end
 --! Converts centre of screen coordinates to world tile positions and stores the values for later recall
 -- param index (integer) Position in recallpositions table
 function GameUI:setMapRecallPosition(index)
-  local cx, cy = self:ScreenToWorld(self.app.config.width / 2, self.app.config.height / 2)
+  local scr_w, scr_h = TheApp.video:getRenderSize()
+  local cx, cy = self:ScreenToWorld(scr_w / 2, scr_h / 2)
   self.recallpositions[index] = {x = cx, y = cy, z = self.zoom_factor}
 end
 
@@ -1235,8 +1233,9 @@ end
 -- param index (integer) Position in recallpositions table
 function GameUI:recallMapPosition(index)
   if self.recallpositions[index] ~= nil then
+    local scr_w, scr_h = TheApp.video:getRenderSize()
     local sx, sy = self.app.map:WorldToScreen(self.recallpositions[index].x,  self.recallpositions[index].y)
-    local dx, dy = self.app.map:ScreenToWorld(self.app.config.width / 2, self.app.config.height / 2)
+    local dx, dy = self.app.map:ScreenToWorld(scr_w / 2, scr_h / 2)
     self:setZoom(self.recallpositions[index].z)
     self:scrollMapTo(sx + dx, sy + dy)
   end

--- a/CorsixTH/Lua/movie_player.lua
+++ b/CorsixTH/Lua/movie_player.lua
@@ -43,7 +43,7 @@ local MoviePlayer = _G["MoviePlayer"]
 local calculateSize = function(me)
   -- calculate target dimensions
   local x, y, w, h, scale
-  local screen_w, screen_h = me.app.config.width, me.app.config.height
+  local screen_w, screen_h = me.app.video:getRenderSize()
   local native_w = me.moviePlayer:getNativeWidth()
   local native_h = me.moviePlayer:getNativeHeight()
   if native_w == 320 and native_h == 200 then

--- a/CorsixTH/Lua/sprite_viewer.lua
+++ b/CorsixTH/Lua/sprite_viewer.lua
@@ -202,7 +202,7 @@ local function Render(canvas)
   font:draw(canvas, msg, 0, y)
   y = y + fonth + sep
   local x = 0
-  local sw, sh = TheApp.config.width, TheApp.config.height
+  local sw, sh = canvas:getRenderSize()
   local tallest = 0
   for i = 0, #sprite_table - 1 do
     local w, h = sprite_table:size(i)

--- a/CorsixTH/Lua/ui.lua
+++ b/CorsixTH/Lua/ui.lua
@@ -300,10 +300,9 @@ function UI:drawTooltip(canvas)
 end
 
 function UI:draw(canvas)
-  local app = self.app
   if self.background then
     local bg_w, bg_h = self.background_width, self.background_height
-    local screen_w, screen_h = app.config.width, app.config.height
+    local screen_w, screen_h = canvas:getRenderSize()
     local factor = math.max(screen_w / bg_w, screen_h / bg_h)
     if canvas:scale(factor, "bitmap") or canvas:scale(factor) then
       self.background:draw(canvas, math.floor((screen_w - bg_w * factor) / 2), math.floor((screen_h - bg_h * factor) / 2))
@@ -547,6 +546,11 @@ function UI:setMenuBackground()
 end
 
 function UI:onChangeResolution()
+  -- Redraw cursor
+  local cursor = self.cursor
+  self.cursor = nil
+  self:setCursor(cursor)
+
   -- If we are in the main menu (== no world), reselect the background
   if not self.app.world then
     self:setMenuBackground()
@@ -604,17 +608,16 @@ function UI:changeResolution(width, height)
     return false
   end
 
-  self.app.config.width = width
-  self.app.config.height = height
+  -- If changing the aspect ratio when fullscreen the window is not resized and
+  -- the pixel size doesn't change so we need to handle updating the config and
+  -- the render dimensions ourselves.
+  if self.app.config.fullscreen then
+    self.app.config.width = width
+    self.app.config.height = height
+    self.app:saveConfig()
 
-  -- Redraw cursor
-  local cursor = self.cursor
-  self.cursor = nil
-  self:setCursor(cursor)
-  -- Save new setting in config
-  self.app:saveConfig()
-
-  self:onChangeResolution()
+    self:onChangeResolution()
+  end
 
   return true
 end
@@ -701,11 +704,6 @@ function UI:toggleFullscreen()
     -- Revert fullscreen mode modifications
     toggleMode(index)
   end
-
-  -- Redraw cursor
-  local cursor = self.cursor
-  self.cursor = nil
-  self:setCursor(cursor)
 
   if success then
     -- Save new setting in config
@@ -886,8 +884,9 @@ function UI:onMouseDown(code, x, y)
     self:setCursor(self.down_cursor)
     repaint = true
   end
+  local scr_w, scr_h = self.app.video:getRenderSize()
   self.down_count = self.down_count + 1
-  if x >= 3 and y >= 3 and x < self.app.config.width - 3 and y < self.app.config.height - 3 then
+  if x >= 3 and y >= 3 and x < scr_w - 3 and y < scr_h - 3 then
     self.buttons_down["mouse_"..button] = true
   end
 
@@ -989,10 +988,26 @@ end
 --! Window has been resized by the user
 --!param width (integer) New window width
 --!param height (integer) New window height
-function UI:onWindowResize(width, height)
+function UI:onWindowResized(width, height)
   if not self.app.config.fullscreen then
-    self:changeResolution(width, height)
+    self.app.config.width = width
+    self.app.config.height = height
+
+    -- Save new setting in config
+    self.app:saveConfig()
   end
+end
+
+--! Render area size has been changed
+-- This could be because the user resized the window or updated the size
+-- through settings, or on a system where the window size is independent of the
+-- render size the window could have been dragged from a HiDPI monitor to a
+-- standard DPI monitor.
+--
+--!param width (integer) New renderer width
+--!param height (integer) New renderer height
+function UI:onWindowPixelSizeChanged(width, height)
+  self:onChangeResolution()
 end
 
 function UI:onMouseMove(x, y, dx, dy)
@@ -1146,6 +1161,7 @@ end
 function UI:afterLoad(old, new)
   -- Get rid of old key handlers from save file.
   self.key_handlers = {}
+
   if old < 5 then
     self.editing_allowed = true
   end

--- a/CorsixTH/Lua/window.lua
+++ b/CorsixTH/Lua/window.lua
@@ -82,8 +82,11 @@ function Window:setPosition(x, y)
   self.x_original = x
   self.y_original = y
   -- Convert x and y to absolute pixel positions with regard to top/left
-  local s = self.apply_ui_scale and TheApp.config.ui_scale or 1
-  local w, h = TheApp.config.width / s, TheApp.config.height / s
+  local w, h = TheApp.video:getRenderSize()
+  if self.apply_ui_scale then
+    w = w / TheApp.config.ui_scale
+    h = h / TheApp.config.ui_scale
+  end
   if x < 0 then
     x = math.ceil(w - self.width + x)
   elseif x < 1 then
@@ -1813,7 +1816,7 @@ function Window:beginDrag(x, y)
     sx = sx - x
     sy = sy - y
     -- Calculate best positioning
-    local w, h = TheApp.config.width, TheApp.config.height
+    local w, h = TheApp.video:getRenderSize()
     if TheApp.key_modifiers.ctrl then
       local px = round(sx / (w - self.width * s), 0.1)
       local py = round(sy / (h - self.height * s), 0.1)

--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -184,7 +184,7 @@ function World:setUI(ui)
 end
 
 function World:adjustZoom(delta)
-  local scr_w = self.ui.app.config.width
+  local scr_w = TheApp.video:getRenderSize()
   local factor = self.ui.app.config.zoom_speed
   local virtual_width = scr_w / (self.ui.zoom_factor or 1)
 

--- a/CorsixTH/Luatest/TH.lua
+++ b/CorsixTH/Luatest/TH.lua
@@ -50,6 +50,9 @@ TheApp = {
     setPatientMarker = function(...) end,
     setStaffMarker = function(...) end,
   },
+  video = {
+    getRenderSize = function() return 0, 0 end
+  }
 }
 
 local sub_S = setmetatable({key = ''}, {

--- a/CorsixTH/Src/sdl_core.cpp
+++ b/CorsixTH/Src/sdl_core.cpp
@@ -288,7 +288,9 @@ constexpr std::string_view dispatch_movie_over("movie_over");
 constexpr std::string_view dispatch_sound_over("sound_over");
 constexpr std::string_view dispatch_timer("timer");
 constexpr std::string_view dispatch_callback("callback");
-constexpr std::string_view dispatch_window_resize("window_resize");
+constexpr std::string_view dispatch_window_resized("window_resized");
+constexpr std::string_view dispatch_window_pixel_size_changed(
+    "window_pixel_size_changed");
 constexpr std::string_view dispatch_frame("frame");
 
 void mainloop(lua_State* L) {
@@ -415,8 +417,15 @@ void mainloop(lua_State* L) {
           lua_pushinteger(L, 0);
           nargs = 2;
           break;
+        case SDL_EVENT_WINDOW_RESIZED:
+          last_dispatch = dispatch_window_resized;
+          push_app_dispatch(L, last_dispatch);
+          lua_pushinteger(L, e.window.data1);
+          lua_pushinteger(L, e.window.data2);
+          nargs = 3;
+          break;
         case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
-          last_dispatch = dispatch_window_resize;
+          last_dispatch = dispatch_window_pixel_size_changed;
           push_app_dispatch(L, last_dispatch);
           lua_pushinteger(L, e.window.data1);
           lua_pushinteger(L, e.window.data2);

--- a/CorsixTH/Src/th_gfx.cpp
+++ b/CorsixTH/Src/th_gfx.cpp
@@ -1205,7 +1205,7 @@ void animation::draw(render_target* canvas, const xy_pair& draw_pos) {
     if (flags & thdf_crop) {
       clip_rect rcNew;
       rcNew.y = 0;
-      rcNew.h = canvas->get_height();
+      rcNew.h = canvas->get_scaled_height();
       rcNew.x = x + (crop_column - 1) * 32 * scale_factor;
       rcNew.w = 64 * scale_factor;
       render_target::scoped_clip clip(canvas, &rcNew);
@@ -1262,7 +1262,7 @@ void animation::draw_morph(render_target* canvas, const xy_pair& draw_pos) {
   // We set the morph rect x and w clip to the entire canvas, so that only
   // vertical clipping is applied.
   oMorphRect.x = 0;
-  oMorphRect.w = canvas->get_width();
+  oMorphRect.w = canvas->get_scaled_width();
   oMorphRect.y = y + morph_target->pixel_offset.x * scale_factor;
   oMorphRect.h = (morph_target->pixel_offset.y - morph_target->pixel_offset.x) *
                  scale_factor;

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -371,8 +371,6 @@ render_target::scoped_target_texture::scoped_target_texture(
   }
 
   // Clear the new texture to transparent/black.
-  SDL_SetRenderLogicalPresentation(target->renderer, rect.w, rect.h,
-                                   SDL_LOGICAL_PRESENTATION_LETTERBOX);
   SDL_SetRenderDrawColor(target->renderer, 0, 0, 0, SDL_ALPHA_TRANSPARENT);
   SDL_RenderClear(target->renderer);
   target->current_target = this;
@@ -399,11 +397,6 @@ render_target::scoped_target_texture::~scoped_target_texture() {
     std::fprintf(stderr, "scoped_target_texture destructor error: %s",
                  SDL_GetError());
   }
-  SDL_SetRenderLogicalPresentation(
-      target->renderer,
-      previous_target ? previous_target->rect.w : target->width,
-      previous_target ? previous_target->rect.h : target->height,
-      SDL_LOGICAL_PRESENTATION_LETTERBOX);
   SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
   target->current_target = previous_target;
   if (scale) {

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -188,6 +188,66 @@ class scoped_color_mod {
   SDL_Texture* texture;
 };
 
+/**
+ * Applies or removes letterboxing while preserving 1:1 pixel output
+ * with the renderer for crisp output.
+ *
+ * \param renderer - The SDL_Renderer to apply to
+ * \param fullscreen - Whether the window is fullscreen. In window mode it is
+ *                     assumed that the aspect ratio matches the window and no
+ *                     letterbox is needed.
+ * \param ar_w - The aspect ratio width, e.g. 16 in 16:9, or 4 in 4:3. Can use
+ *               the target resolution width.
+ * \param ar_h - The aspect ratio height, e.g. 9 in 16:9, or 3 in 4:3. Can use
+ *               the target resolution height.
+ */
+void apply_letterbox(SDL_Renderer* renderer, bool fullscreen, int ar_w,
+                     int ar_h) {
+  // If not fullscreen we can assume a match and exit early
+  SDL_SetRenderViewport(renderer, nullptr);
+  if (!fullscreen) {
+    return;
+  }
+
+  int w;
+  int h;
+  // Get the true render size (without any letterbox/logical voodoo)
+  SDL_GetRenderOutputSize(renderer, &w, &h);
+
+  float real_ar = static_cast<float>(w) / static_cast<float>(h);
+  float target_ar = static_cast<float>(ar_w) / static_cast<float>(ar_h);
+
+  // Common target aspect ratios are 4:3, 16:10, and 16:9 which work out to
+  // 1.333, 1.6, and 1.777
+
+  // If we are closer than 0.01 to the target aspect ratio, assume we
+  // meant to match.
+  if (std::abs(real_ar - target_ar) < 0.01) {
+    return;
+  }
+
+  int target_w;
+  int target_h;
+
+  // Otherwise determine if we are letterboxing vertically or horizontally to
+  // preserve the target aspect ratio.
+
+  // If the real aspect ratio is greater than the target aspect ratio it means
+  // the screen is wider than the target - we want vertical bars.
+  // Otherwise, we want horizontal bars.
+  if (real_ar > target_ar) {
+    target_w = static_cast<int>(h * target_ar);
+    target_h = h;
+  } else {
+    target_w = w;
+    target_h = static_cast<int>(w / target_ar);
+  }
+
+  SDL_Rect viewport = {(w - target_w) / 2, (h - target_h) / 2, target_w,
+                       target_h};
+  SDL_SetRenderViewport(renderer, &viewport);
+}
+
 }  // namespace
 
 palette::palette(const uint8_t* pData, size_t iDataLength, bool is8bit) {
@@ -415,16 +475,16 @@ render_target::scoped_target_texture::~scoped_target_texture() {
 }
 
 render_target::render_target(const render_target_creation_params& params)
-    : width{params.width},
-      height{params.height},
-      direct_zoom{params.direct_zoom} {
+    : direct_zoom{params.direct_zoom} {
   pixel_format = SDL_GetPixelFormatDetails(SDL_PIXELFORMAT_ABGR8888);
 
   SDL_PropertiesID winProps = SDL_CreateProperties();
   SDL_SetStringProperty(winProps, SDL_PROP_WINDOW_CREATE_TITLE_STRING,
                         "CorsixTH");
-  SDL_SetNumberProperty(winProps, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, width);
-  SDL_SetNumberProperty(winProps, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, height);
+  SDL_SetNumberProperty(winProps, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER,
+                        params.width);
+  SDL_SetNumberProperty(winProps, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER,
+                        params.height);
   SDL_SetNumberProperty(winProps, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER,
                         SDL_WINDOW_RESIZABLE);
   SDL_SetBooleanProperty(winProps, SDL_PROP_WINDOW_CREATE_FULLSCREEN_BOOLEAN,
@@ -459,10 +519,7 @@ render_target::render_target(const render_target_creation_params& params)
 
   SDL_SetWindowMinimumSize(window, params.min_width, params.min_height);
 
-  SDL_RendererLogicalPresentation rlp = params.fullscreen
-                                            ? SDL_LOGICAL_PRESENTATION_LETTERBOX
-                                            : SDL_LOGICAL_PRESENTATION_DISABLED;
-  SDL_SetRenderLogicalPresentation(renderer, width, height, rlp);
+  apply_letterbox(renderer, params.fullscreen, params.width, params.height);
 
   // Workaround for https://github.com/libsdl-org/SDL/issues/13920 on MacOS
   SDL_Event evt;
@@ -487,23 +544,14 @@ render_target::~render_target() {
 }
 
 bool render_target::update(const render_target_creation_params& params) {
-  bool bUpdateSize = (width != params.width) || (height != params.height);
-  width = params.width;
-  height = params.height;
-
   bool bIsFullscreen = ((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) ==
                         SDL_WINDOW_FULLSCREEN);
   if (bIsFullscreen != params.fullscreen) {
     SDL_SetWindowFullscreen(window, params.fullscreen);
   }
 
-  if (bUpdateSize || bIsFullscreen != params.fullscreen) {
-    SDL_SetWindowSize(window, width, height);
-    SDL_RendererLogicalPresentation rlp =
-        params.fullscreen ? SDL_LOGICAL_PRESENTATION_LETTERBOX
-                          : SDL_LOGICAL_PRESENTATION_DISABLED;
-    SDL_SetRenderLogicalPresentation(renderer, width, height, rlp);
-  }
+  SDL_SetWindowSize(window, params.width, params.height);
+  apply_letterbox(renderer, params.fullscreen, params.width, params.height);
 
   int old_min_width;
   int old_min_height;
@@ -528,8 +576,10 @@ bool render_target::set_scale_factor(double fScale, scaled_items eWhatToScale) {
         SDL_WINDOW_FULLSCREEN) {
       // Drawing to an intermediate screen sized buffer when fullscreen results
       // in noticeably better text rendering quality.
+      int w = get_width();
+      int h = get_height();
       zoom_buffer =
-          std::make_unique<scoped_target_texture>(this, 0, 0, width, height,
+          std::make_unique<scoped_target_texture>(this, 0, 0, w, h,
                                                   /* bScale = */ true);
     }
     return true;
@@ -537,8 +587,10 @@ bool render_target::set_scale_factor(double fScale, scaled_items eWhatToScale) {
     // Draw everything from now until the next scale to zoom_texture
     // with the appropriate virtual size, which will be copied scaled to
     // fit the window.
-    int virtWidth = static_cast<int>(width / fScale);
-    int virtHeight = static_cast<int>(height / fScale);
+    int w = get_width();
+    int h = get_height();
+    int virtWidth = static_cast<int>(w / fScale);
+    int virtHeight = static_cast<int>(h / fScale);
 
     zoom_buffer = std::make_unique<scoped_target_texture>(
         this, 0, 0, virtWidth, virtHeight, /* bScale = */ false);
@@ -677,15 +729,25 @@ void render_target::pop_clip_rect() {
 }
 
 int render_target::get_width() const {
-  int w;
-  SDL_GetCurrentRenderOutputSize(renderer, &w, nullptr);
-  return static_cast<int>(std::ceil(w / draw_scale()));
+  SDL_Rect rect;
+  SDL_GetRenderViewport(renderer, &rect);
+  return rect.w;
 }
 
 int render_target::get_height() const {
-  int h;
-  SDL_GetCurrentRenderOutputSize(renderer, nullptr, &h);
-  return static_cast<int>(std::ceil(h / draw_scale()));
+  SDL_Rect rect;
+  SDL_GetRenderViewport(renderer, &rect);
+  return rect.h;
+}
+
+int render_target::get_scaled_width() const {
+  int w = get_width();
+  return static_cast<int>(w / draw_scale());
+}
+
+int render_target::get_scaled_height() const {
+  int h = get_height();
+  return static_cast<int>(h / draw_scale());
 }
 
 void render_target::start_nonoverlapping_draws() {

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -458,8 +458,11 @@ render_target::render_target(const render_target_creation_params& params)
   SDL_DestroyTexture(testTexture);
 
   SDL_SetWindowMinimumSize(window, params.min_width, params.min_height);
-  SDL_SetRenderLogicalPresentation(renderer, width, height,
-                                   SDL_LOGICAL_PRESENTATION_LETTERBOX);
+
+  SDL_RendererLogicalPresentation rlp = params.fullscreen
+                                            ? SDL_LOGICAL_PRESENTATION_LETTERBOX
+                                            : SDL_LOGICAL_PRESENTATION_DISABLED;
+  SDL_SetRenderLogicalPresentation(renderer, width, height, rlp);
 
   // Workaround for https://github.com/libsdl-org/SDL/issues/13920 on MacOS
   SDL_Event evt;
@@ -496,11 +499,10 @@ bool render_target::update(const render_target_creation_params& params) {
 
   if (bUpdateSize || bIsFullscreen != params.fullscreen) {
     SDL_SetWindowSize(window, width, height);
-  }
-
-  if (bUpdateSize) {
-    SDL_SetRenderLogicalPresentation(renderer, width, height,
-                                     SDL_LOGICAL_PRESENTATION_LETTERBOX);
+    SDL_RendererLogicalPresentation rlp =
+        params.fullscreen ? SDL_LOGICAL_PRESENTATION_LETTERBOX
+                          : SDL_LOGICAL_PRESENTATION_DISABLED;
+    SDL_SetRenderLogicalPresentation(renderer, width, height, rlp);
   }
 
   int old_min_width;

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -565,6 +565,8 @@ bool render_target::update(const render_target_creation_params& params) {
     SDL_SetWindowMinimumSize(window, params.min_width, params.min_height);
   }
 
+  SDL_SyncWindow(window);
+
   return true;
 }
 

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -487,6 +487,7 @@ render_target::render_target(const render_target_creation_params& params)
                         params.height);
   SDL_SetNumberProperty(winProps, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER,
                         SDL_WINDOW_RESIZABLE);
+  SDL_SetBooleanProperty(winProps, SDL_PROP_WINDOW_CREATE_HIDDEN_BOOLEAN, true);
   SDL_SetBooleanProperty(winProps, SDL_PROP_WINDOW_CREATE_FULLSCREEN_BOOLEAN,
                          params.fullscreen);
   window = SDL_CreateWindowWithProperties(winProps);
@@ -520,6 +521,9 @@ render_target::render_target(const render_target_creation_params& params)
   SDL_SetWindowMinimumSize(window, params.min_width, params.min_height);
 
   apply_letterbox(renderer, params.fullscreen, params.width, params.height);
+
+  SDL_ShowWindow(window);
+  SDL_SyncWindow(window);
 
   // Workaround for https://github.com/libsdl-org/SDL/issues/13920 on MacOS
   SDL_Event evt;

--- a/CorsixTH/Src/th_gfx_sdl.cpp
+++ b/CorsixTH/Src/th_gfx_sdl.cpp
@@ -427,6 +427,8 @@ render_target::render_target(const render_target_creation_params& params)
   SDL_SetNumberProperty(winProps, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, height);
   SDL_SetNumberProperty(winProps, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER,
                         SDL_WINDOW_RESIZABLE);
+  SDL_SetBooleanProperty(winProps, SDL_PROP_WINDOW_CREATE_FULLSCREEN_BOOLEAN,
+                         params.fullscreen);
   window = SDL_CreateWindowWithProperties(winProps);
   SDL_DestroyProperties(winProps);
   if (!window) {
@@ -458,8 +460,6 @@ render_target::render_target(const render_target_creation_params& params)
   SDL_SetWindowMinimumSize(window, params.min_width, params.min_height);
   SDL_SetRenderLogicalPresentation(renderer, width, height,
                                    SDL_LOGICAL_PRESENTATION_LETTERBOX);
-
-  update(params);
 
   // Workaround for https://github.com/libsdl-org/SDL/issues/13920 on MacOS
   SDL_Event evt;

--- a/CorsixTH/Src/th_gfx_sdl.h
+++ b/CorsixTH/Src/th_gfx_sdl.h
@@ -299,11 +299,17 @@ class render_target {
   //! Restore the previous clip rectangle.
   void pop_clip_rect();
 
-  //! Get the width of the render target (in pixels)
+  //! Get the width of the render viewport (in pixels)
   int get_width() const;
 
-  //! Get the height of the render target (in pixels)
+  //! Get the height of the render viewport (in pixels)
   int get_height() const;
+
+  //! Get the width of the render target adjusted by the current scale factor
+  int get_scaled_width() const;
+
+  //! Get the height of the render target adjusted by the current scale factor
+  int get_scaled_height() const;
 
   //! Enable optimisations for non-overlapping draws
   void start_nonoverlapping_draws();
@@ -417,8 +423,6 @@ class render_target {
   cursor* game_cursor{nullptr};
   double bitmap_scale_factor{1.0};  ///< Bitmap scale factor.
   double global_scale_factor{1.0};  ///< Global scale factor.
-  int width{-1};
-  int height{-1};
   int cursor_x{};
   int cursor_y{};
 

--- a/CorsixTH/Src/th_lua_gfx.cpp
+++ b/CorsixTH/Src/th_lua_gfx.cpp
@@ -968,6 +968,13 @@ int l_surface_get_height(lua_State* L) {
   return 1;
 }
 
+int l_surface_get_render_dimensions(lua_State* L) {
+  render_target* pCanvas = luaT_testuserdata<render_target>(L);
+  lua_pushinteger(L, pCanvas->get_width());
+  lua_pushinteger(L, pCanvas->get_height());
+  return 2;
+}
+
 int l_surface_scale(lua_State* L) {
   ZoneScoped;
 
@@ -1195,6 +1202,7 @@ void lua_register_gfx(const lua_register_state* pState) {
     lcb.add_function(l_surface_pop_clip, "popClip");
     lcb.add_function(l_surface_get_width, "getWidth");
     lcb.add_function(l_surface_get_height, "getHeight");
+    lcb.add_function(l_surface_get_render_dimensions, "getRenderSize");
     lcb.add_function(l_surface_screenshot, "takeScreenshot");
     lcb.add_function(l_surface_scale, "scale");
     lcb.add_function(l_surface_set_caption, "setCaption");


### PR DESCRIPTION
This PR prepares for SDL3 HiDPI support for supporting operating systems and window managers where the logical window size does not match actual pixel resolution, such as MacOS and Wayland.

The biggest user visible change here is that the resolution setting no longer dictates the full screen resolution - I didn't see any way of aligning the logical/physical pixel concepts and intentionally selecting a lower resolution. The aspect ratio is respected in this patch; but I'm left wondering if our config is really ideal.

Reading the patches:
The first three commits are simple cleanup/refactor that could be applied without any intention to support HiDPI; removing unnecessary rendering complexity.

The forth commit is by far the biggest, that is where I separate the idea of window size from render pixels in anticipation of HiDPI support. It has one user visible change which is to always apply full screen at (logical) desktop resolution.

The fifth commit is to address some minor flicker and more importantly an SDL issue running on MacOS where a window may not be given focus.

The final commit is to ensure that everything remains in sync on updates as it would have with SDL2. It may not be necessary, but felt safer.

Out of scope:
1. The constraints around the ui_scale option. We went pretty far (too far?) preventing the user from selecting values that didn't make sense for their window size; but now that the window size isn't the actual render size the settings are over constrained. I'm not exactly sure yet how we are going to get out of that one. It either involves automatically/always applying a hidden ui scale factor on top of the user selected scale factor when physical pixels are not the same as window dimensions OR allowing the user the freedom to pick window sizes and ui_scales that would not work together and clamping the size at rendering time instead.

2. A thought I had is to have a 4:3 checkbox option visible in both full screen mode which adds the letter boxing on wide screen monitors. I would then hide the window size option and show the aspect ratio option when full screen was checked. There is NO reason anyone would want an aspect ratio other than their native or 4:3 (original game).

3. Enabling HiDPI. I did not want to regress the experience on MacOS (or Wayland) until we sorted out the ui_scale options.
