### PR TITLE
Expel walk humanoids from construction site

### DIFF
--- a/CorsixTH/Lua/entities/humanoid.lua
+++ b/CorsixTH/Lua/entities/humanoid.lua
@@ -883,6 +883,9 @@ function Humanoid:leaveArea()
     else
       meander.done_walk = false
     end
+  elseif current_action.name == "walk" then
+    -- Make the humanoid to reroute urgently to leave the blueprint
+    self:queueAction(MeanderAction():setCount(1):setMustHappen(true), 0)
   else
     -- Look for a queue action and re-arrange the people in it, which
     -- should cause anyone queueing within the blueprint to move


### PR DESCRIPTION
<!-- If your PR is still being drafted you must either submit it as a "Draft Pull Request" or add [WIP] to your title. -->

*Fixes #3505*

**Describe what the proposed change does**
- Interrupt walking humanoids along construction site and expel them along the shortest possible route (Thanks to 3414 PR).
