### PR TITLE
Fluidsynth player for XMI music

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Install CorsixTH and lua test requirements
         run: |
           sudo apt-get update
-          sudo apt-get install ${{matrix.packages}} liblua5.1-dev lua5.1 luarocks libsdl3-dev libfreetype-dev \
+          sudo apt-get install ${{matrix.packages}} liblua5.1-dev lua5.1 \
+           luarocks libsdl3-dev libfreetype-dev libfluidsynth-dev \
            libcurl4-openssl-dev ${{inputs.animview == 'true' && 'libwxgtk3.0-gtk3-dev' || ''}}
           # Required for lua lint check
           sudo luarocks install luacheck

--- a/CorsixTH/CMakeLists.txt
+++ b/CorsixTH/CMakeLists.txt
@@ -179,6 +179,27 @@ target_link_libraries(
   PUBLIC $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>,SDL3_mixer::SDL3_mixer,SDL3_mixer::SDL3_mixer-static>
 )
 
+# Find FluidSynth
+# FluidSynth upstream provides a CMake config but not all distros seem to carry it.
+find_package(FluidSynth CONFIG)
+if(NOT FluidSynth_FOUND AND PkgConfig_FOUND)
+  pkg_search_module(FLUIDSYNTH REQUIRED fluidsynth)
+  if(FLUIDSYNTH_FOUND)
+    add_library(FluidSynth::libfluidsynth INTERFACE IMPORTED)
+    set_target_properties(
+            FluidSynth::libfluidsynth
+            PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FLUIDSYNTH_INCLUDE_DIRS}" INTERFACE_LINK_LIBRARIES "${FLUIDSYNTH_LIBRARIES}"
+    )
+    set(FluidSynth_FOUND TRUE)
+  endif()
+endif()
+if(FluidSynth_FOUND)
+  message("  FluidSynth found")
+  target_link_libraries(CorsixTH_lib PRIVATE FluidSynth::libfluidsynth)
+else()
+  message(FATAL_ERROR "Error: FluidSynth was not found.")
+endif()
+
 # Find FFMPEG
 if(CORSIX_TH_USE_FFMPEG)
   find_package(

--- a/CorsixTH/Lua/app.lua
+++ b/CorsixTH/Lua/app.lua
@@ -288,10 +288,6 @@ function App:init()
   self:initMusicDir()
   self.audio:init()
 
-  -- Hack to early initialise the audio and reduce delay on Windows
-  self.audio:playRandomBackgroundTrack()
-  self.audio:stopBackgroundTrack()
-
   -- Load movie player
   corsixth.require("movie_player")
   self.moviePlayer = MoviePlayer(self, self.audio, self.video)

--- a/CorsixTH/Lua/audio.lua
+++ b/CorsixTH/Lua/audio.lua
@@ -197,17 +197,16 @@ function Audio:initMidiPlayer()
     self.midi_player = nil
   end
 
-  if TH.GetCompileOptions().midi_device and self.app.config.midi_api then
-    local midi_ok, midi_player = pcall(
-      TH.midiPlayer,
-      self.app.config.midi_api,
-      self.app.config.midi_port,
-      self.app.config.midi_sysex_master_volume)
-    if midi_ok then
-      self.midi_player = midi_player
-    else
-      print("Failed to create midi player: " .. midi_player)
-    end
+  local midi_ok, midi_player = pcall(
+    TH.midiPlayer,
+    self.app.config.midi_api or "",
+    self.app.config.midi_port,
+    self.app.config.midi_sysex_master_volume,
+    self.app:findSoundFont())
+  if midi_ok then
+    self.midi_player = midi_player
+  else
+    print("Failed to create midi player: " .. midi_player)
   end
 end
 

--- a/CorsixTH/Src/CMakeLists.txt
+++ b/CorsixTH/Src/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/random.c
     ${CMAKE_CURRENT_SOURCE_DIR}/bootstrap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fluid_player.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/iso_fs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_rnc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/midi_player.cpp
@@ -47,6 +48,7 @@ target_sources(
     ${CMAKE_CURRENT_SOURCE_DIR}/cp437_table.h
     ${CMAKE_CURRENT_SOURCE_DIR}/cp936_table.h
     ${CMAKE_CURRENT_SOURCE_DIR}/cpmik_table.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/fluid_player.h
     ${CMAKE_CURRENT_SOURCE_DIR}/iso_fs.h
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_rnc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_sdl.h

--- a/CorsixTH/Src/fluid_player.cpp
+++ b/CorsixTH/Src/fluid_player.cpp
@@ -1,0 +1,135 @@
+/*
+Copyright (c) 2026 Stephen Baker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "fluid_player.h"
+
+#include <cstdio>
+#include <memory>
+#include <stdexcept>
+
+#include "xmi2mid.h"
+
+fluid_player::fluid_player(const std::string& soundfont) {
+  SDL_AudioSpec spec;
+  spec.format = th::fluid::audio_format;
+  spec.channels = th::fluid::audio_channels;
+  spec.freq = th::fluid::audio_freq;
+
+  audio_stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK,
+                                           &spec, audio_stream_callback, this);
+
+  settings = new_fluid_settings();
+
+  // match SDL audio settings
+  fluid_settings_setint(settings, "audio.period-size", th::fluid::period_size);
+  fluid_settings_setstr(settings, "audio.sample-format", "float");
+  fluid_settings_setint(settings, "synth.audio-channels", 1);
+  fluid_settings_setint(settings, "synth.audio-groups", 1);
+  fluid_settings_setnum(settings, "synth.sample-rate", th::fluid::audio_freq);
+
+  // Let SDL3 manage the volume
+  fluid_settings_setnum(settings, "synth.gain", 1.0);
+
+  // sound settings, matching defaults from fluidsynth 2.6
+  // older defaults were not ideal.
+  fluid_settings_setnum(settings, "synth.chorus.depth", 4.25);
+  fluid_settings_setnum(settings, "synth.chorus.level", 0.6);
+  fluid_settings_setint(settings, "synth.chorus.nr", 3);
+  fluid_settings_setnum(settings, "synth.chorus.speed", 0.2);
+  fluid_settings_setnum(settings, "synth.reverb.damp", 0.3);
+  fluid_settings_setnum(settings, "synth.reverb.level", 0.7);
+  fluid_settings_setnum(settings, "synth.reverb.room-size", 0.5);
+  fluid_settings_setnum(settings, "synth.reverb.width", 0.8);
+
+  // xmi / TH music settings
+  fluid_settings_setstr(settings, "synth.midi-bank-select", "gm");
+
+  synth = new_fluid_synth(settings);
+  soundfont_id = fluid_synth_sfload(synth, soundfont.c_str(), true);
+  if (soundfont_id == FLUID_FAILED) {
+    std::fprintf(stderr, "Failed to load soundfont: %s\n", soundfont.c_str());
+  }
+}
+
+fluid_player::~fluid_player() {
+  stop();
+  SDL_PauseAudioStreamDevice(audio_stream);
+  SDL_DestroyAudioStream(audio_stream);
+  delete_fluid_synth(synth);
+  delete_fluid_settings(settings);
+}
+
+void fluid_player::set_volume(double volume) {
+  SDL_SetAudioStreamGain(audio_stream, static_cast<float>(volume));
+}
+
+void fluid_player::play_xmi(const unsigned char* xmi_data, size_t xmi_length) {
+  if (player) {
+    stop();
+  }
+
+  size_t midi_length;
+  const std::unique_ptr<uint8_t[]> midi_data{
+      transcode_xmi_to_midi(xmi_data, xmi_length, &midi_length)};
+  if (midi_data == nullptr) {
+    throw std::runtime_error("Unable to transcode XMI data");
+  }
+
+  player = new_fluid_player(synth);
+  fluid_player_add_mem(player, midi_data.get(), midi_length);
+  fluid_player_seek(player, 0);
+  fluid_player_play(player);
+  SDL_ResumeAudioStreamDevice(audio_stream);
+}
+
+void fluid_player::pause() { fluid_player_stop(player); }
+
+void fluid_player::resume() { fluid_player_play(player); }
+
+void fluid_player::stop() {
+  if (player == nullptr) {
+    return;
+  }
+
+  fluid_player_stop(player);
+  fluid_synth_all_notes_off(synth, -1);
+  delete_fluid_player(player);
+  SDL_PauseAudioStreamDevice(audio_stream);
+  player = nullptr;
+}
+
+void fluid_player::audio_stream_callback(void* userdata,
+                                         SDL_AudioStream* stream,
+                                         int additional_amount,
+                                         int /*total_amount*/) {
+  auto* plr = static_cast<fluid_player*>(userdata);
+
+  while (additional_amount > 0) {
+    int buffer_size =
+        std::min(additional_amount,
+                 static_cast<int>(plr->buffer.size() * sizeof(float)));
+    fluid_synth_write_float(plr->synth, buffer_size / th::fluid::frame_size,
+                            plr->buffer.data(), 0, 2, plr->buffer.data(), 1, 2);
+    SDL_PutAudioStreamData(stream, plr->buffer.data(), buffer_size);
+    additional_amount -= buffer_size;
+  }
+}

--- a/CorsixTH/Src/fluid_player.h
+++ b/CorsixTH/Src/fluid_player.h
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2026 Stephen Baker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef CORSIXTH_TOP_LEVEL_FLUID_PLAYER_H
+#define CORSIXTH_TOP_LEVEL_FLUID_PLAYER_H
+#include <SDL3/SDL.h>
+#include <fluidsynth.h>
+
+#include <array>
+#include <string>
+
+namespace th::fluid {
+constexpr SDL_AudioFormat audio_format = SDL_AUDIO_F32;
+constexpr int audio_channels = 2;
+constexpr int audio_freq = 44100;
+constexpr int frame_size = sizeof(float) * audio_channels;
+constexpr int period_size = 2048;
+}  // namespace th::fluid
+
+class fluid_player {
+ public:
+  explicit fluid_player(const std::string& soundfont);
+  fluid_player(const fluid_player&) = delete;
+  fluid_player& operator=(const fluid_player&) = delete;
+  ~fluid_player();
+
+  /**
+   * Set the relative playback volume
+   * @param volume volume between 0 and 1
+   */
+  void set_volume(double volume);
+
+  /**
+   * Play the given XMI file
+   * @param xmi_data The raw bytes of the uncompressed XMI file
+   * @param xmi_length The length of the data
+   */
+  void play_xmi(const unsigned char* xmi_data, size_t xmi_length);
+
+  /**
+   * Stop the currently playing MIDI track
+   *
+   * Resets the MIDI device and stops the playback thread.
+   */
+  void stop();
+
+  /**
+   * Pause the currently playing MIDI track
+   */
+  void pause();
+
+  /**
+   * Resume the current MIDI track if paused
+   */
+  void resume();
+
+ private:
+  static void audio_stream_callback(void* userdata, SDL_AudioStream* stream,
+                                    int additional_amount, int total_amount);
+
+  fluid_settings_t* settings;
+  fluid_synth_t* synth;
+  fluid_player_t* player{nullptr};
+  int soundfont_id;
+  SDL_AudioStream* audio_stream;
+  std::array<float, th::fluid::audio_channels * th::fluid::period_size>
+      buffer{};
+};
+
+#endif  // CORSIXTH_TOP_LEVEL_FLUID_PLAYER_H

--- a/CorsixTH/Src/th_lua_midi.cpp
+++ b/CorsixTH/Src/th_lua_midi.cpp
@@ -20,80 +20,132 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include <stdexcept>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+#include "fluid_player.h"
 #include "lua.hpp"
 #include "midi_player.h"
 #include "th_lua.h"
 #include "th_lua_internal.h"
 
-#ifdef WITH_MIDI_DEVICE
-
-// Delegate object around midi_player with a close method
+// Delegate object around midi_player or fluid_player with a close method
 // suitable for adapting C++ RAII to lua garbage collection.
 class th_lua_midi_player {
  public:
+  explicit th_lua_midi_player(const std::string& soundfont)
+      : player(std::in_place_type<fluid_player>, soundfont) {}
+
+#ifdef WITH_MIDI_DEVICE
   th_lua_midi_player(std::string_view api, std::string_view port,
                      bool use_sysex)
-      : player(std::in_place, api, port, use_sysex) {}
+      : player(std::in_place_type<midi_player>, api, port, use_sysex) {}
+#endif
   th_lua_midi_player(const th_lua_midi_player&) = delete;
   th_lua_midi_player& operator=(const th_lua_midi_player&) = delete;
 
   std::vector<std::string> port_list() const {
-    if (!player.has_value()) {
-      throw std::runtime_error("th_lua_midi_player instance is closed");
-    }
-    return player->port_list();
+    return std::visit(
+        [](const auto& player) -> std::vector<std::string> {
+          using player_type = std::decay_t<decltype(player)>;
+          if constexpr (std::is_same_v<player_type, std::monostate>) {
+            throw std::runtime_error("th_lua_midi_player instance is closed");
+          } else if constexpr (std::is_same_v<player_type, fluid_player>) {
+            return {};
+          } else {
+            return player.port_list();
+          }
+        },
+        player);
   }
 
   void play_xmi(const unsigned char* xmiData, const size_t len) {
-    if (!player.has_value()) {
-      throw std::runtime_error("th_lua_midi_player instance is closed");
-    }
-    player->play_xmi(xmiData, len);
+    std::visit(
+        [&](auto& player) {
+          using player_type = std::decay_t<decltype(player)>;
+          if constexpr (std::is_same_v<player_type, std::monostate>) {
+            throw std::runtime_error("th_lua_midi_player instance is closed");
+          } else {
+            player.play_xmi(xmiData, len);
+          }
+        },
+        player);
   }
 
   void set_volume(const double volume) {
-    if (!player.has_value()) {
-      throw std::runtime_error("th_lua_midi_player instance is closed");
-    }
-    player->set_volume(volume);
+    std::visit(
+        [&](auto& player) {
+          using player_type = std::decay_t<decltype(player)>;
+          if constexpr (std::is_same_v<player_type, std::monostate>) {
+            throw std::runtime_error("th_lua_midi_player instance is closed");
+          } else if constexpr (std::is_same_v<player_type, fluid_player>) {
+            player.set_volume(static_cast<float>(volume));
+          } else {
+            player.set_volume(volume);
+          }
+        },
+        player);
   }
 
   void stop() {
-    if (!player.has_value()) {
-      throw std::runtime_error("th_lua_midi_player instance is closed");
-    }
-    player->stop();
+    std::visit(
+        [](auto& player) {
+          using player_type = std::decay_t<decltype(player)>;
+          if constexpr (std::is_same_v<player_type, std::monostate>) {
+            throw std::runtime_error("th_lua_midi_player instance is closed");
+          } else {
+            player.stop();
+          }
+        },
+        player);
   }
 
   void pause() {
-    if (!player.has_value()) {
-      throw std::runtime_error("th_lua_midi_player instance is closed");
-    }
-    player->pause();
+    std::visit(
+        [](auto& player) {
+          using player_type = std::decay_t<decltype(player)>;
+          if constexpr (std::is_same_v<player_type, std::monostate>) {
+            throw std::runtime_error("th_lua_midi_player instance is closed");
+          } else {
+            player.pause();
+          }
+        },
+        player);
   }
 
   void resume() {
-    if (!player.has_value()) {
-      throw std::runtime_error("th_lua_midi_player instance is closed");
-    }
-    player->resume();
+    std::visit(
+        [](auto& player) {
+          using player_type = std::decay_t<decltype(player)>;
+          if constexpr (std::is_same_v<player_type, std::monostate>) {
+            throw std::runtime_error("th_lua_midi_player instance is closed");
+          } else {
+            player.resume();
+          }
+        },
+        player);
   }
 
-  void close() { player.reset(); }
+  void close() { player.emplace<std::monostate>(); }
 
  private:
-  std::optional<midi_player> player;
-};
+#ifdef WITH_MIDI_DEVICE
+  std::variant<std::monostate, fluid_player, midi_player> player;
 #else
-class th_lua_midi_player {};
+  std::variant<std::monostate, fluid_player> player;
 #endif
+};
 
 namespace {
 
-#ifdef WITH_MIDI_DEVICE
-
 int l_midi_player_api_list(lua_State* L) {
+#ifdef WITH_MIDI_DEVICE
   std::vector<std::string> apis = midi_player::api_list();
+#else
+  std::vector<std::string> apis{};
+#endif
 
   lua_createtable(L, static_cast<int>(apis.size()), 0);
   for (size_t i = 0; i < apis.size(); ++i) {
@@ -106,13 +158,30 @@ int l_midi_player_api_list(lua_State* L) {
 }
 
 int l_midi_player_new(lua_State* L) {
+  if (lua_gettop(L) == 2) {
+    const char* soundfont = luaL_checkstring(L, 2);
+    try {
+      luaT_stdnew<th_lua_midi_player>(L, luaT_environindex, true, soundfont);
+      return 1;
+    } catch (const std::exception& e) {
+      return luaL_error(L, e.what());
+    }
+  }
+
   const char* apiChoice = luaL_optlstring(L, 2, "", nullptr);
   const char* portChoice = luaL_optlstring(L, 3, "", nullptr);
   bool sysexMasterVolume = lua_toboolean(L, 4);
+  const char* soundfont = luaL_optlstring(L, 5, "", nullptr);
 
   try {
-    luaT_stdnew<th_lua_midi_player>(L, luaT_environindex, true, apiChoice,
-                                    portChoice, sysexMasterVolume);
+#ifdef WITH_MIDI_DEVICE
+    if (apiChoice[0] != '\0') {
+      luaT_stdnew<th_lua_midi_player>(L, luaT_environindex, true, apiChoice,
+                                      portChoice, sysexMasterVolume);
+      return 1;
+    }
+#endif
+    luaT_stdnew<th_lua_midi_player>(L, luaT_environindex, true, soundfont);
     return 1;
   } catch (const std::invalid_argument& e) {
     return luaL_error(L, "Invalid MIDI API choice: %s", e.what());
@@ -201,46 +270,6 @@ int l_midi_player_close(lua_State* L) {
   }
   return 0;
 }
-
-#else  // WITH_MIDI_DEVICE
-
-int l_midi_player_api_list(lua_State* L) {
-  lua_newtable(L);
-
-  return 1;
-}
-
-int l_midi_player_new(lua_State* L) {
-  return luaL_error(L, "MIDI support not compiled in");
-}
-
-int l_midi_port_list(lua_State* L) {
-  return luaL_error(L, "MIDI support not compiled in");
-}
-
-int l_midi_player_play_xmi(lua_State* L) {
-  return luaL_error(L, "MIDI support not compiled in");
-}
-
-int l_midi_player_set_volume(lua_State* L) {
-  return luaL_error(L, "MIDI support not compiled in");
-}
-
-int l_midi_player_stop(lua_State* L) {
-  return luaL_error(L, "MIDI support not compiled in");
-}
-
-int l_midi_player_pause(lua_State* L) {
-  return luaL_error(L, "MIDI support not compiled in");
-}
-
-int l_midi_player_resume(lua_State* L) {
-  return luaL_error(L, "MIDI support not compiled in");
-}
-
-int l_midi_player_close(lua_State* L) { return 0; }
-
-#endif  // WITH_MIDI_DEVICE
 
 }  // namespace
 


### PR DESCRIPTION
SDL3_mixer has some annoying behaviour with respect to FluidSynth, performing too much work between each track.

This commit takes advantage of SDL3's built in mixing, and bypasses SDL3_mixer for the built in game music which is the most common case of using SDL3_mixer with FluidSynth.

Fixes #3286
Fixes #3473 