### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/WindowsInstaller.yml
+++ b/.github/workflows/WindowsInstaller.yml
@@ -13,6 +13,9 @@ on:
         required: true
         type: number
 
+permissions:
+  contents: read
+
 jobs:
   WindowsInstaller:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/CorsixTH/CorsixTH/security/code-scanning/2](https://github.com/CorsixTH/CorsixTH/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to only what this workflow needs. The safest minimal non-breaking fix is to set workflow-level:

- `contents: read`

This satisfies CodeQL’s requirement and documents intended least-privilege defaults for all jobs in this workflow. In `.github/workflows/WindowsInstaller.yml`, insert the `permissions` block at the root level (after `on:` inputs section and before `jobs:`). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
