### PR TITLE
Use Gersemi in place of cmakelint

### DIFF
--- a/.gersemirc
+++ b/.gersemirc
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/BlankSpruce/gersemi/0.26.1/gersemi/configuration.schema.json
+
+indent: 2
+line_length: 120

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -53,7 +53,7 @@ jobs:
           # Required for LDocGen
           sudo luarocks install lpeg
           sudo apt-get install doxygen yamllint
-          sudo pip3 install -I codespell==2.2 cmakelint==1.4
+          sudo pip3 install -I codespell==2.2 gersemi==0.26
           sudo luarocks install luafilesystem
       - name: Install CMake 3.16
         if: matrix.cmake
@@ -97,8 +97,8 @@ jobs:
             -L sav,unexpect,persistance,defin,uint,inout,currenty,blong,falsy,manuel \
             AnimView CorsixTH CorsixTH/Lua/languages/english.lua LevelEdit libs || true
           # Cmake file linter
-          cmakelint --filter=-linelength AnimView/CMakeLists.txt CMakeLists.txt CorsixTH/CMakeLists.txt \
-            CorsixTH/CppTest/CMakeLists.txt CorsixTH/Src/CMakeLists.txt CorsixTH/SrcUnshared/CMakeLists.txt \
+          gersemi --diff AnimView/CMakeLists.txt CMakeLists.txt CorsixTH/CMakeLists.txt \
+            CorsixTH/Src/CMakeLists.txt CorsixTH/SrcUnshared/CMakeLists.txt \
             libs/CMakeLists.txt libs/rnc/CMakeLists.txt CMake/GenerateDoc.cmake
           # Validate these build files
           yamllint --config-data "rules: {line-length: disable}" .github/workflows/*.yml

--- a/AnimView/CMakeLists.txt
+++ b/AnimView/CMakeLists.txt
@@ -11,20 +11,18 @@ configure_file(config.h.in config.h)
 
 # Generate source files list
 # Note: do not use generic includes (*.cpp and such) this will break things with cmake
-set(animview_source_files
+set(
+  animview_source_files
   ${CMAKE_CURRENT_BINARY_DIR}/config.h
-
   app.cpp
   frmMain.cpp
   frmSprites.cpp
   th.cpp
-
   app.h
   backdrop.h
   frmMain.h
   frmSprites.h
   th.h
-
   AnimView.rc
 )
 
@@ -33,19 +31,10 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 # Declaration of the executable
 if(APPLE)
   set(corsixth_icon_file ${CMAKE_SOURCE_DIR}/AnimView/Icon.icns)
-  set_source_files_properties(
-    ${corsixth_icon_file}
-    PROPERTIES
-    MACOSX_PACKAGE_LOCATION Resources
-  )
+  set_source_files_properties(${corsixth_icon_file} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
   set(MACOSX_BUNDLE_ICON_FILE Icon.icns)
 
-  add_executable(
-    AnimView
-    MACOSX_BUNDLE
-    ${animview_source_files}
-    ${corsixth_icon_file}
-  )
+  add_executable(AnimView MACOSX_BUNDLE ${animview_source_files} ${corsixth_icon_file})
 
   set_target_properties(AnimView PROPERTIES LINK_FLAGS_MINSIZEREL "-dead_strip")
   set_target_properties(AnimView PROPERTIES XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/../Frameworks")
@@ -89,11 +78,14 @@ if(APPLE)
   install(TARGETS AnimView BUNDLE DESTINATION .)
 
   # Fix the macOS bundle to include required libraries (create a redistributable app)
-  install(CODE "
+  install(
+    CODE
+      "
     INCLUDE(BundleUtilities)
     SET(BU_CHMOD_BUNDLE_ITEMS ON)
     FIXUP_BUNDLE(\"${CMAKE_INSTALL_PREFIX}/AnimView.app\" \"\" \"\")
-    ")
+    "
+  )
 else()
   install(TARGETS AnimView RUNTIME DESTINATION AnimView)
   install(FILES ../LICENSE.txt DESTINATION AnimView)

--- a/CMake/GenerateDoc.cmake
+++ b/CMake/GenerateDoc.cmake
@@ -2,17 +2,31 @@
 if(WITH_LUAJIT)
   set(LUA_PROGRAM_NAMES luajit-2.0.3 luajit)
 else()
-  set(LUA_PROGRAM_NAMES lua53 lua5.3 lua-5.3 lua52 lua5.2 lua-5.2 lua51 lua5.1 lua-5.1 lua)
+  set(
+    LUA_PROGRAM_NAMES
+    lua53
+    lua5.3
+    lua-5.3
+    lua52
+    lua5.2
+    lua-5.2
+    lua51
+    lua5.1
+    lua-5.1
+    lua
+  )
 endif()
 
-find_program(LUA_PROGRAM_PATH ${LUA_PROGRAM_NAMES}
+find_program(
+  LUA_PROGRAM_PATH
+  ${LUA_PROGRAM_NAMES}
   PATHS
-    ENV LUA_DIR
-    /opt
-    /opt/local
-    ~
-    ~/Library/Frameworks
-    /Library/Frameworks
+  ENV LUA_DIR
+  /opt
+  /opt/local
+  ~
+  ~/Library/Frameworks
+  /Library/Frameworks
 )
 
 # Find Doxygen.
@@ -21,60 +35,104 @@ find_package(Doxygen)
 if(DOXYGEN_FOUND OR LUA_PROGRAM_PATH)
   add_custom_target(doc)
   # Add sub-targets of the 'doc' target.
-  file(WRITE  ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html "<!DOCTYPE html>\n<html>\n")
-  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html "<head><title>CorsixTH source code documentation</title></head>\n")
-  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html "<body>\n<h1>CorsixTH main program source code documentation</h1>\n<ul>\n")
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html "<!DOCTYPE html>\n<html>\n")
+  file(
+    APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html
+    "<head><title>CorsixTH source code documentation</title></head>\n"
+  )
+  file(
+    APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html
+    "<body>\n<h1>CorsixTH main program source code documentation</h1>\n<ul>\n"
+  )
 else()
   message("Cannot locate Doxygen or Lua, 'doc' target is not available")
 endif()
 
 if(LUA_PROGRAM_PATH)
-  add_custom_target(doc_corsixth_lua
+  add_custom_target(
+    doc_corsixth_lua
     ${LUA_PROGRAM_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/LDocGen/main.lua
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/LDocGen/output/corner_right.gif ${CMAKE_CURRENT_BINARY_DIR}/doc/corsixth_lua
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/LDocGen/output/logo.png         ${CMAKE_CURRENT_BINARY_DIR}/doc/corsixth_lua
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/LDocGen/output/main.css         ${CMAKE_CURRENT_BINARY_DIR}/doc/corsixth_lua
+    COMMAND
+      ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/LDocGen/output/corner_right.gif
+      ${CMAKE_CURRENT_BINARY_DIR}/doc/corsixth_lua
+    COMMAND
+      ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/LDocGen/output/logo.png
+      ${CMAKE_CURRENT_BINARY_DIR}/doc/corsixth_lua
+    COMMAND
+      ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/LDocGen/output/main.css
+      ${CMAKE_CURRENT_BINARY_DIR}/doc/corsixth_lua
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc
-    COMMENT "Generating API documentation for corsixth_lua" VERBATIM
+    COMMENT "Generating API documentation for corsixth_lua"
+    VERBATIM
   )
   add_dependencies(doc doc_corsixth_lua)
-  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html "<li><a href='corsixth_lua/index.html'>CorsixTH Lua documentation</a>\n")
+  file(
+    APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html
+    "<li><a href='corsixth_lua/index.html'>CorsixTH Lua documentation</a>\n"
+  )
 endif()
 
 if(DOXYGEN_FOUND)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DoxyGen/corsixth_engine.doxygen.in
-    ${CMAKE_CURRENT_BINARY_DIR}/DoxyGen/corsixth_engine.doxygen @ONLY)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/DoxyGen/corsixth_engine.doxygen.in
+    ${CMAKE_CURRENT_BINARY_DIR}/DoxyGen/corsixth_engine.doxygen
+    @ONLY
+  )
 
-  add_custom_target(doc_corsixth_engine
+  add_custom_target(
+    doc_corsixth_engine
     ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/DoxyGen/corsixth_engine.doxygen
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc
-    COMMENT "Generating API documentation for corsixth_engine" VERBATIM
+    COMMENT "Generating API documentation for corsixth_engine"
+    VERBATIM
   )
   add_dependencies(doc doc_corsixth_engine)
-  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html "<li><a href='corsixth_engine/html/index.html'>CorsixTH engine documentation</a>\n")
-  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html "</ul>\n<h1>CorsixTH helper programs source code documentation</h1>\n<ul>\n")
+  file(
+    APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html
+    "<li><a href='corsixth_engine/html/index.html'>CorsixTH engine documentation</a>\n"
+  )
+  file(
+    APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html
+    "</ul>\n<h1>CorsixTH helper programs source code documentation</h1>\n<ul>\n"
+  )
 
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DoxyGen/leveledit.doxygen.in
-    ${CMAKE_CURRENT_BINARY_DIR}/DoxyGen/leveledit.doxygen @ONLY)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/DoxyGen/leveledit.doxygen.in
+    ${CMAKE_CURRENT_BINARY_DIR}/DoxyGen/leveledit.doxygen
+    @ONLY
+  )
 
-  add_custom_target(doc_leveledit
+  add_custom_target(
+    doc_leveledit
     ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/DoxyGen/leveledit.doxygen
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc
-    COMMENT "Generating API documentation for LevelEdit" VERBATIM
+    COMMENT "Generating API documentation for LevelEdit"
+    VERBATIM
   )
   add_dependencies(doc doc_leveledit)
-  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html "<li><a href='leveledit/html/index.html'>Level editor documentation</a>\n")
+  file(
+    APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html
+    "<li><a href='leveledit/html/index.html'>Level editor documentation</a>\n"
+  )
 
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DoxyGen/animview.doxygen.in
-    ${CMAKE_CURRENT_BINARY_DIR}/DoxyGen/animview.doxygen @ONLY)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/DoxyGen/animview.doxygen.in
+    ${CMAKE_CURRENT_BINARY_DIR}/DoxyGen/animview.doxygen
+    @ONLY
+  )
 
-  add_custom_target(doc_animview
+  add_custom_target(
+    doc_animview
     ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/DoxyGen/animview.doxygen
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc
-    COMMENT "Generating API documentation for AnimView" VERBATIM
+    COMMENT "Generating API documentation for AnimView"
+    VERBATIM
   )
   add_dependencies(doc doc_animview)
-  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html "<li><a href='animview/html/index.html'>Animation viewer documentation</a>\n")
+  file(
+    APPEND ${CMAKE_CURRENT_BINARY_DIR}/doc/index.html
+    "<li><a href='animview/html/index.html'>Animation viewer documentation</a>\n"
+  )
 endif()
 
 if(DOXYGEN_FOUND OR LUA_PROGRAM_PATH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,9 +98,11 @@ else()
   set(SEARCH_LOCAL_DATADIRS_DEFAULT OFF)
 endif()
 
-option(SEARCH_LOCAL_DATADIRS
+option(
+  SEARCH_LOCAL_DATADIRS
   "Search resources in the working directory and the program directory where the executable stores."
-  ${SEARCH_LOCAL_DATADIRS_DEFAULT})
+  ${SEARCH_LOCAL_DATADIRS_DEFAULT}
+)
 
 if(APPLE)
   set(WITH_FONT_DEFAULT "/Library/Fonts/Arial Unicode.ttf")

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -42,11 +42,7 @@ endif()
 # Declaration of the executable
 if(APPLE)
   set(corsixth_icon_file ${CMAKE_SOURCE_DIR}/CorsixTH/Icon.icns)
-  set_source_files_properties(
-    ${corsixth_icon_file}
-    PROPERTIES
-    MACOSX_PACKAGE_LOCATION Resources
-  )
+  set_source_files_properties(${corsixth_icon_file} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
   set(MACOSX_BUNDLE_ICON_FILE Icon.icns)
 
   add_executable(CorsixTH MACOSX_BUNDLE ${corsixth_icon_file})
@@ -159,23 +155,24 @@ target_link_libraries(CorsixTH PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 
 # Find SDL_mixer
 if(FETCH_SDL_MIXER)
-  fetchcontent_declare(
-          SDL3_mixer
-          GIT_REPOSITORY https://github.com/libsdl-org/SDL_mixer.git
-          GIT_TAG release-3.2.4)
+  FetchContent_Declare(SDL3_mixer GIT_REPOSITORY https://github.com/libsdl-org/SDL_mixer.git GIT_TAG release-3.2.4)
 
-  fetchcontent_makeavailable(SDL3_mixer)
+  FetchContent_MakeAvailable(SDL3_mixer)
 else()
   find_package(SDL3_mixer CONFIG REQUIRED)
 endif()
 target_link_libraries(
   CorsixTH_lib
-  PUBLIC
-    $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>,SDL3_mixer::SDL3_mixer,SDL3_mixer::SDL3_mixer-static>)
+  PUBLIC $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>,SDL3_mixer::SDL3_mixer,SDL3_mixer::SDL3_mixer-static>
+)
 
 # Find FFMPEG
 if(CORSIX_TH_USE_FFMPEG)
-  find_package(FFmpeg COMPONENTS AVFORMAT AVCODEC SWSCALE SWRESAMPLE AVUTIL REQUIRED)
+  find_package(
+    FFmpeg
+    COMPONENTS AVFORMAT AVCODEC SWSCALE SWRESAMPLE AVUTIL
+    REQUIRED
+  )
   if(FFMPEG_FOUND)
     target_link_libraries(CorsixTH_lib PUBLIC ${FFMPEG_LIBRARIES})
     include_directories(${FFMPEG_INCLUDE_DIRS})
@@ -227,10 +224,11 @@ if(CORSIX_TH_LINK_LUA_MODULES)
   find_package(unofficial-lpeg CONFIG REQUIRED)
   target_link_libraries(CorsixTH_lib PRIVATE unofficial::lpeg::lpeg)
 
-  add_custom_command(TARGET CorsixTH POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-    ${UNOFFICIAL_LPEG_LUA_FILES}
-    $<TARGET_FILE_DIR:CorsixTH>)
+  add_custom_command(
+    TARGET CorsixTH
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${UNOFFICIAL_LPEG_LUA_FILES} $<TARGET_FILE_DIR:CorsixTH>
+  )
 
   if(NOT USE_SOURCE_DATADIRS)
     install(FILES ${UNOFFICIAL_LPEG_LUA_FILES} DESTINATION ${CORSIX_TH_DATADIR})
@@ -249,9 +247,10 @@ if(WITH_MIDI_DEVICE)
     pkg_search_module(RTMIDI REQUIRED rtmidi)
     if(RTMIDI_FOUND)
       add_library(RtMidi::rtmidi INTERFACE IMPORTED)
-      set_target_properties(RtMidi::rtmidi PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${RTMIDI_INCLUDE_DIRS}"
-        INTERFACE_LINK_LIBRARIES "${RTMIDI_LIBRARIES}")
+      set_target_properties(
+        RtMidi::rtmidi
+        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${RTMIDI_INCLUDE_DIRS}" INTERFACE_LINK_LIBRARIES "${RTMIDI_LIBRARIES}"
+      )
       set(RtMidi_FOUND TRUE)
     endif()
   endif()
@@ -264,25 +263,27 @@ if(WITH_MIDI_DEVICE)
 endif()
 
 if(FETCH_SOUNDFONT)
-  fetchcontent_declare(
+  FetchContent_Declare(
     FluidR3
     URL https://raw.githubusercontent.com/Jacalz/fluid-soundfont/master/SF3/FluidR3.sf3
     URL_HASH SHA256=32039e039c2f708467a6f171fbfd9fecdcadfe40a2327837c391490c8de70021
-    DOWNLOAD_NO_EXTRACT TRUE)
+    DOWNLOAD_NO_EXTRACT TRUE
+  )
 
-  fetchcontent_makeavailable(FluidR3)
+  FetchContent_MakeAvailable(FluidR3)
   set(FLUIDR3_FILE ${fluidr3_SOURCE_DIR}/FluidR3.sf3)
 endif()
 
 if(FETCH_UNICODE_FONT)
-  fetchcontent_declare(
+  FetchContent_Declare(
     GoNoto
     URL https://github.com/satbyy/go-noto-universal/releases/download/v7.0/GoNotoKurrent-Regular.ttf
     URL_HASH SHA256=2f2cee5fbb2403df352ca2005247f6c4faa70f3086ebd31b6c62308b5f2f9865
     DOWNLOAD_NO_EXTRACT TRUE
-    DOWNLOAD_NAME CorsixTHUnicode.ttf)
+    DOWNLOAD_NAME CorsixTHUnicode.ttf
+  )
 
-  fetchcontent_makeavailable(GoNoto)
+  FetchContent_MakeAvailable(GoNoto)
   set(GONOTO_FILE ${gonoto_SOURCE_DIR}/CorsixTHUnicode.ttf)
 endif()
 
@@ -300,13 +301,28 @@ endif()
 if(USE_SOURCE_DATADIRS)
   # Do not generate launch script. The default is fine for this case.
 elseif(XCODE)
-  message(WARNING "By default you will not be able to run CorsixTH from Xcode. If you do not plan to deploy then run cmake with -DUSE_SOURCE_DATADIRS. If you want to both run and deploy from Xcode then set the command line arguments in your run scheme to --interpreter=${CMAKE_CURRENT_SOURCE_DIR}/CorsixTH.lua")
+  message(
+    WARNING
+    "By default you will not be able to run CorsixTH from Xcode. If you do not plan to deploy then run cmake with -DUSE_SOURCE_DATADIRS. If you want to both run and deploy from Xcode then set the command line arguments in your run scheme to --interpreter=${CMAKE_CURRENT_SOURCE_DIR}/CorsixTH.lua"
+  )
 elseif(APPLE)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/run-corsix-th-dev.sh.in.apple ${CMAKE_CURRENT_BINARY_DIR}/run-corsixth-dev.sh @ONLY)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/run-corsix-th-dev.sh.in.apple
+    ${CMAKE_CURRENT_BINARY_DIR}/run-corsixth-dev.sh
+    @ONLY
+  )
 elseif(UNIX)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/run-corsix-th-dev.sh.in ${CMAKE_CURRENT_BINARY_DIR}/run-corsixth-dev.sh @ONLY)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/run-corsix-th-dev.sh.in
+    ${CMAKE_CURRENT_BINARY_DIR}/run-corsixth-dev.sh
+    @ONLY
+  )
 elseif(MSVC)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CorsixTH.vcxproj.user.in ${CMAKE_CURRENT_BINARY_DIR}/CorsixTH.vcxproj.user @ONLY)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/CorsixTH.vcxproj.user.in
+    ${CMAKE_CURRENT_BINARY_DIR}/CorsixTH.vcxproj.user
+    @ONLY
+  )
 endif()
 
 # Adding testing files whilst we also have the list of source files and have found libs
@@ -322,7 +338,8 @@ if(NOT USE_SOURCE_DATADIRS)
     # Just use the prefix as it's sufficient to just set the prefix to /Applications on Mac.
     install(TARGETS CorsixTH BUNDLE DESTINATION .)
   elseif(MSVC)
-    install(TARGETS CorsixTH
+    install(
+      TARGETS CorsixTH
       RUNTIME DESTINATION ${CORSIX_TH_DATADIR}
       LIBRARY DESTINATION ${CORSIX_TH_DATADIR}
       ARCHIVE DESTINATION ${CORSIX_TH_DATADIR}
@@ -331,14 +348,16 @@ if(NOT USE_SOURCE_DATADIRS)
 
     # Install dependencies
     if(CMAKE_CONFIGURATION_TYPES)
-      install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/"
+      install(
+        DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/"
         DESTINATION ${CORSIX_TH_DATADIR}
         FILES_MATCHING
         PATTERN "*.dll"
         PATTERN "*.lua"
       )
     else()
-      install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/"
+      install(
+        DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/"
         DESTINATION ${CORSIX_TH_DATADIR}
         FILES_MATCHING
         PATTERN "*.dll"
@@ -351,16 +370,15 @@ if(NOT USE_SOURCE_DATADIRS)
     set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION ${CORSIX_TH_DATADIR})
     include(InstallRequiredSystemLibraries)
   else()
-    install(TARGETS CorsixTH
+    install(
+      TARGETS CorsixTH
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
   endif()
   install(DIRECTORY Campaigns Lua Levels DESTINATION ${CORSIX_TH_DATADIR})
-  install(DIRECTORY Bitmap DESTINATION ${CORSIX_TH_DATADIR}
-    FILES_MATCHING REGEX ".*\\.(tab|pal|dat|png|pl8)$"
-  )
+  install(DIRECTORY Bitmap DESTINATION ${CORSIX_TH_DATADIR} FILES_MATCHING REGEX ".*\\.(tab|pal|dat|png|pl8)$")
   install(FILES CorsixTH.lua ../LICENSE.txt DESTINATION ${CORSIX_TH_DATADIR})
 
   if(FETCH_SOUNDFONT)
@@ -374,25 +392,38 @@ if(NOT USE_SOURCE_DATADIRS)
     install(FILES corsix-th.6 DESTINATION ${CMAKE_INSTALL_MANDIR}/man6)
     install(FILES com.corsixth.corsixth.metainfo.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
     install(FILES com.corsixth.corsixth.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
-    install(FILES Original_Logo.svg DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps RENAME corsix-th.svg)
+    install(
+      FILES Original_Logo.svg
+      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps
+      RENAME corsix-th.svg
+    )
   endif()
 
   if(APPLE)
     # Fix the macOS bundle to include required libraries (create a redistributable app)
-    install(CODE "
+    install(
+      CODE
+        "
       INCLUDE(BundleUtilities)
       SET(BU_CHMOD_BUNDLE_ITEMS ON)
       FIXUP_BUNDLE(\"${CMAKE_INSTALL_PREFIX}/CorsixTH.app\" \"\" \"\")
-      ")
+      "
+    )
     if(WITH_LUAROCKS)
-      install(CODE "execute_process(
+      install(
+        CODE
+          "execute_process(
         COMMAND bash \"${CMAKE_SOURCE_DIR}/scripts/macos_luarocks\" \"${CMAKE_INSTALL_PREFIX}\")
-      ")
+      "
+      )
     endif()
   endif()
 endif()
 
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT CorsixTH)
 
-add_custom_target(windowsconfig ${LUA_PROGRAM_PATH} ${CMAKE_SOURCE_DIR}/scripts/generate_windows_config.lua
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_custom_target(
+  windowsconfig
+  ${LUA_PROGRAM_PATH} ${CMAKE_SOURCE_DIR}/scripts/generate_windows_config.lua
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)

--- a/CorsixTH/Src/CMakeLists.txt
+++ b/CorsixTH/Src/CMakeLists.txt
@@ -1,8 +1,9 @@
 # Modify the config.h based upon our selection of options
 configure_file(${CMAKE_SOURCE_DIR}/CorsixTH/Src/config.h.in ${CMAKE_BINARY_DIR}/CorsixTH/Src/config.h)
 
-target_sources(CorsixTH_lib
-    PRIVATE
+target_sources(
+  CorsixTH_lib
+  PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/random.c
     ${CMAKE_CURRENT_SOURCE_DIR}/bootstrap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/iso_fs.cpp
@@ -39,8 +40,9 @@ target_sources(CorsixTH_lib
 
 # These are for IDEs such as XCode and MSVC to track headers within their
 # project files. They are not used by the build system.
-target_sources(CorsixTH_lib
-    PRIVATE
+target_sources(
+  CorsixTH_lib
+  PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/bootstrap.h
     ${CMAKE_CURRENT_SOURCE_DIR}/cp437_table.h
     ${CMAKE_CURRENT_SOURCE_DIR}/cp936_table.h
@@ -64,12 +66,7 @@ target_sources(CorsixTH_lib
     ${CMAKE_CURRENT_SOURCE_DIR}/th_sound.h
     ${CMAKE_CURRENT_SOURCE_DIR}/th_strings.h
     ${CMAKE_CURRENT_SOURCE_DIR}/xmi2mid.h
-
     ${CMAKE_BINARY_DIR}/CorsixTH/Src/config.h
 )
 
-target_sources(CorsixTH
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/main.h
-)
+target_sources(CorsixTH PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp ${CMAKE_CURRENT_SOURCE_DIR}/main.h)

--- a/CorsixTH/SrcUnshared/CMakeLists.txt
+++ b/CorsixTH/SrcUnshared/CMakeLists.txt
@@ -1,4 +1,1 @@
-target_sources(CorsixTH
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
-)
+target_sources(CorsixTH PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)

--- a/libs/rnc/CMakeLists.txt
+++ b/libs/rnc/CMakeLists.txt
@@ -1,9 +1,6 @@
 project(RncLib)
 
-add_library(RncLib STATIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/rnc.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/rnc.h
-)
+add_library(RncLib STATIC ${CMAKE_CURRENT_SOURCE_DIR}/rnc.cpp ${CMAKE_CURRENT_SOURCE_DIR}/rnc.h)
 
 target_include_directories(RncLib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
**Describe what the proposed change does**
- Switch the abandoned cmakelint for gersemi to check over the cmake files. The new style is to capitalise fetch content, and different whitespace.

Documentation: https://github.com/BlankSpruce/gersemi#usage