### PR TITLE
Prevent reception desk blocking room entrance

### DIFF
--- a/CorsixTH/Lua/dialogs/edit_room.lua
+++ b/CorsixTH/Lua/dialogs/edit_room.lua
@@ -1231,7 +1231,7 @@ local function validDoorTile(xpos, ypos, player_id, world)
   if tile_flags.thob ~= 0 and tile_flags.thob ~= 62 then return false end
   -- check if its passable that no object footprint blocks it
   if tile_flags.passable then return world:isTileExclusivelyPassable(xpos, ypos, 1) end
-  return true
+  return false
 end
 
 --! Calculate position offsets and door blueprint wall values


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3405*

**Describe what the proposed change does**
- In the function `validDoorTile(xpos, ypos, player_id, world)` consider tiles that do not meet any criteria as not suitable by default, rather than suitable for placing a room door.

The fix seems small. But there's actually more there than meets the eye. Check comments in 3405 for the full context.
