### PR TITLE
Fix Ultrascan footprint. Make two tiles impassable [3441]

### DIFF
--- a/CorsixTH/Lua/objects/machines/ultrascanner.lua
+++ b/CorsixTH/Lua/objects/machines/ultrascanner.lua
@@ -72,7 +72,7 @@ object.orientations = {
   north = {
     footprint = { {-1, -1, need_west_side = true}, {0, -1, complete_cell = true}, {1, -1, only_passable = true, complete_cell = true},
                   {-1, 0, only_passable =true, need_west_side = true}, {0, 0}, {1, 0, only_passable = true},
-                  {-1, 1, only_passable = true, need_west_side = true}, {0, 1, only_passable = true} },
+                  {-1, 1, need_west_side = true}, {0, 1} },
     use_position = {-1, 0, need_west_side = true},
     use_position_secondary = {1, -1},
     handyman_position = {2, 0},
@@ -81,8 +81,8 @@ object.orientations = {
   east = {
     render_attach_position = { {0, 0}, {1, 0}, {-1, 1} },
     footprint = { {-1, -1, complete_cell = true}, {0, -1, only_passable = true, need_north_side = true},
-                  {1, -1, only_passable = true, need_north_side = true},
-                  {-1, 0, complete_cell = true}, {0, 0}, {1, 0, only_passable = true},
+                  {1, -1, need_north_side = true},
+                  {-1, 0, complete_cell = true}, {0, 0}, {1, 0},
                   {-1, 1, only_passable = true, complete_cell = true}, {0, 1, only_passable = true} },
     use_position = {0, -1},
     use_position_secondary = {-1, 1},


### PR DESCRIPTION
Fixes #3441

Ultrascan doctors and patients walk through the side of the table because two tiles in the footprint are still marked passable. The save in #3441 shows the gap clearly.

This keeps the change small. North {-1,1},{0,1} and east {-1,1},{0,1} in `CorsixTH/Lua/objects/machines/ultrascanner.lua:72,80` are now blocked. South copies north and west mirrors east so it covers every rotation. The rest of the footprint is left alone for now.

Older saves are preserved. The footprint is bumped to savegame version 265 in `CorsixTH/Lua/app.lua:31` with a preserve in `CorsixTH/Lua/entities/object.lua:920` (`old<265` keeps the old passable tiles and map flags). New rooms get the blocked tiles, old rooms load as before with no shift or crash. A fuller migration that reoccupies the map and moves anyone standing on those tiles can be a future low priority item.

Tested with the attached save `3441 Ultrascan footprint.sav` headless offscreen and xvfb, and with `busted --directory=CorsixTH/Luatest` 65/65 (`spec/entities/ultrascanner_3441_spec.lua` checks the four tiles and 5000 ticks with the gate). `luacheck` clean, `changelog.txt` 0.71.0 unreleased.

Thanks to @ARGAMX for the save and the detail in https://github.com/CorsixTH/CorsixTH/issues/3441#issuecomment-5482117933
