### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -1,6 +1,9 @@
 ---
 name: Linux and Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:
@@ -17,6 +20,9 @@ on:
 
 jobs:
   Linux-apt-get:
+    permissions:
+      contents: write
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix:
@@ -128,6 +134,9 @@ jobs:
           fi
 
   Linux-vcpkg:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-22.04
     name: Linux vcpkg Lua 5.5 ${{inputs.animview == 'true' && 'with AnimView' || ''}}
     env:


### PR DESCRIPTION
Potential fix for [https://github.com/CorsixTH/CorsixTH/security/code-scanning/12](https://github.com/CorsixTH/CorsixTH/security/code-scanning/12)

Add explicit `permissions` blocks in `.github/workflows/Linux.yml`:

1. At workflow root, set a safe default:
   - `contents: read`
2. For the `Linux-apt-get` job, override with:
   - `contents: write` (needed for the docs upload step that commits/pushes to `gh-pages`)
   - `pull-requests: read` (needed for `gh pr checkout`)
3. For the `Linux-vcpkg` job, set least privilege:
   - `contents: read`
   - `pull-requests: read` (also uses `gh pr checkout`)

This preserves existing functionality while making token scope explicit and minimal per job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
