### PR TITLE
Fix #1467: Deferred entity destruction to prevent iteration skip

### DIFF
--- a/CorsixTH/Lua/world.lua
+++ b/CorsixTH/Lua/world.lua
@@ -60,6 +60,7 @@ function World:World(app, free_build_mode)
   self.pathfinder = TH.pathfinder()
   self.pathfinder:setMap(app.map.th)
   self.entities = {} -- List of entities in the world.
+  self.entities_to_destroy = {} -- Entities queued for destruction while iterating self.entities.
   self.dispatcher = CallsDispatcher(self)
   self.objects = {}
   self.objects_notify_occupants = {}
@@ -968,12 +969,13 @@ function World:onTick()
         end
       end
       for _, entity in ipairs(self.entities) do
-        if entity.ticks then
+        if entity.ticks and not entity.to_destroy then
           self.current_tick_entity = entity
           entity:tick()
         end
       end
       self.current_tick_entity = nil
+      self:_flushDestroyedEntities()
       self.map:onTick()
       self.map.th:updateTemperatures(outside_temperatures[self.game_date:monthOfYear()],
           0.25 + self.hospitals[1].heating.radiator_heat * 0.3)
@@ -1051,14 +1053,16 @@ end
 function World:onEndDay()
   local local_hospital = self:getLocalPlayerHospital()
   for _, entity in ipairs(self.entities) do
-    if entity.ticks and class.is(entity, Humanoid) then
+    if entity.ticks and class.is(entity, Humanoid) and not entity.to_destroy then
       self.current_tick_entity = entity
       entity:tickDay()
-    elseif class.is(entity, Plant) then
+    elseif class.is(entity, Plant) and not entity.to_destroy then
+      self.current_tick_entity = entity
       entity:tickDay()
     end
   end
   self.current_tick_entity = nil
+  self:_flushDestroyedEntities()
 
   --check if it's time for a VIP visit
   if self.game_date:isSameDay(self.next_vip_date) then
@@ -1173,12 +1177,13 @@ function World:onEndMonth()
 
   self:makeAvailableStaff(self.game_date:monthOfGame())
   for _, entity in ipairs(self.entities) do
-    if entity.checkForDeadlock then
+    if entity.checkForDeadlock and not entity.to_destroy then
       self.current_tick_entity = entity
       entity:checkForDeadlock()
     end
   end
   self.current_tick_entity = nil
+  self:_flushDestroyedEntities()
 end
 
 -- Called when a month ends. Decides on which dates patients arrive
@@ -1837,13 +1842,54 @@ function World:newEntity(class, animation, mood_marker)
 end
 
 function World:destroyEntity(entity)
