### PR TITLE
Generate per-file pages so the docs file hierarchy links resolve

### DIFF
--- a/LDocGen/main.lua
+++ b/LDocGen/main.lua
@@ -109,6 +109,44 @@ for name, var in globals:pairs() do
     })
   end
 end
+local file_globals = {}
+for _, var in globals:pairs() do
+  local file_name = var:getFile()
+  if file_name then
+    local list = file_globals[file_name]
+    if not list then
+      list = {}
+      file_globals[file_name] = list
+    end
+    list[#list + 1] = var
+  end
+end
+
+local function collect_files(directory, prefix, files)
+  for _, item in ipairs(directory.children) do
+    local path = prefix == "" and item.name or prefix .. "/" .. item.name
+    if class.is(item, LuaDirectory) then
+      collect_files(item, path, files)
+    else
+      files[#files + 1] = {file = item, path = path}
+    end
+  end
+end
+
+local files = {}
+collect_files(project.files, "", files)
+for _, entry in ipairs(files) do
+  WriteHTML(entry.file:getId(), template "page" {
+    title = entry.file:getName() .." File",
+    tab = "files",
+    section = "hierarchy",
+    content = template "file" {
+      file = entry.file,
+      items = file_globals[entry.path] or {},
+    },
+  })
+end
+
 WriteHTML("file_hierarchy", template "page" {
   title = "File Hierarchy",
   tab = "files",

--- a/LDocGen/templates/file.htlua
+++ b/LDocGen/templates/file.htlua
@@ -1,0 +1,20 @@
+<h2 class="file"><!= file:getName() !></h2>
+<! if #items > 0 then !>
+<div class="file_info">
+  <strong>Classes and functions defined:</strong>
+  <ul class="item_list">
+    <! for i = 1, #items do local var = items[i] !>
+      <li>
+        <! if class.is(var, LuaClass) then !>
+          <a href="<!= var:getId() !>.html" class="item"><!= var:getName() !></a> class
+        <! else !>
+          <span class="item"><!= var:getName() !></span> function
+        <! end !>
+        <! if var:getShortDesc() then !> - <!= var:getShortDesc() !> <! end !>
+      </li>
+    <! end !>
+  </ul>
+</div>
+<! else !>
+<p>No classes or functions are documented in this file.</p>
+<! end !>

--- a/LDocGen/templates/lua_file_tree.htlua
+++ b/LDocGen/templates/lua_file_tree.htlua
@@ -1,5 +1,12 @@
 <li class="<!= class.is(item, LuaDirectory) and "dir" or "file" !>">
-  <span><a href="<!= item:getId() !>.html" class="item"><!= item:getName() !></a><!= item:getShortDesc() and (" - ") .. item:getShortDesc() or "" !></span>
+  <span>
+    <! if class.is(item, LuaDirectory) then !>
+      <!= item:getName() !>
+    <! else !>
+      <a href="<!= item:getId() !>.html" class="item"><!= item:getName() !></a>
+    <! end !>
+    <!= item:getShortDesc() and (" - ") .. item:getShortDesc() or "" !>
+  </span>
   <! if class.is(item, LuaDirectory) then !>
     <ul class="file_hierarchy">
       <! for name, item in item:pairs() do !>


### PR DESCRIPTION
Closes #1793

The "Files" tab in the generated Lua docs links every file and directory to a page that does not exist, so all those links 404 on GitHub Pages. LDocGen only ever wrote class pages and index pages, never a page per source file, and the file tree built the hrefs from `LuaFile:getId()` which bakes the directory path and the `.lua` extension into the name.

Changes:
- `LDocGen/main.lua` now writes one page per source file. Each file page lists the classes and functions declared in that file, linking classes to their existing class pages
- `LDocGen/templates/file.htlua` is the new file page template
- `LDocGen/templates/lua_file_tree.htlua` renders directories as plain text (no directory pages exist) and keeps file entries as links to their new pages

Verification: built the docs locally (`cmake --build build --target doc_corsixth_lua`) and checked every local href across all generated pages resolves, 20465 links checked with no broken ones.
