### PR TITLE
[RFC] Object happiness factor calculated from room contents

### DIFF
--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -28,7 +28,7 @@ local SDL = require("sdl")
 -- and add compatibility code in afterLoad functions
 -- Recommended: Also replace/Update the summary comment
 
-local SAVEGAME_VERSION = 264 -- SDL 3
+local SAVEGAME_VERSION = 265 -- Refactor room happiness factor
 
 class "App"
 

--- a/CorsixTH/Lua/dialogs/place_objects.lua
+++ b/CorsixTH/Lua/dialogs/place_objects.lua
@@ -243,6 +243,7 @@ end
 
 -- precondition: self.active_index has to correspond to the object to be removed
 function UIPlaceObjects:removeObject(object, dont_close_if_empty, placed, move_canceled)
+  local x, y = self.object_cell_x, self.object_cell_y
   local existing_object = object.existing_object
 
   local move_cancellation = not placed and existing_object and move_canceled
@@ -309,6 +310,9 @@ function UIPlaceObjects:removeObject(object, dont_close_if_empty, placed, move_c
   if object.object.id == "reception_desk" then -- Rebuild cache of reception desks
     self.ui.hospital:buildReceptionDesksCache()
   end
+
+  local room = self.room or self.world:getRoom(x, y)
+  if room then room:calculateHappinessFactor() end
 end
 
 --! Remove all items from the menu.
@@ -590,6 +594,7 @@ function UIPlaceObjects:placeObject(dont_close_if_empty, dont_remove)
   end
   object.orientation_before = nil
 
+  if room then room:calculateHappinessFactor() end
   return real_obj
 end
 

--- a/CorsixTH/Lua/entities/humanoids/patient.lua
+++ b/CorsixTH/Lua/entities/humanoids/patient.lua
@@ -966,10 +966,10 @@ function Patient:tickDay()
   -- Update health history.
   self:_dailyHealthHistoryRefresh()
 
-  -- Perform Happiness and nausea calculations from nearby objects when not interacting
-  -- with a room.
+  -- Perform Happiness and nausea calculations from nearby objects when in a corridor
   if not self:getRoom() and not self:getCurrentAction().is_entering and
-      not self:getCurrentAction().is_leaving then
+      not self:getCurrentAction().is_leaving and
+      self.world.map.th:getCellFlags(self.tile_x, self.tile_y).buildable then
     local num_nearby_vomit = self:_dailyObjectHappinessEffects()
     -- We only want to calculate vomit chance on patients who have the relevant animation
     -- and aren't an emergency.

--- a/CorsixTH/Lua/entities/humanoids/staff.lua
+++ b/CorsixTH/Lua/entities/humanoids/staff.lua
@@ -66,29 +66,31 @@ function Staff:tickDay()
     self:changeAttribute("happiness", 0.006)
   end
 
-  -- It is nice to see plants, but dead plants make you unhappy
-  local plant = getRandomEntryFromArray(self:findObjectsInSquare(2, "plant"))
-  if plant then
-    self:changeAttribute("happiness", -0.003 + (plant:isPleasingFactor() * 0.001))
-  end
+  local room = self:getRoom()
+  if room then
+    self:changeAttribute("happiness", room.happiness_factor)
+  else
+    -- It is nice to see plants, but dead plants make you unhappy
+    local plant = getRandomEntryFromArray(self:findObjectsInSquare(2, "plant"))
+    if plant then
+      self:changeAttribute("happiness", -0.003 + (plant:isPleasingFactor() * 0.001))
+    end
 
-  -- Seeing various nearby objects boost your happiness, some more than others
-  local good_objects = {
-    ["extinguisher"] = 0.002, -- Makes you feel safe
-    ["bin"]          = 0.001,
-    ["bookcase"]     = 0.003,
-    ["skeleton"]     = 0.002,
-    ["tv"]           = 0.0005,
-  }
+    -- Seeing various nearby objects boost your happiness, some more than others
+    local good_objects = {
+      ["extinguisher"] = 0.002, -- Makes you feel safe
+      ["bin"]          = 0.001,
+    }
 
-  -- Construct an array with the object names.
-  local happy_objects = {}
-  for name, _ in pairs(good_objects) do happy_objects[#happy_objects + 1] = name end
+    -- Construct an array with the object names.
+    local happy_objects = {}
+    for name, _ in pairs(good_objects) do happy_objects[#happy_objects + 1] = name end
 
-  -- Look what's around the humanoid, and adapt the happiness.
-  happy_objects = self:findObjectsInSquare(2, happy_objects)
-  for obj_name, happiness_score in pairs(good_objects) do
-    self:changeAttribute("happiness", #happy_objects[obj_name] * happiness_score)
+    -- Look what's around the humanoid, and adapt the happiness.
+    happy_objects = self:findObjectsInSquare(2, happy_objects)
+    for obj_name, happiness_score in pairs(good_objects) do
+      self:changeAttribute("happiness", #happy_objects[obj_name] * happiness_score)
+    end
   end
 
   -- List of positive rest activities and their happiness effect
@@ -103,10 +105,6 @@ function Staff:tickDay()
     if happiness then self:changeAttribute("happiness", happiness) end
   end
 
-  local room = self:getRoom()
-  if room then
-    self:changeAttribute("happiness", room.happiness_factor)
-  end
 
   return true
 end

--- a/CorsixTH/Lua/entities/object.lua
+++ b/CorsixTH/Lua/entities/object.lua
@@ -56,6 +56,8 @@ function Object:Object(hospital, object_type, x, y, direction, etc)
   self:updateDynamicInfo()
   self:initOrientation(direction)
   self:setTile(x, y)
+  local room = self:getRoom() or self.world:getRoom(x, y)
+  if room then room:calculateHappinessFactor() end
 end
 
 --! Initializes the footprint, finds out what to draw and checks for
@@ -858,6 +860,9 @@ end
 function Object:onPickUp()
   self:resetUsageAndReservaton()
   Entity.onPickUp(self)
+
+  local room = self:getRoom() or self.world:getRoom(self.tile_x, self.tile_y)
+  if room then room:calculateHappinessFactor() end
 end
 
 function Object:resetUsageAndReservaton()

--- a/CorsixTH/Lua/objects/plant.lua
+++ b/CorsixTH/Lua/objects/plant.lua
@@ -117,6 +117,9 @@ function Plant:setNextState(restoring)
   end
 
   self.th:setFrame(self.base_frame + self.current_state)
+  -- Plants have a varying effect on happiness depending on their state
+  local room = self:getRoom() or self.world:getRoom(self.tile_x, self.tile_y)
+  if room then room:calculateHappinessFactor() end
 end
 
 local plant_restoring; plant_restoring = permanent"plant_restoring"( function(plant)

--- a/CorsixTH/Lua/room.lua
+++ b/CorsixTH/Lua/room.lua
@@ -1084,9 +1084,6 @@ function Room:afterLoad(old, new)
     -- no longer using this so empty it
     self.humanoids_enroute = {}
   end
-  if old < 186 then
-    self:calculateHappinessFactor()
-  end
   if old < 233 then
     if self.waiting_staff_member then
       -- Cancel delayed replace existing staff member in room
@@ -1104,6 +1101,9 @@ function Room:afterLoad(old, new)
         room_name ~= "research" then
       self.staff_member_set = nil
     end
+  end
+  if old < 265 then
+    self:calculateHappinessFactor()
   end
 end
 
@@ -1180,10 +1180,11 @@ function Room:calculateRemovalCost()
   return cost
 end
 
---! Calculate the effect the room has on humanoid happiness
+--! Calculate the effect the room has on staff happiness
 function Room:calculateHappinessFactor()
   -- The number of windows affects happiness
-  local window_factor, space_factor, window_count = 0, 0, self:countWindows()
+  local window_factor, space_factor, object_factor = 0, 0, 0
+  local window_count = self:countWindows()
   if window_count > 0 then
     if self.room_info.id == "staff_room" then
       -- Staff are pleased to rest in a staff room with windows
@@ -1200,7 +1201,25 @@ function Room:calculateHappinessFactor()
     space_factor = math.round(math.log(extraspace)) / 1000
   end
 
-  self.happiness_factor = window_factor + space_factor
+  -- Various optional room items affect happiness
+  local room_objects = {
+    extinguisher = 0.002,
+    bin          = 0.001,
+    bookcase     = 0.003,
+    skeleton     = 0.002,
+    tv           = 0.0005,
+    plant  = function(plant) return -0.003 + (plant:isPleasingFactor() * 0.001) end,
+  }
+  for obj, _ in pairs(self.objects) do
+    local name = obj.object_type.id
+    if type(room_objects[name]) == "number" then
+      object_factor = object_factor + room_objects[name]
+    elseif room_objects[name] then
+      object_factor = object_factor + room_objects[name](obj)
+    end
+  end
+
+  self.happiness_factor = window_factor + space_factor + object_factor
 end
 
 --! Get this room machine, if it there


### PR DESCRIPTION
**Describe what the proposed change does**
- Add to the room happiness factor the effect from the room objects. Rely on this factor to add to happiness when in a room. This means plants and litter outside the room don't count, a major change from before. The aim is to reduce the number of object searches. Is this acceptable? Also clarify that happiness factor only applies to staff.
- Add a check for indoors before calculating patient happiness, as plants, litter, etc are only indoors.