-  for i, e in ipairs(self.entities) do
-    if e == entity then
+  if entity.to_destroy then
+    -- Already queued for destruction, so onDestroy has already run.
+    return
+  end
+  if self.current_tick_entity then
+    -- The caller is iterating over self.entities, so defer removing the
+    -- entity from that table to avoid skipping entities in the loop.
+    -- The entity is removed as soon as the iteration has finished.
+    entity.to_destroy = true
+    -- Loaded games created before the deferred destruction existed will
+    -- not have an entities_to_destroy table, so create it lazily.
+    local queue = self.entities_to_destroy
+    if not queue then
+      queue = {}
+      self.entities_to_destroy = queue
+    end
+    queue[#queue + 1] = entity
+    entity:onDestroy()
+  else
+    for i, e in ipairs(self.entities) do
+      if e == entity then
+        table.remove(self.entities, i)
+        break
+      end
+    end
+    entity:onDestroy()
+  end
+end
+
+--! Remove entities that were queued for destruction from self.entities.
+--! Entities are queued by World:destroyEntity while iterating over
+--! self.entities, so this must only be called once that iteration finished.
+function World:_flushDestroyedEntities()
+  local queue = self.entities_to_destroy
+  if not queue or #queue == 0 then
+    -- A missing queue means a game saved before deferred destruction was
+    -- added was loaded, in which case there is nothing to flush.
+    return
+  end
+  self.entities_to_destroy = {}
+  for i = #self.entities, 1, -1 do
+    if self.entities[i].to_destroy then
       table.remove(self.entities, i)
-      break
     end
   end
-  entity:onDestroy()
+  for _, entity in ipairs(queue) do
+    entity.to_destroy = nil
+  end
 end
 
 function World:newObjectType(new_object)

--- a/CorsixTH/Luatest/spec/world_spec.lua
+++ b/CorsixTH/Luatest/spec/world_spec.lua
@@ -1,0 +1,511 @@
+--[[ Copyright (c) 2026 Bruno Lima
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. --]]
+require("corsixth")
+
+require("class_test_base")
+
+require("utility")
+require("persistance")
+
+-- Load the modules world.lua depends on in the same order as app.lua does.
+-- world.lua also reads the global _A (the app) while loading, so provide a
+-- minimal stub for that.
+local saved_A = _G._A
+_G._A = {cheats = {}}
+require("map")
+require("entity")
+require("entities.humanoid")
+require("entities.object")
+require("entities.machine")
+require("room")
+require("humanoid_action")
+require("world")
+_G._A = saved_A
+
+local World = _G["World"]
+
+describe("world.lua: ", function()
+  local function makeWorld(entities)
+    local world = {entities = entities, entities_to_destroy = {}}
+    setmetatable(world, {__index = World})
+    return world
+  end
+
+  local function makeEntity(name)
+    local entity = {
+      name = name,
+      ticks = true,
+      tick_count = 0,
+    }
+    function entity:tick()
+      self.tick_count = self.tick_count + 1
+    end
+    function entity:onDestroy()
+      self.destroyed = true
+    end
+    return entity
+  end
+
+  -- Simulates the entity tick loop of World:onTick, including the guard that
+  -- skips entities queued for destruction and the flush after the loop.
+  local function runTickLoop(world)
+    for _, entity in ipairs(world.entities) do
+      if entity.ticks and not entity.to_destroy then
+        world.current_tick_entity = entity
+        entity:tick()
+      end
+    end
+    world.current_tick_entity = nil
+    world:_flushDestroyedEntities()
+  end
+
+  -- Simulates the entity tickDay loop of World:onEndDay. Mirrors the real
+  -- structure: humanoids and plants are dispatched separately, and plants
+  -- also set current_tick_entity so deferred destruction applies to them.
+  local function runTickDayLoop(world)
+    for _, entity in ipairs(world.entities) do
+      if entity.kind == "humanoid" and not entity.to_destroy then
+        world.current_tick_entity = entity
+        entity:tickDay()
+      elseif entity.kind == "plant" and not entity.to_destroy then
+        world.current_tick_entity = entity
+        entity:tickDay()
+      end
+    end
+    world.current_tick_entity = nil
+    world:_flushDestroyedEntities()
+  end
+
+  -- Simulates the entity checkForDeadlock loop of World:onEndMonth.
+  local function runDeadlockLoop(world)
+    for _, entity in ipairs(world.entities) do
+      if entity.checkForDeadlock and not entity.to_destroy then
+        world.current_tick_entity = entity
+        entity:checkForDeadlock()
+      end
+    end
+    world.current_tick_entity = nil
+    world:_flushDestroyedEntities()
+  end
+
+  it("removes entity immediately outside an entities loop", function()
+    local e1, e2 = makeEntity("e1"), makeEntity("e2")
+    local world = makeWorld({e1, e2})
+
+    world:destroyEntity(e1)
+
+    assert.are.equal(1, #world.entities)
+    assert.is.equal(e2, world.entities[1])
+    assert.is_true(e1.destroyed)
+    assert.are.equal(0, #world.entities_to_destroy)
+  end)
+
+  it("destroys entity not present in the list", function()
+    local e1 = makeEntity("e1")
+    local world = makeWorld({})
+
+    world:destroyEntity(e1)
+
+    assert.is_true(e1.destroyed)
+    assert.are.equal(0, #world.entities)
+  end)
+
+  it("defers removal while iterating the entities list", function()
+    local e1, e2, e3 = makeEntity("e1"), makeEntity("e2"), makeEntity("e3")
+    local world = makeWorld({e1, e2, e3})
+    world.current_tick_entity = e2
+
+    world:destroyEntity(e2)
+
+    assert.are.equal(3, #world.entities)
+    assert.are.equal(1, #world.entities_to_destroy)
+    assert.is_true(e2.destroyed)
+    assert.is_true(e2.to_destroy)
+
+    world.current_tick_entity = nil
+    world:_flushDestroyedEntities()
+
+    assert.are.equal(2, #world.entities)
+    assert.is.equal(e1, world.entities[1])
+    assert.is.equal(e3, world.entities[2])
+    assert.is_nil(e2.to_destroy)
+    assert.are.equal(0, #world.entities_to_destroy)
+  end)
+
+  it("queues an entity for destruction only once", function()
+    local e1 = makeEntity("e1")
+    local world = makeWorld({e1})
+    world.current_tick_entity = e1
+
+    world:destroyEntity(e1)
+    world:destroyEntity(e1)
+
+    assert.are.equal(1, #world.entities_to_destroy)
+  end)
+
+  it("flushes multiple deferred destructions in one pass", function()
+    local e1, e2, e3, e4 = makeEntity("e1"), makeEntity("e2"), makeEntity("e3"), makeEntity("e4")
+    local world = makeWorld({e1, e2, e3, e4})
+    world.current_tick_entity = e2
+
+    world:destroyEntity(e2)
+    world:destroyEntity(e4)
+
+    world.current_tick_entity = nil
+    world:_flushDestroyedEntities()
+
+    assert.are.equal(2, #world.entities)
+    assert.is.equal(e1, world.entities[1])
+    assert.is.equal(e3, world.entities[2])
+  end)
+
+  it("flush does nothing with an empty queue", function()
+    local e1 = makeEntity("e1")
+    local world = makeWorld({e1})
+
+    world:_flushDestroyedEntities()
+
+    assert.are.equal(1, #world.entities)
+    assert.are.equal(0, #world.entities_to_destroy)
+  end)
+
+  it("does not skip entities when an earlier entity is destroyed mid-loop", function()
+    local e1, e2, e3, e4 = makeEntity("e1"), makeEntity("e2"), makeEntity("e3"), makeEntity("e4")
+    local world = makeWorld({e1, e2, e3, e4})
+    e2.tick = function(self)
+      self.tick_count = self.tick_count + 1
+      -- Destroy an entity that already ticked (before the current index) and
+      -- one that has not ticked yet (after the current index). Without the
+      -- deferred removal, e3 would be skipped.
+      world:destroyEntity(e1)
+      world:destroyEntity(e4)
+    end
+
+    runTickLoop(world)
+
+    assert.are.equal(1, e1.tick_count)
+    assert.are.equal(1, e2.tick_count)
+    assert.are.equal(1, e3.tick_count)
+    assert.is_true(e4.destroyed)
+    assert.are.equal(0, e4.tick_count)
+    assert.are.equal(2, #world.entities)
+    assert.is.equal(e2, world.entities[1])
+    assert.is.equal(e3, world.entities[2])
+  end)
+
+  it("does not tick an entity destroyed earlier in the same loop", function()
+    local e1, e2, e3 = makeEntity("e1"), makeEntity("e2"), makeEntity("e3")
+    local world = makeWorld({e1, e2, e3})
+    e1.tick = function(self)
+      self.tick_count = self.tick_count + 1
+      world:destroyEntity(e3)
+    end
+
+    runTickLoop(world)
+
+    assert.are.equal(1, e1.tick_count)
+    assert.are.equal(1, e2.tick_count)
+    assert.is_true(e3.destroyed)
+    assert.are.equal(0, e3.tick_count)
+    assert.are.equal(2, #world.entities)
+  end)
+
+  it("destroys itself during its tick and is removed after the loop", function()
+    local e1, e2 = makeEntity("e1"), makeEntity("e2")
+    local world = makeWorld({e1, e2})
+    e1.tick = function(self)
+      self.tick_count = self.tick_count + 1
+      world:destroyEntity(self)
+    end
+
+    runTickLoop(world)
+
+    assert.are.equal(1, e1.tick_count)
+    assert.are.equal(1, e2.tick_count)
+    assert.is_true(e1.destroyed)
+    assert.are.equal(1, #world.entities)
+    assert.is.equal(e2, world.entities[1])
+  end)
+
+  it("handles cascading destructions during a single loop", function()
+    local e1, e2, e3, e4 = makeEntity("e1"), makeEntity("e2"), makeEntity("e3"), makeEntity("e4")
+    local world = makeWorld({e1, e2, e3, e4})
+    e2.tick = function(self)
+      self.tick_count = self.tick_count + 1
+      world:destroyEntity(e3)
+    end
+    -- Destroying e3 destroys e4 as well, mimicking a room crashing and
+    -- taking its objects with it.
+    e3.onDestroy = function(self)
+      self.destroyed = true
+      world:destroyEntity(e4)
+    end
+
+    runTickLoop(world)
+
+    assert.are.equal(1, e1.tick_count)
+    assert.are.equal(1, e2.tick_count)
+    assert.is_true(e3.destroyed)
+    assert.is_true(e4.destroyed)
+    assert.are.equal(0, e3.tick_count)
+    assert.are.equal(0, e4.tick_count)
+    assert.are.equal(2, #world.entities)
+  end)
+
+  it("ticks entities added to the list during the loop", function()
+    local e1, e2, e3 = makeEntity("e1"), makeEntity("e2"), makeEntity("e3")
+    local world = makeWorld({e1, e2, e3})
+    local e4 = makeEntity("e4")
+    e2.tick = function(self)
+      self.tick_count = self.tick_count + 1
+      world.entities[#world.entities + 1] = e4
+    end
+
+    runTickLoop(world)
+
+    assert.are.equal(1, e1.tick_count)
+    assert.are.equal(1, e2.tick_count)
+    assert.are.equal(1, e3.tick_count)
+    assert.are.equal(1, e4.tick_count)
+    assert.are.equal(4, #world.entities)
+  end)
+
+  it("recovers when the loop is interrupted before flushing", function()
+    local e1, e2, e3 = makeEntity("e1"), makeEntity("e2"), makeEntity("e3")
+    local world = makeWorld({e1, e2, e3})
+    world.current_tick_entity = e1
+    world:destroyEntity(e2)
+    -- The error handling in app.lua clears current_tick_entity without a
+    -- flush, so the queue survives into the next loop.
+    world.current_tick_entity = nil
+
+    runTickLoop(world)
+
+    assert.are.equal(1, e1.tick_count)
+    assert.are.equal(1, e3.tick_count)
+    assert.is_true(e2.destroyed)
+    assert.are.equal(0, e2.tick_count)
+    assert.are.equal(2, #world.entities)
+  end)
+
+  it("does nothing when destroying an already queued entity outside a loop", function()
+    local e1, e2 = makeEntity("e1"), makeEntity("e2")
+    local world = makeWorld({e1, e2})
+    world.current_tick_entity = e1
+    world:destroyEntity(e2)
+    world.current_tick_entity = nil
+
+    world:destroyEntity(e2)
+
+    assert.are.equal(2, #world.entities)
+    assert.is_true(e2.to_destroy)
+    world:_flushDestroyedEntities()
+    assert.are.equal(1, #world.entities)
+  end)
+
+  it("destroys immediately outside a loop even with pending queued entities", function()
+    local e1, e2, e3 = makeEntity("e1"), makeEntity("e2"), makeEntity("e3")
+    local world = makeWorld({e1, e2, e3})
+    world.current_tick_entity = e1
+    world:destroyEntity(e1)
+    world.current_tick_entity = nil
+
+    world:destroyEntity(e3)
+
+    assert.is_true(e3.destroyed)
+    assert.is_nil(e3.to_destroy)
+    assert.are.equal(1, #world.entities_to_destroy)
+    world:_flushDestroyedEntities()
+    assert.are.equal(1, #world.entities)
+    assert.is.equal(e2, world.entities[1])
+  end)
+
+  it("reuses the queue across consecutive loops", function()
+    local e1, e2, e3 = makeEntity("e1"), makeEntity("e2"), makeEntity("e3")
+    local world = makeWorld({e1, e2, e3})
+    e1.tick = function(self)
+      self.tick_count = self.tick_count + 1
+      world:destroyEntity(e2)
+    end
+
+    runTickLoop(world)
+
+    assert.are.equal(2, #world.entities)
+    assert.is_true(e2.destroyed)
+    assert.are.equal(0, #world.entities_to_destroy)
+    e3.tick = function(self)
+      self.tick_count = self.tick_count + 1
+      world:destroyEntity(e1)
+    end
+
+    runTickLoop(world)
+
+    assert.are.equal(1, #world.entities)
+    assert.is.equal(e3, world.entities[1])
+    assert.are.equal(2, e1.tick_count)
+    assert.are.equal(2, e3.tick_count)
+    assert.are.equal(0, #world.entities_to_destroy)
+  end)
+
+  it("does not skip entities destroyed during the tickDay loop", function()
+    local e1 = makeEntity("e1")
+    local e2, e3, e4 = makeEntity("e2"), makeEntity("e3"), makeEntity("e4")
+    e1.kind, e2.kind, e3.kind, e4.kind = "humanoid", "humanoid", "humanoid", "humanoid"
+    local world = makeWorld({e1, e2, e3, e4})
+    e2.tickDay = function(self)
+      self.tick_count = self.tick_count + 1
+      world:destroyEntity(e1)
+      world:destroyEntity(e4)
+    end
+    e1.tickDay = function(self) self.tick_count = self.tick_count + 1 end
+    e3.tickDay = function(self) self.tick_count = self.tick_count + 1 end
+
+    runTickDayLoop(world)
+
+    assert.are.equal(1, e1.tick_count)
+    assert.are.equal(1, e2.tick_count)
+    assert.are.equal(1, e3.tick_count)
+    assert.is_true(e4.destroyed)
+    assert.are.equal(0, e4.tick_count)
+    assert.are.equal(2, #world.entities)
+  end)
+
+  it("defers destruction triggered by a plant during the tickDay loop", function()
+    local plant = makeEntity("plant")
+    local e2, e3 = makeEntity("e2"), makeEntity("e3")
+    plant.kind, e2.kind, e3.kind = "plant", "humanoid", "humanoid"
+    local world = makeWorld({plant, e2, e3})
+    plant.tickDay = function(self)
+      self.tick_count = self.tick_count + 1
+      world:destroyEntity(e3)
+    end
+    e2.tickDay = function(self) self.tick_count = self.tick_count + 1 end
+
+    runTickDayLoop(world)
+
+    assert.are.equal(1, plant.tick_count)
+    assert.are.equal(1, e2.tick_count)
+    assert.is_true(e3.destroyed)
+    assert.are.equal(0, e3.tick_count)
+    assert.are.equal(2, #world.entities)
+    assert.is.equal(plant, world.entities[1])
+    assert.is.equal(e2, world.entities[2])
+  end)
+
+  it("does not skip entities destroyed during the checkForDeadlock loop", function()
+    local e1, e2, e3 = makeEntity("e1"), makeEntity("e2"), makeEntity("e3")
+    local world = makeWorld({e1, e2, e3})
+    e1.checkForDeadlock = function(self)
+      self.tick_count = self.tick_count + 1
+      world:destroyEntity(e3)
+    end
+    e2.checkForDeadlock = function(self) self.tick_count = self.tick_count + 1 end
+
+    runDeadlockLoop(world)
+
+    assert.are.equal(1, e1.tick_count)
+    assert.are.equal(1, e2.tick_count)
+    assert.is_true(e3.destroyed)
+    assert.are.equal(2, #world.entities)
+  end)
+
+  it("flush does nothing when the queue is missing (old savegame)", function()
+    local e1 = makeEntity("e1")
+    local world = makeWorld({e1})
+    world.entities_to_destroy = nil
+
+    world:_flushDestroyedEntities()
+
+    assert.are.equal(1, #world.entities)
+    assert.is_nil(world.entities_to_destroy)
+  end)
+
+  it("creates the queue lazily when destroying during a loop on an old savegame", function()
+    local e1, e2 = makeEntity("e1"), makeEntity("e2")
+    local world = makeWorld({e1, e2})
+    world.entities_to_destroy = nil
+    world.current_tick_entity = e1
+
+    world:destroyEntity(e2)
+
+    assert.is_true(e2.to_destroy)
+    assert.are.equal(1, #world.entities_to_destroy)
+    world.current_tick_entity = nil
+    world:_flushDestroyedEntities()
+    assert.are.equal(1, #world.entities)
+    assert.is.equal(e1, world.entities[1])
+    assert.is_nil(e2.to_destroy)
+    assert.are.equal(0, #world.entities_to_destroy)
+  end)
+
+  it("destroys an entity not in the list during a loop without side effects", function()
+    local e1, e2 = makeEntity("e1"), makeEntity("e2")
+    local stray = makeEntity("stray")
+    local world = makeWorld({e1, e2})
+    world.current_tick_entity = e1
+
+    world:destroyEntity(stray)
+
+    assert.is_true(stray.destroyed)
+    assert.is_true(stray.to_destroy)
+    assert.are.equal(1, #world.entities_to_destroy)
+    world.current_tick_entity = nil
+    world:_flushDestroyedEntities()
+    assert.are.equal(2, #world.entities)
+    assert.is_nil(stray.to_destroy)
+    assert.are.equal(0, #world.entities_to_destroy)
+  end)
+
+  it("flush is safe to call twice in a row", function()
+    local e1, e2 = makeEntity("e1"), makeEntity("e2")
+    local world = makeWorld({e1, e2})
+    world.current_tick_entity = e1
+    world:destroyEntity(e2)
+    world.current_tick_entity = nil
+
+    world:_flushDestroyedEntities()
+    world:_flushDestroyedEntities()
+
+    assert.are.equal(1, #world.entities)
+    assert.are.equal(0, #world.entities_to_destroy)
+  end)
+
+  it("destroys from a nested iteration still defer until the outer loop ends", function()
+    local e1, e2, e3 = makeEntity("e1"), makeEntity("e2"), makeEntity("e3")
+    local world = makeWorld({e1, e2, e3})
+    e2.tick = function(self)
+      self.tick_count = self.tick_count + 1
+      -- Simulates code that iterates world.entities from inside a tick.
+      for _, inner in ipairs(world.entities) do
+        if inner == e3 then
+          world:destroyEntity(e3)
+        end
+      end
+    end
+
+    runTickLoop(world)
+
+    assert.are.equal(1, e1.tick_count)
+    assert.are.equal(1, e2.tick_count)
+    assert.is_true(e3.destroyed)
+    assert.are.equal(0, e3.tick_count)
+    assert.are.equal(2, #world.entities)
+  end)
+end)

--- a/smoketest.lua
+++ b/smoketest.lua
@@ -28,7 +28,7 @@ local function hb(phase, extra)
   end
   local mem_kb = collectgarbage("count")
   local tick = world and world.tick_count or 0
-  local data = string.format('{"phase":"%s","tick":%d,"entities_alive":%d,"to_destroy_flags":%d,"queue_len":%d,"mem_kb":%.1f}', 
+  local data = string.format('{"phase":"%s","tick":%d,"entities_alive":%d,"to_destroy_flags":%d,"queue_len":%d,"mem_kb":%.1f}',
     phase, tick, entities_alive, to_destroy_flags, queue_len, mem_kb)
   if extra then
     for k, v in pairs(extra) do

--- a/smoketest.lua
+++ b/smoketest.lua
@@ -1,0 +1,299 @@
+--[[ CorsixTH smoke test for the #1467 deferred-destroy fix. Invoked via:
+  corsix-th --interpreter=/home/bruno/CorsixTH/smoketest.lua
+--]]
+local base_dir = "/home/bruno/CorsixTH/CorsixTH/"
+
+assert(loadfile(base_dir .. "CorsixTH.lua"))()
+
+local render = os.getenv("SMOKE_RENDER") == "1"
+local load_only = os.getenv("SMOKE_LOAD_ONLY") == "1"
+local heartbeat = os.getenv("SMOKE_HEARTBEAT") == "1"
+
+local function fail(msg)
+  print("SMOKE FAIL: " .. msg)
+  io.stdout:flush()
+  os.exit(1)
+end
+
+local function hb(phase, extra)
+  if not heartbeat then return end
+  local world = TheApp.world
+  local entities_alive = world and #world.entities or 0
+  local queue_len = (world and world.entities_to_destroy) and #world.entities_to_destroy or 0
+  local to_destroy_flags = 0
+  if world then
+    for _, e in ipairs(world.entities) do
+      if e.to_destroy then to_destroy_flags = to_destroy_flags + 1 end
+    end
+  end
+  local mem_kb = collectgarbage("count")
+  local tick = world and world.tick_count or 0
+  local data = string.format('{"phase":"%s","tick":%d,"entities_alive":%d,"to_destroy_flags":%d,"queue_len":%d,"mem_kb":%.1f}', 
+    phase, tick, entities_alive, to_destroy_flags, queue_len, mem_kb)
+  if extra then
+    for k, v in pairs(extra) do
+      data = data:gsub('}$', ',"'..k..'":'..v..'}')
+    end
+  end
+  io.stderr:write(data .. "\n")
+  io.stderr:flush()
+end
+
+local is_demo = TheApp.using_demo_files or false
+local difficulty = is_demo and "easy" or "full"
+print("SMOKE: using_demo_files=" .. tostring(is_demo) .. ", difficulty=" .. difficulty)
+io.stdout:flush()
+
+local ok, err = pcall(TheApp.loadLevel, TheApp, 1, difficulty, nil, nil, nil, nil,
+    "SMOKE: ", nil)
+print("SMOKE: loadLevel returned ok=" .. tostring(ok) .. ", err=" .. tostring(err))
+io.stdout:flush()
+if not ok then fail("loadLevel errored: " .. tostring(err)) end
+if err == false then fail("loadLevel failed (returned false)") end
+print("SMOKE: TheApp.world = " .. tostring(TheApp.world))
+io.stdout:flush()
+
+-- Stop any playing movie (intro movie blocks World:onTick)
+if TheApp.moviePlayer and TheApp.moviePlayer.playing then
+  print("SMOKE: Stopping intro movie...")
+  TheApp.moviePlayer:stop()
+  print("SMOKE: moviePlayer.playing = " .. tostring(TheApp.moviePlayer.playing))
+  io.stdout:flush()
+end
+
+local world = TheApp.world
+if not world then fail("TheApp.world is nil after loadLevel") end
+local hospital = world:getLocalPlayerHospital()
+if not hospital then fail("no local player hospital after loadLevel") end
+print("SMOKE: level loaded, entities=" .. #world.entities)
+io.stdout:flush()
+hb("load_complete", {load_ms = TheApp.load_ms or 0})
+
+if load_only then
+  print("SMOKE: LOAD_ONLY mode - exiting after load")
+  io.stdout:flush()
+  os.exit(0)
+end
+
+TheApp.config.autosave_frequency = 0
+
+local function addStaff(class_name)
+  local profile = StaffProfile(world, class_name, _S.staff_class[class_name:lower()])
+  if class_name == "Doctor" then
+    profile:initDoctor(0, 0, 0, 1, 0, 0)
+  else
+    profile:init(0)
+  end
+  local staff = world:newEntity(profile.humanoid_class, 2, 2)
+  staff:setProfile(profile)
+  local map = world.map.th
+  local map_x_length, map_y_length = map:size()
+  local x, y = map:getCameraTile(hospital:getPlayerIndex())
+  local map_offset = 10
+  local x_safe = math.max(map_offset + 1, math.min(x, map_x_length - map_offset))
+  local y_safe = math.max(map_offset + 1, math.min(y, map_y_length - map_offset))
+  local x_attempt, y_attempt, attempts = x_safe, y_safe, 0
+  repeat
+    x_attempt = x_safe + math.random(-map_offset, map_offset)
+    y_attempt = y_safe + math.random(-map_offset, map_offset)
+    attempts = attempts + 1
+  until attempts > 100 or hospital:isInHospital(x_attempt, y_attempt)
+  if attempts <= 100 then
+    staff:setTile(x_attempt, y_attempt)
+  else
+    staff:setTile(map_x_length / 2, map_y_length / 2)
+  end
+  hospital.staff[#hospital.staff + 1] = staff
+  staff:setHospital(hospital)
+  staff:onPlaceInCorridor()
+  return staff
+end
+
+addStaff("Receptionist")
+addStaff("Doctor")
+print("SMOKE: added receptionist and doctor, entities=" .. #world.entities)
+io.stdout:flush()
+hb("staff_added")
+hospital:open()
+
+local function spawnRealPatient()
+  local spawns = world.spawn_points
+  if #spawns == 0 then return nil end
+  local spawn = spawns[math.random(1, #spawns)]
+  local patient = world:newEntity("Patient", 2, 1)
+  patient:setDisease(world.available_diseases[math.random(1, #world.available_diseases)])
+  patient:setNextAction(SpawnAction("spawn", spawn))
+  patient:setHospital(hospital)
+  return patient
+end
+
+local peak_entities = #world.entities
+local rendered_frames = 0
+local function frame()
+  if render then
+    local okf, errf = pcall(TheApp.drawFrame, TheApp)
+    if not okf then fail("drawFrame error: " .. tostring(errf)) end
+    rendered_frames = rendered_frames + 1
+  end
+end
+if render then
+  local rd = TheApp.video:getRendererDetails()
+  print("SMOKE: renderer=" .. tostring(rd))
+  io.stdout:flush()
+end
+local function runTicks(n, label, patient_every)
+  for i = 1, n do
+    local ok2, err2 = pcall(TheApp.onTick, TheApp)
+    if not ok2 then
+      fail(label .. " onTick error at step " .. i .. ": " .. tostring(err2))
+    end
+    frame()
+    if patient_every and i % patient_every == 0 then
+      spawnRealPatient()
+    end
+    peak_entities = math.max(peak_entities, #world.entities)
+    if heartbeat and i % 100 == 0 then
+      hb(label, {tick_in_phase = i})
+    end
+  end
+  print("SMOKE: " .. label .. " ran " .. n .. " ticks, entities=" .. #world.entities
+    .. " (peak " .. peak_entities .. ")")
+  io.stdout:flush()
+  hb(label .. "_complete")
+end
+
+runTicks(700, "warmup-with-patients", 25)
+if render then
+  print("SMOKE: rendered_frames_after_warmup=" .. rendered_frames)
+  io.stdout:flush()
+end
+
+local save_path = TheApp.savegame_dir .. "smoketest.sav"
+TheApp:save(save_path)
+if not lfs.attributes(save_path) then fail("could not save game") end
+print("SMOKE: saved to " .. save_path)
+io.stdout:flush()
+hb("save_complete")
+local ok3, err3 = pcall(TheApp.load, TheApp, save_path)
+if not ok3 then fail("load savegame errored: " .. tostring(err3)) end
+world = TheApp.world
+hospital = world:getLocalPlayerHospital()
+print("SMOKE: loaded savegame, entities=" .. #world.entities
+  .. " queue=" .. tostring(world.entities_to_destroy and #world.entities_to_destroy))
+io.stdout:flush()
+hb("load_save_complete")
+
+class "SmokeDummy" (Entity)
+function SmokeDummy:SmokeDummy(animation)
+  self:Entity(animation)
+  self.dummy_mode = "none"
+  self.a_ticked = false
+  self.was_ticked = false
+end
+function SmokeDummy:onDestroy()
+  self.destroyed = true
+end
+function SmokeDummy:tick()
+  if self.dummy_mode == "a" then
+    self.a_ticked = true
+  elseif self.dummy_mode == "b" then
+    self.world:destroyEntity(self.target)
+  elseif self.dummy_mode == "c" then
+    self.was_ticked = true
+  elseif self.dummy_mode == "d" then
+    self.world:destroyEntity(self)
+  end
+end
+
+local dummy_a = world:newEntity("SmokeDummy", 2, 1)
+local dummy_b = world:newEntity("SmokeDummy", 2, 1)
+local dummy_c = world:newEntity("SmokeDummy", 2, 1)
+dummy_a.dummy_mode = "a"
+dummy_b.dummy_mode = "b"
+dummy_c.dummy_mode = "c"
+dummy_b.target = dummy_a
+dummy_c.was_ticked = false
+
+local idx_a, idx_b, idx_c
+for i, e in ipairs(world.entities) do
+  if e == dummy_a then idx_a = i end
+  if e == dummy_b then idx_b = i end
+  if e == dummy_c then idx_c = i end
+end
+print("SMOKE: dummy indexes a=" .. idx_a .. " b=" .. idx_b .. " c=" .. idx_c)
+io.stdout:flush()
+if idx_b ~= idx_a + 1 or idx_c ~= idx_b + 1 then
+  fail("dummies not consecutive at the end of entities")
+end
+
+local passes = 0
+local cap = (world.tick_rate or 4) + 2
+while not dummy_a.a_ticked and passes < cap do
+  local ok2, err2 = pcall(TheApp.onTick, TheApp)
+  if not ok2 then fail("skip-bug-repro onTick error: " .. tostring(err2)) end
+  frame()
+  passes = passes + 1
+end
+print("SMOKE: skip-bug-repro ran " .. passes .. " onTick calls (tick_rate=" .. tostring(world.tick_rate) .. ")")
+io.stdout:flush()
+if not dummy_a.a_ticked then fail("dummy A never ticked") end
+if not dummy_c.was_ticked then fail("dummy C was skipped (the #1467 bug)") end
+for _, e in ipairs(world.entities) do
+  if e == dummy_a then fail("dummy A not removed after tick") end
+end
+print("SMOKE: mid-loop destroy of earlier entity worked, no entity was skipped")
+io.stdout:flush()
+hb("skip_bug_repro_complete")
+
+local dummy_d = world:newEntity("SmokeDummy", 2, 1)
+dummy_d.dummy_mode = "d"
+local passes_d = 0
+local cap_d = (world.tick_rate or 4) + 2
+while not dummy_d.destroyed and passes_d < cap_d do
+  local okd, errd = pcall(TheApp.onTick, TheApp)
+  if not okd then fail("self-destroy onTick error: " .. tostring(errd)) end
+  frame()
+  passes_d = passes_d + 1
+end
+print("SMOKE: self-destroy ran " .. passes_d .. " onTick calls")
+io.stdout:flush()
+if not dummy_d.destroyed then fail("dummy D was not destroyed") end
+for _, e in ipairs(world.entities) do
+  if e == dummy_d then fail("dummy D not removed after self-destroy") end
+end
+print("SMOKE: self-destroy during own tick worked")
+io.stdout:flush()
+hb("self_destroy_complete")
+
+runTicks(200, "after-dummy-destroy")
+
+local stale = 0
+for _, e in ipairs(world.entities) do
+  if e.to_destroy then stale = stale + 1 end
+end
+local queue = world.entities_to_destroy and #world.entities_to_destroy or "n/a"
+print("SMOKE: stale to_destroy flags=" .. stale)
+print("SMOKE: entities_to_destroy queue=" .. tostring(queue))
+io.stdout:flush()
+if stale ~= 0 then fail("found " .. stale .. " stale to_destroy flags") end
+if queue ~= 0 then fail("entities_to_destroy queue not empty after ticks") end
+
+world.entities_to_destroy = nil
+runTicks(60, "old-save-sim (nil queue)")
+local q2 = world.entities_to_destroy
+if not q2 then fail("entities_to_destroy not lazily recreated") end
+print("SMOKE: old-save simulation OK, queue=" .. #q2)
+io.stdout:flush()
+local stale2 = 0
+for _, e in ipairs(world.entities) do
+  if e.to_destroy then stale2 = stale2 + 1 end
+end
+if stale2 ~= 0 then fail("stale to_destroy flags after old-save sim") end
+if render then
+  print("SMOKE: total_rendered_frames=" .. rendered_frames)
+  io.stdout:flush()
+end
+print("SMOKE: ALL CHECKS PASSED")
+io.stdout:flush()
+hb("all_passed")
+os.exit(0)


### PR DESCRIPTION
## Fix for #1467: Deferred Entity Destruction

**Problem:** Iterating `world.entities` with `ipairs` while handlers call `destroyEntity` shifts later entries into already-visited slots, skipping their tick calls.

**Solution:** Defer removal until after the iteration. When `current_tick_entity` is set (inside an iteration), `destroyEntity` queues the entity with `to_destroy=true`, calls `onDestroy()` immediately, and removes it in `_flushDestroyedEntities()` after the loop. Outside iterations, destroy immediately.

**Files changed:**
- `CorsixTH/Lua/world.lua` — Core fix + `_flushDestroyedEntities()` + lazy `entities_to_destroy` for old savegames
- `CorsixTH/Luatest/spec/world_spec.lua` — 23 unit tests (immediate/deferred destroy, no-skip, self-destruct, cascading, old-save compat, plant tickDay, checkForDeadlock, nested iterations)
- `smoketest.lua` — Smoke test improvements (heartbeat, load-only, intro movie fix, auto-difficulty)

**Validation:**
- ✅ 86/86 unit tests pass (busted)
- ✅ luacheck clean (297 files)
- ✅ Negative control: disabling the fix reproduces the exact bug ("dummy C was skipped")
- ✅ Full game smoke test passes on full Theme Hospital data:
  - Offscreen (`SDL_VIDEODRIVER=offscreen`): 3/3 green
  - xvfb (`xvfb-run -a`): 3/3 green  
  - Demo data control: 2/2 green
- ✅ Save/load round-trip works
- ✅ Old-save compatibility verified (lazy queue creation)

**Key discovery during testing:** Full game data autoplays the intro movie (`moviePlayer.playing=true`), which blocks `World:onTick` entirely — this was the real cause of the 500s timeout. Fixed by adding `TheApp.moviePlayer:stop()` in the smoketest.

The fix is minimal, targeted, and guarded only when iteration is actually happening.