### PR TITLE
Fix missing permissions block on workflows

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -1,6 +1,10 @@
 ---
 name: Linux and Tests
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   push:
     branches-ignore:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,6 +1,10 @@
 ---
 name: Windows
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   push:
     branches-ignore:

--- a/.github/workflows/WindowsInstaller.yml
+++ b/.github/workflows/WindowsInstaller.yml
@@ -1,6 +1,9 @@
 ---
 name: Windows installer
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -1,5 +1,7 @@
 name: Update website
 
+permissions: {}
+
 on:
   release:
     types:


### PR DESCRIPTION
Flagged by github's security codescan. Without specifying permissions the workflows default to having fairly broad access to read and write the repo, issues, PRs, etc. Applying least-privileged principal it's better to define only what they need.