### PR TITLE
Close in-game file browsers after loading a savegame

### DIFF
--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/load_game.lua
@@ -60,3 +60,7 @@ function UILoadGame:close()
     self.ui:addWindow(UIMainMenu(self.ui))
   end
 end
+
+function UILoadGame:afterLoad()
+  self:close()
+end

--- a/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
+++ b/CorsixTH/Lua/dialogs/resizables/file_browsers/save_game.lua
@@ -111,3 +111,7 @@ function UISaveGame:doSave(filename)
     ui:addWindow(UIInformation(ui, {err}))
   end
 end
+
+function UISaveGame:afterLoad()
+  self:close()
+end


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3515*

**Describe what the proposed change does**
- Closes the load and save dialogs, which should? never be seen when loading a savegame. 
