### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,5 +1,7 @@
 ---
 name: Windows
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CorsixTH/CorsixTH/security/code-scanning/4](https://github.com/CorsixTH/CorsixTH/security/code-scanning/4)

Add an explicit `permissions` block at workflow root in `.github/workflows/Windows.yml`, just below `name:` and before `on:`.  
Best minimal fix without changing behavior is:

- `contents: read` (required baseline for checkout and repository read operations)

This addresses the CodeQL finding by constraining `GITHUB_TOKEN` to least privilege by default for all jobs in this workflow. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
